### PR TITLE
[AST] Enhancements

### DIFF
--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -558,10 +558,13 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID == AST.Benefic2)
             {
                 var aspectedBeneficHoT = FindTargetEffect(AST.Buffs.AspectedBenefic);
+                var NeutralSectBuff = FindTargetEffect(AST.Buffs.NeutralSect);
+                var NeutralSectShield = FindTargetEffect(AST.Buffs.NeutralSectShield);
                 var customEssentialDignity = Service.Configuration.GetCustomIntValue(AST.Config.AstroEssentialDignity);
 
-                if (IsEnabled(CustomComboPreset.AspectedBeneficFeature) && (aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3) || HasEffect(AST.Buffs.NeutralSect) && !HasEffect(AST.Buffs.NeutralSectShield))
+                if (IsEnabled(CustomComboPreset.AspectedBeneficFeature) && (aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3) || (NeutralSectShield is null) && (NeutralSectBuff is not null))
                     return AST.AspectedBenefic;
+
 
                 if (IsEnabled(CustomComboPreset.AstroEssentialDignity) && GetCooldown(AST.EssentialDignity).RemainingCharges > 0 && level >= AST.Levels.EssentialDignity && EnemyHealthPercentage() <= customEssentialDignity)
                     return AST.EssentialDignity;

--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -70,7 +70,10 @@ namespace XIVSlothComboPlugin.Combos
             Ewer = 917,
             Spire = 918,
             Horoscope = 1890,
-            HoroscopeHelios = 1891;
+            HoroscopeHelios = 1891,
+            AspectedBenefic = 835,
+            NeutralSect = 1892,
+            NeutralSectShield = 1921;
         }
 
         public static class Debuffs
@@ -92,7 +95,8 @@ namespace XIVSlothComboPlugin.Combos
                 CrownPlay = 70,
                 CelestialOpposition = 60,
                 CelestialIntersection = 74,
-                Horoscope = 76;
+                Horoscope = 76,
+                NeutralSect = 80;
         }
 
         public static class Config
@@ -302,7 +306,7 @@ namespace XIVSlothComboPlugin.Combos
                     if (horoscopeCD.CooldownRemaining == 0 && level >= AST.Levels.Horoscope)
                         return AST.Horoscope;
 
-                    if (!HasEffect(AST.Buffs.AspectedHelios) && HasEffect(AST.Buffs.Horoscope))
+                    if (!HasEffect(AST.Buffs.AspectedHelios) && HasEffect(AST.Buffs.Horoscope) || HasEffect(AST.Buffs.NeutralSect) && !HasEffect(AST.Buffs.NeutralSectShield))
                         return AST.AspectedHelios;
 
                     if (HasEffect(AST.Buffs.HoroscopeHelios))
@@ -553,16 +557,19 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID == AST.Benefic2)
             {
+                var aspectedBeneficHoT = FindTargetEffect(AST.Buffs.AspectedBenefic);
                 var customEssentialDignity = Service.Configuration.GetCustomIntValue(AST.Config.AstroEssentialDignity);
-                var essentialDignityCD = GetCooldown(AST.EssentialDignity);
-                var celestialIntersectionCD = GetCooldown(AST.CelestialIntersection);
 
-                if (IsEnabled(CustomComboPreset.AstroEssentialDignity) && essentialDignityCD.CooldownRemaining == 0 && level >= AST.Levels.EssentialDignity && EnemyHealthPercentage() <= customEssentialDignity)
+                if (IsEnabled(CustomComboPreset.AspectedBeneficFeature) && (aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3) || HasEffect(AST.Buffs.NeutralSect) && !HasEffect(AST.Buffs.NeutralSectShield))
+                    return AST.AspectedBenefic;
+
+                if (IsEnabled(CustomComboPreset.AstroEssentialDignity) && GetCooldown(AST.EssentialDignity).RemainingCharges > 0 && level >= AST.Levels.EssentialDignity && EnemyHealthPercentage() <= customEssentialDignity)
                     return AST.EssentialDignity;
 
-                if (IsEnabled(CustomComboPreset.CelestialIntersectionFeature) && celestialIntersectionCD.CooldownRemaining == 0 && level >= AST.Levels.CelestialIntersection)
+                if (IsEnabled(CustomComboPreset.CelestialIntersectionFeature) && GetCooldown(AST.CelestialIntersection).RemainingCharges > 0 && level >= AST.Levels.CelestialIntersection)
                     return AST.CelestialIntersection;
             }
+            
 
             return actionID;
         }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -182,6 +182,12 @@ namespace XIVSlothComboPlugin
         [ParentCombo(AstrologianHeliosFeature)]
         [CustomComboInfo("Horoscope Feature", "Adds Horoscope.", AST.JobID, 0)]
         AstrologianHoroscopeFeature = 1026,
+        
+        [ParentCombo(AstrologianSimpleSingleTargetHeal)]
+        [CustomComboInfo("Aspected Benefic Feature", "Adds Aspected Benefic & refreshes it if needed.", AST.JobID, 0)]
+        AspectedBeneficFeature = 1027,
+
+
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
- Essential Dignity and Celestial Intersection will now use all charges available.

- Added Aspected Benefic to single target heals. Applies and refreshes the buff if necessary.

- Aspected Helios and Aspected Benefic will apply their shields while under Neutral Sect.
If the shield is applied Aspected Helios and Aspected Benefic will turn into Helios & Benefic
If the shield breaks it will re-apply it.