### PR TITLE
[DNC] Simple Dancer Additions

### DIFF
--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -428,16 +428,16 @@ namespace XIVSlothComboPlugin.Combos
                     }
                 }
 
+                if (HasEffect(DNC.Buffs.TechnicalStep) && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature))
+                    return gauge.CompletedSteps < 4
+                        ? (uint)gauge.NextStep
+                        : DNC.TechnicalFinish4;
+
                 if (HasEffect(DNC.Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature))
                     return gauge.CompletedSteps < 2
                         ? (uint)gauge.NextStep
                         : DNC.StandardFinish2;
                 
-                if (HasEffect(DNC.Buffs.TechnicalStep) && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature))
-                    return gauge.CompletedSteps < 4
-                        ? (uint)gauge.NextStep
-                        : DNC.TechnicalFinish4;
-                        
 
                 if (!HasTarget() || EnemyHealthPercentage() > 5)
                 {

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -447,11 +447,14 @@ namespace XIVSlothComboPlugin.Combos
                         return DNC.TechnicalStep;
                 }
 
-                if (IsEnabled(CustomComboPreset.DancerSimpleBuffsFeature) && canWeaveAbilities)
+                if (IsEnabled(CustomComboPreset.DancerSimpleDevilmentFeature) && canWeaveAbilities)
                 {
-                    if (level >= DNC.Levels.Devilment && IsOffCooldown(DNC.Devilment))
+                    if (level >= DNC.Levels.Devilment && (HasEffect(DNC.Buffs.TechnicalFinish) && IsOffCooldown(DNC.Devilment))
                         return DNC.Devilment;
-
+                }
+                
+                if (IsEnabled(CustomComboPreset.DancerSimpleFlourishFeature) && canWeaveAbilities)
+                {
                     if (level >= DNC.Levels.Flourish && IsOffCooldown(DNC.Flourish))
                         return DNC.Flourish;
                 }

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -428,23 +428,32 @@ namespace XIVSlothComboPlugin.Combos
                     }
                 }
 
-                if (IsEnabled(CustomComboPreset.DancerSimpleDancesFeature))
+                if (HasEffect(DNC.Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature))
+                    return gauge.CompletedSteps < 2
+                        ? (uint)gauge.NextStep
+                        : DNC.StandardFinish2;
+                
+                if (HasEffect(DNC.Buffs.TechnicalStep) && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature))
+                    return gauge.CompletedSteps < 4
+                        ? (uint)gauge.NextStep
+                        : DNC.TechnicalFinish4;
+                        
+
+                if (!HasTarget() || EnemyHealthPercentage() > 5)
                 {
-                    if (HasEffect(DNC.Buffs.TechnicalStep))
-                        return gauge.CompletedSteps < 4
-                            ? (uint)gauge.NextStep
-                            : DNC.TechnicalFinish4;
-                    
-                    if (HasEffect(DNC.Buffs.StandardStep))
-                            return gauge.CompletedSteps < 2
-                                ? (uint)gauge.NextStep
-                                : DNC.StandardFinish2;
+                    if (
+                        level >= DNC.Levels.StandardStep &&
+                        IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) &&
+                        !HasEffect(DNC.Buffs.TechnicalStep) &&
+                        IsOffCooldown(DNC.StandardStep)
+                    ) return DNC.StandardStep;
 
