### PR TITLE
GNB: All level functionality

### DIFF
--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -82,178 +82,162 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID == DRK.Souleater)
             {
                 var currentMp = LocalPlayer.CurrentMp;
-                var gcd = GetCooldown(DRK.HardSlash);
                 var gauge = GetJobGauge<DRKGauge>();
-                var deliriumTime = FindEffect(DRK.Buffs.Delirium);
-                var bloodgauge = GetJobGauge<DRKGauge>().Blood;
-                var shadowCooldown = GetCooldown(DRK.LivingShadow);
-                var plungeCD = GetCooldown(DRK.Plunge);
-                var actionIDCD = GetCooldown(actionID);
                 var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                
 
-
-                if (IsEnabled(CustomComboPreset.DarkOpenerFeature) && !incombat && level == 90)
+                if (IsEnabled(CustomComboPreset.DarkRangedUptimeFeature) && level >= DRK.Levels.Unmend)
                 {
-                    if (HasEffectAny(DRK.Buffs.BloodWeapon) || HasEffect(DRK.Buffs.BlackestNight))
-                        inOpener = true;
+                    if (!InMeleeRange(true))
+                        return DRK.Unmend;
                 }
 
-                /*if (!incombat)
+                if (!incombat)
                 {
-                    if (IsEnabled(CustomComboPreset.DarkBloodWeaponOpener) && inOpener && HasEffect(DRK.Buffs.BlackestNight))
-                        return DRK.BloodWeapon;
-                    if (HasEffect(DRK.Buffs.BloodWeapon))
-                        return DRK.HardSlash;
-                }*/
-
-                if (IsEnabled(CustomComboPreset.DarkOpenerFeature) && inOpener && incombat && level == 90)
-                {
-                    if (lastComboMove == DRK.Souleater && GetRemainingCharges(DRK.Plunge) == 0)
+                    if (IsEnabled(CustomComboPreset.DarkOpenerFeature) && level == 90)
                     {
-                        inOpener = false;
+                        if (HasEffectAny(DRK.Buffs.BloodWeapon) || HasEffect(DRK.Buffs.BlackestNight))
+                            inOpener = true;
                     }
 
-                    // oGCDs
-                    if (CanWeave(actionID))
+                    if (IsEnabled(CustomComboPreset.DarkBloodWeaponOpener) && inOpener)
                     {
-                        if (GetBuffStacks(DRK.Buffs.Delirium) == 2)
-                        {
-                            if (IsOffCooldown(DRK.CarveAndSpit))
-                                return DRK.CarveAndSpit;
-                            if (IsOnCooldown(DRK.CarveAndSpit))
-                                return DRK.Plunge;
-                        }
-                        
-                        if (GetBuffStacks(DRK.Buffs.Delirium) == 1)
-                        {
-                            if (GetRemainingCharges(DRK.Shadowbringer) == 1)
-                                return DRK.Shadowbringer;
-                            if (GetRemainingCharges(DRK.Shadowbringer) == 0)
-                                return DRK.EdgeOfShadow;
+                        if (IsOnCooldown(DRK.BloodWeapon))
+                            return DRK.HardSlash;
+                        if (IsEnabled(CustomComboPreset.DarkOpenerFeature) && inOpener && HasEffect(DRK.Buffs.BlackestNight))
+                            return DRK.BloodWeapon;
+                    }
+                }
 
+                if (incombat)
+                {
+                    if (IsEnabled(CustomComboPreset.DarkOpenerFeature) && inOpener && level == 90)
+                    {
+                        if (lastComboMove == DRK.Souleater && GetRemainingCharges(DRK.Plunge) == 0)
+                        {
+                            inOpener = false;
                         }
 
+                        // oGCDs
+                        if (CanWeave(actionID))
+                        {
+                            if (GetBuffStacks(DRK.Buffs.Delirium) == 2)
+                            {
+                                if (IsOffCooldown(DRK.CarveAndSpit))
+                                    return DRK.CarveAndSpit;
+                                if (IsOnCooldown(DRK.CarveAndSpit))
+                                    return DRK.Plunge;
+                            }
+
+                            if (GetBuffStacks(DRK.Buffs.Delirium) == 1)
+                            {
+                                if (GetRemainingCharges(DRK.Shadowbringer) == 1)
+                                    return DRK.Shadowbringer;
+                                if (GetRemainingCharges(DRK.Shadowbringer) == 0)
+                                    return DRK.EdgeOfShadow;
+
+                            }
+
+                            if (lastComboMove == DRK.HardSlash)
+                            {
+                                if (gauge.Blood == 10 && HasEffect(DRK.Buffs.BloodWeapon) && IsOffCooldown(DRK.LivingShadow))
+                                {
+                                    if (gauge.DarksideTimeRemaining == 0)
+                                        return DRK.EdgeOfShadow;
+                                    if (gauge.DarksideTimeRemaining > 0)
+                                        return DRK.Delirium;
+                                }
+
+                                if (IsOnCooldown(DRK.LivingShadow) && GetBuffStacks(DRK.Buffs.Delirium) == 3)
+                                {
+                                    if (GetRemainingCharges(DRK.Shadowbringer) == 2)
+                                        return DRK.Shadowbringer;
+                                    if (GetRemainingCharges(DRK.Shadowbringer) == 1)
+                                        return DRK.EdgeOfShadow;
+                                }
+
+                                if (IsOnCooldown(DRK.Shadowbringer) && !HasEffect(DRK.Buffs.Delirium))
+                                {
+                                    if (IsOffCooldown(DRK.SaltAndDarkness))
+                                        return DRK.SaltAndDarkness;
+                                    if (IsOnCooldown(DRK.SaltAndDarkness))
+                                        return DRK.EdgeOfShadow;
+                                }
+
+                            }
+
+                            if (lastComboMove == DRK.Souleater)
+                            {
+                                if (IsOffCooldown(DRK.LivingShadow))
+                                    return DRK.LivingShadow;
+                                if (IsOnCooldown(DRK.LivingShadow))
+                                    return DRK.SaltedEarth;
+                            }
+
+                            if (lastComboMove == DRK.SyphonStrike && GetRemainingCharges(DRK.Shadowbringer) == 0)
+                            {
+                                if (GetRemainingCharges(DRK.Plunge) == 1)
+                                    return DRK.Plunge;
+                                if (GetRemainingCharges(DRK.Plunge) == 0)
+                                    return DRK.EdgeOfShadow;
+                            }
+                        }
+
+                        // GCDs
                         if (lastComboMove == DRK.HardSlash)
                         {
-                            if (gauge.Blood == 10 && HasEffect(DRK.Buffs.BloodWeapon) && IsOffCooldown(DRK.LivingShadow))
-                            {
-                                if (gauge.DarksideTimeRemaining == 0)
-                                    return DRK.EdgeOfShadow;
-                                if (gauge.DarksideTimeRemaining > 0)
-                                    return DRK.Delirium;
-                            }
-
-                            if (IsOnCooldown(DRK.LivingShadow) && GetBuffStacks(DRK.Buffs.Delirium) == 3)
-                            {
-                                if (GetRemainingCharges(DRK.Shadowbringer) == 2)
-                                    return DRK.Shadowbringer;
-                                if (GetRemainingCharges(DRK.Shadowbringer) == 1)
-                                    return DRK.EdgeOfShadow;
-                            }
-
-                            if (IsOnCooldown(DRK.Shadowbringer) && !HasEffect(DRK.Buffs.Delirium))
-                            {
-                                if (IsOffCooldown(DRK.SaltAndDarkness))
-                                    return DRK.SaltAndDarkness;
-                                if (IsOnCooldown(DRK.SaltAndDarkness))
-                                    return DRK.EdgeOfShadow;
-                            }
-
-                        }
-
-                        if (lastComboMove == DRK.Souleater)
-                        {
-                            if (IsOffCooldown(DRK.LivingShadow))
-                                return DRK.LivingShadow;
-                            if (IsOnCooldown(DRK.LivingShadow))
-                                return DRK.SaltedEarth;
-                        }
-
-                        if (lastComboMove == DRK.SyphonStrike && GetRemainingCharges(DRK.Shadowbringer) == 0)
-                        {
-                            if (GetRemainingCharges(DRK.Plunge) == 1)
-                                return DRK.Plunge;
-                            if (GetRemainingCharges(DRK.Plunge) == 0)
-                                return DRK.EdgeOfShadow;
-                        }
-                    }
-
-                    // GCDs
-                    if (lastComboMove == DRK.HardSlash)
-                    {
-                        if (GetBuffStacks(DRK.Buffs.Delirium) > 0 && GetRemainingCharges(DRK.Shadowbringer) < 2)
-                            return DRK.Bloodspiller;
-                        return DRK.SyphonStrike;
-                    }
-
-                    if (lastComboMove == DRK.SyphonStrike && level >= DRK.Levels.Souleater)
-                        return DRK.Souleater;
-                }
-
-                if ((IsEnabled(CustomComboPreset.DarkOpenerFeature) && !inOpener && incombat) || !IsEnabled(CustomComboPreset.DarkOpenerFeature))
-                {
-                    if (IsEnabled(CustomComboPreset.DarkRangedUptimeFeature) && level >= DRK.Levels.Unmend)
-                    {
-                        if (!InMeleeRange(true))
-                            return DRK.Unmend;
-                    }
-
-
-                    if (IsEnabled(CustomComboPreset.DeliriumFeature))
-                    {
-                        if (level >= DRK.Levels.Bloodpiller && level >= DRK.Levels.Delirium && HasEffect(DRK.Buffs.Delirium))
-                            return DRK.Bloodspiller;
-                    }
-
-                    if (HasEffect(DRK.Buffs.Delirium) && deliriumTime.RemainingTime <= 10 && deliriumTime.RemainingTime > 0 && IsEnabled(CustomComboPreset.DeliriumFeatureOption))
-                    {
-                        if (level >= DRK.Levels.Bloodpiller && level >= DRK.Levels.Delirium)
-                            return DRK.Bloodspiller;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.DarkManaOvercapFeature))
-                    {
-                        if (currentMp > 8500 || gauge.DarksideTimeRemaining < 10)
-                        {
-                            if (level >= DRK.Levels.EdgeOfShadow && gcd.CooldownRemaining > 0.7)
-                                return DRK.EdgeOfShadow;
-                            if (level >= DRK.Levels.FloodOfDarkness && level < DRK.Levels.EdgeOfDarkness && gcd.CooldownRemaining > 0.7)
-                                return DRK.FloodOfDarkness;
-                            if (level >= DRK.Levels.EdgeOfDarkness && gcd.CooldownRemaining > 0.7)
-                                return DRK.EdgeOfDarkness;
-                        }
-                    }
-
-                    if (comboTime > 0)
-                    {
-                        if (lastComboMove == DRK.HardSlash && level >= DRK.Levels.SyphonStrike)
+                            if (GetBuffStacks(DRK.Buffs.Delirium) > 0 && GetRemainingCharges(DRK.Shadowbringer) < 2)
+                                return DRK.Bloodspiller;
                             return DRK.SyphonStrike;
+                        }
 
                         if (lastComboMove == DRK.SyphonStrike && level >= DRK.Levels.Souleater)
                             return DRK.Souleater;
                     }
 
-                    if (bloodgauge >= 50 && !shadowCooldown.IsCooldown && CanWeave(actionID) && level >= DRK.Levels.LivingShadow && IsEnabled(CustomComboPreset.DRKLivingShadowFeature))
-                        return DRK.LivingShadow;
-
-
-
-                    if (IsEnabled(CustomComboPreset.DarkBloodGaugeOvercapFeature) && level >= DRK.Levels.Bloodpiller)
+                    if (!inOpener)
                     {
-                        if (lastComboMove == DRK.Souleater && level >= DRK.Levels.Bloodpiller && bloodgauge >= 80)
-                            return DRK.Bloodspiller;
-                    }
-                    if (IsEnabled(CustomComboPreset.DarkPlungeFeature) && level >= DRK.Levels.Plunge)
-                    {
-                        if (plungeCD.CooldownRemaining < 30 && actionIDCD.CooldownRemaining > 0.7)
-                            return DRK.Plunge;
-                    }
-                    // leaves 1 stack
-                    if (IsEnabled(CustomComboPreset.DarkPlungeFeatureOption) && level >= DRK.Levels.Plunge)
-                    {
-                        if (!plungeCD.IsCooldown && actionIDCD.CooldownRemaining > 0.7 && plungeCD.CooldownRemaining < 60)
-                            return DRK.Plunge;
+                        //Delirium Features
+                        if (level >= DRK.Levels.Delirium && IsEnabled(CustomComboPreset.DeliriumFeature))
+                        {
+                            if (IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption) && HasEffect(DRK.Buffs.Delirium) && GetBuffRemainingTime(DRK.Buffs.Delirium) <= 10 && GetBuffRemainingTime(DRK.Buffs.Delirium) > 0)
+                                return DRK.Bloodspiller;
+
+                            if (GetBuffStacks(DRK.Buffs.Delirium) > 0 && IsNotEnabled(CustomComboPreset.DelayedDeliriumFeatureOption))
+                                return DRK.Bloodspiller;
+                        }
+
+                        // oGCDs
+                        if (CanWeave(actionID))
+                        {
+                            if (IsEnabled(CustomComboPreset.DRKLivingShadowFeature) && gauge.Blood >= 50 && IsOffCooldown(DRK.LivingShadow) && level >= DRK.Levels.LivingShadow)
+                                return DRK.LivingShadow;
+
+                            if (IsEnabled(CustomComboPreset.DarkManaOvercapFeature) && (currentMp > 8500 || gauge.DarksideTimeRemaining < 10))
+                            {
+                                if (level >= DRK.Levels.EdgeOfDarkness)
+                                    return OriginalHook(DRK.EdgeOfDarkness);
+                                if (level >= DRK.Levels.FloodOfDarkness && level < DRK.Levels.EdgeOfDarkness)
+                                    return DRK.FloodOfDarkness;
+                            }
+
+                            if (level >= DRK.Levels.Plunge &&
+                                ((IsEnabled(CustomComboPreset.DarkPlungeFeature) && GetRemainingCharges(DRK.Plunge) > 0) || //leave 0 stacks
+                                (IsEnabled(CustomComboPreset.DarkPlungeFeatureOption) && GetRemainingCharges(DRK.Plunge) > 1))) //leaves 1 stack
+                                    return DRK.Plunge;
+                        }
+                        // 1-2-3 combo
+                        if (comboTime > 0)
+                        {
+                            if (lastComboMove == DRK.HardSlash && level >= DRK.Levels.SyphonStrike)
+                                return DRK.SyphonStrike;
+
+                            if (lastComboMove == DRK.SyphonStrike && level >= DRK.Levels.Souleater)
+                            {
+                                if (IsEnabled(CustomComboPreset.DarkBloodGaugeOvercapFeature) && level >= DRK.Levels.Bloodpiller && gauge.Blood >= 90)
+                                    return DRK.Bloodspiller;
+                                return DRK.Souleater;
+                            }
+                        }
                     }
                 }
 
