### PR TITLE
Lucid Dreaming Option on RDM with User Input

### DIFF
--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -43,7 +43,8 @@ namespace XIVSlothComboPlugin.Combos
             Acceleration = 7518,
             Swiftcast = 7561,
             Manafication = 7521,
-            Embolden = 7520;
+            Embolden = 7520,
+            LucidDreaming = 7562;
 
         public static class Buffs
         {
@@ -69,6 +70,7 @@ namespace XIVSlothComboPlugin.Combos
                 Veraero = 10,
                 Verthunder2 = 18,
                 Veraero2 = 22,
+                LucidDreaming = 24,
                 Verraise = 64,
                 Zwerchhau = 35,
                 Swiftcast = 18,
@@ -89,6 +91,11 @@ namespace XIVSlothComboPlugin.Combos
                 Veraero3 = 82,
                 Verthunder3 = 82,
                 Resolution = 90;
+        }
+        public static class Config
+        {
+            public const string
+                RdmLucidMpThreshold = "RdmLucidMpThreshold";
         }
     }
 
@@ -1127,6 +1134,22 @@ namespace XIVSlothComboPlugin.Combos
                 //Avoiding Offbalance difference of 30, Proc adds 5, so 25
                 else if ((HasEffect(RDM.Buffs.VerfireReady)) && (gauge.BlackMana - gauge.WhiteMana) < 25) return RDM.Verfire;
                 else if ((HasEffect(RDM.Buffs.VerstoneReady)) && (gauge.WhiteMana - gauge.BlackMana) < 25) return RDM.Verstone;
+            }
+            return actionID;
+        }
+    }
+
+    internal class RedMageLucidOnJolt : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RedMageLucidOnJolt;
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID is RDM.Jolt or RDM.Jolt2 or RDM.Verfire or RDM.Verstone or RDM.Verthunder2 or RDM.Veraero2)
+            {
+                var needLucid = Service.Configuration.GetCustomIntValue(RDM.Config.RdmLucidMpThreshold);
+
+                if (level >= RDM.Levels.LucidDreaming && IsOffCooldown(RDM.LucidDreaming) && LocalPlayer.CurrentMp <= needLucid && CanWeave(actionID))
+                    return RDM.LucidDreaming;
             }
             return actionID;
         }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -516,7 +516,7 @@ namespace XIVSlothComboPlugin
             }
             if (preset == CustomComboPreset.RedMageLucidOnJolt && enabled)
             {
-                ConfigWindowFunctions.DrawSliderInt(0, 10000, RDM.Config.RdmLucidMpThreshold, "Add Lucid Dreaming when below this MP.");
+                ConfigWindowFunctions.DrawSliderInt(0, 10000, RDM.Config.RdmLucidMpThreshold, "Add Lucid Dreaming when below this MP.",300,100);
             }
             i++;
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -514,6 +514,10 @@ namespace XIVSlothComboPlugin
             {
                 ConfigWindowFunctions.DrawSliderInt(0, 2, WAR.Config.WarKeepOnslaughtCharges, "How many charges to keep ready? (0 = Use All)");
             }
+            if (preset == CustomComboPreset.RedMageLucidOnJolt && enabled)
+            {
+                ConfigWindowFunctions.DrawSliderInt(0, 10000, RDM.Config.RdmLucidMpThreshold, "Add Lucid Dreaming when below this MP.");
+            }
             i++;
 
             var hideChildren = Service.Configuration.HideChildren;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1445,6 +1445,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Jolt into Verproc", "Replaces Jolt with Verstone/Verfire, when proc is available and won't cause severe imbalance", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
         RedMageJoltVerprocCombo = 13021,
 
+        [CustomComboInfo("Lucid Dreaming Feature", "Add Lucid Dreaming to 2-sec spells when below threshold.", RDM.JobID, 0, "Jolt / Verfire / Verstone / Verthunder II / Veraero II -> Lucid Dreaming", "OOM? Git gud.")]
+        RedMageLucidOnJolt = 13022,
+
         #endregion
         // ====================================================================================
         #region SAGE


### PR DESCRIPTION
In response to: https://github.com/Nik-Potokar/XIVSlothCombo/issues/355

Added Lucid Dreaming Option to RDM with a user adjustable MP Level.  Added to all 2 second spells when you can weave only.