-                    if (level >= DNC.Levels.StandardStep && (!HasTarget() || EnemyHealthPercentage() > 5) && IsOffCooldown(DNC.StandardStep))
-                        return DNC.StandardStep;
-
-                    if (level >= DNC.Levels.TechnicalStep && (!HasTarget() || EnemyHealthPercentage() > 5) && IsOffCooldown(DNC.TechnicalStep) && GetCooldown(DNC.StandardStep).CooldownRemaining > 5)
-                        return DNC.TechnicalStep;
+                    if (
+                        level >= DNC.Levels.TechnicalStep &&
+                        IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) &&
+                        !HasEffect(DNC.Buffs.StandardStep) &&
+                        IsOffCooldown(DNC.TechnicalStep)
+                    ) return DNC.TechnicalStep;
                 }
 
                 if (IsEnabled(CustomComboPreset.DancerSimpleDevilmentFeature) && canWeaveAbilities)

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -449,7 +449,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (IsEnabled(CustomComboPreset.DancerSimpleDevilmentFeature) && canWeaveAbilities)
                 {
-                    if (level >= DNC.Levels.Devilment && (HasEffect(DNC.Buffs.TechnicalFinish) && IsOffCooldown(DNC.Devilment))
+                    if (level >= DNC.Levels.Devilment && (HasEffect(DNC.Buffs.TechnicalFinish) && IsOffCooldown(DNC.Devilment)))
                         return DNC.Devilment;
                 }
                 
@@ -481,11 +481,19 @@ namespace XIVSlothComboPlugin.Combos
 
                     if (level >= DNC.Levels.FanDance4 && HasEffect(DNC.Buffs.FourFoldFanDance)) return DNC.FanDance4;
 
-                    if (IsEnabled(CustomComboPreset.DancerSimpleShieldNHealsFeature))
+                    if (IsEnabled(CustomComboPreset.DancerSimpleSambaFeature))
                     {
                         if (level >= DNC.Levels.ShieldSamba && IsOffCooldown(DNC.ShieldSamba)) return DNC.ShieldSamba;
-                        if (level >= DNC.Levels.CuringWaltz && PlayerHealthPercentageHp() < 75 && IsOffCooldown(DNC.CuringWaltz)) return DNC.CuringWaltz;
-                        if (level >= DNC.Levels.SecondWind && PlayerHealthPercentageHp() < 75 && IsOffCooldown(DNC.SecondWind)) return DNC.SecondWind;
+                    }
+                    
+                    if (IsEnabled(CustomComboPreset.DancerSimplePanicHealsFeature))
+                    {
+                        if (level >= DNC.Levels.CuringWaltz && PlayerHealthPercentageHp() < 30 && IsOffCooldown(DNC.CuringWaltz)) return DNC.CuringWaltz;
+                        if (level >= DNC.Levels.SecondWind && PlayerHealthPercentageHp() < 50 && IsOffCooldown(DNC.SecondWind)) return DNC.SecondWind;
+                    }
+                    
+                    if (IsEnabled(CustomComboPreset.DancerSimpleImprovFeature))
+                    {
                         if (level >= DNC.Levels.Improvisation && IsOffCooldown(DNC.Improvisation)) return DNC.Improvisation;
                     }
                 }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -466,15 +466,15 @@ namespace XIVSlothComboPlugin
 
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Samba", "Includes Shield Samba in the rotation when available (not optimal).", DNC.JobID)]
-        DancerSimpleShieldNHealsFeature = 4022,
+        DancerSimpleSambaFeature = 4022,
         
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Panic Heals", "Includes Curing Waltz and Second Wind in the rotation when available and below 30% / 50% HP, respectively.", DNC.JobID)]
-        DancerSimpleShieldNHealsFeature = 4023,
+        DancerSimplePanicHealsFeature = 4023,
         
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Improv", "Includes Improvisation in the rotation when available", DNC.JobID)]
-        DancerSimpleShieldNHealsFeature = 4024,
+        DancerSimpleImprovFeature = 4024,
 
         [CustomComboInfo("Simple Dancer AOE", "BETA - Single button aoe dancer, including songs, flourishes and overprotections.\nConflicts with all other non-simple toggles!!", DNC.JobID)]
         DancerSimpleAoeFeature = 4050,

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -407,18 +407,18 @@ namespace XIVSlothComboPlugin
         DancerDevilmentFeature = 4006,
 
         [ParentCombo(DancerSingleTargetMultibutton)]
-        [CustomComboInfo("Overcap Feature", "Adds SaberBlade to Cascade/Windmil combo if you are about to overcap on esprit.", DNC.JobID)]
+        [CustomComboInfo("Overcap Feature", "Adds Saber Dance to Cascade/Windmil combo if you are about to overcap on Esprit.", DNC.JobID)]
         DancerOvercapFeature = 4007,
 
         [ParentCombo(DancerSingleTargetMultibutton)]
