### PR TITLE
NIN Simple Mudra 

### DIFF
--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -17,9 +17,6 @@ namespace XIVSlothComboPlugin.Combos
             DeathBlossom = 2254,
             AeolianEdge = 2255,
             TrickAttack = 2258,
-            Ninjutsu = 2260,
-            Chi = 2261,
-            JinNormal = 2263,
             Kassatsu = 2264,
             ArmorCrush = 3563,
             DreamWithinADream = 3566,
@@ -27,12 +24,33 @@ namespace XIVSlothComboPlugin.Combos
             Bavacakra = 7402,
             HakkeMujinsatsu = 16488,
             Meisui = 16489,
-            Jin = 18807,
             Bunshin = 16493,
             Huraijin = 25876,
             PhantomKamaitachi = 25774,
             ForkedRaiju = 25777,
-            FleetingRaiju = 25778;
+            FleetingRaiju = 25778,
+
+            //Mudras
+            Ninjutsu = 2260,
+
+            //-- initial state mudras (the ones with charges)
+            Ten = 2259, 
+            Chi = 2261,
+            Jin = 2263,
+
+            //-- mudras used for combos (the one used while you have the mudra buff)
+            TenCombo = 18805,
+            ChiCombo = 18806,
+            JinCombo = 18807,
+
+            //Ninjutsu
+            FumaShuriken = 2265,
+            Hyoton = 2268,
+            Doton = 2270,
+            Katon = 2266,
+            Suiton = 2271,
+            Raiton = 2267,
+            Huton = 2269;
 
         public static class Buffs
         {
@@ -57,6 +75,10 @@ namespace XIVSlothComboPlugin.Combos
             public const byte
                 GustSlash = 4,
                 AeolianEdge = 26,
+                Ten = 30,
+                Chi = 35,
+                Jin = 45,
+                Assassinate = 40,
                 HakkeMujinsatsu = 52,
                 ArmorCrush = 54,
                 Meisui = 72,
@@ -80,7 +102,7 @@ namespace XIVSlothComboPlugin.Combos
                     if (!InMeleeRange(true))
                         return NIN.ThrowingDaggers;
                 }
-                if (CustomCombo.IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && CustomCombo.OriginalHook(NIN.JinNormal) == CustomCombo.OriginalHook(NIN.Jin))
+                if (CustomCombo.IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && CustomCombo.OriginalHook(NIN.Jin) == CustomCombo.OriginalHook(NIN.JinCombo))
                 {
                     return CustomCombo.OriginalHook(NIN.Ninjutsu);
                 }
@@ -158,7 +180,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID == NIN.ArmorCrush)
             {
-                if (CustomCombo.IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && CustomCombo.OriginalHook(NIN.JinNormal) == CustomCombo.OriginalHook(NIN.Jin))
+                if (CustomCombo.IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && CustomCombo.OriginalHook(NIN.Jin) == CustomCombo.OriginalHook(NIN.JinCombo))
                 {
                     return CustomCombo.OriginalHook(NIN.Ninjutsu);
                 }
@@ -206,7 +228,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID == NIN.HakkeMujinsatsu)
             {
-                if (CustomCombo.IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && CustomCombo.OriginalHook(NIN.JinNormal) == CustomCombo.OriginalHook(NIN.Jin))
+                if (CustomCombo.IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && CustomCombo.OriginalHook(NIN.Jin) == CustomCombo.OriginalHook(NIN.JinCombo))
                 {
                     return CustomCombo.OriginalHook(NIN.Ninjutsu);
                 }
@@ -317,6 +339,60 @@ namespace XIVSlothComboPlugin.Combos
             }
 
             return actionID;
