### PR TITLE
GNB and WAR Refactoring and fixes

### DIFF
--- a/XIVSlothCombo/Combos/ALL.cs
+++ b/XIVSlothCombo/Combos/ALL.cs
@@ -9,6 +9,7 @@
             Resurrection = 173,
             Verraise = 7523,
             Raise = 125,
+            Reprisal = 7535,
             Ascend = 3603,
             Egeiro = 24287,
             SolidReason = 232,
@@ -26,7 +27,8 @@
 
         public static class Debuffs
         {
-            // public const short placeholder = 0;
+            public const ushort
+                Reprisal = 1193;
         }
 
         public static class Levels
@@ -69,6 +71,22 @@
                         || (level <= RDM.Levels.Verraise && actionID == RDM.Verraise))
                         return All.Swiftcast;
                 }
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class AllTankReprisalFeature : CustomCombo
+    {
+        protected override CustomComboPreset Preset => CustomComboPreset.AllTankReprisalFeature;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == All.Reprisal)
+            {
+                if (TargetHasEffectAny(All.Debuffs.Reprisal))
+                    return WHM.Stone1;
             }
 
             return actionID;

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -162,8 +162,8 @@ namespace XIVSlothComboPlugin.Combos
                     if (CanWeave(actionID) && level >= GNB.Levels.RoughDivide)
                     {
                         
-                        if (IsEnabled(CustomComboPreset.GunbreakerRoughDivide2StackOption) && GetRemainingCharges(GNB.RoughDivide) is 1 or 2 || // uses all stacks
-                            IsEnabled(CustomComboPreset.GunbreakerRoughDivide1StackOption) && GetRemainingCharges(GNB.RoughDivide) == 2) // leaves 1 stack
+                        if (IsEnabled(CustomComboPreset.GunbreakerRoughDivide2StackOption) && GetRemainingCharges(GNB.RoughDivide) > 0 || // uses all stacks
+                            IsEnabled(CustomComboPreset.GunbreakerRoughDivide1StackOption) && GetRemainingCharges(GNB.RoughDivide) > 1) // leaves 1 stack
                             return GNB.RoughDivide;
                     }
 

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -65,6 +65,7 @@ namespace XIVSlothComboPlugin.Combos
                 BurstStrike = 30,
                 DemonSlaughter = 40,
                 SonicBreak = 54,
+                RoughDivide = 56,
                 GnashingFang = 60,
                 BowShock = 62,
                 Continuation = 70,
@@ -158,16 +159,11 @@ namespace XIVSlothComboPlugin.Combos
                             return GNB.Hypervelocity;
                     }
 
-                    // uses all stacks
-                    if (IsEnabled(CustomComboPreset.GunbreakerRoughDivide2StackOption) && level >= 56)
+                    if (CanWeave(actionID) && level >= GNB.Levels.RoughDivide)
                     {
-                        if (GetRemainingCharges(GNB.RoughDivide) is 1 or 2 && CanWeave(actionID))
-                            return GNB.RoughDivide;
-                    }
-                    // leaves 1 stack
-                    if (IsEnabled(CustomComboPreset.GunbreakerRoughDivide1StackOption) && level >= 56)
-                    {
-                        if (GetRemainingCharges(GNB.RoughDivide) == 1 && CanWeave(actionID))
+                        
+                        if (IsEnabled(CustomComboPreset.GunbreakerRoughDivide2StackOption) && GetRemainingCharges(GNB.RoughDivide) is 1 or 2 || // uses all stacks
+                            IsEnabled(CustomComboPreset.GunbreakerRoughDivide1StackOption) && GetRemainingCharges(GNB.RoughDivide) == 2) // leaves 1 stack
                             return GNB.RoughDivide;
                     }
 
@@ -309,11 +305,8 @@ namespace XIVSlothComboPlugin.Combos
 
                     if(IsEnabled(CustomComboPreset.GunbreakerBowShockFeature) && level >= GNB.Levels.BowShock)
                     {
-                        var bowShockCD = GetCooldown(GNB.BowShock);
-                        if (!bowShockCD.IsCooldown)
-                        {
+                        if (IsOffCooldown(GNB.BowShock))
                             return GNB.BowShock;
-                        }
                     }
 
                     return GNB.DemonSlaughter;
@@ -425,7 +418,6 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID == GNB.LowBlow)
             {
                 var interjectCD = GetCooldown(GNB.Interject);
-                var lowBlowCD = GetCooldown(GNB.LowBlow);
                 if (CanInterruptEnemy() && !interjectCD.IsCooldown)
                     return GNB.Interject;
             }

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -112,7 +112,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
                 }
 
