### PR TITLE
[BRD] Couple tweaks to Simple Bard and RagingJaws features;

### DIFF
--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -555,7 +555,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 var canWeave = CanWeave(actionID);
 
-                if (IsEnabled(CustomComboPreset.BardSimpleOpener) && level >= 80)
+                if (IsEnabled(CustomComboPreset.BardSimpleOpener) && level >= 70)
                 {
                     if (inCombat && lastComboMove == BRD.Stormbite && !inOpener)
                     {
@@ -621,7 +621,7 @@ namespace XIVSlothComboPlugin.Combos
                             }
                             if (subStep == 5)
                             {
-                                if ((usedStraightShotReady && !HasEffect(BRD.Buffs.StraightShotReady)) || lastComboMove == BRD.BurstShot) subStep++;
+                                if ((usedStraightShotReady && !HasEffect(BRD.Buffs.StraightShotReady)) || lastComboMove is BRD.BurstShot or BRD.HeavyShot) subStep++;
                                 else
                                 {
                                     if (HasEffect(BRD.Buffs.StraightShotReady))
@@ -629,7 +629,8 @@ namespace XIVSlothComboPlugin.Combos
                                         usedStraightShotReady = true;
                                         return BRD.RefulgentArrow;
                                     }
-                                    else return BRD.BurstShot;
+                                    else if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                    else return BRD.HeavyShot;
                                 }
                             }
                             if (subStep == 6)
@@ -646,7 +647,7 @@ namespace XIVSlothComboPlugin.Combos
                             }
                             if (subStep == 8)
                             {
-                                if ((usedStraightShotReady && !HasEffect(BRD.Buffs.StraightShotReady)) || lastComboMove == BRD.BurstShot) subStep++;
+                                if ((usedStraightShotReady && !HasEffect(BRD.Buffs.StraightShotReady)) || lastComboMove is BRD.BurstShot or BRD.HeavyShot) subStep++;
                                 else
                                 {
                                     if (HasEffect(BRD.Buffs.StraightShotReady))
@@ -654,7 +655,8 @@ namespace XIVSlothComboPlugin.Combos
                                         usedStraightShotReady = true;
                                         return BRD.RefulgentArrow;
                                     }
-                                    else return BRD.BurstShot;
+                                    else if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                    else return BRD.HeavyShot;
                                 }
                             }
                             if (subStep == 9)
@@ -749,8 +751,9 @@ namespace XIVSlothComboPlugin.Combos
                             {
                                 usedPitchPerfect = false;
 
-                                if (lastComboMove == BRD.BurstShot) subStep++;
-                                else return BRD.BurstShot;
+                                if (lastComboMove is BRD.BurstShot or BRD.HeavyShot) subStep++;
+                                else if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                else return BRD.HeavyShot;
                             }
                             if (subStep == 7)
                             {
@@ -765,7 +768,8 @@ namespace XIVSlothComboPlugin.Combos
                                     {
                                         return BRD.RefulgentArrow;
                                     }
-                                    else return BRD.BurstShot;
+                                    else if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                    else return BRD.HeavyShot;
                                 }
                             }
                             if (subStep == 8)
@@ -796,7 +800,8 @@ namespace XIVSlothComboPlugin.Combos
                                     {
                                         return BRD.RefulgentArrow;
                                     }
-                                    else return BRD.BurstShot;
+                                    else if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                    else return BRD.HeavyShot;
                                 }
                             }
                             if (subStep == 10)
@@ -812,7 +817,8 @@ namespace XIVSlothComboPlugin.Combos
                                     {
                                         return BRD.RefulgentArrow;
                                     }
-                                    else return BRD.BurstShot;
+                                    else if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                    else return BRD.HeavyShot;
                                 }
                             }
                             if (subStep == 11)
@@ -877,7 +883,8 @@ namespace XIVSlothComboPlugin.Combos
                                 else
                                 {
                                     subStep++;
-                                    return BRD.BurstShot;
+                                    if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                    else return BRD.HeavyShot;
                                 }
                             }
                             if (subStep == 5)
