### PR TITLE
feat(BRD): add health checking and raid toggle

### DIFF
--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -171,6 +171,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Simple Buffs - Radiant", "Adds Radiant Finale to the Simple Buffs feature.", BRD.JobID, BRD.HeavyShot, BRD.BurstShot)]
         BardSimpleBuffsRadiantFeature = 218,
 
+        [DependentCombos(SimpleBardFeature)]
+        [CustomComboInfo("Simple Raid Mode", "Removes enemy health checking on mobs for buffs, dots and songs.", BRD.JobID, BRD.HeavyShot, BRD.BurstShot)]
+        BardSimpleRaidMode = 219,
+
         #endregion
         // ====================================================================================
         #region DANCER


### PR DESCRIPTION
Adds health checking to SimpleBard functionalities, such as buffs, songs and DOTs.
Adds a new feature toggle "BardSimpleRaidMode" (219), allowing users to override these health checks in raids, as boss %'s are usually still high at 1% (and you still want to use literally everything at that % in a raid). This lets dungeon running and raiding have slightly different functionalities, as you don't want to go using your song or buffs for half a second of boss HP in dungeons.