### PR TITLE
[SCH, SGE] Features & Fixes

### DIFF
--- a/XIVSlothCombo/Combos/SCH.cs
+++ b/XIVSlothCombo/Combos/SCH.cs
@@ -8,31 +8,48 @@ namespace XIVSlothComboPlugin.Combos
         public const byte JobID = 28;
 
         public const uint
-            FeyBless = 16543,
+
+            // Heals
+            Physick = 190,
+            Adloquium = 185,
+            Succor = 186,
+            Lustrate = 189,
+            SacredSoil = 188,
+            Indomitability = 3583,
             Consolation = 16546,
-            EnergyDrain = 167,
-            LucidDreaming = 7562,
-            Resurrection = 173,
-            Swiftcast = 7561,
-            Aetherflow = 166,
+
+            // Offense
             Bio1 = 17864,
             Bio2 = 17865,
             Biolysis = 16540,
             Ruin1 = 163,
             Ruin2 = 17870,
-            SummonSeraph = 16545,
-            SummonEos = 17215,
-            SummonSelene = 17216,
             Broil1 = 3584,
             Broil2 = 7435,
             Broil3 = 16541,
             Broil4 = 25865,
-            Indomitability = 3583,
+            Scourge = 16539,
+            EnergyDrain = 167,
+
+            // Faerie
+            SummonSeraph = 16545,
+            SummonEos = 17215,
+            SummonSelene = 17216,
             WhisperingDawn = 16537,
             FeyIllumination = 16538,
             Dissipation = 3587,
             Aetherpact = 7437,
-            ChainStratagem = 7436;
+            FeyBlessing = 16543,
+
+            // Other
+            Aetherflow = 166,
+            ChainStratagem = 7436,
+
+            // Role
+            Swiftcast = 7561,
+            Resurrection = 173,
+            LucidDreaming = 7562,
+            Esuna = 5768;
 
         public static class Buffs
         {
@@ -51,7 +68,39 @@ namespace XIVSlothComboPlugin.Combos
 
         public static class Levels
         {
-            // public const byte placeholder = 0;
+            public const byte
+
+                Bio1 = 2,
+                Physick = 4,
+                WhisperingDawn = 20,
+                Bio2 = 26,
+                Adloquium = 30,
+                Succor = 35,
+                Ruin2 = 38,
+                FeyIllumination = 40,
+                Aetherflow = 45,
+                EnergyDrain = 45,
+                Lustrate = 45,
+                Scourge = 46,
+                SacredSoil = 50,
+                Indomitability = 52,
+                Broil = 54,
+                DeploymentTactics = 56,
+                EmergencyTactics = 58,
+                Dissipation = 60,
+                Excogitation = 62,
+                Broil2 = 64,
+                ChainStratagem = 66,
+                Aetherpact = 70,
+                Biolysis = 72,
+                Broil3 = 72,
+                Recitation = 74,
+                FeyBlessing = 76,
+                SummonSeraph = 80,
+                Broil4 = 82,
+                Scoura = 82,
+                Protraction = 86,
+                Expedient = 90;
         }
     }
 
