### PR TITLE
feat(BRD): simple interrupt

### DIFF
--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -450,6 +450,10 @@ namespace XIVSlothComboPlugin.Combos
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             if (actionID == BRD.HeavyShot || actionID == BRD.BurstShot) {
+                if (IsEnabled(CustomComboPreset.BardSimpleInterrupt) && CanInterruptEnemy() && !GetCooldown(All.Interject).IsCooldown) {
+                    return All.Interject;
+                }
+
                 var gauge = GetJobGauge<BRDGauge>();
                 var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
                 var heavyShot = GetCooldown(actionID);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -174,6 +174,9 @@ namespace XIVSlothComboPlugin
         [DependentCombos(SimpleBardFeature)]
         [CustomComboInfo("Simple Raid Mode", "Removes enemy health checking on mobs for buffs, dots and songs.", BRD.JobID, BRD.HeavyShot, BRD.BurstShot)]
         BardSimpleRaidMode = 219,
+        [DependentCombos(SimpleBardFeature)]
+        [CustomComboInfo("Simple Interrupt", "Uses interrupt during simple bard rotation if applicable", BRD.JobID, BRD.HeavyShot, BRD.BurstShot)]
+        BardSimpleInterrupt = 220,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
Another small little addition to BRD's SimpleBard Single Target rotation.
Uses interrupt if applicable, also with toggle for convenience if people would like to interrupt manually :)
