### PR TITLE
NIN add easy Mudra for Raiton when Lvl < 45

### DIFF
--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -360,9 +360,9 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             return OriginalHook(NIN.ChiCombo);
                         }
-                        if (level >= NIN.Levels.Jin && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
+                        if (OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
                         {
-                            return OriginalHook(NIN.JinCombo);
+                            return OriginalHook(level >= NIN.Levels.Jin ? NIN.JinCombo : NIN.ChiCombo);
                         }
                     }
 


### PR DESCRIPTION
Hi! 
I love your new feature "Simple Mudras" for NIN, but I have low-level NIN and I found out that it's impossible to cast Raiton with this feature enabled, because I don't have Jin learned yet. Can we add such an option?

![image](https://user-images.githubusercontent.com/8989548/155862697-226e3404-44e9-471f-a4b7-4c73be96ab34.png)
