### PR TITLE
[BRD] - Simple bard priority of dots; [MNK] - bug fix 

### DIFF
--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -429,9 +429,9 @@ namespace XIVSlothComboPlugin.Combos
 
                 var gauge = GetJobGauge<BRDGauge>();
                 var soulVoice = gauge.SoulVoice;
-                var heavyShotOnCooldown = CanWeave(BRD.HeavyShot);
+                var canWeave = CanWeave(actionID);
 
-                if (heavyShotOnCooldown)
+                if (canWeave)
                 {
                     if (level >= BRD.Levels.PitchPerfect && gauge.Song == Song.WANDERER && gauge.Repertoire == 3)
                         return BRD.PitchPerfect;
@@ -450,7 +450,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady))
                     return BRD.BlastArrow;
 
-                if (IsEnabled(CustomComboPreset.SimpleAoESongOption) && heavyShotOnCooldown)
+                if (IsEnabled(CustomComboPreset.SimpleAoESongOption) && canWeave)
                 {
                     if ((gauge.SongTimer < 1 || gauge.Song == Song.ARMY) && IsOnCooldown(actionID))
                     {
@@ -996,8 +996,6 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     return BRD.HeadGraze;
                 }
-
-                var heavyShot = GetCooldown(actionID);
                 
                 var isEnemyHealthHigh = IsEnabled(CustomComboPreset.BardSimpleRaidMode) ? true : CustomCombo.EnemyHealthPercentage() > 1;
 
@@ -1081,7 +1079,7 @@ namespace XIVSlothComboPlugin.Combos
                         return BRD.Barrage;
                 }
 
-                if (IsEnabled(CustomComboPreset.SimpleBardFeature) && inCombat)
+                if (inCombat)
                 {
                     if (canWeave)
                     {
@@ -1134,30 +1132,7 @@ namespace XIVSlothComboPlugin.Combos
                             }
                         }
                     }
-
-                    if (IsEnabled(CustomComboPreset.BardSimpleOpener) && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
-                    {
-                        if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady))
-                            return BRD.BlastArrow;
-                        if (level >= BRD.Levels.ApexArrow)
-                        {
-                            var songTimerInSeconds = gauge.SongTimer / 1000;
-                            
-                            if (gauge.Song == Song.MAGE && gauge.SoulVoice == 100) return BRD.ApexArrow;
-                            if (gauge.Song == Song.MAGE && gauge.SoulVoice >= 80 && songTimerInSeconds > 18 && songTimerInSeconds < 22) return BRD.ApexArrow;
-                            if (gauge.Song == Song.WANDERER && HasEffect(BRD.Buffs.RagingStrikes) && HasEffect(BRD.Buffs.BattleVoice) && HasEffect(BRD.Buffs.RadiantFinale) && gauge.SoulVoice >= 80) return BRD.ApexArrow;
-                        }
-                    }
-                    else
-                    {
-                        if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady))
-                            return BRD.BlastArrow;
-
-                        if (level >= BRD.Levels.ApexArrow && gauge.SoulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
-                            return BRD.ApexArrow;
-                    }
                 }
-
 
                 if (isEnemyHealthHigh)
                 {
@@ -1215,13 +1190,6 @@ namespace XIVSlothComboPlugin.Combos
                                     return BRD.VenomousBite;
                             }
                         }
-
-                        if (HasEffect(BRD.Buffs.StraightShotReady))
-                        {
-                            return (level >= BRD.Levels.RefulgentArrow) ? BRD.RefulgentArrow : BRD.StraightShot;
-                        }
-
-                        return (level >= BRD.Levels.BurstShot) ? BRD.BurstShot : BRD.HeavyShot;
                     }
 
                     if (inCombat)
@@ -1239,6 +1207,28 @@ namespace XIVSlothComboPlugin.Combos
                                 return BRD.Stormbite;
                         }
                     }
+                }
+
+                if (IsEnabled(CustomComboPreset.BardSimpleOpener) && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature) && inCombat)
+                {
+                    if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady))
+                        return BRD.BlastArrow;
+                    if (level >= BRD.Levels.ApexArrow)
+                    {
+                        var songTimerInSeconds = gauge.SongTimer / 1000;
+
+                        if (gauge.Song == Song.MAGE && gauge.SoulVoice == 100) return BRD.ApexArrow;
+                        if (gauge.Song == Song.MAGE && gauge.SoulVoice >= 80 && songTimerInSeconds > 18 && songTimerInSeconds < 22) return BRD.ApexArrow;
+                        if (gauge.Song == Song.WANDERER && HasEffect(BRD.Buffs.RagingStrikes) && HasEffect(BRD.Buffs.BattleVoice) && HasEffect(BRD.Buffs.RadiantFinale) && gauge.SoulVoice >= 80) return BRD.ApexArrow;
+                    }
+                }
+                else
+                {
+                    if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady))
+                        return BRD.BlastArrow;
+
+                    if (level >= BRD.Levels.ApexArrow && gauge.SoulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
+                        return BRD.ApexArrow;
                 }
 
                 if (HasEffect(BRD.Buffs.StraightShotReady))

--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -79,11 +79,12 @@ namespace XIVSlothComboPlugin.Combos
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkAoECombo;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gauge = GetJobGauge<MNKGauge>();
-            var actionIDCD = GetCooldown(OriginalHook(actionID));
+        {         
             if (actionID == MNK.ArmOfTheDestroyer || actionID == MNK.ShadowOfTheDestroyer)
             {
+                var gauge = GetJobGauge<MNKGauge>();
+                var actionIDCD = GetCooldown(OriginalHook(actionID));
+
                 if (IsEnabled(CustomComboPreset.MonkForbiddenChakraFeature) && gauge.Chakra == 5 && actionIDCD.CooldownRemaining > 0.5 && HasBattleTarget(true) && level >= 40)
                 {
                     return OriginalHook(MNK.Enlightenment);

--- a/XIVSlothCombo/XIVSlothCombo.csproj
+++ b/XIVSlothCombo/XIVSlothCombo.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>attick,Kami,Daemitus,Grammernatzi,Aki,Iaotle,Codemned,PrincessRTFM,damolitionn,ele-starshade </Authors>
     <Company>-</Company>
-    <Version>3.0.6.4</Version> <!-- This is the version that will be used when pushing to the repo.-->
+    <Version>3.0.6.5</Version> <!-- This is the version that will be used when pushing to the repo.-->
     <Description>XIVCombo for lazy players</Description>
     <Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>
     <PackageProjectUrl></PackageProjectUrl>


### PR DESCRIPTION
Hello,

### BRD
   - Raised the priority of refreshing/casting dots on simple bard in relation to Apex/Blast Arrow
       - Noticed it sometimes while raiding this week, if the timing of use of Apex came right when I needed to refresh the dots, the way it was  the apex arrow was gonna cast and dots would fall off because it would immediately try to blast arrow , and not cast an IJ like it does because AA and BA had priority over the dots.
           - This makes that in that case it'll still cast apex , but will do an IJ between ApexA and BlastA

### MNK

   - Changing the way a var is created in the MnkAoeCombo section to avoid the following error:

![image](https://user-images.githubusercontent.com/1184084/155754832-4a0fbbb0-4a57-4ede-950c-fd16adf7e92c.png)


@Iaotle This time I bumped the version :P