### PR TITLE
Fell Cleave/Decimate Option + Edit to Inner Chaos Option

### DIFF
--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -95,9 +95,16 @@ namespace XIVSlothComboPlugin.Combos
                     return WAR.FellCleave;
                 }
 
+
+
                 if (comboTime > 0)
                 {
                     var gauge = GetJobGauge<WARGauge>().BeastGauge;
+
+                    if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= 54)
+                        return WAR.FellCleave;
+                    if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= 35 && level <= 53)
+                        return WAR.InnerBeast;
                     if (lastComboMove == WAR.Maim && level >= 50 && !HasEffectAny(WAR.Buffs.SurgingTempest))
                         return WAR.StormsEye;
                     if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim)
@@ -186,6 +193,8 @@ namespace XIVSlothComboPlugin.Combos
                         return OriginalHook(WAR.Decimate);
                     if (IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.NascentChaos) && level >= 72)
                         return OriginalHook(WAR.ChaoticCyclone);
+                    if (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && HasEffect(WAR.Buffs.SurgingTempest) && level >= 72)
+                        return WAR.ChaoticCyclone;
 
                     if (comboTime > 0)
                     {
@@ -198,6 +207,10 @@ namespace XIVSlothComboPlugin.Combos
                         if (IsEnabled(CustomComboPreset.WarriorMythrilTempestCombo))
                         {
                             var gauge = GetJobGauge<WARGauge>().BeastGauge;
+                            if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= 60)
+                                return WAR.Decimate;
+                            if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= 45 && level <= 59)
+                                return WAR.SteelCyclone;
                             if (lastComboMove == WAR.Infuriate && level >= 60)
                                 return WAR.Decimate;
                             if (lastComboMove == WAR.Overpower && level >= 40)

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -619,8 +619,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Orogeny Feature", "Adds Orogeny onto main AoE combo when you are buffed with Surging Tempest", WAR.JobID, WAR.Orogeny, WAR.MythrilTempest)]
         WarriorOrogenyFeature = 1509,
 
-        [CustomComboInfo("Inner Chaos option", "Adds Inner Chaos to Storms Path Combo if you are buffed with Nascent Chaos and Surging Tempest.\nRequires Storms Path Combo", WAR.JobID, WAR.InnerChaos, WAR.StormsPath)]
+        [CustomComboInfo("Inner Chaos option", "Adds Inner Chaos to Storms Path Combo if you are buffed with Nascent Chaos and Surging Tempest. Does the same with Chaotic Cyclone on the AoE Combo. \nRequires Storms Path Combo", WAR.JobID, WAR.InnerChaos, WAR.StormsPath)]
         WarriorInnerChaosOption = 1510,
+
+        [CustomComboInfo("Fell Cleave/Decimate Option", "Adds Fell Cleave to main combo when gauge is at 50 or more and adds Decimate to the AoE combo", WAR.JobID, WAR.StormsPath)]
+        WarriorSpenderOption = 1511,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
Added the option for the ST/AoE Combos to use their spenders at 50 instead of at overcap with level checks. As well as, adding Chaotic Cyclone to the AoE combo when the Inner Chaos Option is ticked.