@@ -908,7 +915,8 @@ namespace XIVSlothComboPlugin.Combos
                                     {
                                         return BRD.RefulgentArrow;
                                     }
-                                    else return BRD.BurstShot;
+                                    else if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                    else return BRD.HeavyShot;
                                 }
                             }
                             if (subStep == 6)
@@ -939,7 +947,8 @@ namespace XIVSlothComboPlugin.Combos
                                     {
                                         return BRD.RefulgentArrow;
                                     }
-                                    else return BRD.BurstShot;
+                                    else if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                    else return BRD.HeavyShot;
                                 }
                             }
                             if (subStep == 8)
@@ -970,7 +979,8 @@ namespace XIVSlothComboPlugin.Combos
                                     {
                                         return BRD.RefulgentArrow;
                                     }
-                                    else return BRD.BurstShot;
+                                    else if (level >= BRD.Levels.BurstShot) return BRD.BurstShot;
+                                    else return BRD.HeavyShot;
                                 }
                             }
                             if (subStep == 10)

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -98,21 +98,16 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            var actionIDCD = GetCooldown(actionID);
-            if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.Fleche) || IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.ContreSixte))
+            var canWeave = CanWeave(actionID);
+           
+            if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
             {
-                if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                    return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                    return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                if (level >= RDM.Levels.Fleche && level >= RDM.Levels.ContreSixte)
-                    return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
                 if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
                     return RDM.Fleche;
+                if (level >= RDM.Levels.ContreSixte && IsOffCooldown(RDM.ContreSixte))
+                    return RDM.ContreSixte;
             }
+
             if (actionID == RDM.Veraero2)
             {
                 if (HasEffect(RDM.Buffs.Swiftcast) || HasEffect(RDM.Buffs.Dualcast) || HasEffect(RDM.Buffs.Chainspell))
@@ -143,23 +138,17 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var gauge = GetJobGauge<RDMGauge>();
                 var engagementCD = GetCooldown(RDM.Engagement);
-                var actionIDCD = GetCooldown(OriginalHook(actionID));
+                var canWeave = CanWeave(OriginalHook(actionID));
 
-                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.Fleche) || IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.ContreSixte))
+               if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast) )
                 {
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.Fleche && level >= RDM.Levels.ContreSixte)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
                     if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
                         return RDM.Fleche;
+                    if (level >= RDM.Levels.ContreSixte && IsOffCooldown(RDM.ContreSixte))
+                        return RDM.ContreSixte;
                 }
-                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && actionIDCD.IsCooldown && engagementCD.CooldownRemaining < 35 && InMeleeRange(true))
+
+                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && canWeave && engagementCD.CooldownRemaining < 35 && InMeleeRange(true))
                 {
                     return RDM.Engagement;
                 }
@@ -217,21 +206,15 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID == RDM.Verstone)
             {
-                var actionIDCD = GetCooldown(actionID);
-                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.Fleche) || IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.ContreSixte))
+                var canWeave = CanWeave(actionID);
+                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
                 {
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.Fleche && level >= RDM.Levels.ContreSixte)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
                     if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
                         return RDM.Fleche;
+                    if (level >= RDM.Levels.ContreSixte && IsOffCooldown(RDM.ContreSixte))
+                        return RDM.ContreSixte;
                 }
+
                 if (IsEnabled(CustomComboPreset.RedmageResolutionFinisher))
                 {
                     if (lastComboMove == RDM.Scorch && level >= 90)
@@ -369,21 +352,14 @@ namespace XIVSlothComboPlugin.Combos
                 int white = gauge.WhiteMana;
                 int blackThreshold = white + IMBALANCE_DIFF_MAX;
                 int whiteThreshold = black + IMBALANCE_DIFF_MAX;
-                var actionIDCD = GetCooldown(actionID);
+                var canWeave = CanWeave(actionID);
 
-                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.Fleche) || IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.ContreSixte))
+                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
                 {
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.Fleche && level >= RDM.Levels.ContreSixte)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
                     if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
                         return RDM.Fleche;
