### PR TITLE
NIN bug fixes plus hide conflicted combos button

### DIFF
--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -236,12 +236,12 @@ namespace XIVSlothComboPlugin.Combos
                     return NIN.Huraijin;
 
 
-                if ((!GetCooldown(NIN.TrickAttack).IsCooldown || GetCooldown(NIN.TrickAttack).CooldownRemaining <= trickCDThreshold) && level >= 45 && IsEnabled(CustomComboPreset.NinSimpleTrickFeature))
+                if ((!GetCooldown(NIN.TrickAttack).IsCooldown || GetCooldown(NIN.TrickAttack).CooldownRemaining <= trickCDThreshold) && (!HasEffect(NIN.Buffs.Kassatsu) || (HasEffect(NIN.Buffs.Kassatsu) && IsEnabled(CustomComboPreset.NinSimpleTrickKassatsuFeature))) && level >= 45 && IsEnabled(CustomComboPreset.NinSimpleTrickFeature))
                 {
                     if (HasEffect(NIN.Buffs.Suiton) && !GetCooldown(NIN.TrickAttack).IsCooldown)
                         return NIN.TrickAttack;
 
-                    if (!HasEffect(NIN.Buffs.Mudra) && !HasEffect(NIN.Buffs.Suiton) && GetCooldown(NIN.Chi).RemainingCharges > 0)
+                    if (!HasEffect(NIN.Buffs.Mudra) && !HasEffect(NIN.Buffs.Suiton) && (GetCooldown(NIN.Chi).RemainingCharges > 0 || (HasEffect(NIN.Buffs.Kassatsu) && IsEnabled(CustomComboPreset.NinSimpleTrickKassatsuFeature))))
                         return OriginalHook(NIN.Chi);
 
                     if (level >= NIN.Levels.Ten && !HasEffect(NIN.Buffs.Suiton) &&  OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
@@ -420,7 +420,7 @@ namespace XIVSlothComboPlugin.Combos
                         return NIN.Bunshin;
                     if (HasEffect(NIN.Buffs.PhantomReady) && level >= 82)
                         return NIN.PhantomKamaitachi;
-                    if (gauge.Ninki >= 50 && actionIDCD.IsCooldown)
+                    if (gauge.Ninki >= 50 && actionIDCD.IsCooldown && IsEnabled(CustomComboPreset.NinSimpleHellfrogFeature))
                         return NIN.Hellfrog;
 
                     if (comboTime > 0f && lastComboMove == NIN.DeathBlossom && level >= 52)

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -90,8 +90,11 @@ namespace XIVSlothComboPlugin
         {
             ImGui.Text("This window allows you to enable and disable custom combos to your liking.");
 
-            ImGui.SameLine();
-            ImGui.TextColored(ImGuiColors.DalamudRed, $" Notice! All Settings Have Been Reset!");
+
+
+            //Settings were reset many, many versions ago. This message is no longer relevant?
+            //ImGui.SameLine();
+            //ImGui.TextColored(ImGuiColors.DalamudRed, $" Notice! All Settings Have Been Reset!");
 
             var isAprilFools = DateTime.Now.Day == 1 && DateTime.Now.Month == 4 ? true : false;
 
@@ -117,6 +120,26 @@ namespace XIVSlothComboPlugin
                 Service.Configuration.HideChildren = hideChildren;
                 Service.Configuration.Save();
             }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.TextUnformatted("Hides all options a combo might have until you enable it.");
+                ImGui.EndTooltip();
+            }
+
+            var hideConflicting = Service.Configuration.HideConflictedCombos;
+            if (ImGui.Checkbox("Hide Conflicted Combos", ref hideConflicting))
+            {
+                Service.Configuration.HideConflictedCombos = hideConflicting;
+                Service.Configuration.Save();
+            }
+
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.TextUnformatted("Hides any combos that conflict with anything you have selected.");
+                ImGui.EndTooltip();
+            }
 
             var slothIrl = isAprilFools ? Service.Configuration.AprilFoolsSlothIrl : false;
             if (isAprilFools)
@@ -134,6 +157,9 @@ namespace XIVSlothComboPlugin
                 Service.Configuration.Save();
             }
 
+
+
+
             ImGui.BeginChild("scrolling", new Vector2(0, -1), true);
 
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0, 5));
@@ -147,7 +173,35 @@ namespace XIVSlothComboPlugin
                 {
                     foreach (var (preset, info) in this.groupedPresets[jobName])
                     {
-                        this.DrawPreset(preset, info, ref i);
+                        if (Service.Configuration.HideConflictedCombos)
+                        {
+                            //Presets that are contained within a ConflictedAttribute
+                            var conflictOriginals = Service.Configuration.GetConflicts(preset);
+
+                            //Presets with the ConflictedAttribute
+                            var conflictsSource = Service.Configuration.GetAllConflicts();
+
+                            if (conflictsSource.Where(x => x == preset).Count() == 0 || conflictOriginals.Length == 0)
+                            {
+                                this.DrawPreset(preset, info, ref i);
+                                continue;
+                            }
+                            if (conflictOriginals.Any(x => Service.Configuration.IsEnabled(x)))
+                            {
+                                Service.Configuration.EnabledActions.Remove(preset);
+                                Service.Configuration.Save();
+                            }
+                            else
+                            {
+                                this.DrawPreset(preset, info, ref i);
+                                continue;
+                            }
+
+                        }
+                        else
+                        {
+                            this.DrawPreset(preset, info, ref i);
+                        }
                     }
                 }
                 else