@@ -61,7 +110,7 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SCH.FeyBless)
+            if (actionID == SCH.FeyBlessing)
             {
                 var gauge = GetJobGauge<SCHGauge>();
                 if (gauge.SeraphTimer > 0)
@@ -140,21 +189,21 @@ namespace XIVSlothComboPlugin.Combos
                 var bio2Debuff = FindTargetEffect(SCH.Debuffs.Bio2);
                 var bio1Debuff = FindTargetEffect(SCH.Debuffs.Bio1);
 
-                if (IsEnabled(CustomComboPreset.SCHDPSAlternateFeature) && level >= 72)
+                if (IsEnabled(CustomComboPreset.SCHDPSAlternateFeature) && level >= SCH.Levels.Biolysis)
                 {
-                    if ((!TargetHasEffect(SCH.Debuffs.Biolysis) && incombat && level >= 72) || (biolysisDebuff.RemainingTime < 5 && incombat && level >= 72))
+                    if ((!TargetHasEffect(SCH.Debuffs.Biolysis) && incombat && level >= SCH.Levels.Biolysis) || (biolysisDebuff.RemainingTime < 5 && incombat && level >= SCH.Levels.Biolysis))
                         return SCH.Biolysis;
                 }
 
-                if (IsEnabled(CustomComboPreset.SCHDPSAlternateFeature) && level >= 26 && level <= 71)
+                if (IsEnabled(CustomComboPreset.SCHDPSAlternateFeature) && level >= SCH.Levels.Bio2 && level < SCH.Levels.Biolysis)
                 {
-                    if ((!TargetHasEffect(SCH.Debuffs.Bio2) && level <= 71 && level >= 26) || (bio2Debuff.RemainingTime < 5 && incombat && level >= 26 && level <= 71))
+                    if ((!TargetHasEffect(SCH.Debuffs.Bio2) && level < SCH.Levels.Biolysis && level >= SCH.Levels.Bio2) || (bio2Debuff.RemainingTime < 5 && incombat && level >= SCH.Levels.Bio2 && level < SCH.Levels.Biolysis))
                         return SCH.Bio2;
                 }
 
-                if (IsEnabled(CustomComboPreset.SCHDPSAlternateFeature) && level >= 2 && level <= 25)
+                if (IsEnabled(CustomComboPreset.SCHDPSAlternateFeature) && level < SCH.Levels.Bio2)
                 {
-                    if ((!TargetHasEffect(SCH.Debuffs.Bio1) && level >= 2 && level <= 25) || (bio1Debuff.RemainingTime < 5 && incombat && level >= 2 && level <= 25))
+                    if ((!TargetHasEffect(SCH.Debuffs.Bio1) && level < SCH.Levels.Bio2) || (bio1Debuff.RemainingTime < 5 && incombat && level < SCH.Levels.Bio2))
                         return SCH.Bio1;
                 }
             }
@@ -167,7 +216,7 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if(actionID == SCH.WhisperingDawn || actionID == SCH.FeyBless || actionID == SCH.FeyBless || actionID == SCH.FeyIllumination || actionID == SCH.Dissipation || actionID == SCH.Aetherpact)
+            if(actionID == SCH.WhisperingDawn || actionID == SCH.FeyBlessing || actionID == SCH.FeyBlessing || actionID == SCH.FeyIllumination || actionID == SCH.Dissipation || actionID == SCH.Aetherpact)
             {
                 var gauge = GetJobGauge<SCHGauge>();
                 if (!Service.BuddyList.PetBuddyPresent && gauge.SeraphTimer == 0)
@@ -176,53 +225,50 @@ namespace XIVSlothComboPlugin.Combos
             return actionID;
         }
     }
+
     internal class ScholarDPSFeature : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ScholarDPSFeature;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SCH.Broil4 || actionID == SCH.Broil3 || actionID == SCH.Broil2 || actionID == SCH.Broil1 || actionID == SCH.Ruin1)
+            if (actionID is SCH.Broil4 or SCH.Broil3 or SCH.Broil2 or SCH.Broil1 or SCH.Ruin1)
             {
                 var actionIDCD = GetCooldown(actionID);
                 var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var gauge = GetJobGauge<SCHGauge>();
                 var lucidDreaming = GetCooldown(SCH.LucidDreaming);
-                // biosys
-                var biosys = FindTargetEffect(SCH.Debuffs.Biolysis);
-                // bio 1
+                var biolysis = FindTargetEffect(SCH.Debuffs.Biolysis);
                 var bio1 = FindTargetEffect(SCH.Debuffs.Bio1);
-                // bio 2
                 var bio2 = FindTargetEffect(SCH.Debuffs.Bio2);
-                // buff
                 var chainBuff = GetCooldown(SCH.ChainStratagem);
                 var chainTarget = TargetHasEffect(SCH.Debuffs.ChainStratagem);
+                var canWeave = CanWeave(actionID);
+
                 if (IsEnabled(CustomComboPreset.ScholarLucidDPSFeature))
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= 8000 && actionIDCD.CooldownRemaining > 0.2)
+                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= 8000 && canWeave)
                         return SCH.LucidDreaming;
                 }
-                if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= 72 && incombat)
+                if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= SCH.Levels.Biolysis && incombat)
                 {
-                    if ((biosys is null) || (biosys.RemainingTime <= 3))
+                    if ((biolysis is null) || (biolysis.RemainingTime <= 3))
                         return SCH.Biolysis;
                 }
-                if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= 26 && level <= 71 && incombat)
+                if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= SCH.Levels.Bio2 && level < SCH.Levels.Biolysis && incombat)
                 {
                     if ((bio2 is null) || (bio2.RemainingTime <= 3))
                         return SCH.Bio2;
                 }
