### PR TITLE
[DRK] Blood Gauge Overcap Feature [PLD] Interrupt/Low blow/Shield Bash onto one button

### DIFF
--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -136,9 +136,10 @@ namespace XIVSlothComboPlugin.Combos
                     return DRK.LivingShadow;
                 }
 
-                if (lastComboMove == DRK.Souleater && level >= DRK.Levels.Bloodpiller && bloodgauge >= 80)
+                if (IsEnabled(CustomComboPreset.DarkBloodGaugeOvercapFeature) && level >= 62)
                 {
-                    return DRK.Bloodspiller;
+                    if (lastComboMove == DRK.Souleater && level >= DRK.Levels.Bloodpiller && bloodgauge >= 80)
+                        return DRK.Bloodspiller;
                 }
                 if (IsEnabled(CustomComboPreset.DarkPlungeFeature) && level >= 54)
                 {

--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -45,7 +45,9 @@ namespace XIVSlothComboPlugin.Combos
         public static class Levels
         {
             public const byte
+                HardSlash = 1,
                 SyphonStrike = 2,
+                Unleash = 6,
                 Souleater = 26,
                 FloodOfDarkness = 30,
                 EdgeOfDarkness = 40,
@@ -58,8 +60,11 @@ namespace XIVSlothComboPlugin.Combos
                 StalwartSoul = 72,
                 Shadow = 74,
                 EdgeOfShadow = 74,
+                LivingShadow = 80,
                 SaltAndDarkness = 86,
-                Shadowbringer = 90;
+                Shadowbringer = 90,
+                Plunge = 54,
+                Unmend = 15;
         }
     }
 
@@ -86,7 +91,7 @@ namespace XIVSlothComboPlugin.Combos
                 var livingshadowCD = GetCooldown(DRK.LivingShadow);
                 var saltedCD = GetCooldown(DRK.SaltedEarth);
                 var carveCD = GetCooldown(DRK.CarveAndSpit);
-                if (IsEnabled(CustomComboPreset.DarkRangedUptimeFeature) && level >= 15)
+                if (IsEnabled(CustomComboPreset.DarkRangedUptimeFeature) && level >= DRK.Levels.Unmend)
                 {
                     if (!InMeleeRange(true))
                         return DRK.Unmend;
@@ -121,33 +126,33 @@ namespace XIVSlothComboPlugin.Combos
                     if (lastComboMove == DRK.SyphonStrike && level >= DRK.Levels.Souleater)
                         return DRK.Souleater;
                 }
-                if (bloodgauge >= 50 && !shadowCooldown.IsCooldown && (double)gcdCooldown1.CooldownRemaining > 0.8 && level >= 80 && IsEnabled(CustomComboPreset.DRKLivingShadowFeature))
+                if (bloodgauge >= 50 && !shadowCooldown.IsCooldown && (double)gcdCooldown1.CooldownRemaining > 0.8 && level >= DRK.Levels.LivingShadow && IsEnabled(CustomComboPreset.DRKLivingShadowFeature))
                 {
                     return DRK.LivingShadow;
                 }
 
-                if (bloodgauge >= 50 && !shadowCooldown.IsCooldown && (double)gcdCooldown2.CooldownRemaining > 0.8 && level >= 80 && IsEnabled(CustomComboPreset.DRKLivingShadowFeature))
+                if (bloodgauge >= 50 && !shadowCooldown.IsCooldown && (double)gcdCooldown2.CooldownRemaining > 0.8 && level >= DRK.Levels.LivingShadow && IsEnabled(CustomComboPreset.DRKLivingShadowFeature))
                 {
                     return DRK.LivingShadow;
                 }
 
-                if (bloodgauge >= 50 && !shadowCooldown.IsCooldown && (double)gcdCooldown3.CooldownRemaining > 0.8 && level >= 80 && IsEnabled(CustomComboPreset.DRKLivingShadowFeature))
+                if (bloodgauge >= 50 && !shadowCooldown.IsCooldown && (double)gcdCooldown3.CooldownRemaining > 0.8 && level >= DRK.Levels.LivingShadow && IsEnabled(CustomComboPreset.DRKLivingShadowFeature))
                 {
                     return DRK.LivingShadow;
                 }
 