@@ -305,7 +289,7 @@ namespace XIVSlothComboPlugin.Combos
                     if (level >= DRK.Levels.Quietus && level >= DRK.Levels.Delirium && HasEffect(DRK.Buffs.Delirium))
                         return DRK.Quietus;
                 }
-                if (HasEffect(DRK.Buffs.Delirium) && deliriumTime.RemainingTime <= 10 && deliriumTime.RemainingTime > 0 && IsEnabled(CustomComboPreset.DeliriumFeatureOption))
+                if (HasEffect(DRK.Buffs.Delirium) && deliriumTime.RemainingTime <= 10 && deliriumTime.RemainingTime > 0 && IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption))
                 {
                     if (level >= DRK.Levels.Quietus && level >= DRK.Levels.Delirium)
                         return DRK.Quietus;

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -106,8 +106,8 @@ namespace XIVSlothComboPlugin.Combos
                             IsOffCooldown(GNB.NoMercy) && level < GNB.Levels.BurstStrike)) //no cartridges unlocked
                             return GNB.NoMercy;
                         if (level >= GNB.Levels.RoughDivide &&
-                            (IsEnabled(CustomComboPreset.GunbreakerRoughDivide2StackOption) && GetRemainingCharges(GNB.RoughDivide) > 0 || // uses all stacks
-                            IsEnabled(CustomComboPreset.GunbreakerRoughDivide1StackOption) && GetRemainingCharges(GNB.RoughDivide) > 1)) // leaves 1 stack
+                            ((IsEnabled(CustomComboPreset.GunbreakerRoughDivide2StackOption) && GetRemainingCharges(GNB.RoughDivide) > 0) || // uses all stacks
+                            (IsEnabled(CustomComboPreset.GunbreakerRoughDivide1StackOption) && GetRemainingCharges(GNB.RoughDivide) > 1))) // leaves 1 stack
                                 return GNB.RoughDivide;
                         if (IsEnabled(CustomComboPreset.GunbreakerCDsOnMainComboFeature) && level >= GNB.Levels.DangerZone && !HasEffect(GNB.Buffs.NoMercy) && IsOffCooldown(GNB.DangerZone) &&
                             ((IsOnCooldown(GNB.GnashingFang) && gauge.AmmoComboStep != 1 && GetCooldown(GNB.GnashingFang).CooldownRemaining > 20) || //Post Gnashing Fang

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -101,84 +101,84 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (IsEnabled(CustomComboPreset.GunbreakerBloodfestonST) && gauge.Ammo == 0 && IsOffCooldown(GNB.Bloodfest) && level >= GNB.Levels.Bloodfest)
                             return GNB.Bloodfest;
-                        if (IsEnabled(CustomComboPreset.GunbreakerNoMercyonST) && IsOffCooldown(GNB.NoMercy) && IsOffCooldown(GNB.GnashingFang) && gauge.Ammo == GNB.MaxCartridges(level) && level >= GNB.Levels.NoMercy)
+                        if (IsEnabled(CustomComboPreset.GunbreakerNoMercyonST) && level >= GNB.Levels.NoMercy && 
+                            ((IsOffCooldown(GNB.NoMercy) && IsOffCooldown(GNB.GnashingFang) && gauge.Ammo == GNB.MaxCartridges(level) && level >= GNB.Levels.BurstStrike) || //Cartridges unlocked
+                            IsOffCooldown(GNB.NoMercy) && level < GNB.Levels.BurstStrike)) //no cartridges unlocked
                             return GNB.NoMercy;
                         if (level >= GNB.Levels.RoughDivide &&
                             (IsEnabled(CustomComboPreset.GunbreakerRoughDivide2StackOption) && GetRemainingCharges(GNB.RoughDivide) > 0 || // uses all stacks
                             IsEnabled(CustomComboPreset.GunbreakerRoughDivide1StackOption) && GetRemainingCharges(GNB.RoughDivide) > 1)) // leaves 1 stack
                                 return GNB.RoughDivide;
+                        if (IsEnabled(CustomComboPreset.GunbreakerCDsOnMainComboFeature) && level >= GNB.Levels.DangerZone && !HasEffect(GNB.Buffs.NoMercy) && IsOffCooldown(GNB.DangerZone) &&
+                            ((IsOnCooldown(GNB.GnashingFang) && gauge.AmmoComboStep != 1 && GetCooldown(GNB.GnashingFang).CooldownRemaining > 20) || //Post Gnashing Fang
+                            (level < GNB.Levels.GnashingFang) && IsOnCooldown(GNB.NoMercy))) //Pre Gnashing Fang
+                                return OriginalHook(GNB.DangerZone);
+                        if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.Continuation &&
+                            (HasEffect(GNB.Buffs.ReadyToRip) || HasEffect(GNB.Buffs.ReadyToTear) || HasEffect(GNB.Buffs.ReadyToGouge)) && level >= GNB.Levels.Continuation)
+                                return OriginalHook(GNB.Continuation);
+                    }
+                    // 60s window features
+                    if (HasEffect(GNB.Buffs.NoMercy))
+                    {
+                        if (level >= GNB.Levels.DoubleDown)
+                        {
+                            if (IsEnabled(CustomComboPreset.GunbreakerDDonMain) && IsOffCooldown(GNB.DoubleDown) && gauge.Ammo is 2 or 3 && !HasEffect(GNB.Buffs.ReadyToRip))
+                                return GNB.DoubleDown;
+                            if (IsEnabled(CustomComboPreset.GunbreakerCDsOnMainComboFeature) && IsOnCooldown(GNB.DoubleDown))
+                            {
+                                if (CanWeave(actionID))
+                                {
+                                    if (IsOffCooldown(GNB.DangerZone))
+                                        return OriginalHook(GNB.DangerZone);
+                                    if (IsOffCooldown(GNB.BowShock))
+                                        return GNB.BowShock;
+                                }
+
+                                if (IsOffCooldown(GNB.SonicBreak))
+                                    return GNB.SonicBreak;
+                            }
+                        }
+
+                        if (IsEnabled(CustomComboPreset.GunbreakerCDsOnMainComboFeature) && level < GNB.Levels.DoubleDown)
+                        {
+                            if (level >= GNB.Levels.SonicBreak && IsOffCooldown(GNB.SonicBreak) && !HasEffect(GNB.Buffs.ReadyToRip))
+                                return GNB.SonicBreak;
+                            if (IsOnCooldown(GNB.SonicBreak) && CanWeave(actionID))
+                            {
+                                if (level >= GNB.Levels.BowShock && IsOffCooldown(GNB.BowShock))
+                                    return GNB.BowShock;
+                                if (level >= GNB.Levels.DangerZone && IsOffCooldown(GNB.DangerZone))
+                                    return OriginalHook(GNB.DangerZone);
+                            }
+                            //sub level 54 functionality
+                            if (level >= GNB.Levels.DangerZone && level < GNB.Levels.SonicBreak && IsOffCooldown(GNB.DangerZone))
+                                return OriginalHook(GNB.DangerZone);
+                        }
                     }
 