-                if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= 4 && level <= 25 && incombat)
+                if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= SCH.Levels.Bio1 && level < SCH.Levels.Bio2 && incombat)
                 {
                     if ((bio1 is null) || (bio1.RemainingTime <= 3))
                         return SCH.Bio1;
                 }
-                if (IsEnabled(CustomComboPreset.ScholarDPSFeatureBuffOption) && level >= 66)
+                if (IsEnabled(CustomComboPreset.ScholarDPSFeatureBuffOption) && level >= SCH.Levels.ChainStratagem)
                 {
                     if (!chainBuff.IsCooldown && !chainTarget && actionIDCD.IsCooldown && incombat)
                         return SCH.ChainStratagem;
                 }
-
 
             }
             return actionID;

--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -7,10 +7,10 @@ namespace XIVSlothComboPlugin.Combos
         public const byte JobID = 40;
 
         public const uint
+
             // Heals and Shields
             Diagnosis = 24284,
             Prognosis = 24286,
-            Egeiro = 24287,
             Physis = 24288,
             Druochole = 24296,
             Kerachole = 24298,
@@ -21,6 +21,7 @@ namespace XIVSlothComboPlugin.Combos
             Haima = 24305,
             Panhaima = 24311,
             Holos = 24310,
+
             // DPS
             Dosis1 = 24283,
             Dosis2 = 24306,
@@ -35,17 +36,21 @@ namespace XIVSlothComboPlugin.Combos
             Dyskrasia2 = 24315,
             Toxikon = 24304,
             Pneuma = 24318,
+
             // Buffs
             Soteria = 24294,
             Zoe = 24300,
             Krasis = 24317,
+
             // Other
-            Swiftcast = 7561,
-            LucidDreaming = 7562,
             Kardia = 24285,
             Eukrasia = 24290,
-            Rhizomata = 24309;
-			
+            Rhizomata = 24309,
+
+            // Role
+            Egeiro = 24287,
+            Swiftcast = 7561,
+            LucidDreaming = 7562;
 
         public static class Buffs
         {
@@ -69,12 +74,14 @@ namespace XIVSlothComboPlugin.Combos
                 Dosis = 1,
                 Prognosis = 10,
                 Phlegma = 26,
+                Eukrasia = 30,
                 Soteria = 35,
                 Druochole = 45,
                 Kerachole = 50,
                 Ixochole = 52,
                 Physis2 = 60,
                 Taurochole = 62,
+                Toxikon = 66,
                 Haima = 70,
                 Phlegma2 = 72,
                 Dosis2 = 72,
@@ -153,7 +160,7 @@ namespace XIVSlothComboPlugin.Combos
                         return OriginalHook(SGE.Toxikon);
                 }
 