-                if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && (HasEffect(WAR.Buffs.InnerRelease) || HasEffect(WAR.Buffs.Berserk)) && level >= WAR.Levels.InnerBeast && HasEffect(WAR.Buffs.SurgingTempest)) ||
+                if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.InnerBeast && HasEffect(WAR.Buffs.SurgingTempest)) ||
                     (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.InnerChaos) ||
                     (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.InnerBeast))
                         return OriginalHook(WAR.InnerBeast);
@@ -187,7 +187,7 @@ namespace XIVSlothComboPlugin.Combos
                             return OriginalHook(WAR.PrimalRend);
                     }
 
-                    if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && (HasEffect(WAR.Buffs.InnerRelease) || HasEffect(WAR.Buffs.Berserk)) && level >= WAR.Levels.SteelCyclone && HasEffect(WAR.Buffs.SurgingTempest)) ||
+                    if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.SteelCyclone && HasEffect(WAR.Buffs.SurgingTempest)) ||
                         (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.SteelCyclone) ||
                         (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.ChaoticCyclone))
                             return OriginalHook(WAR.SteelCyclone);

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -105,9 +105,9 @@ namespace XIVSlothComboPlugin.Combos
                         if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(WAR.Upheaval) && level >= WAR.Levels.Upheaval)
                             return WAR.Upheaval;
                         if (level >= WAR.Levels.Onslaught &&
-                            ((IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && GetRemainingCharges(WAR.Onslaught) is 1 or 2 or 3) || //uses all stacks
-                            (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOptionTwo) && GetRemainingCharges(WAR.Onslaught) == 3 && level >= 88) || // leaves 2 stacks
-                            (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOption) && ((GetRemainingCharges(WAR.Onslaught) is 2 or 3 && level >= 88) || (GetRemainingCharges(WAR.Onslaught) == 2 && level < 88))))) // leaves 1 stack
+                            ((IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && GetRemainingCharges(WAR.Onslaught) > 0) || //uses all stacks
+                            (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOptionTwo) && GetRemainingCharges(WAR.Onslaught) > 2 && level >= 88) || // leaves 2 stacks
+                            (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOption) && GetRemainingCharges(WAR.Onslaught) > 1))) // leaves 1 stack
                                 return WAR.Onslaught;
                     }
                 }

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -51,11 +51,15 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const byte
                 Maim = 4,
+                Tomahawk = 15,
                 StormsPath = 26,
+                InnerBeast = 35,
                 MythrilTempest = 40,
                 StormsEye = 50,
                 FellCleave = 54,
                 Decimate = 60,
+                Onslaught = 62,
+                Upheaval = 64,
                 MythrilTempestTrait = 74,
                 NascentFlash = 76,
                 InnerChaos = 80,
