### PR TITLE
Adding a sub feature to simple bard - Simple RagingJaws

### DIFF
--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -941,18 +941,17 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     if (level >= BRD.Levels.RagingStrikes && IsOffCooldown(BRD.RagingStrikes))
                         return BRD.RagingStrikes;
-                    if (level >= BRD.Levels.BattleVoice && IsOffCooldown(BRD.BattleVoice))
-                        return BRD.BattleVoice;
-                    if (level >= BRD.Levels.Barrage && IsOffCooldown(BRD.Barrage))
-                        return BRD.Barrage;
-
-                    if (IsEnabled(CustomComboPreset.BardSimpleBuffsRadiantFeature) && Array.TrueForAll(gauge.Coda, BRD.SongIsNotNone))
+                    if (IsEnabled(CustomComboPreset.BardSimpleBuffsRadiantFeature) && Array.TrueForAll(gauge.Coda, BRD.SongIsNotNone) && IsOnCooldown(BRD.BattleVoice))
                     {
                         if (level >= BRD.Levels.RadiantFinale && IsOffCooldown(BRD.RadiantFinale))
                         {
                             return BRD.RadiantFinale;
                         }
                     }
+                    if (level >= BRD.Levels.BattleVoice && IsOffCooldown(BRD.BattleVoice))
+                        return BRD.BattleVoice;
+                    if (level >= BRD.Levels.Barrage && IsOffCooldown(BRD.Barrage))
+                        return BRD.Barrage;
                 }
 
                 if (IsEnabled(CustomComboPreset.SimpleBardFeature) && inCombat)
@@ -963,6 +962,8 @@ namespace XIVSlothComboPlugin.Combos
                             return BRD.PitchPerfect;
                         if (level >= BRD.Levels.EmpyrealArrow && IsOffCooldown(BRD.EmpyrealArrow))
                             return BRD.EmpyrealArrow;
+                        if (level >= BRD.Levels.Sidewinder && IsOffCooldown(BRD.Sidewinder))
+                            return BRD.Sidewinder;
                         if (level >= BRD.Levels.Bloodletter)
                         {
                             var bloodletterCharges = GetRemainingCharges(BRD.Bloodletter);
@@ -989,8 +990,6 @@ namespace XIVSlothComboPlugin.Combos
                                 return BRD.Bloodletter;
                             }
                         }
-                        if (level >= BRD.Levels.Sidewinder && IsOffCooldown(BRD.Sidewinder))
-                            return BRD.Sidewinder;
                     }
 
                     if (IsEnabled(CustomComboPreset.BardSimpleOpener) && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
@@ -1029,11 +1028,15 @@ namespace XIVSlothComboPlugin.Combos
                     var causticDuration = FindTargetEffect(BRD.Debuffs.CausticBite);
                     var stormbiteDuration = FindTargetEffect(BRD.Debuffs.Stormbite);
 
+                    var ragingStrikesDuration = FindEffect(BRD.Buffs.RagingStrikes);
+
                     var useIronJaws = (
-                        level >= BRD.Levels.IronJaws &&
-                        ((venomous && venomousDuration.RemainingTime < 4) || (caustic && causticDuration.RemainingTime < 4)) ||
-                        level >= BRD.Levels.IronJaws &&
-                        ((windbite && windbiteDuration.RemainingTime < 4) || (stormbite && stormbiteDuration.RemainingTime < 4))
+                        level >= BRD.Levels.IronJaws && 
+                            ((venomous && venomousDuration.RemainingTime < 4) || (caustic && causticDuration.RemainingTime < 4)) ||
+                        level >= BRD.Levels.IronJaws && 
+                            ((windbite && windbiteDuration.RemainingTime < 4) || (stormbite && stormbiteDuration.RemainingTime < 4)) ||
+                        level >= BRD.Levels.IronJaws && 
+                            (IsEnabled(CustomComboPreset.BardSimpleRagingJaws) && HasEffect(BRD.Buffs.RagingStrikes) && ragingStrikesDuration.RemainingTime < 3)
                     );
 
                     if (level < BRD.Levels.BiteUpgrade)

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -316,6 +316,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Simple Pooling", "BETA TESTING - Pools bloodletter chargers to allow for optimum burst phases", BRD.JobID)]
         BardSimplePooling = 3023,
 
+        [ParentCombo(SimpleBardFeature)]
+        [CustomComboInfo("Simple RagingJaws", "BETA TESTING - Enable the snapshotting of dots by the end of raging strikes", BRD.JobID)]
+        BardSimpleRagingJaws = 3024,
+
         #endregion
         // ====================================================================================
         #region DANCER


### PR DESCRIPTION
### What it does

-  Add the ability to toggle a feature that snapshot buffed up dots in the end of the raging strike buff window when using SimpleBard.

### General improvements

- Raises up the priority of sidewinder in relation to Bloodletters, making it drift less.
- Make sure Radiant Finale is only called after Battle Voice, to better align buffs in the burst window.


