### PR TITLE
GNB Overhaul

### DIFF
--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -52,13 +52,17 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const byte
                 BrutalShell = 4,
+                DangerZone = 18,
                 SolidBarrel = 26,
+                BurstStrike = 30,
                 DemonSlaughter = 40,
                 SonicBreak = 54,
+                GnashingFang = 60,
                 BowShock = 62,
                 Continuation = 70,
                 FatedCircle = 72,
                 Bloodfest = 76,
+                BlastingZone = 80,
                 EnhancedContinuation = 86,
                 CartridgeCharge3 = 88,
                 DoubleDown = 90;
@@ -75,79 +79,77 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (comboTime > 0)
                 {
-                    var maincomboCD1 = GetCooldown(GNB.KeenEdge);
-                    var maincomboCD2 = GetCooldown(GNB.BrutalShell);
-                    var maincomboCD3 = GetCooldown(GNB.SolidBarrel);
+                    var gauge = GetJobGauge<GNBGauge>();
+                    var maxAmmo = level >= GNB.Levels.CartridgeCharge3 ? 3 : 2;
+                    var GCD = GetCooldown(actionID);
                     var blastingzoneCD = GetCooldown(GNB.BlastingZone);
-                    var doubleDownCD = GetCooldown(GNB.DoubleDown);
-                    var bulletGauge = GetJobGauge<GNBGauge>();
+                    var doubledownCD = GetCooldown(GNB.DoubleDown);
                     var sonicbreakCD = GetCooldown(GNB.SonicBreak);
-                    var noMercyCD = GetCooldown(GNB.NoMercy);
+                    var bowshockCD = GetCooldown(GNB.BowShock);
+                    var roughdivideCD = GetCooldown(GNB.RoughDivide);
 
-                    if (IsEnabled(CustomComboPreset.GunbreakerDangerZoneFeature))
-                    {
-                        if (lastComboMove == GNB.KeenEdge && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level >= 80 && HasEffect(GNB.Buffs.NoMercy) || lastComboMove == GNB.KeenEdge && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level >= 80 && !HasEffect(GNB.Buffs.NoMercy) && noMercyCD.IsCooldown)
-                            return GNB.BlastingZone;
-                        if (lastComboMove == GNB.BrutalShell && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level >= 80 && HasEffect(GNB.Buffs.NoMercy) || lastComboMove == GNB.BrutalShell && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level >= 80 && !HasEffect(GNB.Buffs.NoMercy) && noMercyCD.IsCooldown)
-                            return GNB.BlastingZone;
-                        if (lastComboMove == GNB.SolidBarrel && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level >= 80 && HasEffect(GNB.Buffs.NoMercy) || lastComboMove == GNB.SolidBarrel && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level >= 80 && !HasEffect(GNB.Buffs.NoMercy) && noMercyCD.IsCooldown)
-                            return GNB.BlastingZone;
-                        if (lastComboMove == GNB.KeenEdge && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level <= 79 && HasEffect(GNB.Buffs.NoMercy) || lastComboMove == GNB.KeenEdge && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level <= 79 && !HasEffect(GNB.Buffs.NoMercy) && noMercyCD.IsCooldown)
-                            return GNB.DangerZone;
-                        if (lastComboMove == GNB.BrutalShell && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level <= 79 && HasEffect(GNB.Buffs.NoMercy) || lastComboMove == GNB.BrutalShell && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level <= 79 && HasEffect(GNB.Buffs.NoMercy) && noMercyCD.IsCooldown)
-                            return GNB.DangerZone;
-                        if (lastComboMove == GNB.SolidBarrel && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level <= 79 && HasEffect(GNB.Buffs.NoMercy) || lastComboMove == GNB.SolidBarrel && !blastingzoneCD.IsCooldown && maincomboCD1.CooldownRemaining > 0.7 && level <= 79 && HasEffect(GNB.Buffs.NoMercy) && noMercyCD.IsCooldown)
-                            return GNB.DangerZone;
-                    }
-                    if (IsEnabled(CustomComboPreset.GunbreakerDoubleDownOnMainComboFeature))
-                    {
-                        var gauge = GetJobGauge<GNBGauge>();
-                        if (lastComboMove == GNB.KeenEdge && !doubleDownCD.IsCooldown && level >= GNB.Levels.DoubleDown && HasEffect(GNB.Buffs.NoMercy) && gauge.Ammo >= 2)
-                            return GNB.DoubleDown;
-                        if (lastComboMove == GNB.BrutalShell && !doubleDownCD.IsCooldown && level >= GNB.Levels.DoubleDown && HasEffect(GNB.Buffs.NoMercy) && gauge.Ammo >= 2)
-                            return GNB.DoubleDown;
-                        if (lastComboMove == GNB.SolidBarrel && !doubleDownCD.IsCooldown && level >= GNB.Levels.DoubleDown && HasEffect(GNB.Buffs.NoMercy) && gauge.Ammo >= 2)
-                            return GNB.DoubleDown;
-                    }
-                    if (IsEnabled(CustomComboPreset.GunbreakerSonicBreakOnMainComboFeature))
-                    {
-                        if (lastComboMove == GNB.KeenEdge && !sonicbreakCD.IsCooldown  && level >= GNB.Levels.SonicBreak && HasEffect(GNB.Buffs.NoMercy))
-                            return GNB.SonicBreak;
-                        if (lastComboMove == GNB.BrutalShell && !sonicbreakCD.IsCooldown  && level >= GNB.Levels.SonicBreak && HasEffect(GNB.Buffs.NoMercy))
-                            return GNB.SonicBreak;
-                        if (lastComboMove == GNB.SolidBarrel && !sonicbreakCD.IsCooldown  && level >= GNB.Levels.SonicBreak && HasEffect(GNB.Buffs.NoMercy))
-                            return GNB.SonicBreak;
-                    }
-                    if (IsEnabled(CustomComboPreset.GunbreakerRoughDivideFeature) && level >= 56)
-                    {
-                        var roughdivideCD = GetCooldown(GNB.RoughDivide);
-                        var actionIDCD = GetCooldown(actionID);
+                    // Gnashing Fang combo + Continuation, Gnashing Fang needs to be used manually in order for users to control for any delay based on fight times
+                    if (level >= GNB.Levels.GnashingFang && IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain))
+                        if (HasEffect(GNB.Buffs.ReadyToRip) && level >= GNB.Levels.Continuation)
+                            return GNB.JugularRip;
+                        if (HasEffect(GNB.Buffs.NoMercy))
+                        {
+                            if (!doubledownCD.IsCooldown && level >= GNB.Levels.DoubleDown && gauge.Ammo == 2 && IsEnabled(CustomComboPreset.GunbreakerDDonMain))
+                                return GNB.DoubleDown;
+                            if (IsEnabled(CustomComboPreset.GunbreakerCDsOnMainComboFeature))
+                            {
+                                if (level >= GNB.Levels.DangerZone && !blastingzoneCD.IsCooldown)
+                                    return OriginalHook(GNB.DangerZone);
+                                if (level >= GNB.Levels.BowShock && !bowshockCD.IsCooldown)
+                                    return GNB.BowShock;
+                                if (level >= GNB.Levels.SonicBreak && !sonicbreakCD.IsCooldown)
+                                    return GNB.SonicBreak;
+                            }
+                        }
 
-                        if (roughdivideCD.CooldownRemaining < 30 && actionIDCD.CooldownRemaining > 0.7)
+                        if (gauge.AmmoComboStep == 1)
+                            return OriginalHook(GNB.GnashingFang);
+                        if (HasEffect(GNB.Buffs.ReadyToTear) && level >= GNB.Levels.Continuation)
+                            return GNB.AbdomenTear;
+                        if (!HasEffect(GNB.Buffs.NoMercy) && !blastingzoneCD.IsCooldown && level >= GNB.Levels.DangerZone && gauge.AmmoComboStep == 2 && IsEnabled(CustomComboPreset.GunbreakerCDsOnMainComboFeature))
+                            return OriginalHook(GNB.DangerZone); //aligns it with 2nd GCD in NM.
+                        if (gauge.AmmoComboStep == 2)
+                           return OriginalHook(GNB.GnashingFang);
+                        if (HasEffect(GNB.Buffs.ReadyToGouge) && level >= GNB.Levels.Continuation)
+                           return GNB.EyeGouge;
+
+                    // uses all stacks
+                    if (IsEnabled(CustomComboPreset.GunbreakerRoughDivide2StackOption) && level >= 56)
+                    {
+                        if (roughdivideCD.CooldownRemaining < 30 && GCD.CooldownRemaining > 0.7)
                             return GNB.RoughDivide;
                     }
                     // leaves 1 stack
-                    if (IsEnabled(CustomComboPreset.GunbreakerRoughDivideFeatureOption) && level >= 56)
+                    if (IsEnabled(CustomComboPreset.GunbreakerRoughDivide1StackOption) && level >= 56)
                     {
-                        var roughdivideCD = GetCooldown(GNB.RoughDivide);
-                        var actionIDCD = GetCooldown(actionID);
-
-                        if (roughdivideCD.CooldownRemaining < 60 && !roughdivideCD.IsCooldown && actionIDCD.CooldownRemaining > 0.7)
+                        if (roughdivideCD.CooldownRemaining < 60 && !roughdivideCD.IsCooldown && GCD.CooldownRemaining > 0.7)
                             return GNB.RoughDivide;
                     }
 
-
-
+                    // Regular 1-2-3 combo with overcap feature
                     if (lastComboMove == GNB.KeenEdge && level >= GNB.Levels.BrutalShell)
                         return GNB.BrutalShell;
-                    if (lastComboMove == GNB.BrutalShell && level >= 88 && bulletGauge.Ammo == 3)
-                        return GNB.BurstStrike;
-                    if (lastComboMove == GNB.BrutalShell && level >= 4 && level <= 87 && bulletGauge.Ammo == 2)
-                        return GNB.BurstStrike;
-                    if (lastComboMove == GNB.BrutalShell && level >= GNB.Levels.EnhancedContinuation && IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && HasEffect(GNB.Buffs.ReadyToBlast))
-                        return GNB.Hypervelocity;
                     if (lastComboMove == GNB.BrutalShell && level >= GNB.Levels.SolidBarrel)
+                    {
+                        if (IsEnabled(CustomComboPreset.GunbreakerAmmoOvercapFeature))
+                        {
+                            if (IsEnabled(CustomComboPreset.GunbreakerAmmoOvercapFeature))
+                            {
+                                if (level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast) && IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature))
+                                    return GNB.Hypervelocity;
+                            }
+
+                            if (level >= GNB.Levels.BurstStrike && gauge.Ammo == maxAmmo)
+                                return GNB.BurstStrike;
+                        }
+
                         return GNB.SolidBarrel;
