### PR TITLE
[AST] Lazy Lady feature

### DIFF
--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -264,6 +264,16 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID == AST.AspectedHelios)
             {
+                if (IsEnabled(CustomComboPreset.AstrologianLazyLadyFeature) && level >= 70)
+                {
+                    var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var gauge = GetJobGauge<ASTGauge>();
+
+                    if (gauge.DrawnCrownCard == CardType.LADY && incombat && level >= 70)
+                        return AST.LadyOfCrown;
+                }
+
+
                 var celestialOppositionCD = GetCooldown(AST.CelestialOpposition);
                 if (IsEnabled(CustomComboPreset.AstrologianCelestialOppositionFeature) && celestialOppositionCD.CooldownRemaining == 0 && level >= AST.Levels.CelestialOpposition)
                     return AST.CelestialOpposition;

--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -273,7 +273,6 @@ namespace XIVSlothComboPlugin.Combos
                         return AST.LadyOfCrown;
                 }
 
-
                 var celestialOppositionCD = GetCooldown(AST.CelestialOpposition);
                 if (IsEnabled(CustomComboPreset.AstrologianCelestialOppositionFeature) && celestialOppositionCD.CooldownRemaining == 0 && level >= AST.Levels.CelestialOpposition)
                     return AST.CelestialOpposition;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -166,9 +166,6 @@ namespace XIVSlothComboPlugin
         [ParentCombo(AstrologianHeliosFeature)]
         [CustomComboInfo("Lazy Lady Feature", "Adds Lady of Crowns, if the card is drawn", AST.JobID, 0)]
         AstrologianLazyLadyFeature = 1022,
-
-
-
         
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -163,6 +163,13 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Celestial Opposition Feature", "Adds Celestial Opposition", AST.JobID, 0)]
         AstrologianCelestialOppositionFeature = 1021,
 
+        [ParentCombo(AstrologianHeliosFeature)]
+        [CustomComboInfo("Lazy Lady Feature", "Adds Lady of Crowns, if the card is drawn", AST.JobID, 0)]
+        AstrologianLazyLadyFeature = 1022,
+
+
+
+        
         #endregion
         // ====================================================================================
         #region BLACK MAGE


### PR DESCRIPTION
Adds Lady of Crowns, to aoe heals if the card is drawn and player is in combat.

Priority: Lady of Crowns > Celestial Opposition (if enabled) > Aspected Helios > Helios