-                    // Gnashing Fang combo + Continuation, Gnashing Fang needs to be used manually in order for users to control for any delay based on fight times
-                    if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.GnashingFang )
+                    //Pre Gnashing Fang stuff
+
+                    if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && (IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 && level >= GNB.Levels.GnashingFang))
                     {
+                        if (gauge.Ammo == GNB.MaxCartridges(level) && HasEffectAny(GNB.Buffs.NoMercy) ||
+                            (gauge.Ammo > 0 && !HasEffectAny(GNB.Buffs.NoMercy) && GetCooldown(GNB.NoMercy).CooldownRemaining > 17))
+                            return GNB.GnashingFang;
+                    }
 
-                        if (HasEffect(GNB.Buffs.NoMercy) && IsOnCooldown(GNB.GnashingFang))
-                        {
-                            if (level >= GNB.Levels.DoubleDown)
-                            {
-                                if (IsEnabled(CustomComboPreset.GunbreakerDDonMain) && IsOffCooldown(GNB.DoubleDown) && gauge.Ammo is 2 or 3 && !HasEffect(GNB.Buffs.ReadyToRip))
-                                    return GNB.DoubleDown;
-                                if (IsEnabled(CustomComboPreset.GunbreakerCDsOnMainComboFeature) && IsOnCooldown(GNB.DoubleDown))
-                                {
-                                    if (CanWeave(actionID))
-                                    {
-                                        if (IsOffCooldown(GNB.BlastingZone))
-                                            return OriginalHook(GNB.DangerZone);
-                                        if (IsOffCooldown(GNB.BowShock))
-                                            return GNB.BowShock;
-                                    }
+                    if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.GnashingFang && gauge.AmmoComboStep is 1 or 2)
+                        return OriginalHook(GNB.GnashingFang);
 
-                                    if (IsOffCooldown(GNB.SonicBreak))
-                                        return GNB.SonicBreak;
-                                }
-                            }
-
-                            if (IsEnabled(CustomComboPreset.GunbreakerCDsOnMainComboFeature) && level < GNB.Levels.DoubleDown)
-                            {
-                                if (level >= GNB.Levels.SonicBreak && IsOffCooldown(GNB.SonicBreak) && !HasEffect(GNB.Buffs.ReadyToRip))
-                                    return GNB.SonicBreak;
-                                if (IsOnCooldown(GNB.SonicBreak) && CanWeave(actionID))
-                                {
-                                    if (level >= GNB.Levels.BowShock && IsOffCooldown(GNB.BowShock))
-                                        return GNB.BowShock;
-                                    if (level >= GNB.Levels.DangerZone && IsOffCooldown(GNB.BlastingZone))
-                                        return OriginalHook(GNB.DangerZone);
-                                }
-                            }
-                        }
-
-                        if (CanWeave(actionID))
-                        {
-                            if (IsEnabled(CustomComboPreset.GunbreakerCDsOnMainComboFeature) && level >= GNB.Levels.DangerZone && !HasEffect(GNB.Buffs.NoMercy)
-                                && IsOnCooldown(GNB.GnashingFang) && IsOffCooldown(GNB.BlastingZone) && gauge.AmmoComboStep != 1 && GetCooldown(GNB.GnashingFang).CooldownRemaining > 20)
-                                    return OriginalHook(GNB.DangerZone);
-                            if ((HasEffect(GNB.Buffs.ReadyToRip) || HasEffect(GNB.Buffs.ReadyToTear) || HasEffect(GNB.Buffs.ReadyToGouge)) && level >= GNB.Levels.Continuation)
-                                return OriginalHook(GNB.Continuation);
-                        }
-
-                        if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && (IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 && level >= GNB.Levels.GnashingFang))
-                        {
-                            if (gauge.Ammo == GNB.MaxCartridges(level) && HasEffectAny(GNB.Buffs.NoMercy) ||
-                                (gauge.Ammo > 0 && !HasEffectAny(GNB.Buffs.NoMercy) && GetCooldown(GNB.NoMercy).CooldownRemaining > 17))
-                                return GNB.GnashingFang;
-                        }
-                        
-                        if (gauge.AmmoComboStep is 1 or 2)
-                                return OriginalHook(GNB.GnashingFang);
-                        
-                        if (HasEffect(GNB.Buffs.NoMercy) && gauge.AmmoComboStep == 0)
-                        {
-                            if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
-                                return GNB.Hypervelocity;
-                            if ((gauge.Ammo != 0) && level >= GNB.Levels.BurstStrike)
-                                return GNB.BurstStrike;
-                        }
-
-                        //final check if Burst Strike is used right before No Mercy ends
+                    if (HasEffect(GNB.Buffs.NoMercy) && gauge.AmmoComboStep == 0)
+                    {
                         if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
                             return GNB.Hypervelocity;
+                        if ((gauge.Ammo != 0) && level >= GNB.Levels.BurstStrike)
+                            return GNB.BurstStrike;
                     }
