### PR TITLE
MCH : Review of simple machinist;

### DIFF
--- a/XIVSlothCombo/Combos/MCH.cs
+++ b/XIVSlothCombo/Combos/MCH.cs
@@ -375,6 +375,7 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var inCombat = InCombat();
                 var gauge = GetJobGauge<MCHGauge>();
+                var canWeaveNormal = CanWeave(actionID);
 
                 if (!inCombat)
                 {
@@ -382,172 +383,201 @@ namespace XIVSlothComboPlugin.Combos
                     
                 }
 
-                if (CanWeave(actionID)) // normal weaves
-                {
-                    if (IsEnabled(CustomComboPreset.MachinistSimpleInterrupt) && CanInterruptEnemy() && IsOffCooldown(MCH.HeadGraze))
-                    {
-                        return MCH.HeadGraze;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.MachinistSimpleStabilizer) && gauge.Heat < 50 &&
+                if (canWeaveNormal && IsEnabled(CustomComboPreset.MachinistSimpleStabilizer) && gauge.Heat <= 55 &&
                         IsOffCooldown(MCH.BarrelStabilizer) && level >= MCH.Levels.BarrelStabilizer &&
-                        GetCooldown(MCH.Wildfire).CooldownRemaining < 10 )
-                        return MCH.BarrelStabilizer;
+                        GetCooldown(MCH.Wildfire).CooldownRemaining < 8)
+                    return MCH.BarrelStabilizer;
 
-                    if (openerFinished && !gauge.IsRobotActive && IsEnabled(CustomComboPreset.MachinistSimpleGadget) )
+                if (canWeaveNormal && IsEnabled(CustomComboPreset.MachinistSimpleInterrupt) && CanInterruptEnemy() && IsOffCooldown(MCH.HeadGraze))
+                {
+                    return MCH.HeadGraze;
+                }
+
+                if (canWeaveNormal && openerFinished && !gauge.IsRobotActive && IsEnabled(CustomComboPreset.MachinistSimpleGadget))
+                {
+                    //overflow protection
+                    if (gauge.Battery == 100)
                     {
-                        //overflow protection
-                        if (gauge.Battery == 100)
+                        if (level >= MCH.Levels.QueenOverdrive)
                         {
-                            if (level >= MCH.Levels.QueenOverdrive)
-                            {
-                                return MCH.AutomatonQueen;
-                            }
-
-                            if (level >= MCH.Levels.RookOverdrive)
-                            {
-                                return MCH.RookAutoturret;
-                            }
+                            return MCH.AutomatonQueen;
                         }
-                        else if (gauge.Battery >= 50 && CombatEngageDuration().Seconds >= 55 )
-                        {
-                            if (level >= MCH.Levels.QueenOverdrive)
-                            {
-                                return MCH.AutomatonQueen;
-                            }
 
-                            if (level >= MCH.Levels.RookOverdrive)
-                            {
-                                return MCH.RookAutoturret;
-                            }
-                        } else if (gauge.LastSummonBatteryPower == 0 && gauge.Battery >= 50)
+                        if (level >= MCH.Levels.RookOverdrive)
                         {
-                            if (level >= MCH.Levels.QueenOverdrive)
-                            {
-                                return MCH.AutomatonQueen;
-                            }
-
-                            if (level >= MCH.Levels.RookOverdrive)
-                            {
-                                return MCH.RookAutoturret;
-                            }
-                        } 
-                        
+                            return MCH.RookAutoturret;
+                        }
                     }
