### PR TITLE
RPR add level check for SoulSlice/SoulScythe

### DIFF
--- a/XIVSlothCombo/Combos/RPR.cs
+++ b/XIVSlothCombo/Combos/RPR.cs
@@ -69,6 +69,8 @@ namespace XIVSlothComboPlugin.Combos
                 SpinningScythe = 25,
                 InfernalSlice = 30,
                 NightmareScythe = 45,
+                SoulSlice = 60,
+                SoulScythe = 65,
                 SoulReaver = 70,
                 Regress = 74,
                 Gluttony = 76,
@@ -131,7 +133,7 @@ namespace XIVSlothComboPlugin.Combos
                 var actionIDCD = GetCooldown(RPR.SoulScythe);
                 if (IsEnabled(CustomComboPreset.ReaperSoulSliceFeature))
                 {
-                    if (gauge.Soul <= 50 && !actionIDCD.IsCooldown && TargetHasEffect(RPR.Debuffs.DeathsDesign))
+                    if (level >= RPR.Levels.SoulSlice && gauge.Soul <= 50 && !actionIDCD.IsCooldown && TargetHasEffect(RPR.Debuffs.DeathsDesign))
                         return RPR.SoulSlice;
                 }
                 if ((IsEnabled(CustomComboPreset.ReaperShadowOfDeathFeature) && !(FindTargetEffect(RPR.Debuffs.DeathsDesign)?.RemainingTime > 3)) && !HasEffectAny(RPR.Buffs.SoulReaver) && !(FindEffect(RPR.Buffs.Enshrouded)?.RemainingTime <= 10))
@@ -196,7 +198,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (IsEnabled(CustomComboPreset.ReaperSoulScytheFeature))
                 {
-                    if (gauge.Soul <= 50 && IsOffCooldown(RPR.SoulScythe) && TargetHasEffect(RPR.Debuffs.DeathsDesign))
+                    if (level >= RPR.Levels.SoulScythe && gauge.Soul <= 50 && IsOffCooldown(RPR.SoulScythe) && TargetHasEffect(RPR.Debuffs.DeathsDesign))
                         return RPR.SoulScythe;
                 }
                 if (IsEnabled(CustomComboPreset.ReaperLemureFeature))


### PR DESCRIPTION
Hi!
I've faced an issue with RPR job: when downsynced to lvl 50 and enabled option "Soul Slice Feature" or "Soul Scythe Feature" main combo (or main aoe combo) becomes unusable because it transforms to Soul Slice/Soul Scythe which cannot be used at that level

Picture for attracting attention xD

![image](https://user-images.githubusercontent.com/8989548/156924761-b4d96c63-c011-454c-b213-078edda58054.png)
