### PR TITLE
BLM Level Sync Fixes

### DIFF
--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -59,8 +59,8 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const byte
                 Fire3 = 34,
-                Freeze = 35,
-                Blizzard3 = 40,
+                Blizzard3 = 35,
+                Freeze = 40,
                 Thunder3 = 45,
                 Flare = 50,
                 LeyLines = 52,
@@ -209,7 +209,7 @@ namespace XIVSlothComboPlugin.Combos
                                 return BLM.Thunder3;
                         }
 
-                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !thunder3DebuffOnTarget && lastComboMove != BLM.Thunder3)
+                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !thunder3DebuffOnTarget && lastComboMove != BLM.Thunder3 && LocalPlayer.CurrentMp >= 400)
                             return BLM.Thunder3;
 
                         if (gauge.IsParadoxActive && level >= 90)
@@ -225,7 +225,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (level >= BLM.Levels.Fire4)
                 {
-                    if (gauge.ElementTimeRemaining >= 6000 && CustomCombo.IsEnabled(CustomComboPreset.BlackThunderFeature))
+                    if (gauge.ElementTimeRemaining >= 6000 && IsEnabled(CustomComboPreset.BlackThunderFeature))
                     {
                         if (HasEffect(BLM.Buffs.Thundercloud))
                         {
@@ -233,11 +233,11 @@ namespace XIVSlothComboPlugin.Combos
                                 return BLM.Thunder3;
                         }
 
-                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !thunder3DebuffOnTarget && lastComboMove != BLM.Thunder3)
+                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !thunder3DebuffOnTarget && lastComboMove != BLM.Thunder3 && LocalPlayer.CurrentMp >= 400)
                             return BLM.Thunder3;
                     }
 
-                    if (gauge.ElementTimeRemaining < 3000 && HasEffect(BLM.Buffs.Firestarter) && CustomCombo.IsEnabled(CustomComboPreset.BlackFire13Feature))
+                    if (gauge.ElementTimeRemaining < 3000 && HasEffect(BLM.Buffs.Firestarter) && IsEnabled(CustomComboPreset.BlackFire13Feature))
                     {
                         return BLM.Fire3;
                     }
@@ -254,7 +254,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
                     }
 
-                    if (gauge.ElementTimeRemaining > 0 && LocalPlayer.CurrentMp < 2400 && level >= BLM.Levels.Despair && CustomCombo.IsEnabled(CustomComboPreset.BlackDespairFeature))
+                    if (gauge.ElementTimeRemaining > 0 && LocalPlayer.CurrentMp < 2400 && level >= BLM.Levels.Despair && IsEnabled(CustomComboPreset.BlackDespairFeature))
                     {
                         return BLM.Despair;
                     }
@@ -281,20 +281,52 @@ namespace XIVSlothComboPlugin.Combos
                     return BLM.Fire4;
                 }
 
-                if (gauge.ElementTimeRemaining >= 5000 && IsEnabled(CustomComboPreset.BlackThunderFeature) && level < BLM.Levels.Thunder3)
+                if (gauge.ElementTimeRemaining >= 5000 && IsEnabled(CustomComboPreset.BlackThunderFeature))
                 {
-                    if (HasEffect(BLM.Buffs.Thundercloud))
+                    if (level < BLM.Levels.Thunder3)
                     {
-                        if (TargetHasEffect(BLM.Debuffs.Thunder) && thunderOneDebuff.RemainingTime < 4)
-                            return BLM.Thunder;
+                        if (HasEffect(BLM.Buffs.Thundercloud))
+                        {
+                            if (TargetHasEffect(BLM.Debuffs.Thunder) && thunderOneDebuff.RemainingTime < 4)
+                                return BLM.Thunder;
+                        }
+                    }
+                    else
+                    {
+                        if (HasEffect(BLM.Buffs.Thundercloud))
+                        {
+                            if (TargetHasEffect(BLM.Debuffs.Thunder3) && thunderdebuffontarget.RemainingTime < 4)
+                                return BLM.Thunder3;
+                        }
                     }
 
-                    if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !TargetHasEffect(BLM.Debuffs.Thunder) && lastComboMove != BLM.Thunder)
-                        return BLM.Thunder;
+                    if (level < BLM.Levels.Thunder3)
+                    {
+                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !TargetHasEffect(BLM.Debuffs.Thunder) && lastComboMove != BLM.Thunder && LocalPlayer.CurrentMp >= 200)
+                            return BLM.Thunder;
+                    }
+                    else
+                    {
+                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !TargetHasEffect(BLM.Debuffs.Thunder3) && lastComboMove != BLM.Thunder3 && LocalPlayer.CurrentMp >= 400)
+                            return BLM.Thunder3;
+                    }
                 }
 
                 if (level < BLM.Levels.Fire3)