-
-                    if (gauge.Heat >= 50 && openerFinished && IsEnabled(CustomComboPreset.MachinistSimpleWildCharge) )
+                    else if (gauge.Battery >= 50 && (CombatEngageDuration().Seconds >= 55 || CombatEngageDuration().Seconds <= 05))
                     {
-                        if (level >= MCH.Levels.Hypercharge && !gauge.IsOverheated )
+                        if (level >= MCH.Levels.QueenOverdrive)
                         {
-                            //protection
-                            if (HasEffect(MCH.Buffs.Wildfire) || (gauge.Heat == 100 && 
-                                (GetCooldown(MCH.Wildfire).CooldownRemaining > 6 || level < MCH.Levels.Wildfire))) return MCH.Hypercharge;
+                            return MCH.AutomatonQueen;
+                        }
 
-                            if (level >= MCH.Levels.Drill && GetCooldown(MCH.Drill).CooldownRemaining > 8)
-                            {
-                                if (level >= MCH.Levels.AirAnchor && GetCooldown(MCH.AirAnchor).CooldownRemaining > 8)
-                                {
-                                    if (level >= MCH.Levels.ChainSaw && GetCooldown(MCH.ChainSaw).CooldownRemaining > 8)
-                                    {
-                                        if (IsOffCooldown(MCH.Wildfire))
-                                            return MCH.Wildfire;
-
-                                        if (GetCooldown(MCH.Wildfire).CooldownRemaining > 14) return MCH.Hypercharge;
-                                    }
-                                    else if (level < MCH.Levels.ChainSaw)
-                                    {
-                                        if (IsOffCooldown(MCH.Wildfire))
-                                            return MCH.Wildfire;
-
-                                        if (GetCooldown(MCH.Wildfire).CooldownRemaining > 14) return MCH.Hypercharge;
-                                    }
-                                }
-                                else if (level < MCH.Levels.AirAnchor)
-                                {
-                                    if (IsOffCooldown(MCH.Wildfire))
-                                        return MCH.Wildfire;
-
-                                    if (GetCooldown(MCH.Wildfire).CooldownRemaining > 14) return MCH.Hypercharge;
-                                }
-                            }
-                            else if (level < MCH.Levels.Drill)
-                            {
-                                if (level >= MCH.Levels.Wildfire && IsOffCooldown(MCH.Wildfire))
-                                    return MCH.Wildfire;
-
-                                if (GetCooldown(MCH.Wildfire).CooldownRemaining > 14 || level < MCH.Levels.Wildfire)  return MCH.Hypercharge;
-                            }
-                        }       
+                        if (level >= MCH.Levels.RookOverdrive)
+                        {
+                            return MCH.RookAutoturret;
+                        }
                     }
+                    else if (gauge.LastSummonBatteryPower == 0 && gauge.Battery >= 50)
+                    {
+                        if (level >= MCH.Levels.QueenOverdrive)
+                        {
+                            return MCH.AutomatonQueen;
+                        }
+
+                        if (level >= MCH.Levels.RookOverdrive)
+                        {
+                            return MCH.RookAutoturret;
+                        }
+                    }
+
                 }
 
-                if ( IsEnabled(CustomComboPreset.MachinistSimpleGaussRicochet) && GetCooldown(actionID).CooldownRemaining > 0.6) //gauss and ricochet weave
+                if (canWeaveNormal && gauge.Heat >= 50 && !gauge.IsOverheated && openerFinished && IsOffCooldown(MCH.Wildfire) && level >= MCH.Levels.Wildfire &&
+                        IsEnabled(CustomComboPreset.MachinistSimpleWildCharge))
                 {
-                    var gaussCharges = GetRemainingCharges(MCH.GaussRound);
-                    var ricochetCharges = GetRemainingCharges(MCH.Ricochet);
+                    if (CombatEngageDuration().Minutes == 0 && GetRemainingCharges(MCH.Reassemble) == 0) return MCH.Wildfire;
+                    else if (CombatEngageDuration().Minutes > 0 && GetCooldownRemainingTime(MCH.ChainSaw) > 50 ) return MCH.Wildfire;
+                }     
 
-                    var chargeLimit = openerFinished || level < MCH.Levels.Ricochet ? 0 : 1;
-                    
-                    if ((gaussCharges >= ricochetCharges || level < MCH.Levels.Ricochet) && gaussCharges > chargeLimit &&
-                        level >= MCH.Levels.GaussRound )
-                        return MCH.GaussRound;
-                    else if (ricochetCharges > 0 && level >= MCH.Levels.Ricochet)
-                        return MCH.Ricochet;
-                }
-
-                if (gauge.IsOverheated && level >= MCH.Levels.HeatBlast )
+                if (gauge.IsOverheated && level >= MCH.Levels.HeatBlast)
                 {
+                    if (IsEnabled(CustomComboPreset.MachinistSimpleGaussRicochet) && CanWeave(actionID, 0.6)) //gauss and ricochet weave
+                    {
+                        var gaussCharges = GetRemainingCharges(MCH.GaussRound);
+                        var ricochetCharges = GetRemainingCharges(MCH.Ricochet);
+                        var usingReasmSoon = IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && GetRemainingCharges(MCH.Reassemble) > 0 && openerFinished &&
+                            (
+                             (GetCooldownRemainingTime(MCH.Drill) < 2 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
+                             (GetCooldownRemainingTime(MCH.AirAnchor) < 2 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
+                             (GetCooldownRemainingTime(MCH.ChainSaw) < 2 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5))
+                            );
+
+                        //var chargeLimit = openerFinished || level < MCH.Levels.Ricochet ? 0 : 1;
+
+                        if ((gaussCharges >= ricochetCharges || level < MCH.Levels.Ricochet) && gaussCharges > 0 &&
+                            level >= MCH.Levels.GaussRound && !usingReasmSoon)
+                            return MCH.GaussRound;
+                        else if (ricochetCharges > 0 && level >= MCH.Levels.Ricochet && !usingReasmSoon)
+                            return MCH.Ricochet;
+                    }
+
                     return MCH.HeatBlast;
                 }
 
-                if (IsOffCooldown(MCH.AirAnchor) && level >= MCH.Levels.AirAnchor)
+                if ((IsOffCooldown(MCH.AirAnchor) || GetCooldownRemainingTime(MCH.AirAnchor) < 1) && level >= MCH.Levels.AirAnchor)
                 {
-                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && (!openerFinished || level < MCH.Levels.ChainSaw) && 
-                        !HasEffect(MCH.Buffs.Reassembled) && GetRemainingCharges(MCH.Reassemble) > 0)
+                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && !HasEffect(MCH.Buffs.Reassembled) && IsEnabled(CustomComboPreset.MachinistSimpleAssemblingAirAnchor) &&
+                        GetRemainingCharges(MCH.Reassemble) > 0)
                     {
-                        return MCH.Reassemble;
+                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssemblingAirAnchorMaxCharges) && GetRemainingCharges(MCH.Reassemble) == 2) return MCH.Reassemble;
+                        else if (!IsEnabled(CustomComboPreset.MachinistSimpleAssemblingAirAnchorMaxCharges)) return MCH.Reassemble;
+
                     }
                     return MCH.AirAnchor;