+
+                    //final check if Burst Strike is used right before No Mercy ends
+                    if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
+                        return GNB.Hypervelocity;
 
                     // Regular 1-2-3 combo with overcap feature
                     if (lastComboMove == GNB.KeenEdge && level >= GNB.Levels.BrutalShell)
@@ -227,7 +227,7 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             if (CanWeave(actionID))
                             {
-                                if (IsOffCooldown(GNB.BlastingZone))
+                                if (IsOffCooldown(GNB.DangerZone))
                                     return OriginalHook(GNB.DangerZone);
                                 if (IsOffCooldown(GNB.BowShock))
                                     return GNB.BowShock;
@@ -246,7 +246,7 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             if (level >= GNB.Levels.BowShock && IsOffCooldown(GNB.BowShock))
                                 return GNB.BowShock;
-                            if (level >= GNB.Levels.DangerZone && IsOffCooldown(GNB.BlastingZone))
+                            if (level >= GNB.Levels.DangerZone && IsOffCooldown(GNB.DangerZone))
                                 return OriginalHook(GNB.DangerZone);
                         }
                     }
@@ -255,7 +255,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (CanWeave(actionID))
                 {
-                    if (level >= GNB.Levels.DangerZone && IsOnCooldown(GNB.GnashingFang) && !HasEffect(GNB.Buffs.NoMercy) && IsOffCooldown(GNB.BlastingZone) && gauge.AmmoComboStep != 1 && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF))
+                    if (level >= GNB.Levels.DangerZone && IsOnCooldown(GNB.GnashingFang) && !HasEffect(GNB.Buffs.NoMercy) && IsOffCooldown(GNB.DangerZone) && gauge.AmmoComboStep != 1 && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF))
                         return OriginalHook(GNB.DangerZone);
                     if ((HasEffect(GNB.Buffs.ReadyToRip) || HasEffect(GNB.Buffs.ReadyToTear) || HasEffect(GNB.Buffs.ReadyToGouge)) && level >= GNB.Levels.Continuation)
                         return OriginalHook(GNB.Continuation);

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -104,28 +104,29 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (HasEffect(WAR.Buffs.SurgingTempest))
                 {
-                    if (CanWeave(actionID))
-                    {
-                        if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(WAR.Upheaval) && level >= WAR.Levels.Upheaval)
-                            return WAR.Upheaval;
-                        if (IsEnabled(CustomComboPreset.WarriorIRonST) && IsOffCooldown(OriginalHook(WAR.Berserk)) && !HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.Berserk)
-                            return OriginalHook(WAR.Berserk);
-                        if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && level >= WAR.Levels.Onslaught && GetRemainingCharges(WAR.Onslaught) > onslaughtChargesRemaining)
-                            return WAR.Onslaught;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady))
-                        return WAR.PrimalRend;
-
-                    if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.InnerBeast) ||
-                        (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.InnerChaos) ||
-                        (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.InnerBeast &&
-                        (IsOffCooldown(WAR.InnerRelease) || GetCooldown(WAR.InnerRelease).CooldownRemaining > 35) || HasEffect(WAR.Buffs.NascentChaos)))
-                            return OriginalHook(WAR.InnerBeast);
-                }
 
                 if (comboTime > 0)
                 {
+                        if (CanWeave(actionID))
+                        {
+                            if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(WAR.Upheaval) && level >= WAR.Levels.Upheaval)
+                                return WAR.Upheaval;
+                            if (IsEnabled(CustomComboPreset.WarriorIRonST) && IsOffCooldown(OriginalHook(WAR.Berserk)) && !HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.Berserk)
+                                return OriginalHook(WAR.Berserk);
+                            if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && level >= WAR.Levels.Onslaught && GetRemainingCharges(WAR.Onslaught) > onslaughtChargesRemaining)
+                                return WAR.Onslaught;
+                        }
+
+                        if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady))
+                            return WAR.PrimalRend;
+
+                        if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.InnerBeast) ||
+                            (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.InnerChaos) ||
+                            (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.InnerBeast &&
+                            (IsOffCooldown(WAR.InnerRelease) || GetCooldown(WAR.InnerRelease).CooldownRemaining > 35) || HasEffect(WAR.Buffs.NascentChaos)))
+                            return OriginalHook(WAR.InnerBeast);
+                    }
+
                     if (IsEnabled(CustomComboPreset.WarriorInfuriateonST) && level >= WAR.Levels.Infuriate && GetRemainingCharges(WAR.Infuriate) >= 1 && !HasEffect(WAR.Buffs.NascentChaos) && !HasEffect(WAR.Buffs.InnerRelease) && gauge <= 50)
                         return WAR.Infuriate;
 

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -102,31 +102,30 @@ namespace XIVSlothComboPlugin.Combos
                         return WAR.Tomahawk;
                 }
 