-        [CustomComboInfo("Overcap Feature Option", "Adds SaberBlade to Cascade/Windmill if you have at least 50 esprit.", DNC.JobID)]
+        [CustomComboInfo("Overcap Feature Option", "Adds Saber Dance to Cascade/Windmill if you have at least 50 Esprit.", DNC.JobID)]
         DancerSaberDanceInstantSaberDanceComboFeature = 4008,
 
         [ConflictingCombos(DancerDanceComboCompatibility, DancerDanceStepCombo)]
-        [CustomComboInfo("CombinedDanceFeature", "Standard And Technical Dance on one button(StandardStep) Standard>Technical This is combo out into Tilana and StarfallDance.", DNC.JobID)]
+        [CustomComboInfo("CombinedDanceFeature", "Standard And Technical Dance on one button(SS). Standard>Technical. This combos out into Tillana and Starfall Dance.", DNC.JobID)]
         DancerDanceStepComboTest = 4009,
 
-        [CustomComboInfo("FanSaberDanceFeature", "Adds SaberDance onto all FanDance Skills when no feathers are available and you have 50+ gauge", DNC.JobID)]
+        [CustomComboInfo("FanSaberDanceFeature", "Adds SaberDance onto all Fan Dance skills when no feathers are available and you have 50+ Esprit", DNC.JobID)]
         DancerSaberFanDanceFeature = 4010,
 
         [ParentCombo(DancerSingleTargetMultibutton)]
@@ -437,54 +437,58 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Flourish On Combined Dance Feature", "Adds Flourish to the CombinedStepCombo.", DNC.JobID)]
         DancerFlourishOnCombinedDanceFeature = 4014,
 
-        [CustomComboInfo("Simple Dancer", "BETA TESTING - Single button single target dancer, including songs, flourishes and overprotections.\nConflicts with all other non-simple toggles!!", DNC.JobID)]
+        [CustomComboInfo("Simple Dancer", "BETA - Single button, single target dancer. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles.", DNC.JobID)]
         DancerSimpleFeature = 4015,
 
         [ParentCombo(DancerSimpleFeature)]
-        [CustomComboInfo("Simple Interrupt", "Includes an interrupt in the st rotation", DNC.JobID)]
-        DancerSimpleInterruptFeature = 4017,
+        [CustomComboInfo("Simple Interrupt", "Includes an interrupt in the rotation", DNC.JobID)]
+        DancerSimpleInterruptFeature = 4016,
 
         [ParentCombo(DancerSimpleFeature)]
-        [CustomComboInfo("Simple Dances", "Includes standard and technical step in the st rotation", DNC.JobID)]
-        DancerSimpleDancesFeature = 4018,
+        [CustomComboInfo("Simple Dances", "Includes Standard Step and Technical Step in the rotation", DNC.JobID)]
+        DancerSimpleDancesFeature = 4017,
 
         [ParentCombo(DancerSimpleFeature)]
-        [CustomComboInfo("Simple Buffs", "Includes delivment and flourish in the st rotation", DNC.JobID)]
-        DancerSimpleBuffsFeature = 4019,
+        [CustomComboInfo("Simple Tech Devilment", "Includes Devilment in the rotation (during Technical Finish).", DNC.JobID)]
+        DancerSimpleDevilmentFeature = 4018,
 
         [ParentCombo(DancerSimpleFeature)]
-        [CustomComboInfo("Simple Feather", "Includes feather usage in the st rotation", DNC.JobID)]
+        [CustomComboInfo("Simple Flourish", "Includes Flourish in the rotation", DNC.JobID)]
+        DancerSimpleFlourishFeature = 4019,
+
+        [ParentCombo(DancerSimpleFeature)]
+        [CustomComboInfo("Simple Feather", "Includes feather usage in the rotation", DNC.JobID)]
         DancerSimpleFeatherFeature = 4020,
 
         [ParentCombo(DancerSimpleFeature)]
-        [CustomComboInfo("Simple Feather Pooling", "Makes it so the st rotation only uses feathers when you have more than 3\nor when you are under the effects of technical step", DNC.JobID)]
+        [CustomComboInfo("Simple Feather Pooling", "Makes the rotation only use feathers when you have more than 3, or when under the effects of Technical Step", DNC.JobID)]
         DancerSimpleFeatherPoolingFeature = 4021,
 
         [ParentCombo(DancerSimpleFeature)]