-                } else if (IsOffCooldown(MCH.HotShot) && level >= MCH.Levels.Hotshot && level < MCH.Levels.AirAnchor)
+                }
+                else if ((IsOffCooldown(MCH.HotShot) || GetCooldownRemainingTime(MCH.HotShot) < 1) && level >= MCH.Levels.Hotshot && level < MCH.Levels.AirAnchor)
                     return MCH.HotShot;
 
-
-                if (IsOffCooldown(MCH.Drill) && level >= MCH.Levels.Drill)
+                if ((IsOffCooldown(MCH.Drill) || GetCooldownRemainingTime(MCH.Drill) < 1) && level >= MCH.Levels.Drill)
                 {
-                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && level < MCH.Levels.AirAnchor && 
+                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && IsEnabled(CustomComboPreset.MachinistSimpleAssemblingDrill) &&
                         !HasEffect(MCH.Buffs.Reassembled) && GetRemainingCharges(MCH.Reassemble) > 0)
                     {
-                        return MCH.Reassemble;
+                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssemblingDrillMaxCharges) && GetRemainingCharges(MCH.Reassemble) == 2) return MCH.Reassemble;
+                        else if (!IsEnabled(CustomComboPreset.MachinistSimpleAssemblingDrillMaxCharges)) return MCH.Reassemble;
                     }
                     return MCH.Drill;
                 }
-                   
-                if (IsOffCooldown(MCH.ChainSaw) && level >= MCH.Levels.ChainSaw && openerFinished)
+
+                if ((IsOffCooldown(MCH.ChainSaw) || GetCooldownRemainingTime(MCH.ChainSaw) < 1) && level >= MCH.Levels.ChainSaw && openerFinished)
                 {
-                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && !HasEffect(MCH.Buffs.Reassembled) && 
+                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && IsEnabled(CustomComboPreset.MachinistSimpleAssemblingChainSaw) && !HasEffect(MCH.Buffs.Reassembled) &&
                         GetRemainingCharges(MCH.Reassemble) > 0)
                     {
-                        return MCH.Reassemble;
+                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssemblingChainSawMaxCharges) && GetRemainingCharges(MCH.Reassemble) == 2) return MCH.Reassemble;
+                        else if (!IsEnabled(CustomComboPreset.MachinistSimpleAssemblingChainSawMaxCharges)) return MCH.Reassemble;
                     }
                     return MCH.ChainSaw;
                 }
 
-                if (comboTime > 0)
+                if (canWeaveNormal && gauge.Heat >= 50 && openerFinished && IsEnabled(CustomComboPreset.MachinistSimpleWildCharge) )
                 {
-                    if (lastComboMove == MCH.SplitShot && level >= MCH.Levels.SlugShot)
-                        return OriginalHook(MCH.SlugShot);
-
-                    if (lastComboMove == MCH.SlugShot && level >= MCH.Levels.CleanShot)
+                    if (level >= MCH.Levels.Hypercharge && !gauge.IsOverheated )
                     {
-                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && 
-                            level < MCH.Levels.Drill && !HasEffect(MCH.Buffs.Reassembled) && GetRemainingCharges(MCH.Reassemble) > 0)
-                        {
-                            return MCH.Reassemble;
-                        }
-                        return OriginalHook(MCH.CleanShot);
-                    }
-                } 
+                        //protection
+                        if (HasEffect(MCH.Buffs.Wildfire) || level < MCH.Levels.Wildfire) return MCH.Hypercharge;
 