@@ -171,7 +225,6 @@ namespace XIVSlothComboPlugin
             var conflicts = Service.Configuration.GetConflicts(preset);
             var parent = Service.Configuration.GetParent(preset);
             var irlsloth = Service.Configuration.AprilFoolsSlothIrl;
-
 
             if (secret && !showSecrets)
                 return;
@@ -219,6 +272,7 @@ namespace XIVSlothComboPlugin
 
                     Service.Configuration.Save();
                 }
+
             }
 
 
@@ -267,7 +321,7 @@ namespace XIVSlothComboPlugin
 
 
                     var conflictInfo = conflict.GetAttribute<CustomComboInfoAttribute>();
-                    if (irlsloth) 
+                    if (irlsloth)
                     {
                         //kek
                         return $"\n - {conflictInfo.MemeName}";
@@ -434,7 +488,7 @@ namespace XIVSlothComboPlugin
             }
             if (preset == CustomComboPreset.NinSimpleTrickFeature && enabled)
             {
-                ConfigWindowFunctions.DrawSliderInt(2, 15, NIN.Config.TrickCooldownRemaining, "Set the amount of time in seconds for the feature to try and set up \nSuiton in advance of Trick Attack coming off cooldown");
+                ConfigWindowFunctions.DrawSliderInt(0, 15, NIN.Config.TrickCooldownRemaining, "Set the amount of time in seconds for the feature to try and set up \nSuiton in advance of Trick Attack coming off cooldown");
             }
             if (preset == CustomComboPreset.NinjaHuraijinFeature && enabled)
             {
@@ -464,6 +518,7 @@ namespace XIVSlothComboPlugin
                     ImGui.Unindent();
                 }
             }
+
 
         }
 

--- a/XIVSlothCombo/ConfigWindowFunctions.cs
+++ b/XIVSlothCombo/ConfigWindowFunctions.cs
@@ -14,7 +14,7 @@ namespace XIVSlothComboPlugin.ConfigFunctions
     {
         public static void DrawSliderInt(int minValue, int maxValue, string config, string sliderDescription, float itemWidth = 150)
         {
-            var output = Service.Configuration.GetCustomIntValue(config);
+            var output = Service.Configuration.GetCustomIntValue(config, minValue);
             var inputChanged = false;
             ImGui.PushItemWidth(itemWidth);
             inputChanged |= ImGui.SliderInt(sliderDescription, ref output, minValue, maxValue);
@@ -30,7 +30,7 @@ namespace XIVSlothComboPlugin.ConfigFunctions
 
         public static void DrawSliderFloat(float minValue, float maxValue, string config, string sliderDescription, float itemWidth = 150)
         {
-            var output = Service.Configuration.GetCustomConfigValue(config);
+            var output = Service.Configuration.GetCustomConfigValue(config, minValue);
             var inputChanged = false;
             ImGui.PushItemWidth(itemWidth);
             inputChanged |= ImGui.SliderFloat(sliderDescription, ref output, minValue, maxValue);

--- a/XIVSlothCombo/PluginConfiguration.cs
+++ b/XIVSlothCombo/PluginConfiguration.cs
@@ -61,6 +61,11 @@ namespace XIVSlothComboPlugin
         public bool EnableSecretCombos { get; set; } = false;
 
         /// <summary>
+        /// Gets or sets a value indicating whether to hide combos which conflict with enabled presets.
+        /// </summary>
+        public bool HideConflictedCombos { get; set; } = false;
+
+        /// <summary>
         /// Gets or sets a value indicating whether to hide the children of a feature if it is disabled.
         /// </summary>
         public bool HideChildren { get; set; } = false;
@@ -113,6 +118,19 @@ namespace XIVSlothComboPlugin
         /// <returns>The parent preset.</returns>
         public CustomComboPreset? GetParent(CustomComboPreset preset)
             => ParentCombos[preset];
+
+        /// <summary>
+        /// Gets the full list of conflicted combos
+        /// </summary>
+        public List<CustomComboPreset> GetAllConflicts()
+            => ConflictingCombos.Keys.ToList();
+
+        /// <summary>
+        /// Get all the info from conflicted combos
+        /// </summary>
+        public List<CustomComboPreset[]> GetAllConflictOriginals()
+            => ConflictingCombos.Values.ToList();
+
         public float EnemyHealthPercentage { get; set; } = 0;
 
         public float EnemyHealthMaxHp { get; set; } = 0;
@@ -138,11 +156,11 @@ namespace XIVSlothComboPlugin
         [JsonProperty]
         private static Dictionary<string, bool> CustomBoolValues { get; set; } = new Dictionary<string, bool>();
 
-        public float GetCustomConfigValue(string config)
+        public float GetCustomConfigValue(string config, float defaultMinValue = 0)
         {
             float configValue;
 
-            if (!CustomConfigValues.TryGetValue(config, out configValue)) return 0;
+            if (!CustomConfigValues.TryGetValue(config, out configValue)) return defaultMinValue;
 
             return configValue;
         }
@@ -152,11 +170,11 @@ namespace XIVSlothComboPlugin
             CustomConfigValues[config] = value;
         }
 
-        public int GetCustomIntValue(string config)
+        public int GetCustomIntValue(string config, int defaultMinVal = 0)
         {
             int configValue;
 
-            if (!CustomIntValues.TryGetValue(config, out configValue)) return 0;
+            if (!CustomIntValues.TryGetValue(config, out configValue)) return defaultMinVal;
 
             return configValue;
         }


### PR DESCRIPTION
Fixes NIN simple single target kassatsu buff messing up trick window. Made it optional.