### PR TITLE
[BLM] Update to all-in-one rotation and aoe for level sync

### DIFF
--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -265,10 +265,19 @@ namespace XIVSlothComboPlugin.Combos
                             return BLM.HighBlizzardII;
                     }
                 }
-                if (IsEnabled(CustomComboPreset.BlackAoEComboFeature) && level >= BLM.Levels.Blizzard4)
+                if (IsEnabled(CustomComboPreset.BlackAoEComboFeature))
                 {
                     if (gauge.InUmbralIce && gauge.UmbralHearts <= 2)
-                        return BLM.Freeze;
+                    {
+                        if (level >= BLM.Levels.Blizzard4)
+                        {
+                            return BLM.Freeze;
+                        }
+                        else if (currentMP < 10000)
+                        {
+                            return BLM.Freeze;
+                        }
+                    }
                 }
                 if (IsEnabled(CustomComboPreset.BlackAoEComboFeature) && level >= 26 && level <= 63)
                 {

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -273,7 +273,7 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             return BLM.Freeze;
                         }
-                        else if (currentMP < 10000)
+                        else if (currentMP < 10000 && thunder2Debuff)
                         {
                             return BLM.Freeze;
                         }
@@ -281,7 +281,9 @@ namespace XIVSlothComboPlugin.Combos
                 }
                 if (IsEnabled(CustomComboPreset.BlackAoEComboFeature) && level >= 26 && level <= 63)
                 {
-                    if ((gauge.InUmbralIce && gauge.UmbralHearts == 3 && !thunder2Debuff) || (gauge.InUmbralIce && gauge.UmbralHearts == 3 && thunder2Timer.RemainingTime <= 3 && level >= 26 && level <= 63) || (gauge.InAstralFire && !thunder2Debuff && level >= 26 && level <= 63))
+                    if ((gauge.InUmbralIce && (gauge.UmbralHearts == 3 || level < BLM.Levels.Blizzard4) && !thunder2Debuff) || 
+                        (gauge.InUmbralIce && (gauge.UmbralHearts == 3 || level < BLM.Levels.Blizzard4) && thunder2Timer.RemainingTime <= 3 && level >= 26 && level <= 63) || 
+                        (gauge.InAstralFire && !thunder2Debuff && level >= 26 && level <= 63))
                     {
                         if (lastComboMove == BLM.Thunder2)
                         {
@@ -308,7 +310,8 @@ namespace XIVSlothComboPlugin.Combos
                 // low level
                 if (IsEnabled(CustomComboPreset.BlackAoEComboFeature) && level >= 26 && level <= 63)
                 {
-                    if ((gauge.InUmbralIce && gauge.UmbralHearts == 3 && thunder2Debuff && thunder2Timer.RemainingTime >= 3) || (gauge.InUmbralIce && gauge.UmbralHearts == 3 && lastComboMove == BLM.Thunder2))
+                    if ((gauge.InUmbralIce && (gauge.UmbralHearts == 3 || level < BLM.Levels.Blizzard4) && thunder2Debuff && thunder2Timer.RemainingTime >= 3) || 
+                        (gauge.InUmbralIce && (gauge.UmbralHearts == 3 || level < BLM.Levels.Blizzard4) && lastComboMove == BLM.Thunder2))
                     {
                         if (level <= 81)
                             return BLM.Fire2;

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -184,7 +184,7 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     if (gauge.ElementTimeRemaining >= 6000 && CustomCombo.IsEnabled(CustomComboPreset.BlackThunderFeature))
                     {
-                        if (HasEffect(BLM.Buffs.Thundercloud) && LocalPlayer.CurrentMp > 0)
+                        if (HasEffect(BLM.Buffs.Thundercloud))
                         {
                             if ((TargetHasEffect(BLM.Debuffs.Thunder3) && thunderdebuffontarget.RemainingTime < 4) || (!thunder3DebuffOnTarget && HasEffect(BLM.Buffs.Thundercloud) && thundercloudduration.RemainingTime > 0 && thundercloudduration.RemainingTime < 35))
                                 return BLM.Thunder3;

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -172,7 +172,7 @@ namespace XIVSlothComboPlugin.Combos
                         if (gauge.IsParadoxActive && level >= 90)
                             return BLM.Paradox;
 
-                        if (gauge.UmbralHearts == 3 && LocalPlayer.CurrentMp >= 10000)
+                        if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && gauge.UmbralHearts == 3 && LocalPlayer.CurrentMp >= 10000)
                             return BLM.Fire3;
 
                     }
@@ -195,7 +195,7 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         return BLM.Fire3;
                     }
-                    if (LocalPlayer.CurrentMp == 0 && level >= BLM.Levels.Blizzard3)
+                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp == 0 && level >= BLM.Levels.Blizzard3)
                     {
                         return BLM.Blizzard3;
                     }
@@ -229,7 +229,7 @@ namespace XIVSlothComboPlugin.Combos
                         return BLM.Paradox;
                     if (HasEffect(BLM.Buffs.Firestarter))
                         return BLM.Fire3;
-                    if (LocalPlayer.CurrentMp < 1600)
+                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp < 1600)
                         return BLM.Blizzard3;
 
                     return BLM.Fire;

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -273,7 +273,7 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             return BLM.Freeze;
                         }
-                        else if (currentMP < 10000 && thunder2Debuff)
+                        else if (level >= 40 && currentMP < 10000 && thunder2Debuff)
                         {
                             return BLM.Freeze;
                         }

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -265,7 +265,7 @@ namespace XIVSlothComboPlugin.Combos
                             return BLM.HighBlizzardII;
                     }
                 }
