### PR TITLE
Primal Rend on Inner Release

### DIFF
--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -22,7 +22,7 @@ namespace XIVSlothComboPlugin.Combos
             Upheaval = 7387,
             LowBlow = 7540,
             Interject = 7538,
-            InnerRelease = 8768,
+            InnerRelease = 7389,
             RawIntuition = 3551,
             MythrilTempest = 16462,
             ChaoticCyclone = 16463,
@@ -307,6 +307,21 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (rageGauge.BeastGauge <= rageThreshold && GetCooldown(WAR.Infuriate).RemainingCharges > 0 && !isZerking && !hasNascent && level >= WAR.Levels.Infuriate)
                     return OriginalHook(WAR.Infuriate);
+            }
+
+            return actionID;
+        }
+    }
+    internal class WarriorPrimalRendOnInnerRelease : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorPrimalRendOnInnerRelease;
+
+        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        {
+            if (actionID is WAR.Berserk or WAR.InnerRelease)
+            {
+                if (HasEffect(WAR.Buffs.PrimalRendReady))
+                    return WAR.PrimalRend;
             }
 
             return actionID;

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -320,7 +320,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID is WAR.Berserk or WAR.InnerRelease)
             {
-                if (HasEffect(WAR.Buffs.PrimalRendReady))
+                if (level >= WAR.Levels.PrimalRend && HasEffect(WAR.Buffs.PrimalRendReady))
                     return WAR.PrimalRend;
             }
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -628,7 +628,7 @@ namespace XIVSlothComboPlugin
             if (preset == CustomComboPreset.WarriorInfuriateFellCleave)
                 ConfigWindowFunctions.DrawSliderInt(0, 50, WAR.Config.WarInfuriateRange, "Set how much rage to be at or under to use this feature.");
                 
-                            if (preset == CustomComboPreset.WarriorStormsPathCombo && enabled)
+            if (preset == CustomComboPreset.WarriorStormsPathCombo && enabled)
                 ConfigWindowFunctions.DrawSliderInt(0, 30, WAR.Config.WarSurgingRefreshRange, "Seconds remaining before refreshing Surging Tempest.");
                 
             if (preset == CustomComboPreset.WarriorOnslaughtFeature && enabled)

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1820,6 +1820,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Infuriate on Fell Cleave / Decimate", "Turns Fell Cleave and Decimate into Infuriate if at or under set rage value", WAR.JobID)]
         WarriorInfuriateFellCleave = 18018,
 
+        [CustomComboInfo("Primal Rend Option", "Turns Inner Release into Primal Rend on use.", WAR.JobID)]
+        WarriorPrimalRendOnInnerRelease = 18019,
+
         #endregion
         // ====================================================================================
         #region WHITE MAGE


### PR DESCRIPTION
Couple of things to get Primal Rend working and some clean-up.

 - Fixed InnerRelease actionID number (8768 > 7389)
 - Added Primal Rend on Inner Release option
 - Removed extra spaces in ConfigWindow.cs to make it ★pretty★

In response to me believing that option was always there and https://github.com/Nik-Potokar/XIVSlothCombo/issues/278