### PR TITLE
MCH : Fix for the AOE not calling hypercharge; Changed the Feature na…

### DIFF
--- a/XIVSlothCombo/Combos/MCH.cs
+++ b/XIVSlothCombo/Combos/MCH.cs
@@ -68,6 +68,7 @@ namespace XIVSlothComboPlugin.Combos
                 BioBlaster = 72,
                 ChargedActionMastery = 74,
                 QueenOverdrive = 80,
+                Scattergun = 82,
                 BarrelStabilizer = 66,
                 ChainSaw = 90;
         }
@@ -245,39 +246,44 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID == MCH.SpreadShot || actionID == MCH.Scattergun)
             {
+                var canWeave = CanWeave(actionID);
+
                 var battery = GetJobGauge<MCHGauge>().Battery;
-                if (IsEnabled(CustomComboPreset.MachinistAoEOverChargeOption) && GetCooldown(MCH.CleanShot).CooldownRemaining > 0.7)
+                if (IsEnabled(CustomComboPreset.MachinistAoEOverChargeOption) && canWeave)
                 {
-                    if (battery == 100 && level >= 40 && level <= 79)
-                        return MCH.RookAutoturret;
-                    if (battery == 100 && level >= 80)
+                    if (battery == 100 && level >= MCH.Levels.QueenOverdrive)
                         return MCH.AutomatonQueen;
+                    if (battery == 100 && level >= MCH.Levels.RookOverdrive)
+                        return MCH.RookAutoturret;
                 }
                 var gauge = GetJobGauge<MCHGauge>();
 
-
-                if (IsEnabled(CustomComboPreset.MachinistAoEGaussRicochetFeature) && GetCooldown(MCH.CleanShot).CooldownRemaining > 0.7 && (IsEnabled(CustomComboPreset.MachinistAoEGaussOption) || gauge.IsOverheated))
+                if (IsEnabled(CustomComboPreset.MachinistAoEHyperchargeFeature) && canWeave)
                 {
-                    var gaussCd = GetCooldown(MCH.GaussRound);
-                    var ricochetCd = GetCooldown(MCH.Ricochet);
-
-                    // Prioritize the original if both are off cooldown
-                    if (level <= 49)
-                        return MCH.GaussRound;
-
-                    if (gaussCd.CooldownRemaining < ricochetCd.CooldownRemaining)
-                        return MCH.GaussRound;
-
-                    return MCH.Ricochet;
+                    if (gauge.Heat >= 50 && level >= MCH.Levels.Hypercharge && !gauge.IsOverheated)
+                        return MCH.Hypercharge;
                 }
 
-                var bioblaster = GetCooldown(MCH.BioBlaster);
-                if (!bioblaster.IsCooldown && level >= 72 && !gauge.IsOverheated && IsEnabled(CustomComboPreset.MachinistBioblasterFeature))
-                    return MCH.BioBlaster;
-                if (!gauge.IsOverheated && level >= 82)
-                    return MCH.Scattergun;
+                if (IsEnabled(CustomComboPreset.MachinistAoEGaussRicochetFeature) && canWeave && (IsEnabled(CustomComboPreset.MachinistAoEGaussOption) || gauge.IsOverheated))
+                {
+                    var gaussCharges = GetRemainingCharges(MCH.GaussRound);
+                    var ricochetCharges = GetRemainingCharges(MCH.Ricochet);
+
+                    if ((gaussCharges >= ricochetCharges || level < MCH.Levels.Ricochet) &&
+                        level >= MCH.Levels.GaussRound)
+                        return MCH.GaussRound;
+                    else if (ricochetCharges > 0 && level >= MCH.Levels.Ricochet)
+                        return MCH.Ricochet;
+
+                }
+
                 if (gauge.IsOverheated && level >= MCH.Levels.AutoCrossbow)
                     return MCH.AutoCrossbow;
+
+                var bioblaster = GetCooldown(MCH.BioBlaster);
+                if (!bioblaster.IsCooldown && level >= MCH.Levels.BioBlaster && !gauge.IsOverheated && IsEnabled(CustomComboPreset.MachinistBioblasterFeature))
+                    return MCH.BioBlaster;
+
 
 
             }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -732,9 +732,6 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("(Heated) Shot Combo", "Replace either form of Clean Shot with its combo chain.", MCH.JobID)]
         MachinistMainCombo = 8000,
 
-        [CustomComboInfo("Spread Shot/Scattergun Heat, +BioBlaster", "Spread Shot turns into Scattergun when lvl 82 or higher, Both turn into Auto Crossbow when overheated\nand Bioblaster is used first whenever it is off cooldown.", MCH.JobID)]
-        MachinistSpreadShotFeature = 8001,
-
         [CustomComboInfo("Overdrive Feature", "Replace Rook Autoturret and Automaton Queen with Overdrive while active.", MCH.JobID)]
         MachinistOverdriveFeature = 8002,
 
@@ -776,7 +773,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Gauss Round Ricochet on AOE Feature", "Adds Gauss Round/Ricochet to the AoE combo during Hypercharge.", MCH.JobID)]
         MachinistAoEGaussRicochetFeature = 8011,
 
-        [ParentCombo(MachinistSpreadShotFeature)]
+        [ParentCombo(MachinistAoEGaussRicochetFeature)]
         [CustomComboInfo("Always Gauss Round/Ricochet on AoE Option", "Adds Gauss Round/Ricochet to the AoE combo outside of Hypercharge windows.", MCH.JobID)]
         MachinistAoEGaussOption = 8012,
 
@@ -832,6 +829,13 @@ namespace XIVSlothComboPlugin
         [ParentCombo(MachinistSimpleFeature)]
         [CustomComboInfo("Simple Stabilizer", "Adds Barrel Stabilizer to the feature.\n When heat < 50 and Wildfire is off CD or about to come off CD.", MCH.JobID)]
         MachinistSimpleStabilizer = 8026,
+
+        [ParentCombo(MachinistSpreadShotFeature)]
+        [CustomComboInfo("Hypercharge", "Adds hypercharge to the AoE.", MCH.JobID)]
+        MachinistAoEHyperchargeFeature = 8027,
+
+        [CustomComboInfo("Simple Machinist AOE", "Spread Shot turns into Scattergun when lvl 82 or higher, Both turn into Auto Crossbow when overheated\nand Bioblaster is used first whenever it is off cooldown.", MCH.JobID)]
+        MachinistSpreadShotFeature = 8028,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
- Use of Hypercharge on AOE;
- Changed the feature name to `Machinist Simple AOE` from `Scattershot/Spread shot , + Bioblaster`