### PR TITLE
Blu Final Sting Adjustments

### DIFF
--- a/XIVSlothCombo/Combos/BLU.cs
+++ b/XIVSlothCombo/Combos/BLU.cs
@@ -130,20 +130,27 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (!HasEffect(BLU.Buffs.MoonFlute))
                     return BLU.MoonFlute;
-                if (!GetCooldown(BLU.RoseOfDestruction).IsCooldown)
-                    return BLU.RoseOfDestruction;
-                if (!GetCooldown(BLU.FeatherRain).IsCooldown)
-                    return BLU.FeatherRain;
-                if (!GetCooldown(BLU.GlassDance).IsCooldown)
-                    return BLU.GlassDance;
-                if (!GetCooldown(BLU.JKick).IsCooldown)
-                    return BLU.JKick;
+                if (IsEnabled(CustomComboPreset.BluPrimals))
+                {
+
+                    if (!GetCooldown(BLU.RoseOfDestruction).IsCooldown)
+                        return BLU.RoseOfDestruction;
+                    if (!GetCooldown(BLU.FeatherRain).IsCooldown)
+                        return BLU.FeatherRain;
+                    if (!GetCooldown(BLU.GlassDance).IsCooldown)
+                        return BLU.GlassDance;
+                    if (!GetCooldown(BLU.JKick).IsCooldown)
+                        return BLU.JKick;
+                }
+
                 if (!HasEffect(BLU.Buffs.Tingle))
                     return BLU.Tingle;
-                if (!GetCooldown(BLU.ShockStrike).IsCooldown)
+                if (!GetCooldown(BLU.ShockStrike).IsCooldown && IsEnabled(CustomComboPreset.BluPrimals))
                     return BLU.ShockStrike;
                 if (!HasEffect(BLU.Buffs.Whistle))
                     return BLU.Whistle;
+                if (!GetCooldown(BLU.Swiftcast).IsCooldown)
+                    return BLU.Swiftcast;
                 return BLU.FinalSting;
             }
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -111,6 +111,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Final Sting Combo", "Turns Final Sting into the buff combo of: Moon Flute, Tingle, Whistle, Final Sting. Will use any primals off CD before casting Final Sting. \n Primals used: Feather Rain, Shock Strike, Glass Dance, J Kick, Rose of Destruction.", BLU.JobID, BLU.FinalSting)]
         BluFinalSting = 1903,
 
+        [DependentCombos(BluFinalSting)]
+        [CustomComboInfo("Off CD Primal Additions", "Adds any Primals that are off CD to the Final Sting Combo. ", BLU.JobID, BLU.FinalSting)]
+        BluPrimals = 1904,
+
         #endregion
         // ====================================================================================
         #region BARD


### PR DESCRIPTION
Added an option to add the primals to Final Sting so I can toggle it on and off between doing it for raids or 1-shotting ARR primals for Wondrous Tails.