### PR TITLE
Added target check to MNK aoe combo.

### DIFF
--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -79,7 +79,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             var gauge = GetJobGauge<MNKGauge>();
             var actionIDCD = GetCooldown(OriginalHook(actionID));
-            if (IsEnabled(CustomComboPreset.MonkForbiddenChakraFeature) && gauge.Chakra == 5 && actionIDCD.IsCooldown && level >= 40)
+            if (IsEnabled(CustomComboPreset.MonkForbiddenChakraFeature) && gauge.Chakra == 5 && actionIDCD.IsCooldown && HasBattleTarget(true) && level >= 40)
             {
                 return OriginalHook(MNK.Enlightenment);
             }

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -360,5 +360,14 @@ namespace XIVSlothComboPlugin.Combos
 
             return currentHealth / maxHealth * 100;
         }
+                protected static bool HasBattleTarget(bool v)
+        {
+            if (CurrentTarget is null)
+                return false;
+            if (CurrentTarget is not BattleChara chara)
+                return false;
+
+            return true;
+        }
     }
 }

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -360,7 +360,7 @@ namespace XIVSlothComboPlugin.Combos
 
             return currentHealth / maxHealth * 100;
         }
-                protected static bool HasBattleTarget(bool v)
+        protected static bool HasBattleTarget(bool v)
         {
             if (CurrentTarget is null)
                 return false;


### PR DESCRIPTION
Mnk is one of the few classes that are able to aoe without a target, due to this as its currently set up there are small windows in which they can't use an ability that requires a target.

I'm not 100% sure if this existed already but I've added a check to see if the player has a battle target.

From what I can tell it works as expected, returns the 1-2-3 combo if you don't have a target, otherwise shows gauge spender.