+                        if (level >= MCH.Levels.Drill && GetCooldown(MCH.Drill).CooldownRemaining > 8)
+                        {
+                            if (level >= MCH.Levels.AirAnchor && GetCooldown(MCH.AirAnchor).CooldownRemaining > 8)
+                            {
+                                if (level >= MCH.Levels.ChainSaw && (GetCooldown(MCH.ChainSaw).CooldownRemaining > 8 || CombatEngageDuration().Minutes % 2 == 0) )
+                                {
+                                    if (CombatEngageDuration().Minutes % 2 == 1 && gauge.Heat >= 90 )
+                                    {
+                                        return MCH.Hypercharge;
+                                    } else if (CombatEngageDuration().Minutes % 2 == 0)
+                                    {
+                                        if (CombatEngageDuration().Minutes != 0)
+                                        {
+                                            return MCH.Hypercharge;
+                                        } 
+                                    }
+                                }
+                                else if (level < MCH.Levels.ChainSaw)
+                                {
+                                    if (GetCooldown(MCH.Wildfire).CooldownRemaining > 8) return MCH.Hypercharge;
+                                }
+                            }
+                            else if (level < MCH.Levels.AirAnchor)
+                            {
+                                if (GetCooldown(MCH.Wildfire).CooldownRemaining > 8) return MCH.Hypercharge;
+                            }
+                        }
+                        else if (level < MCH.Levels.Drill)
+                        {
+                            if (GetCooldown(MCH.Wildfire).CooldownRemaining > 8 || level < MCH.Levels.Wildfire)  return MCH.Hypercharge;
+                        }
+                    }       
+                }
+
+                if (IsEnabled(CustomComboPreset.MachinistSimpleGaussRicochet) && CanWeave(actionID, 0.6)) //gauss and ricochet weave
+                {
+                    var gaussCharges = GetRemainingCharges(MCH.GaussRound);
+                    var ricochetCharges = GetRemainingCharges(MCH.Ricochet);
+                    var usingReasmSoon = IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && GetRemainingCharges(MCH.Reassemble) > 0 && openerFinished &&
+                        (
+                         (GetCooldownRemainingTime(MCH.Drill) < 2 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
+                         (GetCooldownRemainingTime(MCH.AirAnchor) < 2 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
+                         (GetCooldownRemainingTime(MCH.ChainSaw) < 2 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5))
+                        );
+
+                    //var chargeLimit = openerFinished || level < MCH.Levels.Ricochet ? 0 : 1;
+
+                    if ((gaussCharges >= ricochetCharges || level < MCH.Levels.Ricochet) && gaussCharges > 0 &&
+                        level >= MCH.Levels.GaussRound && !usingReasmSoon)
+                        return MCH.GaussRound;
+                    else if (ricochetCharges > 0 && level >= MCH.Levels.Ricochet && !usingReasmSoon)
+                        return MCH.Ricochet;
+                }
+
+
+                if (lastComboMove == MCH.SplitShot && level >= MCH.Levels.SlugShot)
+                    return OriginalHook(MCH.SlugShot);
+
+                if (lastComboMove == MCH.SlugShot && level >= MCH.Levels.CleanShot)
+                {
+                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && 
+                        level < MCH.Levels.Drill && !HasEffect(MCH.Buffs.Reassembled) && GetRemainingCharges(MCH.Reassemble) > 0)
+                    {
+                        return MCH.Reassemble;
+                    }
+                    return OriginalHook(MCH.CleanShot);
+                }
+                
                 if (lastComboMove == MCH.CleanShot) openerFinished = true;
             }
 

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -390,6 +390,22 @@ namespace XIVSlothComboPlugin.Combos
             => Service.ComboCache.GetCooldown(actionID);
 
         /// <summary>