-                if (IsEnabled(CustomComboPreset.BlackAoEComboFeature))
+                if (IsEnabled(CustomComboPreset.BlackAoEComboFeature) && level >= BLM.Levels.Blizzard4)
                 {
                     if (gauge.InUmbralIce && gauge.UmbralHearts <= 2)
                         return BLM.Freeze;

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -171,6 +171,10 @@ namespace XIVSlothComboPlugin.Combos
 
                         if (gauge.IsParadoxActive && level >= 90)
                             return BLM.Paradox;
+
+                        if (gauge.UmbralHearts == 3 && LocalPlayer.CurrentMp >= 10000)
+                            return BLM.Fire3;
+
                     }
 
                     return BLM.Blizzard4;
@@ -180,7 +184,7 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     if (gauge.ElementTimeRemaining >= 6000 && CustomCombo.IsEnabled(CustomComboPreset.BlackThunderFeature))
                     {
-                        if (HasEffect(BLM.Buffs.Thundercloud))
+                        if (HasEffect(BLM.Buffs.Thundercloud) && LocalPlayer.CurrentMp > 0)
                         {
                             if ((TargetHasEffect(BLM.Debuffs.Thunder3) && thunderdebuffontarget.RemainingTime < 4) || (!thunder3DebuffOnTarget && HasEffect(BLM.Buffs.Thundercloud) && thundercloudduration.RemainingTime > 0 && thundercloudduration.RemainingTime < 35))
                                 return BLM.Thunder3;
@@ -188,7 +192,13 @@ namespace XIVSlothComboPlugin.Combos
                     }
 
                     if (gauge.ElementTimeRemaining < 3000 && HasEffect(BLM.Buffs.Firestarter) && CustomCombo.IsEnabled(CustomComboPreset.BlackFire13Feature))
+                    {
                         return BLM.Fire3;
+                    }
+                    if (LocalPlayer.CurrentMp == 0 && level >= BLM.Levels.Blizzard3)
+                    {
+                        return BLM.Blizzard3;
+                    }
                     if (LocalPlayer.CurrentMp < 2400 && level >= BLM.Levels.Despair && CustomCombo.IsEnabled(CustomComboPreset.BlackDespairFeature))
                     {
                         return BLM.Despair;
@@ -212,12 +222,16 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (level < BLM.Levels.Fire3)
                     return BLM.Fire;
+
                 if (gauge.InAstralFire)
                 {
                     if (HasEffect(BLM.Buffs.Firestarter) && level == 90)
                         return BLM.Paradox;
                     if (HasEffect(BLM.Buffs.Firestarter))
                         return BLM.Fire3;
+                    if (LocalPlayer.CurrentMp < 1600)
+                        return BLM.Blizzard3;
+
                     return BLM.Fire;
                 }
             }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -102,6 +102,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Blizzard Paradox Feature", "Adds Paradox onto ice phase combo", BLM.JobID, BLM.Paradox)]
         BlackBlizzardParadoxFeature = 109,
 
+        [DependentCombos(BlackEnochianFeature)]
+        [CustomComboInfo("Aspect Swap Feature", "Changes Scathe to Blizzard 3 when at 0 MP in Astral Fire or to Fire 3 when at 10000 MP in Umbral Ice with 3 Umbral Hearts.", BLM.JobID, BLM.Scathe)]
+        BlackAspectSwapFeature = 110,
+
         #endregion
         // ====================================================================================
         #region BLUE MAGE

--- a/XIVSlothCombo/XIVSlothCombo.csproj
+++ b/XIVSlothCombo/XIVSlothCombo.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>attick,Kami,Daemitus,Grammernatzi,Aki,Iaotle,Codemned,PrincessRTFM,damolitionn</Authors>
     <Company>-</Company>
-    <Version>2.1.1.3</Version> <!-- This is the version that will be used when pushing to the repo.-->
+    <Version>2.1.1.4</Version> <!-- This is the version that will be used when pushing to the repo.-->
     <Description>XIVCombo for lazy players</Description>
     <Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>
     <PackageProjectUrl></PackageProjectUrl>


### PR DESCRIPTION
Change Scathe to Fire 3 when MP is maxed, in Umbral Ice and with 3 Umbral Hearts.
Change Scathe to Blizzard 3 when MP is 0 and in Astral Fire.
Change Scathe to Blizzard 3 when MP is below 1600 and in Astral Fire at low levels.
Change Freeze to be cast only when MP is below 10000 in Umbral Ice at low levels since Umbral Hearts aren't granted.

Tested changes locally and should be fine, but feel free to make comments.