+                    if (level >= RDM.Levels.ContreSixte && IsOffCooldown(RDM.ContreSixte))
+                        return RDM.ContreSixte;
                 }
                 if (lastComboMove == RDM.Scorch && level >= RDM.Levels.Resolution)
                     return RDM.Resolution;
@@ -442,26 +418,19 @@ namespace XIVSlothComboPlugin.Combos
                 int black = gauge.BlackMana;
                 int white = gauge.WhiteMana;
                 var engagementCD = GetCooldown(RDM.Engagement);
-                var actionIDCD = GetCooldown(OriginalHook(actionID));
+                var canWeave = CanWeave(OriginalHook(actionID));
 
                 if (IsEnabled(CustomComboPreset.RedMageVerprocOpenerSmartCastFeature))
                 {
                     if (!HasEffect(RDM.Buffs.VerfireReady) && !HasCondition(ConditionFlag.InCombat) && level >= RDM.Levels.Verthunder)
                         return OriginalHook(RDM.Verthunder);
                 }
-                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.Fleche) || IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.ContreSixte))
+                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
                 {
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.Fleche && level >= RDM.Levels.ContreSixte)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
                     if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
                         return RDM.Fleche;
+                    if (level >= RDM.Levels.ContreSixte && IsOffCooldown(RDM.ContreSixte))
+                        return RDM.ContreSixte;
                 }
                 if (actionID is RDM.Veraero or RDM.Verthunder)
                 {
@@ -611,22 +580,16 @@ namespace XIVSlothComboPlugin.Combos
                 int blackThreshold = white + IMBALANCE_DIFF_MAX;
                 int whiteThreshold = black + IMBALANCE_DIFF_MAX;
                 var engagementCD = GetCooldown(RDM.Engagement);
-                var actionIDCD = GetCooldown(OriginalHook(actionID));
-                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.Fleche) || IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && actionIDCD.IsCooldown && IsOffCooldown(RDM.ContreSixte))
+                var canWeave = CanWeave(OriginalHook(actionID));
+                
+                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
                 {
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.ContreSixte && level <= RDM.Levels.Fleche)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
-                    if (level >= RDM.Levels.Fleche && level >= RDM.Levels.ContreSixte)
-                        return CalcBestAction(actionID, RDM.ContreSixte, RDM.Fleche);
-
                     if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
                         return RDM.Fleche;
+                    if (level >= RDM.Levels.ContreSixte && IsOffCooldown(RDM.ContreSixte))
+                        return RDM.ContreSixte;
                 }
-                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && actionIDCD.IsCooldown && engagementCD.CooldownRemaining < 35 && InMeleeRange(true))
+                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && canWeave && engagementCD.CooldownRemaining < 35 && InMeleeRange(true))
                 {
                     return RDM.Engagement;
                 }
@@ -1073,7 +1036,7 @@ namespace XIVSlothComboPlugin.Combos
                     SimpleRedMage.step = 0;
                 }
 
