### PR TITLE
[MNK] Believe I've resolved the AOE gauge spender issue.

### DIFF
--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -71,13 +71,21 @@ namespace XIVSlothComboPlugin.Combos
         }
     }
 
-    internal class MnkAoECombo : CustomCombo
+internal class MnkAoECombo : CustomCombo
     {
         protected override CustomComboPreset Preset => CustomComboPreset.MnkAoECombo;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == MNK.ShadowOfTheDestroyer || actionID == MNK.ArmOfTheDestroyer)
+            var gauge = GetJobGauge<MNKGauge>();
+            var actionIDCD = GetCooldown(OriginalHook(actionID));
+
+            if (actionID == MNK.ArmOfTheDestroyer || actionID == MNK.ShadowOfTheDestroyer)
+
+                if (IsEnabled(CustomComboPreset.MonkForbiddenChakraFeature) && gauge.Chakra == 5 && actionIDCD.IsCooldown && level >= 40)
+                {
+                    return OriginalHook(MNK.Enlightenment);
+                }
             {
                 if (HasEffect(MNK.Buffs.OpoOpoForm))
                     return OriginalHook(MNK.ArmOfTheDestroyer);
@@ -88,16 +96,12 @@ namespace XIVSlothComboPlugin.Combos
                 if (HasEffect(MNK.Buffs.CoerlForm) && level >= MNK.Levels.Rockbreaker)
                     return MNK.Rockbreaker;
             }
-            var gauge = GetJobGauge<MNKGauge>();
+
             if (gauge.BlitzTimeRemaining > 0 && level >= 60)
             {
                 return OriginalHook(MNK.MasterfulBlitz);
             }
-            var actionIDCD = GetCooldown(OriginalHook(actionID));
-            if (IsEnabled(CustomComboPreset.MonkForbiddenChakraFeature) && gauge.Chakra == 5 && actionIDCD.IsCooldown && level >= 40)
-            {
-                return OriginalHook(MNK.Enlightenment);
-            }
+            
             if (HasEffect(MNK.Buffs.PerfectBalance) && IsEnabled(CustomComboPreset.MonkMasterfullBlizOnAoECombo))
             {
                 var pbStacks = FindEffectAny(MNK.Buffs.PerfectBalance);

--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -71,7 +71,7 @@ namespace XIVSlothComboPlugin.Combos
         }
     }
 
-internal class MnkAoECombo : CustomCombo
+    internal class MnkAoECombo : CustomCombo
     {
         protected override CustomComboPreset Preset => CustomComboPreset.MnkAoECombo;
 


### PR DESCRIPTION
Moved the gauge spender code above the 1-2-3 to mirror the single target version.
Howling Fist/Enlightenment now appears properly when GCD is on cooldown just like Forbidden Chakra for single target.

Tested in Zadnor, my mnk isn't above 80 yet.