+                    }
                 }
 
                 return GNB.KeenEdge;
@@ -211,7 +213,7 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (comboTime > 0 && lastComboMove == GNB.DemonSlice && level >= GNB.Levels.DemonSlaughter)
                 {
-                    if (IsEnabled(CustomComboPreset.GunbreakerFatedCircleFeature) && level >= GNB.Levels.FatedCircle)
+                    if (IsEnabled(CustomComboPreset.GunbreakerAmmoOvercapFeature) && level >= GNB.Levels.FatedCircle)
                     {
                         var gauge = GetJobGauge<GNBGauge>();
                         var cartridgeMax = level >= 88 ? 3 : 2;
@@ -249,56 +251,45 @@ namespace XIVSlothComboPlugin.Combos
         }
     }
 
-    internal class GunbreakerNoMercyFeature : CustomCombo
+    internal class GunbreakerNoMercyRotationFeature : CustomCombo
     {
-        protected override CustomComboPreset Preset => CustomComboPreset.GunbreakerNoMercyFeature;
+        protected override CustomComboPreset Preset => CustomComboPreset.GunbreakerNoMercyRotationFeature;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             if (actionID == GNB.NoMercy)
             {
-                if (HasEffect(GNB.Buffs.NoMercy))
+                var gauge = GetJobGauge<GNBGauge>();
+                var gnashingfangCD = GetCooldown(GNB.GnashingFang);
+                var blastingzoneCD = GetCooldown(GNB.BlastingZone);
+                var doubledownCD = GetCooldown(GNB.DoubleDown);
+                var sonicbreakCD = GetCooldown(GNB.SonicBreak);
+                var bowshockCD = GetCooldown(GNB.BowShock);
+
+                if (level >= GNB.Levels.GnashingFang && HasEffect(GNB.Buffs.NoMercy))
                 {
-                    var sonicbreakcd = GetCooldown(GNB.SonicBreak);
-                    var doubledownCD = GetCooldown(GNB.DoubleDown);
-                    var gauge = GetJobGauge<GNBGauge>();
-                    if (!doubledownCD.IsCooldown && level >= GNB.Levels.DoubleDown && IsEnabled(CustomComboPreset.DoubleDownNoMercyFeature) && gauge.Ammo >= 2)
+                    if (gauge.AmmoComboStep == 0 && !gnashingfangCD.IsCooldown)
+                        return OriginalHook(GNB.GnashingFang);
+                    if (HasEffect(GNB.Buffs.ReadyToRip) && level >= GNB.Levels.Continuation)
+                        return OriginalHook(GNB.Continuation);
+                    if (!doubledownCD.IsCooldown && level >= GNB.Levels.DoubleDown && gauge.Ammo == 2)
                         return GNB.DoubleDown;
-
-                    if (level >= GNB.Levels.BowShock && !TargetHasEffect(GNB.Debuffs.BowShock) && sonicbreakcd.IsCooldown)
+                    if (level >= GNB.Levels.DangerZone && !blastingzoneCD.IsCooldown)
+                        return OriginalHook(GNB.DangerZone);
+                    if (level >= GNB.Levels.BowShock && !bowshockCD.IsCooldown)
                         return GNB.BowShock;
-
-                    if (level >= GNB.Levels.SonicBreak)
+                    if (level >= GNB.Levels.SonicBreak && !sonicbreakCD.IsCooldown)
                         return GNB.SonicBreak;
+                    if (gauge.AmmoComboStep == 1)
+                        return OriginalHook(GNB.GnashingFang);
+                    if (HasEffect(GNB.Buffs.ReadyToTear) && level >= GNB.Levels.Continuation)
+                        return OriginalHook(GNB.Continuation);
+                    if (gauge.AmmoComboStep == 2)
+                        return OriginalHook(GNB.GnashingFang);
+                    if (HasEffect(GNB.Buffs.ReadyToGouge))
+                        return OriginalHook(GNB.Continuation);
                 }
-            }
-
-            return actionID;
-        }
-    }
-    internal class GunbreakerNoMercyoGCDFeature : CustomCombo
-    {
-        protected override CustomComboPreset Preset => CustomComboPreset.GunbreakerNoMercyoGCDFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == GNB.NoMercy)
-            {
-                if (HasEffect(GNB.Buffs.NoMercy))
-                {
-                    var dangerzoneCD = GetCooldown(OriginalHook(GNB.DangerZone));
-                    if (level >= GNB.Levels.BowShock && !TargetHasEffect(GNB.Debuffs.BowShock))
-                        return GNB.BowShock;
-                    if (IsEnabled(CustomComboPreset.GunbreakerDangerZoneFeature) && !dangerzoneCD.IsCooldown)
-                        return OriginalHook(GNB.DangerZone);
-                }
-                if (!HasEffect(GNB.Buffs.NoMercy))
-                {
-                    var dangerzoneCD = GetCooldown(OriginalHook(GNB.DangerZone));
-                    var noMercyCD = GetCooldown(GNB.NoMercy);
-                    if (IsEnabled(CustomComboPreset.GunbreakerDangerZoneFeature) && !dangerzoneCD.IsCooldown && noMercyCD.IsCooldown)
-                        return OriginalHook(GNB.DangerZone);
-                }
+                return GNB.NoMercy;
             }
 
             return actionID;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -301,48 +301,44 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain.", GNB.JobID, GNB.SolidBarrel)]
         GunbreakerSolidBarrelCombo = 600,
 
