### PR TITLE
feat(BRD): simple bard bloodletter pooling toggle

### DIFF
--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -49,7 +49,8 @@ namespace XIVSlothComboPlugin.Combos
                 ArmysPaeon = 137,
                 RadiantFinale = 2722,
                 BattleVoice = 141,
-                Barrage = 128;
+                Barrage = 128,
+                RagingStrikes = 125;
         }
 
         public static class Debuffs
@@ -810,8 +811,27 @@ namespace XIVSlothComboPlugin.Combos
                             return BRD.PitchPerfect;
                         if (level >= BRD.Levels.EmpyrealArrow && !GetCooldown(BRD.EmpyrealArrow).IsCooldown)
                             return BRD.EmpyrealArrow;
-                        if (level >= BRD.Levels.Bloodletter && GetCooldown(BRD.Bloodletter).CooldownRemaining < 30)
-                            return BRD.Bloodletter;
+                        if (level >= BRD.Levels.Bloodletter) {
+                            var bloodletterCD = GetCooldown(BRD.Bloodletter).CooldownRemaining;
+
+                            if (IsEnabled(CustomComboPreset.BardSimplePooling) && level >= BRD.Levels.WanderersMinuet) {
+                                if (gauge.Song == Song.WANDERER) {
+                                    if (
+                                        (HasEffect(BRD.Buffs.RagingStrikes) || GetCooldown(BRD.RagingStrikes).CooldownRemaining > 10) &&
+                                        bloodletterCD < 30
+                                    ) {
+                                        return BRD.Bloodletter;
+                                    }
+                                }
+
+                                if (gauge.Song == Song.ARMY && bloodletterCD == 0) return BRD.Bloodletter;
+                                if (gauge.Song == Song.MAGE && bloodletterCD < 30) return BRD.Bloodletter;
+                                if (gauge.Song == Song.NONE && bloodletterCD == 0)  return BRD.Bloodletter;
+
+                            } else if (bloodletterCD < 30) {
+                                return BRD.Bloodletter;
+                            }
+                        }
                         if (level >= BRD.Levels.Sidewinder && !GetCooldown(BRD.Sidewinder).IsCooldown)
                             return BRD.Sidewinder;
                     }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -208,6 +208,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Simple Opener", "BETA TESTING - Adds the optimum opener to simple bard.\nThis conflicts with pretty much everything outside of simple bard options due to the nature of the opener.", BRD.JobID, BRD.HeavyShot, BRD.BurstShot)]
         BardSimpleOpener = 222,
 
+        [DependentCombos(SimpleBardFeature)]
+        [CustomComboInfo("Simple Pooling", "BETA TESTING - Pools bloodletter chargers to allow for optimum burst phases", BRD.JobID, BRD.HeavyShot, BRD.BurstShot)]
+        BardSimplePooling = 223,
+
         #endregion
         // ====================================================================================
         #region DANCER


### PR DESCRIPTION
Pools bloodletter charges during AP, uses them during burst window of raging strikes on WM. 

#189 