-        [CustomComboInfo("Simple Heals n Shields", "Makes it so the st rotation uses shield n heal ogcd's when available", DNC.JobID)]
+        [CustomComboInfo("Simple Samba/Waltz", "Includes Shield Samba/Curing Waltz in the rotation when available", DNC.JobID)]
         DancerSimpleShieldNHealsFeature = 4022,
 
-        [CustomComboInfo("Simple Dancer AOE", "BETA TESTING - Single button aoe dancer, including songs, flourishes and overprotections.\nConflicts with all other non-simple toggles!!", DNC.JobID)]
+        [CustomComboInfo("Simple Dancer AOE", "BETA - Single button aoe dancer, including songs, flourishes and overprotections.\nConflicts with all other non-simple toggles!!", DNC.JobID)]
         DancerSimpleAoeFeature = 4050,
 
         [ParentCombo(DancerSimpleAoeFeature)]
-        [CustomComboInfo("Simple AOE Standard", "Includes standard step in the simple aoe rotation", DNC.JobID)]
+        [CustomComboInfo("Simple AOE Standard", "Includes Standard Step in the AoE rotation", DNC.JobID)]
         DancerSimpleAoeStandardFeature = 4051,
 
         [ParentCombo(DancerSimpleAoeFeature)]
-        [CustomComboInfo("Simple AOE Technical", "Includes technical step in the simple aoe rotation", DNC.JobID)]
+        [CustomComboInfo("Simple AOE Technical", "Includes Technical Step in the AoE rotation", DNC.JobID)]
         DancerSimpleAoeTechnicalFeature = 4052,
 
         [ParentCombo(DancerSimpleAoeFeature)]
-        [CustomComboInfo("Simple AOE Buffs", "Includes devilment and flourish in the simple aoe rotation", DNC.JobID)]
+        [CustomComboInfo("Simple AOE Buffs", "Includes Devilment and Flourish in the AoE rotation", DNC.JobID)]
         DancerSimpleAoeBuffsFeature = 4053,
 
         [ParentCombo(DancerSimpleAoeFeature)]
-        [CustomComboInfo("Simple AOE Feathers", "Includes feather usage in the simple aoe rotation", DNC.JobID)]
+        [CustomComboInfo("Simple AOE Feathers", "Includes feather usage in the AoE rotation", DNC.JobID)]
         DancerSimpleAoeFeatherFeature = 4054,
 
         [ParentCombo(DancerSimpleAoeFeature)]
-        [CustomComboInfo("Simple AOE Feather Pooling", "Makes it so the aoe rotation only uses feathers when you have more than 3", DNC.JobID)]
+        [CustomComboInfo("Simple AOE Feather Pooling", "Makes it so the AoE rotation only uses feathers when you have more than 3", DNC.JobID)]
         DancerSimpleAoeFeatherPoolingFeature = 4055,
 
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -445,36 +445,40 @@ namespace XIVSlothComboPlugin
         DancerSimpleInterruptFeature = 4016,
 
         [ParentCombo(DancerSimpleFeature)]
-        [CustomComboInfo("Simple Dances", "Includes Standard Step and Technical Step in the rotation", DNC.JobID)]
-        DancerSimpleDancesFeature = 4017,
+        [CustomComboInfo("Simple Standard Step", "Includes Standard Step in the rotation", DNC.JobID)]
+        DancerSimpleStandardFeature = 4017,
+        
+        [ParentCombo(DancerSimpleFeature)]
+        [CustomComboInfo("Simple Technical Step", "Includes Technical Step in the rotation", DNC.JobID)]
+        DancerSimpleTechnicalFeature = 4018,
 
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Tech Devilment", "Includes Devilment in the rotation (during Technical Finish).", DNC.JobID)]
-        DancerSimpleDevilmentFeature = 4018,
+        DancerSimpleDevilmentFeature = 4019,
 
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Flourish", "Includes Flourish in the rotation", DNC.JobID)]
-        DancerSimpleFlourishFeature = 4019,
+        DancerSimpleFlourishFeature = 4020,
 
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Feather", "Includes feather usage in the rotation", DNC.JobID)]
-        DancerSimpleFeatherFeature = 4020,
+        DancerSimpleFeatherFeature = 4021,
 
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Feather Pooling", "Makes the rotation only use feathers when you have more than 3, or when under the effects of Technical Step", DNC.JobID)]
-        DancerSimpleFeatherPoolingFeature = 4021,
+        DancerSimpleFeatherPoolingFeature = 4022,
 
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Samba", "Includes Shield Samba in the rotation when available (not optimal).", DNC.JobID)]
-        DancerSimpleSambaFeature = 4022,
+        DancerSimpleSambaFeature = 4023,
         
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Panic Heals", "Includes Curing Waltz and Second Wind in the rotation when available and below 30% / 50% HP, respectively.", DNC.JobID)]
-        DancerSimplePanicHealsFeature = 4023,
+        DancerSimplePanicHealsFeature = 4024,
         
         [ParentCombo(DancerSimpleFeature)]
         [CustomComboInfo("Simple Improv", "Includes Improvisation in the rotation when available", DNC.JobID)]
