### PR TITLE
Added two options to RPR Slice combo: a Stun (Leg Sweep) and a Heal (Bloodbath & Second Wind)

### DIFF
--- a/XIVSlothCombo/Combos/RPR.cs
+++ b/XIVSlothCombo/Combos/RPR.cs
@@ -191,7 +191,7 @@ namespace XIVSlothComboPlugin.Combos
                     return RPR.InfernalSlice;
                 }
 
-                 // If target can be stunned this will attempt to stun an intrruptable cast. 
+                 // If target can be stunned this will attempt to stun an interruptible cast. 
                 if (level >= RPR.Levels.LegSweep && IsEnabled(CustomComboPreset.ReaperSimpleInterruptFeature))
                 {
                     if (CanInterruptEnemy() && IsOffCooldown(RPR.LegSweep))

--- a/XIVSlothCombo/Combos/RPR.cs
+++ b/XIVSlothCombo/Combos/RPR.cs
@@ -38,6 +38,9 @@ namespace XIVSlothComboPlugin.Combos
             Harpe = 24386,
             Soulsow = 24387,
             HarvestMoon = 24388,
+            LegSweep = 7863,    
+            SecondWind = 7541,  
+            Bloodbath = 7542,
             // Gauge
             SoulSlice = 24380,
             SoulScythe = 24381;
@@ -67,6 +70,9 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const byte
                 WaxingSlice = 5,
+                SecondWind = 8,
+                LegSweep =10,
+                Bloodbath = 12,
                 HellsIngress = 20,
                 HellsEgress = 20,
                 SpinningScythe = 25,
@@ -184,6 +190,22 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     return RPR.InfernalSlice;
                 }
+
+                 // If target can be stunned this will attempt to stun an intrruptable cast. 
+                if (level >= RPR.Levels.LegSweep && IsEnabled(CustomComboPreset.ReaperSimpleInterruptFeature))
+                {
+                    if (CanInterruptEnemy() && IsOffCooldown(RPR.LegSweep))
+                    {
+                        return RPR.LegSweep;
+                    }
+                }
+
+                // Simple heal in combo
+                if (IsEnabled(CustomComboPreset.ReaperSimplePanicHealsFeature))
+                    {
+                        if (level >= RPR.Levels.Bloodbath && PlayerHealthPercentageHp() < 30 && IsOffCooldown(RPR.Bloodbath)) return RPR.Bloodbath;
+                        if (level >= RPR.Levels.SecondWind && PlayerHealthPercentageHp() < 50 && IsOffCooldown(RPR.SecondWind)) return RPR.SecondWind;
+                    }
 
             }
             return actionID;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1050,6 +1050,13 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Combat Harpe Option", "Prevent Harvest Moon replacing Harpe when you are not in combat.", RPR.JobID)]
         ReaperHarpeHarvestMoonCombatOption = 12023,
 
+        [ParentCombo(ReaperSliceCombo)]
+        [CustomComboInfo("Simple Panic Heals", "Includes Bloodbath and Second Wind in the rotation when available and below 30% / 50% HP, respectively.", RPR.JobID)]
+        ReaperSimplePanicHealsFeature = 12024,
+
+        [ParentCombo(ReaperSliceCombo)]
+        [CustomComboInfo("Simple Stun", "Includes a stun in the rotation, but only to attempt an interrupt.", RPR.JobID)]
+        ReaperSimpleInterruptFeature = 12025,
 
 
         #endregion


### PR DESCRIPTION
Two more options for the Reaper Slice combo.  Bloodbath and Second Wind as panic heals based on HP % and added leg sweep to check for interruptible cast.  