-                if (IsEnabled(CustomComboPreset.DarkBloodGaugeOvercapFeature) && level >= 62)
+                if (IsEnabled(CustomComboPreset.DarkBloodGaugeOvercapFeature) && level >= DRK.Levels.Bloodpiller)
                 {
                     if (lastComboMove == DRK.Souleater && level >= DRK.Levels.Bloodpiller && bloodgauge >= 80)
                         return DRK.Bloodspiller;
                 }
-                if (IsEnabled(CustomComboPreset.DarkPlungeFeature) && level >= 54)
+                if (IsEnabled(CustomComboPreset.DarkPlungeFeature) && level >= DRK.Levels.Plunge)
                 {
                     if (plungeCD.CooldownRemaining < 30 && actionIDCD.CooldownRemaining > 0.7)
                         return DRK.Plunge;
                 }
                 // leaves 1 stack
-                if (IsEnabled(CustomComboPreset.DarkPlungeFeatureOption) && level >= 54)
+                if (IsEnabled(CustomComboPreset.DarkPlungeFeatureOption) && level >= DRK.Levels.Plunge)
                 {
                     if (!plungeCD.IsCooldown && actionIDCD.CooldownRemaining > 0.7 && plungeCD.CooldownRemaining < 60)
                         return DRK.Plunge;
@@ -176,17 +181,17 @@ namespace XIVSlothComboPlugin.Combos
                     if (LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10)
                     {
                         var gcd = GetCooldown(actionID);
-                        if (level >= 30 && gcd.IsCooldown)
+                        if (level >= DRK.Levels.FloodOfDarkness && gcd.IsCooldown)
                             return OriginalHook(DRK.FloodOfDarkness);
 
                     }
                 }
-                if (IsEnabled(CustomComboPreset.DRKStalwartabyssalDrainFeature) && level >= 56)
+                if (IsEnabled(CustomComboPreset.DRKStalwartabyssalDrainFeature) && level >= DRK.Levels.AbyssalDrain)
                 {
                     if (actionIDCD.IsCooldown && IsOffCooldown(DRK.AbyssalDrain) && PlayerHealthPercentageHp() <= 60)
                         return DRK.AbyssalDrain;
                 }
-                if (IsEnabled(CustomComboPreset.DRKStalwartShadowbringerFeature) && level >= 90)
+                if (IsEnabled(CustomComboPreset.DRKStalwartShadowbringerFeature) && level >= DRK.Levels.Shadowbringer)
                 {
                     if (actionIDCD.IsCooldown && GetRemainingCharges(DRK.Shadowbringer) > 0 && gauge.DarksideTimeRemaining > 0)
                         return DRK.Shadowbringer;
@@ -230,7 +235,7 @@ namespace XIVSlothComboPlugin.Combos
                 var saltedCD = GetCooldown(DRK.SaltedEarth);
                 var actionIDCD = GetCooldown(actionID);
 
-                if (gauge.Blood >= 50 && !livingshadowCD.IsCooldown && level >= 80)
+                if (gauge.Blood >= 50 && !livingshadowCD.IsCooldown && level >= DRK.Levels.LivingShadow)
                     return DRK.LivingShadow;
                 if (!saltedCD.IsCooldown && level >= DRK.Levels.SaltedEarth)
                     return DRK.SaltedEarth;

--- a/XIVSlothCombo/Combos/PLD.cs
+++ b/XIVSlothCombo/Combos/PLD.cs
@@ -447,6 +447,11 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var interjectCD = GetCooldown(PLD.Interject);
                 var lowBlowCD = GetCooldown(PLD.LowBlow);
+                if (IsEnabled(CustomComboPreset.PaladinShieldBashOption))
+                {
+                    if (CanInterruptEnemy() && interjectCD.IsCooldown && lowBlowCD.IsCooldown)
+                        return PLD.ShieldBash;
+                }
                 if (CanInterruptEnemy() && !interjectCD.IsCooldown)
                     return PLD.Interject;
             }

