### PR TITLE
User Defined Sliders: Surging Tempest & Onslaught (with feature clean up)

### DIFF
--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -74,6 +74,8 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const string
                 WarInfuriateRange = "WarInfuriateRange";
+            public const string
+                WarSurgingRefreshRange = "WarSurgingRefreshRange";
         }
     }
 
@@ -88,6 +90,7 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var stormseyeBuff = FindEffectAny(WAR.Buffs.SurgingTempest);
                 var gauge = GetJobGauge<WARGauge>().BeastGauge;
+                var surgingThreshold = Service.Configuration.GetCustomIntValue(WAR.Config.WarSurgingRefreshRange);
 
                 if (IsEnabled(CustomComboPreset.WARRangedUptimeFeature) && level >= WAR.Levels.Tomahawk)
                 {
@@ -130,7 +133,7 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (HasEffectAny(WAR.Buffs.SurgingTempest) && gauge >= 90 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= WAR.Levels.InnerBeast)
                             return OriginalHook(WAR.InnerBeast);
-                        if ((!HasEffectAny(WAR.Buffs.SurgingTempest) || stormseyeBuff.RemainingTime < 15) && level >= WAR.Levels.StormsEye)
+                        if ((!HasEffectAny(WAR.Buffs.SurgingTempest) || stormseyeBuff.RemainingTime < surgingThreshold) && level >= WAR.Levels.StormsEye)
                             return WAR.StormsEye;
                         return WAR.StormsPath;
                     }

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -76,6 +76,8 @@ namespace XIVSlothComboPlugin.Combos
                 WarInfuriateRange = "WarInfuriateRange";
             public const string
                 WarSurgingRefreshRange = "WarSurgingRefreshRange";
+            public const string
+                WarKeepOnslaughtCharges = "WarKeepOnslaughtCharges";
         }
     }
 
@@ -91,6 +93,7 @@ namespace XIVSlothComboPlugin.Combos
                 var stormseyeBuff = FindEffectAny(WAR.Buffs.SurgingTempest);
                 var gauge = GetJobGauge<WARGauge>().BeastGauge;
                 var surgingThreshold = Service.Configuration.GetCustomIntValue(WAR.Config.WarSurgingRefreshRange);
+                var onslaughtChargesRemaining = Service.Configuration.GetCustomIntValue(WAR.Config.WarKeepOnslaughtCharges);
 
                 if (IsEnabled(CustomComboPreset.WARRangedUptimeFeature) && level >= WAR.Levels.Tomahawk)
                 {
@@ -107,11 +110,14 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(WAR.Upheaval) && level >= WAR.Levels.Upheaval)
                             return WAR.Upheaval;
-                        if (level >= WAR.Levels.Onslaught &&
+                        if (level >= WAR.Levels.Onslaught && 
+                            IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && GetRemainingCharges(WAR.Onslaught) > onslaughtChargesRemaining)
+/*
                             ((IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && GetRemainingCharges(WAR.Onslaught) > 0) || //uses all stacks
                             (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOptionTwo) && GetRemainingCharges(WAR.Onslaught) > 2 && level >= 88) || // leaves 2 stacks
                             (IsEnabled(CustomComboPreset.WarriorOnslaughtFeatureOption) && GetRemainingCharges(WAR.Onslaught) > 1))) // leaves 1 stack
-                                return WAR.Onslaught;
+*/
+                           return WAR.Onslaught;
                     }
                 }
 
@@ -133,7 +139,7 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (HasEffectAny(WAR.Buffs.SurgingTempest) && gauge >= 90 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= WAR.Levels.InnerBeast)
                             return OriginalHook(WAR.InnerBeast);
-                        if ((!HasEffectAny(WAR.Buffs.SurgingTempest) || stormseyeBuff.RemainingTime < surgingThreshold) && level >= WAR.Levels.StormsEye)
+                        if ((!HasEffectAny(WAR.Buffs.SurgingTempest) || stormseyeBuff.RemainingTime <= surgingThreshold) && level >= WAR.Levels.StormsEye)
                             return WAR.StormsEye;
                         return WAR.StormsPath;
                     }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -506,6 +506,10 @@ namespace XIVSlothComboPlugin
             {
                 ConfigWindowFunctions.DrawSliderInt(0, 50, WAR.Config.WarInfuriateRange, "Set how much rage to be at or under to use this feature.");
             }