-                if (HasEffect(WAR.Buffs.SurgingTempest))
+                if (HasEffect(WAR.Buffs.SurgingTempest) && HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
                 {
+                    if (CanWeave(actionID))
+                    {
+                        if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(WAR.Upheaval) && level >= WAR.Levels.Upheaval)
+                            return WAR.Upheaval;
+                        if (IsEnabled(CustomComboPreset.WarriorIRonST) && IsOffCooldown(OriginalHook(WAR.Berserk)) && !HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.Berserk)
+                            return OriginalHook(WAR.Berserk);
+                        if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && level >= WAR.Levels.Onslaught && GetRemainingCharges(WAR.Onslaught) > onslaughtChargesRemaining)
+                            return WAR.Onslaught;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady))
+                        return WAR.PrimalRend;
+
+                    if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.InnerBeast) ||
+                        (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.InnerChaos) ||
+                        (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.InnerBeast &&
+                        (IsOffCooldown(WAR.InnerRelease) || GetCooldown(WAR.InnerRelease).CooldownRemaining > 35) || HasEffect(WAR.Buffs.NascentChaos)))
+                            return OriginalHook(WAR.InnerBeast);
+                }
 
                 if (comboTime > 0)
                 {
-                        if (CanWeave(actionID))
-                        {
-                            if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(WAR.Upheaval) && level >= WAR.Levels.Upheaval)
-                                return WAR.Upheaval;
-                            if (IsEnabled(CustomComboPreset.WarriorIRonST) && IsOffCooldown(OriginalHook(WAR.Berserk)) && !HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.Berserk)
-                                return OriginalHook(WAR.Berserk);
-                            if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && level >= WAR.Levels.Onslaught && GetRemainingCharges(WAR.Onslaught) > onslaughtChargesRemaining)
-                                return WAR.Onslaught;
-                        }
-
-                        if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady))
-                            return WAR.PrimalRend;
-
-                        if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.InnerBeast) ||
-                            (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.InnerChaos) ||
-                            (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.InnerBeast &&
-                            (IsOffCooldown(WAR.InnerRelease) || GetCooldown(WAR.InnerRelease).CooldownRemaining > 35) || HasEffect(WAR.Buffs.NascentChaos)))
-                            return OriginalHook(WAR.InnerBeast);
-                    }
-
                     if (IsEnabled(CustomComboPreset.WarriorInfuriateonST) && level >= WAR.Levels.Infuriate && GetRemainingCharges(WAR.Infuriate) >= 1 && !HasEffect(WAR.Buffs.NascentChaos) && !HasEffect(WAR.Buffs.InnerRelease) && gauge <= 50)
                         return WAR.Infuriate;
 

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -120,7 +120,7 @@ namespace XIVSlothComboPlugin.Combos
                     if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.InnerBeast) ||
                         (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.InnerChaos) ||
                         (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.InnerBeast &&
-                        (IsOffCooldown(WAR.InnerRelease) || GetCooldown(WAR.InnerRelease).CooldownRemaining > 35) || HasEffect(WAR.Buffs.NascentChaos)))
+                        (IsOffCooldown(WAR.InnerRelease) || GetCooldown(WAR.InnerRelease).CooldownRemaining > 35 || HasEffect(WAR.Buffs.NascentChaos))))
                             return OriginalHook(WAR.InnerBeast);
                 }
 

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -307,6 +307,11 @@ namespace XIVSlothComboPlugin.Combos
             Status? eff = FindEffect(effectId);
             return eff?.StackCount ?? 0;
         }
