### PR TITLE
sam fix

### DIFF
--- a/XIVSlothCombo/Combos/SAM.cs
+++ b/XIVSlothCombo/Combos/SAM.cs
@@ -67,6 +67,7 @@ namespace XIVSlothComboPlugin.Combos
                 Kasha = 40,
                 Oka = 45,
                 Yukikaze = 50,
+                Kaiten = 52,
                 TsubameGaeshi = 76,
                 Shoha = 80;
         }
@@ -363,7 +364,7 @@ namespace XIVSlothComboPlugin.Combos
 
     internal class SamuraiIaijutsuShohaFeature : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SamuraiYukikazeCombo;
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SamuraiIaijutsuShohaFeature;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
@@ -403,7 +404,7 @@ namespace XIVSlothComboPlugin.Combos
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
 
-            if(actionID == SAM.Iaijutsu)
+            if (actionID == SAM.Iaijutsu)
             {
                 //var iaijutsuCD = GetCooldown(SAM.Iaijutsu);
                 var gauge = GetJobGauge<SAMGauge>();
@@ -415,35 +416,34 @@ namespace XIVSlothComboPlugin.Combos
                 var banana = FindTargetEffect(SAM.Debuffs.Higanbana);
 
 
-                if (!kaiten && level >= SAM.Levels.Iaijutsu)
+                if (!kaiten && level >= SAM.Levels.Iaijutsu && level >= SAM.Levels.Kaiten && gauge.Kenki >= 20)
                 {
                     int numSen = (ka ? 1 : 0) + (getsu ? 1 : 0) + (setsu ? 1 : 0);
                     if (IsEnabled(CustomComboPreset.SamuraiKaitenFeature1) && numSen == 1)
                     {
-                        if ((!hasBanana || banana.RemainingTime < 5) && gauge.Kenki >= 20)
+                        if ((!hasBanana || banana.RemainingTime < 5))
+                        {
                             return SAM.Kaiten;
-                        return OriginalHook(SAM.Iaijutsu);
+                        }
                     }
                     if (IsEnabled(CustomComboPreset.SamuraiKaitenFeature2) && numSen == 2)
                     {
-                        if (gauge.Kenki >= 20)
+                        {
                             return SAM.Kaiten;
-                        return OriginalHook(SAM.Iaijutsu);
+                        }
                     }
                     if (IsEnabled(CustomComboPreset.SamuraiKaitenFeature3) && numSen == 3)
                     {
-                        if (gauge.Kenki >= 20)
+                        {
                             return SAM.Kaiten;
-                        return OriginalHook(SAM.Iaijutsu);
+                        }
                     }
 
                 }
 
-                if (actionID == SAM.Iaijutsu)
+                if (level >= SAM.Levels.TsubameGaeshi && gauge.Sen == Sen.NONE)
                 {
-                    if (level >= SAM.Levels.TsubameGaeshi && gauge.Sen == Sen.NONE)
-                        return OriginalHook(SAM.TsubameGaeshi);
-                    return OriginalHook(SAM.Iaijutsu);
+                    return OriginalHook(SAM.TsubameGaeshi);
                 }
             }
 


### PR DESCRIPTION
- Fixes bug with Shoha being added to laijutsu while YukikazeCombo was active
- Adds Kaiten level check
- Allows player to better see Tsubame stacks