+            if (preset == CustomComboPreset.WarriorStormsPathCombo && enabled)
+            {
+                ConfigWindowFunctions.DrawSliderInt(0, 30, WAR.Config.WarSurgingRefreshRange, "Set how many seconds remaining before refreshing Surging Tempest.");
+            }
             i++;
 
             var hideChildren = Service.Configuration.HideChildren;

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -508,7 +508,11 @@ namespace XIVSlothComboPlugin
             }
             if (preset == CustomComboPreset.WarriorStormsPathCombo && enabled)
             {
-                ConfigWindowFunctions.DrawSliderInt(0, 30, WAR.Config.WarSurgingRefreshRange, "Set how many seconds remaining before refreshing Surging Tempest.");
+                ConfigWindowFunctions.DrawSliderInt(0, 30, WAR.Config.WarSurgingRefreshRange, "Seconds remaining before refreshing Surging Tempest.");
+            }
+            if (preset == CustomComboPreset.WarriorOnslaughtFeature && enabled)
+            {
+                ConfigWindowFunctions.DrawSliderInt(0, 2, WAR.Config.WarKeepOnslaughtCharges, "How many charges to keep ready? (0 = Use All)");
             }
             i++;
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1762,11 +1762,12 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Fell Cleave/Decimate Option", "Adds Fell Cleave to main combo when gauge is at 50 or more and adds Decimate to the AoE combo .\nWill use Inner Chaos/Chaotic Cyclone if Infuriate is used.", WAR.JobID, 0, "", "MORE CLEAVE!")]
         WarriorSpenderOption = 18011,
 
-        [ConflictingCombos(WarriorOnslaughtFeatureOption, WarriorOnslaughtFeatureOptionTwo)]
+//        [ConflictingCombos(WarriorOnslaughtFeatureOption, WarriorOnslaughtFeatureOptionTwo)]
         [ParentCombo(WarriorStormsPathCombo)]
-        [CustomComboInfo("Onslaught Feature", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff (Uses all stacks)", WAR.JobID, 0, "", "Onslaught! Full Power!")]
+        [CustomComboInfo("Onslaught Feature", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff", WAR.JobID, 0, "", "Onslaught! Full Power!")]
         WarriorOnslaughtFeature = 18012,
 
+/*
         [ConflictingCombos(WarriorOnslaughtFeature, WarriorOnslaughtFeatureOptionTwo)]
         [ParentCombo(WarriorStormsPathCombo)]
         [CustomComboInfo("Onslaught Option", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff (Leaves 1 stack)", WAR.JobID, 0, "", "Onslaught! But a bit less!")]
@@ -1776,6 +1777,7 @@ namespace XIVSlothComboPlugin
         [ParentCombo(WarriorStormsPathCombo)]
         [CustomComboInfo("Onslaught Option Two", "Adds Onslaught to Storm's Path feature combo if you are under Surging Tempest Buff (Leaves 2 stacks, only usable at 88 and above)", WAR.JobID, 0, "", "Did you really need three versions of this? Just hit the boss 4hed")]
         WarriorOnslaughtFeatureOptionTwo = 18014,
+*/
 
         [CustomComboInfo("Infuriate Feature", "Replaces Infuriate with Fell Cleave when under Inner Release buff.\nReplaces Infuriate with Inner Chaos When under Nascent Chaos buff", WAR.JobID, 0, "Cleave of annoyance", "Infuriating stuff, if you ask me. Truly chaotic.")]
         WarriorInfuriateFeature = 18015,


### PR DESCRIPTION
I saw someone else mention that the duration was long, but personally, I like it longer.  So I thought I'd get a little practice doing a user defined slider.

-Added User Defined Slider input to seconds remaining before refreshing Surging Tempest.
-Added User Defined Slider input to number of Onslaught charges to keep.
-Removed Onslaught Option and Option 2 (Commented out) as they were made redundant by the previous change.