@@ -72,101 +76,52 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (IsEnabled(CustomComboPreset.WarriorStormsPathCombo) && actionID == WAR.StormsPath)
             {
-                var heavyswingCD = GetCooldown(WAR.HeavySwing);
-                var upheavalCD = GetCooldown(WAR.Upheaval);
-                var innerreleaseCD = GetCooldown(WAR.InnerRelease);
-                var beserkCD = GetCooldown(WAR.Berserk);
                 var stormseyeBuff = FindEffectAny(WAR.Buffs.SurgingTempest);
-                var innerReleaseBuff = HasEffect(WAR.Buffs.InnerRelease);
-                var onslaughtCD = GetCooldown(WAR.Onslaught);
-                var actionIDCD = GetCooldown(actionID);
-                var surgingtempestBuff = HasEffect(WAR.Buffs.SurgingTempest);
                 var gauge = GetJobGauge<WARGauge>().BeastGauge;
 
-                if (IsEnabled(CustomComboPreset.WARRangedUptimeFeature) && level >= 15)
+                if (IsEnabled(CustomComboPreset.WARRangedUptimeFeature) && level >= WAR.Levels.Tomahawk)
                 {
                     if (!InMeleeRange(true))
                         return WAR.Tomahawk;
                 }
-                if (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && HasEffect(WAR.Buffs.SurgingTempest) && gauge >= 50 && level >= 80)
-                    return WAR.InnerChaos;
 
-                if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && !upheavalCD.IsCooldown && heavyswingCD.CooldownRemaining > 0.7 && HasEffect(WAR.Buffs.SurgingTempest) && beserkCD.IsCooldown && level >= 64 && level <= 69)
-                    return WAR.Upheaval;
-                else
-                if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && !upheavalCD.IsCooldown && heavyswingCD.CooldownRemaining > 0.7 && HasEffect(WAR.Buffs.SurgingTempest) && level >= 70)
-                    return WAR.Upheaval;
-
-                if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady))
+                if (HasEffect(WAR.Buffs.SurgingTempest))
                 {
-                    return WAR.PrimalRend;
-                }
-
-                if (IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease))
-                {
-                    return WAR.FellCleave;
-                }
-                // uses all stacks
-                if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && level >= 62)
-                {
-                    if (onslaughtCD.CooldownRemaining < 60 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff)
-                        return WAR.Onslaught;
-                }
-                // leaves 1 stack
-                if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOption) && level >= 62)
-                {
-                    if (onslaughtCD.CooldownRemaining < 30 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff)
-                        return WAR.Onslaught;
-                }
-                // leaves 2 stacks
-                if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOptionTwo) && level >= 64)
-                {
-                    if (level >= 88)
+                    if (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && gauge >= 50 && level >= WAR.Levels.InnerChaos)
+                        return WAR.InnerChaos;
+                    if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady))
+                        return WAR.PrimalRend;
+                    if (IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease))
+                        return WAR.FellCleave;
+                    if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.InnerBeast)
+                        return OriginalHook(WAR.InnerBeast);
+                    if (CanWeave(actionID))
                     {
-                        if (onslaughtCD.CooldownRemaining < 1 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff && level >= 88)
-                            return WAR.Onslaught;
+                        if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(WAR.Upheaval) && level >= WAR.Levels.Upheaval)
+                            return WAR.Upheaval;
+
+                        if (level >= WAR.Levels.Onslaught &&
+                            ((IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && GetRemainingCharges(WAR.Onslaught) is 1 or 2 or 3) || //uses all stacks
+                            (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOptionTwo) && GetRemainingCharges(WAR.Onslaught) == 3 && level >= 88) || // leaves 2 stacks
+                            (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOption) && ((GetRemainingCharges(WAR.Onslaught) is 2 or 3 && level >= 88) || (GetRemainingCharges(WAR.Onslaught) == 2 && level < 88))))) // leaves 1 stack
+                                return WAR.Onslaught;
                     }
-                    else
-                        if (onslaughtCD.CooldownRemaining < 30 && actionIDCD.CooldownRemaining > 0.7 && surgingtempestBuff && level >= 62)
-                        return WAR.Onslaught;
                 }
+
                 if (comboTime > 0)
                 {
-
-                    if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= 54)
-                        return WAR.FellCleave;
-                    if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= 35 && level <= 53)
-                        return WAR.InnerBeast;
-                    if (lastComboMove == WAR.Maim && level >= 50 && !HasEffectAny(WAR.Buffs.SurgingTempest))
-                        return WAR.StormsEye;
                     if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim)
                     {
-                        if (gauge == 100 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= 35 && level <= 53)
-                        {
-                            return WAR.InnerBeast;
-                        }
-
-                        if (gauge == 100 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= 54)
-                        {
-                            return WAR.FellCleave;
-                        }
-
+                        if (HasEffectAny(WAR.Buffs.SurgingTempest) && gauge == 100 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= WAR.Levels.InnerBeast)
+                            return OriginalHook(WAR.InnerBeast);
                         return WAR.Maim;
                     }
 
                     if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsPath)
                     {
-                        if (gauge >= 90 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= 35 && level <= 53)
-                        {
+                        if (HasEffectAny(WAR.Buffs.SurgingTempest) && gauge >= 90 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= WAR.Levels.InnerBeast)
                             return OriginalHook(WAR.InnerBeast);
-                        }
-
-                        if (gauge >= 90 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= 54)
-                        {
-                            return OriginalHook(WAR.FellCleave);
-                        }
-
-                        if (stormseyeBuff.RemainingTime < 15 && level > 50)
+                        if ((!HasEffectAny(WAR.Buffs.SurgingTempest) || stormseyeBuff.RemainingTime < 15) && level >= WAR.Levels.StormsEye)
                             return WAR.StormsEye;
                         return WAR.StormsPath;
                     }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -718,6 +718,7 @@ namespace XIVSlothComboPlugin
         GunbreakerBowShockFeature = 7017,
         
         [ConflictingCombos(GunbreakerRoughDivide1StackOption)]
