### PR TITLE
Should fix #407

### DIFF
--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -295,7 +295,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
                     if (HasEffect(NIN.Buffs.Kassatsu))
                         return NIN.JinCombo;
-                    if (GetCooldown(NIN.Jin).RemainingCharges > 0)
+                    if (GetCooldown(NIN.Jin).RemainingCharges > 0 && level >= NIN.Levels.Jin)
                         return NIN.Jin;
                 }
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -88,14 +88,13 @@ namespace XIVSlothComboPlugin
         }
         public override void Draw()
         {
+            ImGui.Columns(2, null, false);
             ImGui.Text("This window allows you to enable and disable custom combos to your liking.");
 
 
-
-            ImGui.TextColored(ImGuiColors.ParsedPurple, $"NEW: We now have a shiny new Discord server! Come and say hi!\nLink is on the GitHub page.");
-
-            var isAprilFools = DateTime.Now.Day == 1 && DateTime.Now.Month == 4 ? true : false;
-
+            ImGui.NextColumn();
+            ImGui.TextColored(ImGuiColors.ParsedPurple, $"NEW: We now have a shiny new Discord server! Come and say hi!");
+            ImGui.NextColumn();
 
             var showSecrets = Service.Configuration.EnableSecretCombos;
             if (ImGui.Checkbox("Enable PvP Combos", ref showSecrets))
@@ -110,6 +109,18 @@ namespace XIVSlothComboPlugin
                 ImGui.TextUnformatted("Adds PVP Combos To The Combo Setup Screen");
                 ImGui.EndTooltip();
             }
+
+
+            ImGui.NextColumn();
+            if (ImGui.Button("Click here to join our Discord Server!"))
+            {
+                Util.OpenLink("https://discord.gg/xT7zyjzjtY");
+            }
+            ImGui.Columns(1);
+            var isAprilFools = DateTime.Now.Day == 1 && DateTime.Now.Month == 4 ? true : false;
+
+
+
 
 
             var hideChildren = Service.Configuration.HideChildren;

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -352,9 +352,43 @@ namespace XIVSlothComboPlugin
                     ImGui.Indent();
 
                     foreach (var (childPreset, childInfo) in children)
-                        this.DrawPreset(childPreset, childInfo, ref i);
+                    {
+                        if (Service.Configuration.HideConflictedCombos)
+                        {
+                            //Presets that are contained within a ConflictedAttribute
+                            var conflictOriginals = Service.Configuration.GetConflicts(childPreset);
+
+                            //Presets with the ConflictedAttribute
+                            var conflictsSource = Service.Configuration.GetAllConflicts();
+
+                            if (conflictsSource.Where(x => x == childPreset || x == preset).Count() == 0 || conflictOriginals.Length == 0)
+                            {
+                                this.DrawPreset(childPreset, childInfo, ref i);
+                                continue;
+                            }
+                            if (conflictOriginals.Any(x => Service.Configuration.IsEnabled(x)))
+                            {
+                                Service.Configuration.EnabledActions.Remove(preset);
+                                Service.Configuration.Save();
+                            }
+                            else
+                            {
+                                this.DrawPreset(childPreset, childInfo, ref i);
+                                continue;
+                            }
+
+                        }
+                        else
+                        {
+                            this.DrawPreset(childPreset, childInfo, ref i);
+                        }
+
+                        
+                    }
+                        
 
                     ImGui.Unindent();
+
                 }
             }
 

--- a/XIVSlothCombo/ConfigWindowFunctions.cs
+++ b/XIVSlothCombo/ConfigWindowFunctions.cs
@@ -56,22 +56,25 @@ namespace XIVSlothComboPlugin.ConfigFunctions
             ImGui.Spacing();
         }
 
-        public static void DrawCheckboxSingle(string config, string checkBoxName, string checkboxDescription, float itemWidth = 150, Vector4 descriptionColor = new Vector4())
+        public static void DrawRadioButton(string config, string checkBoxName, string checkboxDescription, int outputValue, float itemWidth = 150, Vector4 descriptionColor = new Vector4())
         {
-            if (descriptionColor == new Vector4()) descriptionColor = ImGuiColors.TankBlue;
-            var output = Service.Configuration.GetCustomBoolValue(config);
+            ImGui.Indent();
+            if (descriptionColor == new Vector4()) descriptionColor = ImGuiColors.DalamudYellow;
+            var output = Service.Configuration.GetCustomIntValue(config);
+            Dalamud.Logging.PluginLog.Debug(output.ToString());
             ImGui.PushItemWidth(itemWidth);
+            var enabled = output == outputValue ? true : false;
 
-            if (ImGui.Checkbox(checkBoxName, ref output))
+            if (ImGui.Checkbox(checkBoxName, ref enabled))
             {
-                Service.Configuration.SetCustomBoolValue(config, output);
+                Service.Configuration.SetCustomIntValue(config, outputValue);
                 Service.Configuration.Save();
 
             }
             ImGui.PushStyleColor(ImGuiCol.Text, descriptionColor);
             ImGui.TextWrapped(checkboxDescription);
             ImGui.PopStyleColor();
-
+            ImGui.Unindent();
             ImGui.Spacing();
         }
 


### PR DESCRIPTION
Adds level check to under level 76 starter mudra.

Also adds checks for child conflicted combos on the hide feature plus a new shiny "joyn deescorduh" button.

Oh, and radio buttons I guess. 