-                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave )
+                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast) )
                 {
                     if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
                         return RDM.Fleche;

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -9,6 +9,7 @@ using Dalamud.Interface.Windowing;
 using Dalamud.Utility;
 using ImGuiNET;
 using XIVSlothComboPlugin.Attributes;
+using XIVSlothComboPlugin.Combos;
 
 namespace XIVSlothComboPlugin
 {
@@ -275,6 +276,25 @@ namespace XIVSlothComboPlugin
                 {
                     Service.Configuration.SkillCooldownRemaining = SkillCooldownRemaining;
 
+                    Service.Configuration.Save();
+                }
+
+                ImGui.Spacing();
+            }
+            if (preset == CustomComboPreset.BardSimpleRagingJaws && enabled)
+            {
+                var ragingJawsRenewTime = Service.Configuration.GetCustomConfigValue(BRD.Config.RagingJawsRenewTime);
+
+                var inputChanged = false;
+                ImGui.PushItemWidth(75);
+                inputChanged |= ImGui.InputFloat("Remaining time (In seconds)", ref ragingJawsRenewTime);
+                
+                if (inputChanged)
+                {
+                    ragingJawsRenewTime = ragingJawsRenewTime < 3 ? 3 : ragingJawsRenewTime;
+
+                    Service.Configuration.SetCustomConfigValue(BRD.Config.RagingJawsRenewTime, ragingJawsRenewTime);
+                    
                     Service.Configuration.Save();
                 }
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -343,7 +343,7 @@ namespace XIVSlothComboPlugin
         BardIronJawsApexFeature = 3024,
         
         [ParentCombo(SimpleBardFeature)]
-        [CustomComboInfo("Simple RagingJaws", "BETA TESTING - Enable the snapshotting of dots by the end of raging strikes", BRD.JobID)]
+        [CustomComboInfo("Simple RagingJaws", "BETA TESTING - Enable the snapshotting of dots, within the remaining time of Raging Strikes below:", BRD.JobID)]
         BardSimpleRagingJaws = 3025,
 
         #endregion

--- a/XIVSlothCombo/PluginConfiguration.cs
+++ b/XIVSlothCombo/PluginConfiguration.cs
@@ -125,5 +125,24 @@ namespace XIVSlothComboPlugin
 
         public float SkillCooldownRemaining { get; set; } = 0;
 
+        [JsonProperty]
+        private static Dictionary<string,float> CustomConfigValues { get; set; } = new Dictionary<string,float>();
+
+        //public static Dictionary<string, float> CustomConfigValues = new Dictionary<string, float>();
+
+
+        public float GetCustomConfigValue(string config)
+        {
+            float configValue;
+
+            if (!CustomConfigValues.TryGetValue(config, out configValue)) return 0;
+
+            return configValue;
+        }
+
+        public void SetCustomConfigValue(string config, float value)
+        {
+            CustomConfigValues[config] = value;
+        }
     }
 }

--- a/XIVSlothCombo/XIVSlothCombo.csproj
+++ b/XIVSlothCombo/XIVSlothCombo.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Authors>attick,Kami,Daemitus,Grammernatzi,Aki,Iaotle,Codemned,PrincessRTFM,damolitionn,ele-starshade </Authors>
     <Company>-</Company>
-    <Version>3.0.6.6</Version> <!-- This is the version that will be used when pushing to the repo.-->
+    <Version>3.0.6.7</Version> <!-- This is the version that will be used when pushing to the repo.-->
     <Description>XIVCombo for lazy players</Description>
     <Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>
     <PackageProjectUrl></PackageProjectUrl>


### PR DESCRIPTION
Hello

### Modified

   - Simple Bard
       - Most notable:
           -  Added an option in the config window to customize the time which the snapshot happens relative to the remaining time of raging strikes.
                - Had the need to change that when using different attack skill spds, the reasoning behind it was that i had to change it almost every time i changed my threshold to avoid clipping etc @_@
           - Tweak on the opener to make compatible with lv80+ instead of only lv 90.
           - Tweak on pooling feature of BLs inside AP, start pooling at 30s on the song, to squeeze a little more dps.

### Note

 The custom time config , can be extended to any jobs that need a custom time for anything. I looked out on the other jobs that did something similar, but all of them shared the same variable , so changing the config in one changed on the other potentially messing up with each other, needed something that could store different values for different jobs, and the specification detached from central configuration.

```
public static class Config
        {
            public const string
                RagingJawsRenewTime = "ragingJawsRenewTime";
        }
```

on any job class representing a unique name for the config and call the config with:

`Service.Configuration.GetCustomConfigValue(BRD.Config.RagingJawsRenewTime);`

The code for the UI can be found in the ConfigWindow.cs, it stores the config on disk together with the others.

It only accepts configurations that represent time, a float.
