### PR TITLE
[MNK] Adjustments for low level/level sync and cleanup.

### DIFF
--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -77,7 +77,7 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == OriginalHook(MNK.ShadowOfTheDestroyer))
+            if (actionID == MNK.ShadowOfTheDestroyer || actionID == MNK.ArmOfTheDestroyer)
             {
                 if (HasEffect(MNK.Buffs.OpoOpoForm))
                     return OriginalHook(MNK.ArmOfTheDestroyer);

--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -77,7 +77,7 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == MNK.ShadowOfTheDestroyer || actionID == MNK.ArmOfTheDestroyer)
+            if (actionID == OriginalHook(MNK.ShadowOfTheDestroyer))
             {
                 if (HasEffect(MNK.Buffs.OpoOpoForm))
                     return OriginalHook(MNK.ArmOfTheDestroyer);
@@ -94,9 +94,8 @@ namespace XIVSlothComboPlugin.Combos
                 return OriginalHook(MNK.MasterfulBlitz);
             }
             var actionIDCD = GetCooldown(OriginalHook(actionID));
-            if (IsEnabled(CustomComboPreset.MonkForbiddenChakraFeature)  && level >= 74)
+            if (IsEnabled(CustomComboPreset.MonkForbiddenChakraFeature) && gauge.Chakra == 5 && actionIDCD.IsCooldown && level >= 40)
             {
-                if(gauge.Chakra == 5)
                 return OriginalHook(MNK.Enlightenment);
             }
             if (HasEffect(MNK.Buffs.PerfectBalance) && IsEnabled(CustomComboPreset.MonkMasterfullBlizOnAoECombo))
@@ -126,6 +125,15 @@ namespace XIVSlothComboPlugin.Combos
                     if (pbStacks.StackCount == 1 && HasEffect(MNK.Buffs.PerfectBalance))
                         return MNK.Rockbreaker;
                 }
+                if (lunarNadi && HasEffect(MNK.Buffs.PerfectBalance) && level >= 60)
+                {
+                    if (pbStacks.StackCount == 3 && HasEffect(MNK.Buffs.PerfectBalance))
+                        return OriginalHook(MNK.ArmOfTheDestroyer);
+                    if (pbStacks.StackCount == 2 && HasEffect(MNK.Buffs.PerfectBalance) && lastComboMove == OriginalHook(MNK.ArmOfTheDestroyer))
+                        return MNK.FourPointFury;
+                    if (pbStacks.StackCount == 1 && HasEffect(MNK.Buffs.PerfectBalance) && lastComboMove == MNK.FourPointFury)
+                        return MNK.Rockbreaker;
+                }
                 // highlevel
                 if (!nadiNONE && !lunarNadi && HasEffect(MNK.Buffs.PerfectBalance) && level >= 82)
                 {
@@ -144,16 +152,6 @@ namespace XIVSlothComboPlugin.Combos
                         return OriginalHook(MNK.ArmOfTheDestroyer);
                     if (pbStacks.StackCount == 1 && HasEffect(MNK.Buffs.PerfectBalance))
                         return OriginalHook(MNK.ArmOfTheDestroyer);
-                }
-                if (lunarNadi && HasEffect(MNK.Buffs.PerfectBalance) && level >= 82)
-                {
-                    if (pbStacks.StackCount == 3 && HasEffect(MNK.Buffs.PerfectBalance))
-                        return OriginalHook(MNK.ArmOfTheDestroyer);
-                    if (pbStacks.StackCount == 2 && HasEffect(MNK.Buffs.PerfectBalance) && lastComboMove == OriginalHook(MNK.ArmOfTheDestroyer))
-                        return MNK.FourPointFury;
-                    if (pbStacks.StackCount == 1 && HasEffect(MNK.Buffs.PerfectBalance) && lastComboMove == MNK.FourPointFury)
-                        return MNK.Rockbreaker;
-
                 }
             }
             return actionID;
@@ -254,7 +252,7 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     return OriginalHook(MNK.MasterfulBlitz);
                 }
-                if (IsEnabled(CustomComboPreset.MonkForbiddenChakraFeature) && gauge.Chakra == 5 && actionIDCD.IsCooldown && level >= 54)
+                if (IsEnabled(CustomComboPreset.MonkForbiddenChakraFeature) && gauge.Chakra == 5 && actionIDCD.IsCooldown && level >= 15)
                 {
                     return OriginalHook(MNK.ForbiddenChakra);
                 }


### PR DESCRIPTION
Adjusted L80 due to some funkiness with gauge spender, aoe gauge spender works as expected after change.
Cleaned up L97 to be more like its single target equivalent, adjusted level due to MNK having a aoe gauge spender at 40
Adjusted L128-L136, Mnk was not currently able to generate a solar nadi the way it was set up even though they can do it no problem, moved solar nadi from "high level" to low level for ease of reading and adjusted level check, it works as expected lv60+.
Adjusted L255 level check, MNK gets a single target gauge spender at lv15.

Fairly sure everything works right as I've been leveling mnk with these changes, feel free to make any comments/edits if things are wrong.