-                if (level >= 66)
+                if (level >= SGE.Levels.Toxikon)
                 {
                     if (GetCooldown(SGE.Phlegma2).CooldownRemaining > 45 && GetJobGauge<SGEGauge>().Addersting > 0)
                         return OriginalHook(SGE.Toxikon);
@@ -207,7 +214,7 @@ namespace XIVSlothComboPlugin.Combos
                 var dosis2Debuff = FindTargetEffect(SGE.Debuffs.EukrasianDosis2);
                 var dosis3Debuff = FindTargetEffect(SGE.Debuffs.EukrasianDosis3);
 
-                if (IsEnabled(CustomComboPreset.SageDPSFeature) && level >= 82 && incombat)
+                if (IsEnabled(CustomComboPreset.SageDPSFeature) && level >= SGE.Levels.Dosis3 && incombat)
                 {
                     if (HasEffect(SGE.Buffs.Eukrasia))
                         return SGE.EukrasianDosis3;
@@ -215,7 +222,7 @@ namespace XIVSlothComboPlugin.Combos
                         return SGE.Eukrasia;
                 }
 
-                if (IsEnabled(CustomComboPreset.SageDPSFeature) && level >= 72 && level <= 81 && incombat)
+                if (IsEnabled(CustomComboPreset.SageDPSFeature) && level >= SGE.Levels.Dosis2 && level < SGE.Levels.Dosis3 && incombat)
                 {
                     if (HasEffect(SGE.Buffs.Eukrasia))
                         return SGE.EukrasianDosis2;
@@ -223,7 +230,7 @@ namespace XIVSlothComboPlugin.Combos
                         return SGE.Eukrasia;
                 }
 
-                if (IsEnabled(CustomComboPreset.SageDPSFeature) && level >= 30 && level <= 71 && incombat)
+                if (IsEnabled(CustomComboPreset.SageDPSFeature) && level >= SGE.Levels.Eukrasia && level < SGE.Levels.Dosis2 && incombat)
                 {
                     if (HasEffect(SGE.Buffs.Eukrasia))
                         return SGE.EukrasianDosis1;
@@ -298,7 +305,7 @@ namespace XIVSlothComboPlugin.Combos
                 var PercentageHpValue = Service.Configuration.EnemyHealthPercentage;
                 var CurrentHpValue = Service.Configuration.EnemyCurrentHp;
 
-                if (IsEnabled(CustomComboPreset.SageDPSFeatureTest) && level >= 82 && incombat)
+                if (IsEnabled(CustomComboPreset.SageDPSFeatureTest) && level >= SGE.Levels.Dosis3 && incombat)
                 {
                     if (HasEffect(SGE.Buffs.Eukrasia))
                         return SGE.EukrasianDosis3;
@@ -306,7 +313,7 @@ namespace XIVSlothComboPlugin.Combos
                         return SGE.Eukrasia;
                 }
 
-                if (IsEnabled(CustomComboPreset.SageDPSFeatureTest) && level >= 72 && level <= 81 && incombat)
+                if (IsEnabled(CustomComboPreset.SageDPSFeatureTest) && level >= SGE.Levels.Dosis2 && level < SGE.Levels.Dosis3 && incombat)
                 {
                     if (HasEffect(SGE.Buffs.Eukrasia))
                         return SGE.EukrasianDosis2;
@@ -314,7 +321,7 @@ namespace XIVSlothComboPlugin.Combos
                         return SGE.Eukrasia;
                 }
 
-                if (IsEnabled(CustomComboPreset.SageDPSFeatureTest) && level >= 30 && level <= 71 && incombat)
+                if (IsEnabled(CustomComboPreset.SageDPSFeatureTest) && level >= SGE.Levels.Eukrasia && level < SGE.Levels.Dosis2 && incombat)
                 {
                     if (HasEffect(SGE.Buffs.Eukrasia))
                         return SGE.EukrasianDosis1;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1442,20 +1442,22 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("SCH Raise Alternate Feature", "Changes Resurrection To Swiftcast when Swiftcast is available.", SCH.JobID)]
         SCHAlternateRaiseFeature = 16008,
 
-        [CustomComboInfo("SCH Alternate DPS Feature", "Adds Biolysis on Ruin II. Won't work below level 38", SCH.JobID)]
-        SCHDPSAlternateFeature = 16003,
-
         [CustomComboInfo("Fairy Feature", "Change every action that requires a fairy into Summon Eos if you do not have a fairy summoned.", SCH.JobID)]
         ScholarFairyFeature = 16004,
 
         [CustomComboInfo("DPS Feature", "Adds Bio1/Bio2/Biosys to Broil/Ruin whenever the debuff is not present or about to expire.", SCH.JobID)]
         ScholarDPSFeature = 16005,
 
+        [ParentCombo(ScholarDPSFeature)]
         [CustomComboInfo("DPS Feature Buff Option", "Adds Chainstratagem to the DPS Feature.", SCH.JobID)]
         ScholarDPSFeatureBuffOption = 16006,
 
+        [ParentCombo(ScholarDPSFeature)]
         [CustomComboInfo("DPS Feature Lucid Dreaming Option", "Adds Lucid dreaming to the DPS feature when below 8k mana.", SCH.JobID)]
         ScholarLucidDPSFeature = 16007,
+
+        [CustomComboInfo("SCH Alternate DPS Feature", "Adds Biolysis on Ruin II. Won't work below level 38", SCH.JobID)]
+        SCHDPSAlternateFeature = 16003,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
[SCH]
- Added all skills from Lv20 - 90 to `Levels` class
- Reorganised skill IDs into relevant sections
- Made all level checks use `SCH.Levels` class
- Removed `var gauge = GetJobGauge<SCHGauge>();` from DPS feature (it doesn't read gauge at the moment anyway)
- Replaced some weave-related functions with `canWeave` for better reliability
- Killed all `&& level >= 2` code. Just don't use Sloth at level 1, dingus
- Renamed occurrences of `biosys` and `biolysys` to `biolysis`

- *Reading the word 'biolysis' a thousand times tonight has given me an aneurysm. You're welcome.*

[SGE]
- Added `Eukrasia` and `Toxikon` to skill IDs and `Levels` class
- Made all level checks use `SGE.Levels` class