### PR TITLE
feat: optimise BRD SimpleSongOption song usage

### DIFF
--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -500,9 +500,7 @@ namespace XIVSlothComboPlugin.Combos
                                 return BRD.MagesBallad;
                             }
                         }
-                    }
-
-                    if (gauge.SongTimer < 1 || gauge.Song == Song.ARMY) {
+                    } else if (gauge.SongTimer < 1 || gauge.Song == Song.ARMY) {
                         if (level >= BRD.Levels.MagesBallad && !GetCooldown(BRD.MagesBallad).IsCooldown)
                             return BRD.MagesBallad;
                         if (level >= BRD.Levels.WanderersMinuet && !GetCooldown(BRD.WanderersMinuet).IsCooldown)

--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -463,8 +463,46 @@ namespace XIVSlothComboPlugin.Combos
                     }
                 }
 
-                if (IsEnabled(CustomComboPreset.SimpleSongOption)) {
-                    if (heavyShot.IsCooldown && (gauge.SongTimer < 1 || gauge.Song == Song.ARMY)) {
+                if (IsEnabled(CustomComboPreset.SimpleSongOption) && heavyShot.IsCooldown) {
+                    // Limit optimisation to only when you are high enough to benefit from it.
+                    if (level >= BRD.Levels.WanderersMinuet) {
+                        // 43s of Wanderer's Minute, ~34s of Mage's Ballad, and ~43s of Army Peon
+                        var songTimerInSeconds = gauge.SongTimer / 1000;
+                        var minuetCooldown = GetCooldown(BRD.WanderersMinuet).IsCooldown;
+                        var balladCooldown = GetCooldown(BRD.MagesBallad).IsCooldown;
+                        var paeonCooldown = GetCooldown(BRD.ArmysPaeon).IsCooldown;
+
+                        if (gauge.SongTimer == 0) {
+                            // Do logic to determine first song
+
+                            if (!minuetCooldown) return BRD.WanderersMinuet;
+                            if (!balladCooldown) return BRD.MagesBallad;
+                            if (!paeonCooldown) return BRD.ArmysPaeon;
+                        }
+
+                        if (gauge.Song == Song.WANDERER) {
+                            // Move to Mage's Ballad if <=3 seconds left on song
+                            if (songTimerInSeconds <= 2 && !balladCooldown) {
+                                return BRD.MagesBallad;
+                            }
+                        }
+
+                        if (gauge.Song == Song.MAGE) {
+                            // Move to Army's Paeon if <=12 seconds left on song
+                            if (songTimerInSeconds <= 10 && !paeonCooldown) {
+                                return BRD.ArmysPaeon;
+                            }
+                        }
+
+                        if (gauge.Song == Song.ARMY) {
+                            // Move to Army's Paeon if <= 3 seconds left on song
+                            if (songTimerInSeconds <= 2 && !balladCooldown) {
+                                return BRD.MagesBallad;
+                            }
+                        }
+                    }
+
+                    if (gauge.SongTimer < 1 || gauge.Song == Song.ARMY) {
                         if (level >= BRD.Levels.MagesBallad && !GetCooldown(BRD.MagesBallad).IsCooldown)
                             return BRD.MagesBallad;
                         if (level >= BRD.Levels.WanderersMinuet && !GetCooldown(BRD.WanderersMinuet).IsCooldown)


### PR DESCRIPTION
#119 Optimises BRD's SimpleSongOption to use timings based on The Balance (and the Issue's) advice.

I have tested it in-game, the rotation did have to be a slightly longer Ballad otherwise you would end up with no song on for a few seconds whilst Minuet was on CD.

The rotation goes as;
43-ish seconds of Minuet
35-ish seconds of Ballad
43-ish seconds of Paeon

I have also put an initial song check in, so that if songs are used on the AOE option or individually on pulls in dungeons, it won't affect the rotation too much. (It'll just pick up where it can, and go into the rotation asap).

I have also put it around a Minuet level check, because optimising when you're under that level is a bit pointless.