+        }
+    }
+
+    internal class NinjaSimpleMudras : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaSimpleMudras;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID is NIN.Ten or NIN.Chi or NIN.Jin )
+            {
+                if (HasEffect(NIN.Buffs.Mudra)) 
+                {
+                    if (level >= NIN.Levels.Ten && actionID == NIN.Ten)
+                    {
+                        if (level >= NIN.Levels.Chi && OriginalHook(NIN.Ninjutsu) == NIN.Hyoton)
+                        {
+                            return OriginalHook(NIN.ChiCombo);
+                        }
+                        if (level >= NIN.Levels.Jin && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
+                        {
+                            return OriginalHook(NIN.JinCombo);
+                        }
+                    }
+
+                    if (level >= NIN.Levels.Chi && actionID == NIN.Chi)
+                    {
+                        if (level >= NIN.Levels.Jin && OriginalHook(NIN.Ninjutsu) == NIN.Katon)
+                        {
+                            return OriginalHook(NIN.JinCombo);
+                        }
+                        if (level >= NIN.Levels.Ten && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
+                        {
+                            return OriginalHook(NIN.TenCombo);
+                        }
+                    }
+
+                    if (level >= NIN.Levels.Jin && actionID == NIN.Jin)
+                    {
+                        if (level >= NIN.Levels.Ten && OriginalHook(NIN.Ninjutsu) == NIN.Raiton)
+                        {
+                            return OriginalHook(NIN.TenCombo);
+                        }
+                        if (level >= NIN.Levels.Chi && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
+                        {
+                            return OriginalHook(NIN.ChiCombo);
+                        }
+                    }
+
+                    return OriginalHook(NIN.Ninjutsu);
+                }
+            }
+
+            return OriginalHook(actionID);
         }
     }
 }

--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -50,7 +50,9 @@ namespace XIVSlothComboPlugin.Combos
             Katon = 2266,
             Suiton = 2271,
             Raiton = 2267,
-            Huton = 2269;
+            Huton = 2269,
+            GokaMekkyaku = 16491,
+            HyoshoRanryu = 16492;
 
         public static class Buffs
         {
@@ -354,7 +356,7 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     if (level >= NIN.Levels.Ten && actionID == NIN.Ten)
                     {
-                        if (level >= NIN.Levels.Chi && OriginalHook(NIN.Ninjutsu) == NIN.Hyoton)
+                        if (level >= NIN.Levels.Chi && (OriginalHook(NIN.Ninjutsu) is NIN.Hyoton or NIN.HyoshoRanryu))
                         {
                             return OriginalHook(NIN.ChiCombo);
                         }
@@ -366,7 +368,7 @@ namespace XIVSlothComboPlugin.Combos
 
                     if (level >= NIN.Levels.Chi && actionID == NIN.Chi)
                     {
-                        if (level >= NIN.Levels.Jin && OriginalHook(NIN.Ninjutsu) == NIN.Katon)
+                        if (level >= NIN.Levels.Jin && (OriginalHook(NIN.Ninjutsu) is NIN.Katon or NIN.GokaMekkyaku))
                         {
                             return OriginalHook(NIN.JinCombo);
                         }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -811,6 +811,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("DreamWithinADream Feature", "Adds Assassinate/DwD onto main combo (Not optimal prob).", NIN.JobID)]
         NinjaDreamWithinADream = 10019,
 
+        [CustomComboInfo("Simple Mudras", "Simplify the mudra casting to avoid failing.", NIN.JobID)]
+        NinjaSimpleMudras = 10020,
+
         #endregion
         // ====================================================================================
         #region PALADIN


### PR DESCRIPTION
Greetings,

### What it does
- Implement a preset for casting ninjutsu without failing
    - semi-auto
        - Lv1 should still be called with ninjutsu.
        - Lv2 can be casted with ninjutsu or any of the other 2 mudras , they will change to ninjutsu to avoid miscast.
        - Lv3 should make all mudras change to the ninjutsu.

- should solve #266 
    -  1st example, will try to make the 2nd example later.

### Known issues
- During my tests I have not met any, but feedback will be necessary for the high lv special ninjutsu's , lv76+ , since my ninja is not that high xD

Fun fact
The mudras are oGCDs disguised as GCDs, and you cant track them at all after the initial state, you have to track the ninjutsu that come from using the "combo" mudras.

ps: I need to rebase my fork , the commit list is starting to get out of hand >.>