--- a/XIVSlothCombo/Combos/PLD.cs
+++ b/XIVSlothCombo/Combos/PLD.cs
@@ -443,17 +443,14 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == PLD.LowBlow)
+            if (actionID == PLD.ShieldBash)
             {
                 var interjectCD = GetCooldown(PLD.Interject);
                 var lowBlowCD = GetCooldown(PLD.LowBlow);
-                if (IsEnabled(CustomComboPreset.PaladinShieldBashOption))
-                {
-                    if (CanInterruptEnemy() && interjectCD.IsCooldown && lowBlowCD.IsCooldown)
-                        return PLD.ShieldBash;
-                }
                 if (CanInterruptEnemy() && !interjectCD.IsCooldown)
                     return PLD.Interject;
+                if (!lowBlowCD.IsCooldown)
+                    return PLD.LowBlow;
             }
 
             return actionID;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -626,6 +626,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("FoS Overcap Feature", "Uses FoS if you are above 8.5k mana or Darkside is about to expire (10sec or less)", DRK.JobID, 0, "Something about mana", "You're basically a black mage! Well done!")]
         DarkManaOvercapAoEFeature = 5015,
 
+        [ParentCombo(DarkSouleaterCombo)]
+        [CustomComboInfo("Blood Gauge Overcap Feature", "Adds Bloodspiller onto main combo when at 80 blood gauge or higher", DRK.JobID, 0, "", "Take the plunge. Or, just dip your toes in. Whatever.")]
+        DarkBloodGaugeOvercapFeature = 5016,
         #endregion
         // ====================================================================================
         #region DRAGOON

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1117,12 +1117,8 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Atonement Drop Feature (Custom Value Test)", "Drops Atonement to prevent Potency loss when FoF is about to expire.", PLD.JobID, 0, "", "Clumsy-ass dropped the Atonement again")]
         SkillCooldownRemaining = 11018,
 
-        [CustomComboInfo("Interrupt Feature", "Replaces Low Blow with Interject when target can be interrupted .", PLD.JobID, 0, "Lower blow", "Blow, but low.")]
+        [CustomComboInfo("Interrupt Feature", "Replaces Shield Bash with Interject when target can be interrupted or Low Blow if it's off cooldown. .", PLD.JobID, 0, "Lower blow", "Blow, but low.")]
         PaladinInterruptFeature = 11019,
-
-        [ParentCombo(PaladinInterruptFeature)]
-        [CustomComboInfo("Shield Bash option", "If target is interruptable, will use Interject, Low Blow, Shield Bash in that order", PLD.JobID, 0, "", "Clumsy-ass dropped the Atonement again")]
-        PaladinShieldBashOption = 11020,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1120,6 +1120,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Interrupt Feature", "Replaces Low Blow with Interject when target can be interrupted .", PLD.JobID, 0, "Lower blow", "Blow, but low.")]
         PaladinInterruptFeature = 11019,
 
+        [ParentCombo(PaladinInterruptFeature)]
+        [CustomComboInfo("Shield Bash option", "If target is interruptable, will use Interject, Low Blow, Shield Bash in that order", PLD.JobID, 0, "", "Clumsy-ass dropped the Atonement again")]
+        PaladinShieldBashOption = 11020,
+
         #endregion
         // ====================================================================================
         #region REAPER


### PR DESCRIPTION
Makes Blood Gauge Overcap Feature a toggle option instead of on by default. Someone mentioned this yesterday on Discord so I figured it'd be a nice way to test if I could figure out how to add options.

Also changed hardcoded DRK levels

#355 PLD suggestion added as well: Changed Low blow to Shield bash, made it so Interject is used first if enemy is interruptable, Low Blow if it's off cooldown, and otherwise Shield Bash if both don't apply.