-        DancerSimpleImprovFeature = 4024,
+        DancerSimpleImprovFeature = 4025,
 
         [CustomComboInfo("Simple Dancer AOE", "BETA - Single button aoe dancer, including songs, flourishes and overprotections.\nConflicts with all other non-simple toggles!!", DNC.JobID)]
         DancerSimpleAoeFeature = 4050,

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -437,7 +437,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Flourish On Combined Dance Feature", "Adds Flourish to the CombinedStepCombo.", DNC.JobID)]
         DancerFlourishOnCombinedDanceFeature = 4014,
 
-        [CustomComboInfo("Simple Dancer", "BETA - Single button, single target dancer. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles.", DNC.JobID)]
+        [CustomComboInfo("Simple Dancer", "BETA - Single button, single target dancer. Includes songs, flourishes and overprotections. Conflicts with all other non-simple toggles.", DNC.JobID)]
         DancerSimpleFeature = 4015,
 
         [ParentCombo(DancerSimpleFeature)]
@@ -465,8 +465,16 @@ namespace XIVSlothComboPlugin
         DancerSimpleFeatherPoolingFeature = 4021,
 
         [ParentCombo(DancerSimpleFeature)]
-        [CustomComboInfo("Simple Samba/Waltz", "Includes Shield Samba/Curing Waltz in the rotation when available", DNC.JobID)]
+        [CustomComboInfo("Simple Samba", "Includes Shield Samba in the rotation when available (not optimal).", DNC.JobID)]
         DancerSimpleShieldNHealsFeature = 4022,
+        
+        [ParentCombo(DancerSimpleFeature)]
+        [CustomComboInfo("Simple Panic Heals", "Includes Curing Waltz and Second Wind in the rotation when available and below 30% / 50% HP, respectively.", DNC.JobID)]
+        DancerSimpleShieldNHealsFeature = 4023,
+        
+        [ParentCombo(DancerSimpleFeature)]
+        [CustomComboInfo("Simple Improv", "Includes Improvisation in the rotation when available", DNC.JobID)]
+        DancerSimpleShieldNHealsFeature = 4024,
 
         [CustomComboInfo("Simple Dancer AOE", "BETA - Single button aoe dancer, including songs, flourishes and overprotections.\nConflicts with all other non-simple toggles!!", DNC.JobID)]
         DancerSimpleAoeFeature = 4050,


### PR DESCRIPTION
- Moved SS priority above TS (just for steps, not beginning/end of dances)

- Removed SimpleDanceFeature and replaced with SimpleStandardFeature and SimpleTechnicalFeature.

- Split DancerSimpleBuffs into DancerSimpleDevilmentFeature and DancerSimpleFlourishFeature.

- Added (HasEffect(DNC.Buffs.TechnicalFinish) to Devilment feature.
When enabled and at level, Devilment should now only trigger on the main rotation if off cooldown and under the effect of Technical Finish.

- Split DancerSimpleShieldNHealsFeature into DancerSimpleSambaFeature, DancerSimplePanicHealsFeature and DancerSimpleImprovFeature.
Set HP thresholds for Curing Waltz and Second Wind to 30% and 50% respectively, with the intention of Waltz being used manually before hitting the threshold, but available as a backup heal, and with Second Wind aiming to be more of a passive heal when the weave is available.

- Tidied up some descriptions etc.

---
Apologies for the double-pull request, I think I have to go about it like this now since I renamed the branch on my end (?)