### PR TITLE
Added feature to replace riddle of fire with brotherhood when on CD

### DIFF
--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -27,6 +27,8 @@ namespace XIVSlothComboPlugin.Combos
             FlintStrike = 25882,
             RisingPhoenix = 25768,
             ShadowOfTheDestroyer = 25767,
+            RiddleOfFire = 7395,
+            Brotherhood = 7396,
             ForbiddenChakra = 3546;
 
 
@@ -377,6 +379,29 @@ namespace XIVSlothComboPlugin.Combos
                         return MNK.Demolish;
                 }
 
+            }
+            return actionID;
+        }
+    }
+    internal class MnkRiddleOfFireBrotherhoodFeature : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkRiddleOfFireBrotherhoodFeature;
+        
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            var RoFCD = GetCooldown(MNK.RiddleOfFire);
+            var BrotherhoodCD = GetCooldown(MNK.Brotherhood);
+
+            if (actionID == MNK.RiddleOfFire)
+            {
+                if (level >= 68 && level < 70)
+                    return MNK.RiddleOfFire;
+                if (RoFCD.IsCooldown && BrotherhoodCD.IsCooldown && level >= 70)
+                    return MNK.RiddleOfFire;
+                if (RoFCD.IsCooldown && !BrotherhoodCD.IsCooldown && level >= 70)
+                    return MNK.Brotherhood;
+
+                return MNK.RiddleOfFire;
             }
             return actionID;
         }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -635,6 +635,9 @@ namespace XIVSlothComboPlugin
 
         [CustomComboInfo("Forbidden Chakra Feature", "Adds Forbidden Chakra/Enlightement to the Main/AoE feature combo. Testing Only for now!", MNK.JobID)]
         MonkForbiddenChakraFeature = 9010,
+        
+        [CustomComboInfo("Riddle of Fire/Brotherhood Feature", "Replaces Riddle of Fire with Brotherhood when Riddle of Fire is on cooldown.", MNK.JobID)]
+        MnkRiddleOfFireBrotherhoodFeature = 9012,
 
 
         #endregion


### PR DESCRIPTION
Just a feature I had thought of since you should always be using both when both are ready to keep cooldowns aligned (60s/120s)
If anybody has any suggestions, I'd more than welcome them.