-        [CustomComboInfo("Gnashing Fang Combo", "Replace Gnashing Fang with its combo chain.", GNB.JobID, GNB.GnashingFang)]
-        GunbreakerGnashingFangCombo = 601,
+        [DependentCombos(GunbreakerSolidBarrelCombo)]
+        [CustomComboInfo("Gnashing Fang and Continuation on Main Combo", "Adds Gnashing Fang to the main combo. Gnashing Fang must be started manually and the combo will finish it off.\n Useful for when Gnashing Fang needs to be help due to downtime.", GNB.JobID, GNB.DoubleDown, GNB.SolidBarrel)]
+        GunbreakerGnashingFangOnMain = 601,
+
+        [DependentCombos(GunbreakerSolidBarrelCombo)]
+        [CustomComboInfo("Sonic Break/Bow Shock/Blasting Zone on Main Combo", "Adds Sonic Break/Bow Shock/Blasting Zone on main combo when under No Mercy buff", GNB.JobID, GNB.SolidBarrel)]
+        GunbreakerCDsOnMainComboFeature = 602,
+
+        [DependentCombos(GunbreakerSolidBarrelCombo)]
+        [CustomComboInfo("Double Down on Main Combo", "Adds Double Down on main combo when under No Mercy buff", GNB.JobID, GNB.SolidBarrel)]
+        GunbreakerDDonMain = 603,
+
+        [DependentCombos(GunbreakerSolidBarrelCombo)]
+        [ConflictingCombos(GunbreakerRoughDivide2StackOption)]
+        [CustomComboInfo("Rough Divide Option (Leaves 1 Stack)", "Adds Rough Divide onto main combo whenever it's available (Leaves 1 stack).", GNB.JobID, GNB.SolidBarrel)]
+        GunbreakerRoughDivide1StackOption = 604,
+
+        [ConflictingCombos(GunbreakerRoughDivide1StackOption)]
+        [CustomComboInfo("Rough Divide Option (Uses all stacks)", "Adds Rough Divide onto main combo whenever its available (Uses all stacks).", GNB.JobID, GNB.SolidBarrel)]
+        GunbreakerRoughDivide2StackOption = 605,
 
         [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain.", GNB.JobID, GNB.DemonSlaughter)]
-        GunbreakerDemonSlaughterCombo = 602,
+        GunbreakerDemonSlaughterCombo = 606,
 
-        [CustomComboInfo("Fated Circle Feature", "In addition to the Demon Slaughter combo, add Fated Circle when charges are full.", GNB.JobID, GNB.DemonSlaughter)]
-        GunbreakerFatedCircleFeature = 603,
+        [CustomComboInfo("Ammo Overcap Feature", "Uses Burst Strike/Fated Circle on the respective ST/AoE combos when ammo is about to overcap.", GNB.JobID, GNB.DemonSlaughter)]
+        GunbreakerAmmoOvercapFeature = 607,
+
+        [CustomComboInfo("Gnashing Fang Combo", "Replace Gnashing Fang with its combo chain.", GNB.JobID, GNB.GnashingFang)]
+        GunbreakerGnashingFangCombo = 608,
+
+        [CustomComboInfo("BurstStrikeContinuation", "Adds Hypervelocity on Burst Strike Continuation combo and main combo", GNB.JobID, GNB.BurstStrike, GNB.Hypervelocity)]
+        GunbreakerBurstStrikeConFeature = 609,
 
         [CustomComboInfo("Burst Strike to Bloodfest Feature", "Replace Burst Strike with Bloodfest if you have no powder gauge.", GNB.JobID, GNB.BurstStrike)]
-        GunbreakerBloodfestOvercapFeature = 604,
+        GunbreakerBloodfestOvercapFeature = 610,
 
-        [ConflictingCombos(GunbreakerNoMercyoGCDFeature)]
-        [CustomComboInfo("No Mercy Feature", "Replace No Mercy with Bow Shock, and then Sonic Break, while No Mercy is active.", GNB.JobID, GNB.NoMercy)]
-        GunbreakerNoMercyFeature = 605,
-
-        [CustomComboInfo("DangerZoneFeature", "Adds DangerZone/BlastingZone on main combo and NoMercyoGCD Feature when NoMercy buff is present or NoMercy is on cooldown.", GNB.JobID, GNB.DangerZone)]
-        GunbreakerDangerZoneFeature = 606,
-
-        [CustomComboInfo("DoubleDownFeature", "Adds DoubleDown on main combo when under NoMercy buff", GNB.JobID, GNB.DoubleDown, GNB.SolidBarrel)]
-        GunbreakerDoubleDownOnMainComboFeature = 607,
-
-        [CustomComboInfo("DoubleDownNoMercyFeature", "Adds DoubleDown to NoMercy Feature, while No Mercy is active.", GNB.JobID, GNB.NoMercy)]
-        DoubleDownNoMercyFeature = 608,
-
-        [ConflictingCombos(GunbreakerNoMercyFeature)]
-        [CustomComboInfo("oGCD NoMercy Feature", "Changes NoMercy into BowShock when you are under NoMercy buff", GNB.JobID, GNB.NoMercy)]
-        GunbreakerNoMercyoGCDFeature = 609,
-
-        [CustomComboInfo("SonicBreakMainComboFeature", "Adds SonicBreak on main combo when under NoMercy buff", GNB.JobID, GNB.DoubleDown, GNB.SolidBarrel)]
-        GunbreakerSonicBreakOnMainComboFeature = 610,
-
-        [CustomComboInfo("BurstStrikeContinuation", "Adds Hypervelocity on Burst Strike Continuation combo", GNB.JobID, GNB.BurstStrike, GNB.Hypervelocity)]
-        GunbreakerBurstStrikeConFeature = 611,
-
-        [ConflictingCombos(GunbreakerRoughDivideFeatureOption)]
-        [CustomComboInfo("Rough Divide Feature", "Adds Rough Divide onto main combo whenever its available (Uses all stacks).", GNB.JobID, GNB.SolidBarrel)]
-        GunbreakerRoughDivideFeature = 612,
-
-        [ConflictingCombos(GunbreakerRoughDivideFeature)]
-        [CustomComboInfo("Rough Divide Option", "Adds Rough Divide onto main combo whenever its available (Leaves 1 stack).", GNB.JobID, GNB.SolidBarrel)]
-        GunbreakerRoughDivideFeatureOption = 613,
+        [CustomComboInfo("No Mercy Rotation Feature", "Turns No Mercy into the the No Mercy Gnashing Fang Rotation when used. \nCurrently coded for the level 90 burst window.", GNB.JobID, GNB.NoMercy)]
+        GunbreakerNoMercyRotationFeature = 611,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
Complete overhaul of GNB including features asked for in #141 (who even did the original because that was rough).

Features added:
 - Added Gnashing Fang, Continuation, Double Down, Bow Shock, Sonic Break, Blasting Zone/Danger Zone, Rough Divide into main combo. Gnashing Fang will need to be started manually (as requested in the #141) in order for users to have more control during unfortunate phase change timing. These abilities are modular for increased choice in the main combo
 - Overcap features for both ST and AoE
 - No Mercy Rotation on No Mercy: Added the full Gnashing Fang/DD/oGCDs/Continuation burst into No Mercy.