+        protected static float GetBuffRemainingTime(ushort effectId)
+        {
+            Status? eff = FindEffect(effectId);
+            return eff?.RemainingTime ?? 0;
+        }
 
         /// <summary>
         /// Finds an effect on the player.

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -871,11 +871,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Gnashing Fang and Continuation on Main Combo", "Adds Gnashing Fang to the main combo. Gnashing Fang must be started manually and the combo will finish it off.\n Useful for when Gnashing Fang needs to be help due to downtime.", GNB.JobID, 0, "Fashing Gnang", "Why grandma, what big teeth you have!")]
         GunbreakerGnashingFangOnMain = 7001,
 
-        [ParentCombo(GunbreakerGnashingFangOnMain)]
+        [ParentCombo(GunbreakerSolidBarrelCombo)]
         [CustomComboInfo("Sonic Break/Bow Shock/Blasting Zone on Main Combo", "Adds Sonic Break/Bow Shock/Blasting Zone on main combo when under No Mercy buff", GNB.JobID, 0, "Gee Whiz!", "Mom, I can't manage my oGCDs!")]
         GunbreakerCDsOnMainComboFeature = 7002,
 
-        [ParentCombo(GunbreakerGnashingFangOnMain)]
+        [ParentCombo(GunbreakerSolidBarrelCombo)]
         [CustomComboInfo("Double Down on Main Combo", "Adds Double Down on main combo when under No Mercy buff", GNB.JobID, 0, "ALL the deeps", "For when you're both feeling merciless and are stuffed full of powder. BANG!")]
         GunbreakerDDonMain = 7003,
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -630,7 +630,6 @@ namespace XIVSlothComboPlugin
         DarkStalwartSoulCombo = 5001,
 
         [ParentCombo(DarkSouleaterCombo)]
