### PR TITLE
Added a new MNK CustomCombo for Twin Snakes

### DIFF
--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -183,6 +183,30 @@ namespace XIVSlothComboPlugin.Combos
         }
     }
 
+    internal class MnkTwinSnakesFeature : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkTwinSnakesFeature;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == MNK.TrueStrike)
+            {
+                var disciplinedFistBuff = HasEffect(MNK.Buffs.DisciplinedFist);
+                var disciplinedFistDuration = FindEffect(MNK.Buffs.DisciplinedFist);
+
+                if (level >= MNK.Levels.TrueStrike)
+                {
+                    if ((!disciplinedFistBuff && level >= MNK.Levels.TwinSnakes) || (disciplinedFistDuration.RemainingTime < 6 && level >= MNK.Levels.TwinSnakes))
+                        return MNK.TwinSnakes;
+                    return MNK.TrueStrike;
+                }
+
+            }
+
+            return actionID;
+        }
+    }
+
     internal class MnkBasicCombo : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkBasicCombo;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -593,6 +593,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Monk Bootshine Feature", "Replaces Dragon Kick with Bootshine if both a form and Leaden Fist are up.", MNK.JobID)]
         MnkBootshineFeature = 9001,
 
+        [CustomComboInfo("Monk Twin Snakes Feature", "Replaces True Strike with Twin Snakes if Disciplined Fist is not applied or is less than 6 seconds from falling off.", MNK.JobID)]
+        MnkTwinSnakesFeature = 9011,
+
         [ConflictingCombos(MnkBasicComboPlus)]
         [CustomComboInfo("Monk Basic Rotation", "Basic Monk Combo on one button", MNK.JobID)]
         MnkBasicCombo = 9002,

--- a/XIVSlothCombo/XIVSlothCombo.csproj
+++ b/XIVSlothCombo/XIVSlothCombo.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>attick,Kami,Daemitus,Grammernatzi,Aki,Iaotle,Codemned,PrincessRTFM,damolitionn,ele-starshade </Authors>
     <Company>-</Company>
-    <Version>3.0.0.9</Version> <!-- This is the version that will be used when pushing to the repo.-->
+    <Version>3.0.1.0</Version> <!-- This is the version that will be used when pushing to the repo.-->
     <Description>XIVCombo for lazy players</Description>
     <Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>
     <PackageProjectUrl></PackageProjectUrl>


### PR DESCRIPTION
Wanted the Twin Snakes/True Strike swapping function as a standalone.  It should swap the skill regardless of form/pb, the only checked variables being level and Disciplined Fist duration. Set the duration to < 6 seconds to future-proof skillspeed and accommodate people who gotta go fast (potential to get fancy with actual skillspeed math but I don't wanna)

resolves #221