+        [ParentCombo(GunbreakerSolidBarrelCombo)]
         [CustomComboInfo("Rough Divide Option (Uses all stacks)", "Adds Rough Divide onto main combo whenever its available (Uses all stacks).", GNB.JobID, 0, "Divide... Rougher!", "Ayo pour two out for the homie Squall")]
         GunbreakerRoughDivide2StackOption = 7005,
 
@@ -742,7 +743,6 @@ namespace XIVSlothComboPlugin
         [ParentCombo(GunbreakerGnashingFangCombo)]
         [CustomComboInfo("CDs on Gnashing Fang", "Adds Sonic Break/Bow Shock/Blasting Zone on Gnashing Fang, order dependent on No Mercy buff. \nBurst Strike added if there's charges while No Mercy buff is up.", GNB.JobID, 0, "More Teeth", "Gnashing fang, but like, if a shark did it. Or something.")]
         GunbreakerCDsOnGF = 7011,
-
 
         [CustomComboInfo("BurstStrikeContinuation", "Adds Hypervelocity on Burst Strike Continuation combo and main combo and Gnashing Fang.", GNB.JobID, 0, "Swish, swoosh", "Now we're cooking with gas! Hyper!")]
         GunbreakerBurstStrikeConFeature = 7012,
@@ -1636,11 +1636,12 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Overpower Combo", "Add combos to Overpower", WAR.JobID, 0, "Underpower", "Bet you wish you had damage like DRK right now, huh")]
         WarriorMythrilTempestCombo = 18002,
 
+        [ConflictingCombos(WarriorSpenderOption)]
         [CustomComboInfo("Warrior Gauge Overcap Feature", "Replace Single target or AoE combo with gauge spender if you are about to overcap and are before a step of a combo that would generate beast gauge", WAR.JobID, 0, "", "Taming the beast... for now.")]
         WarriorGaugeOvercapFeature = 18003,
 
         [ParentCombo(WarriorStormsPathCombo)]