+        /// Gets the cooldown total remaining time.
+        /// </summary>
+        /// <param name="actionID">Action ID to check.</param>
+        /// <returns>Total remaining time of the cooldown.</returns>
+        protected static float GetCooldownRemainingTime(uint actionID)
+            => Service.ComboCache.GetCooldown(actionID).CooldownRemaining;
+
+        /// <summary>
+        /// Gets the cooldown remaining time for the next charge.
+        /// </summary>
+        /// <param name="actionID">Action ID to check.</param>
+        /// <returns>Remaining time for the next charge of the cooldown.</returns>
+        protected static float GetCooldownChargeRemainingTime(uint actionID)
+            => Service.ComboCache.GetCooldown(actionID).ChargeCooldownRemaining;
+
+        /// <summary>
         /// Gets a value indicating whether an action is on cooldown.
         /// </summary>
         /// <param name="actionID">Action ID to check.</param>

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -995,7 +995,7 @@ namespace XIVSlothComboPlugin
         MachinistSimpleGadget = 8022,
 
         [ParentCombo(MachinistSimpleFeature)]
-        [CustomComboInfo("Simple Assembling", "Adds optimal reassemble uses to the feature.", MCH.JobID, 0, "Megablox", "It's like Lego bricks! But worse!")]
+        [CustomComboInfo("Simple Assembling", "Pairs reassemble uses with the following skills.\nBefore acquiring Drill it will be used with Clean Shot.", MCH.JobID, 0, "Megablox", "It's like Lego bricks! But worse!")]
         MachinistSimpleAssembling = 8023,
 
         [ParentCombo(MachinistSimpleFeature)]
@@ -1016,6 +1016,30 @@ namespace XIVSlothComboPlugin
 
         [CustomComboInfo("Simple Machinist AOE", "Spread Shot turns into Scattergun when lvl 82 or higher, Both turn into Auto Crossbow when overheated\nand Bioblaster is used first whenever it is off cooldown.", MCH.JobID, 0, "Dungeon go zzzz", "AoE, but you're just not here. Go make a coffee.")]
         MachinistSpreadShotFeature = 8028,
+
+        [ParentCombo(MachinistSimpleAssembling)]
+        [CustomComboInfo("Drill","Use Reassemble with Drill when available.", MCH.JobID,0,"GigaDrillBreaker","The Drill that will pierce the heavens!")]
+        MachinistSimpleAssemblingDrill = 8029,
+
+        [ParentCombo(MachinistSimpleAssembling)]
+        [CustomComboInfo("Air Anchor", "Use Reassemble with Air Anchor when available.", MCH.JobID, 0, "Air Guitar", "Play the tunes!")]
+        MachinistSimpleAssemblingAirAnchor = 8030,
+
+        [ParentCombo(MachinistSimpleAssembling)]
+        [CustomComboInfo("Chain Saw", "Use Reassemble with Chain Saw when available.", MCH.JobID, 0, "Giga Sauce", "The secret to life.")]
+        MachinistSimpleAssemblingChainSaw = 8031,
+
+        [ParentCombo(MachinistSimpleAssemblingDrill)]
+        [CustomComboInfo("Only use Drill...", "...when you have max charges of reassemble.", MCH.JobID, 0, "GigaDrillBreaker MAX", "Mow pow in the pew!")]
+        MachinistSimpleAssemblingDrillMaxCharges = 8032,
+
+        [ParentCombo(MachinistSimpleAssemblingAirAnchor)]
+        [CustomComboInfo("Only use Air Anchor...", "...when you have max charges of reassemble.", MCH.JobID, 0, "GigaDrillBreaker MAX", "Mow pow in the pew!")]
+        MachinistSimpleAssemblingAirAnchorMaxCharges = 8033,
+
+        [ParentCombo(MachinistSimpleAssemblingChainSaw)]
+        [CustomComboInfo("Only use Chain Saw...", "...when you have max charges of reassemble.", MCH.JobID, 0, "GigaDrillBreaker MAX", "Mow pow in the pew!")]
+        MachinistSimpleAssemblingChainSawMaxCharges = 8034,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
### Review of Simple Machinist
   - Most logic was changed to be more precise;
   - Drift problems where squashed;
   - Added options for reassemble uses;
       - Now its the user who tells with what ability it wants to use reassemble with.
           - Can select to only use determined ability only when it have the max charges of reassemble to correct overflow if they so whishes to;
   -  Misc. QoL changes;


### Notes

   - After the opener and before the 2m mark on the fight , you will probably overflow 1 time (2 at most) with 105 heat , that is intended, do not panic. I have tried to find some nice heat numbers without delaying anything and still be able to enter the 2m phase with 100 heat or more than 50 , and i was not able to. I'm open to suggestions on that regard.
      -  But after the 2m burst , everything falls in place and you do not overflow anymore, you will have high heat at some moments but that is intended. I do not believe any dps is lost, its only lost if you let it overflow for too much.
      - People can find an "expired combo" on their logs with a split shot , that occurs only once, that is a by product of the 1st point, sorry for that , but for now I don't have a solution for that, should not influence your dps too.