### PR TITLE
Warrior fixes

### DIFF
--- a/XIVSlothCombo/Combos/MCH.cs
+++ b/XIVSlothCombo/Combos/MCH.cs
@@ -119,7 +119,6 @@ namespace XIVSlothComboPlugin.Combos
                     else
                     if (level >= 84)
                     {
-
                         if (HasEffect(MCH.Buffs.Reassembled) && reassembleCD.CooldownRemaining <= 55 && !airAnchorCD.IsCooldown)
                             return MCH.AirAnchor;
                         if (reassembleCD.CooldownRemaining >= 55 && !chainsawCD.IsCooldown && level >= 90)

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -111,16 +111,16 @@ namespace XIVSlothComboPlugin.Combos
                         return WAR.Onslaught;
                 }
                 // leaves 2 stacks
-                if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOptionTwo) && level >= 62)
-                {
-                    if (onslaughtCD.CooldownRemaining < 30 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff)
-                        return WAR.Onslaught;
-                    else
-                    if (level >= 84)
+                if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOptionTwo) && level >= 64)
+                {                    
+                    if (level >= 88)
                     {
-                        if (onslaughtCD.CooldownRemaining < 1 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff)
+                        if (onslaughtCD.CooldownRemaining < 1 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff && level >= 88)
+                            return WAR.Onslaught;
+                    }
+                    else
+                        if (onslaughtCD.CooldownRemaining < 30 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff && level >= 62)
                         return WAR.Onslaught;
-                     }
                 }
                 if (comboTime > 0)
                 {
@@ -211,6 +211,16 @@ namespace XIVSlothComboPlugin.Combos
                     var mythrilCd = GetCooldown(WAR.MythrilTempest);
                     var decimateCD = GetCooldown(WAR.Decimate);
 
+
+                    if (IsEnabled(CustomComboPreset.WarriorOrogenyFeature) && !orogenyCD.IsCooldown && decimateCD.CooldownRemaining > 0.7 && HasEffect(WAR.Buffs.SurgingTempest) && lastComboMove == WAR.Decimate && level >= 86)
+                    {
+                        return WAR.Orogeny;
+                    }
+                    if (IsEnabled(CustomComboPreset.WarriorOrogenyFeature) && !orogenyCD.IsCooldown && mythrilCd.CooldownRemaining > 0.7 && HasEffect(WAR.Buffs.SurgingTempest) && level >= 86)
+                    {
+                        return WAR.Orogeny;
+                    }
+
                     if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady) && level >= 90)
                         return OriginalHook(WAR.PrimalRend);
                     if (IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease))
@@ -240,14 +250,7 @@ namespace XIVSlothComboPlugin.Combos
                             if ((lastComboMove == WAR.Overpower && level >= 60) || (lastComboMove == WAR.MythrilTempest && gauge >= 90 && level >= 60 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature)))
                                 return WAR.Decimate;
                         }
-                        if (IsEnabled(CustomComboPreset.WarriorOrogenyFeature) && !orogenyCD.IsCooldown && decimateCD.CooldownRemaining > 0.7 && HasEffect(WAR.Buffs.SurgingTempest) && lastComboMove == WAR.Decimate && level >= 86)
-                        {
-                            return WAR.Orogeny;
-                        }
-                        if (IsEnabled(CustomComboPreset.WarriorOrogenyFeature) && !orogenyCD.IsCooldown && mythrilCd.CooldownRemaining > 0.7 && HasEffect(WAR.Buffs.SurgingTempest) && level >= 86)
-                        {
-                            return WAR.Orogeny;
-                        }
+                       
                     }
 
                     return WAR.Overpower;

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -113,8 +113,14 @@ namespace XIVSlothComboPlugin.Combos
                 // leaves 2 stacks
                 if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOptionTwo) && level >= 62)
                 {
-                    if (onslaughtCD.CooldownRemaining < 1 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff)
+                    if (onslaughtCD.CooldownRemaining < 30 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff)
                         return WAR.Onslaught;
+                    else
+                    if (level >= 84)
+                    {
+                        if (onslaughtCD.CooldownRemaining < 1 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff)
+                        return WAR.Onslaught;
+                     }
                 }
                 if (comboTime > 0)
                 {

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -213,13 +213,10 @@ namespace XIVSlothComboPlugin.Combos
 
 
                     if (IsEnabled(CustomComboPreset.WarriorOrogenyFeature) && !orogenyCD.IsCooldown && decimateCD.CooldownRemaining > 0.7 && HasEffect(WAR.Buffs.SurgingTempest) && lastComboMove == WAR.Decimate && level >= 86)
-                    {
                         return WAR.Orogeny;
-                    }
                     if (IsEnabled(CustomComboPreset.WarriorOrogenyFeature) && !orogenyCD.IsCooldown && mythrilCd.CooldownRemaining > 0.7 && HasEffect(WAR.Buffs.SurgingTempest) && level >= 86)
-                    {
                         return WAR.Orogeny;
-                    }
+                    
 
                     if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady) && level >= 90)
                         return OriginalHook(WAR.PrimalRend);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -739,7 +739,7 @@ namespace XIVSlothComboPlugin
         WarriorOnslaughtFeatureOption = 1513,
 
         [ConflictingCombos(WarriorOnslaughtFeature, WarriorOnslaughtFeatureOption)]
-        [CustomComboInfo("Onslaught Option Two", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff (Leaves 2 stacks)", WAR.JobID, WAR.StormsPath)]
+        [CustomComboInfo("Onslaught Option Two", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff (Leaves 1/2 stacks depending on lvl)", WAR.JobID, WAR.StormsPath)]
         WarriorOnslaughtFeatureOptionTwo = 1514,
 
         #endregion


### PR DESCRIPTION
Fixed OnslaughtOptionTwo and adjusted description. Now leaves 1 charge below 88.

Moved Orogeny combo up, so it will activate in time with Upheaval. Will still wait for Storm's buff

Attempt at cleaning up my ugly formatting