-        [CustomComboInfo("Inner Release Feature", "Replace Single target and AoE combo with Fell Cleave/Decimate during Inner Release", WAR.JobID, 0, "", "Unleash your deepest thoughts and feelings upon the party. They'll love it!")]
+        [CustomComboInfo("Inner Release Feature", "Replace Single target and AoE combo with Fell Cleave/Decimate during Inner Release and Surging Tempest", WAR.JobID, 0, "", "Unleash your deepest thoughts and feelings upon the party. They'll love it!")]
         WarriorInnerReleaseFeature = 18004,
 
         [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76", WAR.JobID, 0, "Nasty-ass Flash", "Jeez. Keep it to yourself.")]
@@ -1651,11 +1652,11 @@ namespace XIVSlothComboPlugin
         WarriorFellCleaveOvercapFeature = 18006,
 
         [ParentCombo(WarriorStormsPathCombo)]
-        [CustomComboInfo("Upheaval Feature", "Adds Upheaval into maincombo if you have Surging Tempest and if you're synced below 70 while Beserk buff is ON CD", WAR.JobID, 0, "", "I use this feature when I'm moving house.")]
+        [CustomComboInfo("Upheaval Feature", "Adds Upheaval into maincombo if you have Surging Tempest", WAR.JobID, 0, "", "I use this feature when I'm moving house.")]
         WarriorUpheavalMainComboFeature = 18007,
 
         [ParentCombo(WarriorStormsPathCombo)]
-        [CustomComboInfo("Primal Rend Feature", "Replace Inner Beast and Steel Cyclone with Primal Rend when available (Also added onto Main AoE combo)", WAR.JobID, 0, "", "Going back to our roots. Let's get Primal!")]
+        [CustomComboInfo("Primal Rend Feature", "Replace Inner Beast and Steel Cyclone with Primal Rend when available and under Surging Tempest (Also added onto Main AoE combo)", WAR.JobID, 0, "", "Going back to our roots. Let's get Primal!")]
         WarriorPrimalRendFeature = 18008,
 
         [CustomComboInfo("Orogeny Feature", "Adds Orogeny onto main AoE combo when you are buffed with Surging Tempest", WAR.JobID, 0, "Orange-y feature", "Orange flavour. Mm.")]
@@ -1664,19 +1665,23 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Inner Chaos option", "Adds Inner Chaos to Storms Path Combo and Chaotic Cyclone to Overpower Combo if you are buffed with Nascent Chaos and Surging Tempest.\nRequires Storms Path Combo and Overpower Combo", WAR.JobID, 0, "", "THE EYE OF THE TIGERRRRR")]
         WarriorInnerChaosOption = 18010,
 
+        [ConflictingCombos(WarriorGaugeOvercapFeature)]
         [CustomComboInfo("Fell Cleave/Decimate Option", "Adds Fell Cleave to main combo when gauge is at 50 or more and adds Decimate to the AoE combo", WAR.JobID, 0, "", "MORE CLEAVE!")]
         WarriorSpenderOption = 18011,
 
         [ConflictingCombos(WarriorOnslaughtFeatureOption, WarriorOnslaughtFeatureOptionTwo)]
+        [ParentCombo(WarriorStormsPathCombo)]
         [CustomComboInfo("Onslaught Feature", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff (Uses all stacks)", WAR.JobID, 0, "", "Onslaught! Full Power!")]
         WarriorOnslaughtFeature = 18012,
 
         [ConflictingCombos(WarriorOnslaughtFeature, WarriorOnslaughtFeatureOptionTwo)]
+        [ParentCombo(WarriorStormsPathCombo)]
         [CustomComboInfo("Onslaught Option", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff (Leaves 1 stack)", WAR.JobID, 0, "", "Onslaught! But a bit less!")]
         WarriorOnslaughtFeatureOption = 18013,
 
         [ConflictingCombos(WarriorOnslaughtFeature, WarriorOnslaughtFeatureOption)]
-        [CustomComboInfo("Onslaught Option Two", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff (Leaves 1/2 stacks depending on lvl)", WAR.JobID, 0, "", "Did you really need three versions of this? Just hit the boss 4hed")]
+        [ParentCombo(WarriorStormsPathCombo)]
+        [CustomComboInfo("Onslaught Option Two", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff (Leaves 2 stacks, only usable at 88 and above)", WAR.JobID, 0, "", "Did you really need three versions of this? Just hit the boss 4hed")]
         WarriorOnslaughtFeatureOptionTwo = 18014,
 
         [CustomComboInfo("Infuriate Feature", "Replaces Infuriate with Fell Cleave when under Inner Release buff.\nReplaces Infuriate with Inner Chaos When under Nascent Chaos buff", WAR.JobID, 0, "Cleave of annoyance", "Infuriating stuff, if you ask me. Truly chaotic.")]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1647,12 +1647,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Overpower Combo", "Add combos to Overpower", WAR.JobID, 0, "Underpower", "Bet you wish you had damage like DRK right now, huh")]
         WarriorMythrilTempestCombo = 18002,
 
-        [ConflictingCombos(WarriorSpenderOption)]
         [CustomComboInfo("Warrior Gauge Overcap Feature", "Replace Single target or AoE combo with gauge spender if you are about to overcap and are before a step of a combo that would generate beast gauge", WAR.JobID, 0, "", "Taming the beast... for now.")]
         WarriorGaugeOvercapFeature = 18003,
 
-        [ParentCombo(WarriorStormsPathCombo)]
-        [CustomComboInfo("Inner Release Feature", "Replace Single target and AoE combo with Fell Cleave/Decimate during Inner Release and Surging Tempest", WAR.JobID, 0, "", "Unleash your deepest thoughts and feelings upon the party. They'll love it!")]
+        [CustomComboInfo("Inner Release Feature", "Replace Single target and AoE combo with Fell Cleave/Decimate during Inner Release/Berserk", WAR.JobID, 0, "", "Unleash your deepest thoughts and feelings upon the party. They'll love it!")]
         WarriorInnerReleaseFeature = 18004,
 
         [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76", WAR.JobID, 0, "Nasty-ass Flash", "Jeez. Keep it to yourself.")]
@@ -1666,18 +1664,19 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Upheaval Feature", "Adds Upheaval into maincombo if you have Surging Tempest", WAR.JobID, 0, "", "I use this feature when I'm moving house.")]
         WarriorUpheavalMainComboFeature = 18007,
 
-        [ParentCombo(WarriorStormsPathCombo)]
-        [CustomComboInfo("Primal Rend Feature", "Replace Inner Beast and Steel Cyclone with Primal Rend when available and under Surging Tempest (Also added onto Main AoE combo)", WAR.JobID, 0, "", "Going back to our roots. Let's get Primal!")]
+        [CustomComboInfo("Primal Rend Feature", "Replace Inner Beast and Steel Cyclone with Primal Rend when available (Also added onto Main AoE combo)", WAR.JobID, 0, "", "Going back to our roots. Let's get Primal!")]
         WarriorPrimalRendFeature = 18008,
 
+        [ParentCombo(WarriorMythrilTempestCombo)]
         [CustomComboInfo("Orogeny Feature", "Adds Orogeny onto main AoE combo when you are buffed with Surging Tempest", WAR.JobID, 0, "Orange-y feature", "Orange flavour. Mm.")]
         WarriorOrogenyFeature = 18009,
 
-        [CustomComboInfo("Inner Chaos option", "Adds Inner Chaos to Storms Path Combo and Chaotic Cyclone to Overpower Combo if you are buffed with Nascent Chaos and Surging Tempest.\nRequires Storms Path Combo and Overpower Combo", WAR.JobID, 0, "", "THE EYE OF THE TIGERRRRR")]
+        [ConflictingCombos(WarriorSpenderOption)]
+        [CustomComboInfo("Inner Chaos option", "Adds Inner Chaos to Storms Path Combo and Chaotic Cyclone to Overpower Combo if you are buffed with Nascent Chaos.\nRequires Storms Path Combo and Overpower Combo", WAR.JobID, 0, "", "THE EYE OF THE TIGERRRRR")]
         WarriorInnerChaosOption = 18010,
 
-        [ConflictingCombos(WarriorGaugeOvercapFeature)]
-        [CustomComboInfo("Fell Cleave/Decimate Option", "Adds Fell Cleave to main combo when gauge is at 50 or more and adds Decimate to the AoE combo", WAR.JobID, 0, "", "MORE CLEAVE!")]
+        [ConflictingCombos(WarriorInnerChaosOption)]
+        [CustomComboInfo("Fell Cleave/Decimate Option", "Adds Fell Cleave to main combo when gauge is at 50 or more and adds Decimate to the AoE combo .\nWill use Inner Chaos/Chaotic Cyclone if Infuriate is used.", WAR.JobID, 0, "", "MORE CLEAVE!")]
         WarriorSpenderOption = 18011,
 
         [ConflictingCombos(WarriorOnslaughtFeatureOption, WarriorOnslaughtFeatureOptionTwo)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1650,7 +1650,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Warrior Gauge Overcap Feature", "Replace Single target or AoE combo with gauge spender if you are about to overcap and are before a step of a combo that would generate beast gauge", WAR.JobID, 0, "", "Taming the beast... for now.")]
         WarriorGaugeOvercapFeature = 18003,
 
-        [CustomComboInfo("Inner Release Feature", "Replace Single target and AoE combo with Fell Cleave/Decimate during Inner Release/Berserk", WAR.JobID, 0, "", "Unleash your deepest thoughts and feelings upon the party. They'll love it!")]
+        [CustomComboInfo("Inner Release Feature", "Replace Single target and AoE combo with Fell Cleave/Decimate during Inner Release", WAR.JobID, 0, "", "Unleash your deepest thoughts and feelings upon the party. They'll love it!")]
         WarriorInnerReleaseFeature = 18004,
 
         [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76", WAR.JobID, 0, "Nasty-ass Flash", "Jeez. Keep it to yourself.")]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1657,10 +1657,6 @@ namespace XIVSlothComboPlugin
         WarriorNascentFlashFeature = 18005,
 
         [ParentCombo(WarriorStormsPathCombo)]
-        [CustomComboInfo("Fellcleave/IB Feature", "Replaces Main Combo With Fell Cleave/IB When you are about to overcap ", WAR.JobID, 0, "All you're good for", "Cleavey cleave cleave. Right?")]
-        WarriorFellCleaveOvercapFeature = 18006,
-
-        [ParentCombo(WarriorStormsPathCombo)]
         [CustomComboInfo("Upheaval Feature", "Adds Upheaval into maincombo if you have Surging Tempest", WAR.JobID, 0, "", "I use this feature when I'm moving house.")]
         WarriorUpheavalMainComboFeature = 18007,
 


### PR DESCRIPTION
- Fixed issue in #347 
- Minor GNB Refactoring
- WAR Refactoring (and fixes for level checks)
- Made Inner Chaos Option and Fell Cleave/Decimate Option mutually exclusive
- Removed Fellcleave/IB Feature as the Overcap Feature makes it obsolete
- Removed Berserk Condition when under level 70 for Upheaval Feature