+                {
                     return BLM.Fire;
+                }
+                else if (IsEnabled(CustomComboPreset.BlackEnochainRecoveryFeature) && gauge.ElementTimeRemaining <= 0)
+                {
+                    if (LocalPlayer.CurrentMp >= 2000)
+                    {
+                        return BLM.Fire3;
+                    }
+                    else
+                    {
+                        return BLM.Blizzard3;
+                    }
+                }
 
                 if (gauge.InAstralFire)
                 {
@@ -302,7 +334,7 @@ namespace XIVSlothComboPlugin.Combos
                         return BLM.Paradox;
                     if (HasEffect(BLM.Buffs.Firestarter))
                         return BLM.Fire3;
-                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp < 1600)
+                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp < 1600 && level >= BLM.Levels.Blizzard3)
                     {
                         if (IsEnabled(CustomComboPreset.BlackManafontFeature) && IsOffCooldown(BLM.Manafont) && CanWeave(lastComboMove))
                         {
@@ -315,6 +347,11 @@ namespace XIVSlothComboPlugin.Combos
                     }
 
                     return BLM.Fire;
+                }
+
+                if (gauge.InUmbralIce)
+                {
+                    return BLM.Blizzard;
                 }
             }
 

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -351,6 +351,9 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (gauge.InUmbralIce)
                 {
+                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp >= 10000)
+                        return BLM.Fire3;
+
                     return BLM.Blizzard;
                 }
             }

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -58,7 +58,7 @@ namespace XIVSlothComboPlugin.Combos
         public static class Levels
         {
             public const byte
-                Fire3 = 34,
+                Fire3 = 35,
                 Blizzard3 = 35,
                 Freeze = 40,
                 Thunder3 = 45,
@@ -351,7 +351,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (gauge.InUmbralIce)
                 {
-                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp >= 10000)
+                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp >= 10000 && level >= BLM.Levels.Fire3)
                         return BLM.Fire3;
 
                     return BLM.Blizzard;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -223,7 +223,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Amplifier Feature", "Changes Scathe to Amplifier when available to weave.", BLM.JobID)]
         BlackAmplifierFeature = 2015,
 
-        [CustomComboInfo("Ley Lines Auto Feature", "Changes to Scathe to Ley Lines when available.", BLM.JobID)]
+        [CustomComboInfo("Ley Lines Auto Feature", "Changes to Scathe to Ley Lines when available to weave.", BLM.JobID)]
         BlackLeyLinesAutoFeature = 2016,
 
         [ParentCombo(BlackEnochianFeature)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -203,6 +203,32 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Aspect Swap Feature", "Changes Scathe to Blizzard 3 when at 0 MP in Astral Fire or to Fire 3 when at 10000 MP in Umbral Ice with 3 Umbral Hearts.", BLM.JobID)]
         BlackAspectSwapFeature = 2010,
 
+        [ParentCombo(BlackThunderFeature)]
+        [CustomComboInfo("Thunder Uptime Feature", "Changes Scathe to Thunder 1/3 when not detected on target.", BLM.JobID)]
+        BlackThunderUptimeFeature = 2011,
+
+        [ParentCombo(BlackAspectSwapFeature)]
+        [CustomComboInfo("Manafont Feature", "Adds Manafont when 0 mana in astral fire phase and available to weave.", BLM.JobID)]
+        BlackManafontFeature = 2012,
+
+        [ParentCombo(BlackEnochianFeature)]
+        [CustomComboInfo("Polygot Overcap Feature", "Changes Scathe to Xenoglossy / Foul when polygot stacks are capped.", BLM.JobID)]
+        BlackPolygotFeature = 2013,
+
+        [ParentCombo(BlackEnochianFeature)]
+        [CustomComboInfo("Sharpcast Feature", "Changes Scathe to Sharpcast when available to weave.", BLM.JobID)]
+        BlackSharpcastFeature = 2014,
+
+        [ParentCombo(BlackEnochianFeature)]
+        [CustomComboInfo("Amplifier Feature", "Changes Scathe to Amplifier when available to weave.", BLM.JobID)]
+        BlackAmplifierFeature = 2015,
+
+        [CustomComboInfo("Ley Lines Auto Feature", "Changes to Scathe to Ley Lines when available.", BLM.JobID)]
+        BlackLeyLinesAutoFeature = 2016,
+
+        [ParentCombo(BlackEnochianFeature)]
+        [CustomComboInfo("Enochain Recovery Feature", "Changes Scathe to Fire3 / Blizzard3 depending on current player's mana when enochain is inactive.", BLM.JobID)]
+        BlackEnochainRecoveryFeature = 2017,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
Fix wrong levels being defined for BLM.
Update BLM to cast Thunder/Thunder 3 only if it has enough MP.
Update BLM to cast Blizzard under Umbral Ice, and cast Fire3 when at max MP.
Update BLM to change Scathe to Fire 3/Blizzard 3 when it has access to those abilities.