-        [ConflictingCombos(DeliriumFeatureOption)]
         [CustomComboInfo("Delirium Feature", "Replace Souleater and Stalwart Soul with Bloodspiller and Quietus when Delirium is active.", DRK.JobID, 0, "", "Delirium is what you have if you choose to play DRK.\nDoc's words, not mine")]
         DeliriumFeature = 5002,
 
@@ -662,10 +661,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Plunge Option", "Adds Plunge onto main combo whenever its available (Leaves 1 stack).", DRK.JobID, 0, "", "Take the plunge. Or, just dip your toes in. Whatever.")]
         DarkPlungeFeatureOption = 5009,
 
-        [ParentCombo(DarkSouleaterCombo)]
-        [ConflictingCombos(DeliriumFeature)]
-        [CustomComboInfo("Delirium Feature Option", "Replaces Souleather with Bloodspiller when Delirium has 10sec or less remaining.", DRK.JobID, 0, "", "Delirium is what you have if you choose to play DRK.\nDoc's words, not mine")]
-        DeliriumFeatureOption = 5010,
+        [ParentCombo(DeliriumFeature)]
+        [CustomComboInfo("Delayed Delirium Feature", "Delays Bloodspiller by 2 GCDs when Delirium is used. Useful for feeding into raid buffs at level 90.", DRK.JobID, 0)]
+        DelayedDeliriumFeatureOption = 5010,
 
         [ParentCombo(DarkSouleaterCombo)]
         [CustomComboInfo("Unmend Uptime Feature", "Replace Souleater Combo Feature with Unmend when you are out of range.", DRK.JobID, 0, "Ranged DPS job now, duh", "Stubby little arms, huh")]
@@ -692,9 +690,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Level 90 Dark Knight Opener", "Adds the Level 90 Dark Knight Opener to the Main Combo. \nOpener triggered by using The Blackest Night or Blood Weapon before combat.", DRK.JobID, 0)]
         DarkOpenerFeature = 5017,
 
-        /*[ParentCombo(DarkOpenerFeature)]
+        [ParentCombo(DarkOpenerFeature)]
         [CustomComboInfo("Blood Weapon out of Combat Feature", "If TBN is used outside of combat, turns the main combo into Blood Weapon in preparation for the opener.", DRK.JobID, 0)]
-        DarkBloodWeaponOpener = 5018,*/
+        DarkBloodWeaponOpener = 5018,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
GNB: Simple GNB should work for all levels now
GNB: Minor syntax fix
WAR: Fixed infuriate persisting outside of combat
WAR: Spender Option fix
DRK: Refactoring
DRK: Renamed DeliriumFeatureOption to DelayedDeliriumFeatureOption and moved it under DeliriumFeature as a child combo. Refactored to avoid conflicts.
DRK: Added DarkBloodWeaponOpener
Framework: Added GetBuffRemainingTime as a quicker call for FindEffect(actionID).Remaining Time