### PR TITLE
SMN One button combo level sync fixes

### DIFF
--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -127,6 +127,7 @@ namespace XIVSlothComboPlugin.Combos
                 OutburstMastery2 = 82,
                 Slipstream = 86,
                 MountainBuster = 86,
+                SearingLight = 66,
 
                 Bahamut = 70,
                 Phoenix = 80,
@@ -202,16 +203,16 @@ namespace XIVSlothComboPlugin.Combos
                     var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
                     var buffCD = GetCooldown(SMN.SearingLight);
 
-                    if (IsEnabled(CustomComboPreset.BuffOnSimpleSummoner) && gauge.IsBahamutReady && !bahaCD.IsCooldown && !buffCD.IsCooldown && incombat)
+                    if (IsEnabled(CustomComboPreset.BuffOnSimpleSummoner) && gauge.IsBahamutReady && !bahaCD.IsCooldown && !buffCD.IsCooldown && incombat && level >= SMN.Levels.SearingLight)
                         return SMN.SearingLight;
 
                     // Egis
                     if (gauge.IsTitanReady && !gauge.IsGarudaAttuned && !gauge.IsIfritAttuned && gauge.SummonTimerRemaining == 0 && bahaCD.IsCooldown && phoenixCD.IsCooldown && incombat)
-                        return SMN.SummonTitan;
+                        return OriginalHook(SMN.SummonTopaz);
                     if (gauge.IsGarudaReady && !gauge.IsTitanAttuned && !gauge.IsIfritAttuned && gauge.SummonTimerRemaining == 0 && bahaCD.IsCooldown && phoenixCD.IsCooldown && incombat && !HasEffect(SMN.Buffs.TitansFavor))
-                        return SMN.SummonGaruda;
+                        return OriginalHook(SMN.SummonEmerald);
                     if (gauge.IsIfritReady && !gauge.IsGarudaAttuned && !gauge.IsTitanAttuned && gauge.SummonTimerRemaining == 0 && bahaCD.IsCooldown && phoenixCD.IsCooldown && incombat)
-                        return SMN.SummonIfrit;
+                        return OriginalHook(SMN.SummonRuby);
 
                     // Demi
                     if (gauge.IsBahamutReady && !gauge.IsPhoenixReady && gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && incombat && !bahaCD.IsCooldown && buffCD.IsCooldown )

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -216,9 +216,9 @@ namespace XIVSlothComboPlugin.Combos
 
                     // Demi
                     if (gauge.IsBahamutReady && !gauge.IsPhoenixReady && gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && incombat && !bahaCD.IsCooldown && buffCD.IsCooldown )
-                        return SMN.SummonBahamut;
+                        return OriginalHook(SMN.Aethercharge);
                     if (gauge.IsPhoenixReady && !gauge.IsBahamutReady && gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && incombat && !phoenixCD.IsCooldown)
-                        return SMN.SummonPhoenix;
+                        return OriginalHook(SMN.Aethercharge);
 
 
                 }

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -102,6 +102,7 @@ namespace XIVSlothComboPlugin.Combos
             Resurrection = 173,
 
             // buff 
+            Aethercharge = 25800,
             SearingLight = 25801;
 
         public static class Buffs
@@ -228,9 +229,9 @@ namespace XIVSlothComboPlugin.Combos
                     var phoenixCD = GetCooldown(SMN.SummonPhoenix);
                     var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
                     if (gauge.IsBahamutReady && !gauge.IsPhoenixReady && gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && incombat && !bahaCD.IsCooldown)
-                        return SMN.SummonBahamut;
+                        return OriginalHook(SMN.Aethercharge);
                     if (gauge.IsPhoenixReady && !gauge.IsBahamutReady && gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && incombat && !phoenixCD.IsCooldown)
-                        return SMN.SummonPhoenix;
+                        return OriginalHook(SMN.Aethercharge);
                 }
                 if (IsEnabled(CustomComboPreset.SummonerLazyFesterFeature))
                 {


### PR DESCRIPTION
Level sync fix for Searing Light one button combo (need to be level 66 or greater, wasn't working while sub 66)
Also fix for one button combo egi summons, was returning summon titan (I) instead of summon titan II at level 90 and was nonfunctional.
Also fixed one button combo for pre-bahamut level sync, had summon bahamut when you couldn't click it.
Unsure if I did this entirely correctly but it does seem to work fine in-game when testing at sub 66 for searing light, and sub 30/post 30 for carbuncles and egis.