### PR TITLE
Implementation of Combat Time Duration tracking

### DIFF
--- a/XIVSlothCombo/Combos/MCH.cs
+++ b/XIVSlothCombo/Combos/MCH.cs
@@ -403,9 +403,7 @@ namespace XIVSlothComboPlugin.Combos
                                 return MCH.RookAutoturret;
                             }
                         }
-                        // even bursts ?
-                        else if (gauge.Battery >= 80 && (IsOnCooldown(MCH.Wildfire) || GetCooldown(MCH.Wildfire).CooldownRemaining < 5) && GetCooldown(MCH.AirAnchor).CooldownRemaining < 7 &&
-                            GetCooldown(MCH.Drill).CooldownRemaining < 10 && GetCooldown(MCH.ChainSaw).CooldownRemaining < 17)
+                        else if (gauge.Battery >= 50 && CombatEngageDuration().Seconds >= 55 )
                         {
                             if (level >= MCH.Levels.QueenOverdrive)
                             {
@@ -416,20 +414,6 @@ namespace XIVSlothComboPlugin.Combos
                             {
                                 return MCH.RookAutoturret;
                             }
-                        //odd bursts ?
-                        } else if (gauge.Battery >= 50 && (IsOnCooldown(MCH.Wildfire) || GetCooldown(MCH.Wildfire).CooldownRemaining < 5) &&
-                            GetCooldown(MCH.ChainSaw).CooldownRemaining < 17)
-                        {
-                            if (level >= MCH.Levels.QueenOverdrive)
-                            {
-                                return MCH.AutomatonQueen;
-                            }
-
-                            if (level >= MCH.Levels.RookOverdrive)
-                            {
-                                return MCH.RookAutoturret;
-                            }
-                        //opener
                         } else if (gauge.LastSummonBatteryPower == 0 && gauge.Battery >= 50)
                         {
                             if (level >= MCH.Levels.QueenOverdrive)


### PR DESCRIPTION
- Implemented a way to keep track of combat duration.
    - `CombatEngageDuration()` return a `TimeSpan`
    - Simply call `CombatEngageDuration().Seconds`, `CombatEngageDuration().Minutes` or `CombatEngageDuration().TotalSeconds` , etc,  