### PR TITLE
Add RPR Enshrouded Combos to BloodSwathe Option

### DIFF
--- a/XIVSlothCombo/Combos/RPR.cs
+++ b/XIVSlothCombo/Combos/RPR.cs
@@ -395,6 +395,10 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (HasEffect(RPR.Buffs.Enshrouded) && level >= 80)
                 {
+                    if (HasEffect(RPR.Buffs.EnhancedCrossReaping) && HasEffect(RPR.Buffs.Enshrouded))
+                    {
+                        return OriginalHook(RPR.Gallows);
+                    }
                     if (gauge.VoidShroud >= 2)
                     {
                         return OriginalHook(RPR.BloodStalk);
@@ -403,7 +407,7 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         return OriginalHook(RPR.Communio);
                     }
-                    return OriginalHook(RPR.Gallows);
+                    return OriginalHook(RPR.Gibbet);
                 }
 
                 if (!HasEffect(RPR.Buffs.SoulReaver))

--- a/XIVSlothCombo/Combos/RPR.cs
+++ b/XIVSlothCombo/Combos/RPR.cs
@@ -389,8 +389,23 @@ namespace XIVSlothComboPlugin.Combos
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             var gluttonyCD = GetCooldown(RPR.Gluttony);
+            var gauge = GetJobGauge<RPRGauge>();
+
             if (actionID == RPR.BloodStalk)
             {
+                if (HasEffect(RPR.Buffs.Enshrouded) && level >= 80)
+                {
+                    if (gauge.VoidShroud >= 2)
+                    {
+                        return OriginalHook(RPR.BloodStalk);
+                    }
+                    if (gauge.LemureShroud == 1 && gauge.VoidShroud == 0 && level >= 90)
+                    {
+                        return OriginalHook(RPR.Communio);
+                    }
+                    return OriginalHook(RPR.Gallows);
+                }
+
                 if (!HasEffect(RPR.Buffs.SoulReaver))
                 {
                     if ((actionID == RPR.BloodStalk) && !gluttonyCD.IsCooldown && level >= 76)
@@ -417,8 +432,22 @@ namespace XIVSlothComboPlugin.Combos
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             var gluttonyCD = GetCooldown(RPR.Gluttony);
+            var gauge = GetJobGauge<RPRGauge>();
             if (actionID == RPR.GrimSwathe)
             {
+                if (HasEffect(RPR.Buffs.Enshrouded) && level >= 80)
+                {
+                    if (gauge.VoidShroud >= 2)
+                    {
+                        return OriginalHook(RPR.GrimSwathe);
+                    }
+                    if (gauge.LemureShroud == 1 && gauge.VoidShroud == 0 && level >= 90)
+                    {
+                        return OriginalHook(RPR.Communio);
+                    }
+                    return OriginalHook(RPR.Guillotine);
+                }
+
                 if (!HasEffect(RPR.Buffs.SoulReaver))
                 {
                     if ((actionID == RPR.GrimSwathe) && !gluttonyCD.IsCooldown && level >= 76)

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -686,11 +686,11 @@ namespace XIVSlothComboPlugin
         ReaperBloodSwatheFeature = 1712,
 
         [ConflictingCombos(ReaperBloodSwatheFeature)]
-        [CustomComboInfo("Blood Stalk Combo Option", "Turns Blood Stalk into Gluttony when off-cooldown and puts Gibbets and Gallows on the same button as Blood Stalk. \n Conflicts with Blood Stalk / Grim Swathe Feature.", RPR.JobID, RPR.BloodStalk)]
+        [CustomComboInfo("Blood Stalk Combo Option", "Turns Blood Stalk into Gluttony when off-cooldown and puts Gibbets and Gallows on the same button as Blood Stalk. Adds Enshrouded Combo to button as well", RPR.JobID, RPR.BloodStalk)]
         ReaperBloodSwatheComboFeature = 1713,
 
         [ConflictingCombos(ReaperBloodSwatheFeature)]
-        [CustomComboInfo("Grim Swathe Combo Option", "Turns Grim Swathe into Gluttony when off-cooldown and puts Guillotine on the same button as Grim Swathe. \n Conflicts with Blood Stalk / Grim Swathe Feature.", RPR.JobID, RPR.GrimSwathe)]
+        [CustomComboInfo("Grim Swathe Combo Option", "Turns Grim Swathe into Gluttony when off-cooldown and puts Guillotine on the same button as Grim Swathe. Adds Enshrouded Combo to button as well", RPR.JobID, RPR.GrimSwathe)]
         ReaperGrimSwatheComboOption = 1714,
 
 


### PR DESCRIPTION
Added Cross/Void Reaping + Communio to BloodSwathe Option as requested in #76.

Redoing my PR because I'm stupid and I forgot to do checks for Enhanced Cross/Void Reaping.