### PR TITLE
Updates to RDM Lucid Dreaming feature and WAR Bug Fix

### DIFF
--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -1151,14 +1151,14 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is RDM.Jolt or RDM.Jolt2 or RDM.Verfire or RDM.Verstone or RDM.Verthunder2 or RDM.Veraero2)
+            if (actionID is RDM.Verthunder or RDM.Veraero or RDM.Scatter or RDM.Verthunder3 or RDM.Veraero3 or RDM.Impact)
             {
                 var canWeave = CanWeave(actionID);
                 var castingSpell = LocalPlayer.IsCasting;
                 var inCombat = HasCondition(ConditionFlag.InCombat);
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(RDM.Config.RdmLucidMpThreshold);
 
-                if (!canWeave || !inCombat) // Reset following weave window or exit combat if enemy dies
+                if (!canWeave || !inCombat || IsOnCooldown(RDM.LucidDreaming) || lastComboMove == RDM.EnchantedRedoublement || lastComboMove == RDM.Verflare || lastComboMove == RDM.Verholy || lastComboMove == RDM.Scorch) // Reset following weave window or exit combat if enemy dies
                 {
                     showLucid = false;
                     return actionID;

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -1146,14 +1146,33 @@ namespace XIVSlothComboPlugin.Combos
     internal class RedMageLucidOnJolt : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RedMageLucidOnJolt;
+
+        internal static bool showLucid = false;
+
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             if (actionID is RDM.Jolt or RDM.Jolt2 or RDM.Verfire or RDM.Verstone or RDM.Verthunder2 or RDM.Veraero2)
             {
-                var needLucid = Service.Configuration.GetCustomIntValue(RDM.Config.RdmLucidMpThreshold);
+                var canWeave = CanWeave(actionID);
+                var castingSpell = LocalPlayer.IsCasting;
+                var inCombat = HasCondition(ConditionFlag.InCombat);
+                var lucidThreshold = Service.Configuration.GetCustomIntValue(RDM.Config.RdmLucidMpThreshold);
 
-                if (level >= RDM.Levels.LucidDreaming && IsOffCooldown(RDM.LucidDreaming) && LocalPlayer.CurrentMp <= needLucid && CanWeave(actionID))
+                if (!canWeave || !inCombat) // Reset following weave window or exit combat if enemy dies
+                {
+                    showLucid = false;
+                    return actionID;
+                }
+
+                if (level >= RDM.Levels.LucidDreaming && IsOffCooldown(RDM.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold) // Check to show Lucid Dreaming
+                {
+                    showLucid = true;
+                }
+
+                if (showLucid && canWeave && !castingSpell) // Change abilities to Lucid Dreaming for entire weave window
+                {
                     return RDM.LucidDreaming;
+                }
             }
             return actionID;
         }

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -126,7 +126,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (comboTime > 0)
                 {
-                    if (IsEnabled(CustomComboPreset.WarriorInfuriateonST) && level >= WAR.Levels.Infuriate && GetRemainingCharges(WAR.Infuriate) >= 1 && !HasEffect(WAR.Buffs.NascentChaos) && !HasEffect(WAR.Buffs.InnerRelease) && gauge <= 50)
+                    if (IsEnabled(CustomComboPreset.WarriorInfuriateonST) && level >= WAR.Levels.Infuriate && GetRemainingCharges(WAR.Infuriate) >= 1 && !HasEffect(WAR.Buffs.NascentChaos) && !HasEffect(WAR.Buffs.InnerRelease) && gauge <= 50 && CanWeave(actionID))
                         return WAR.Infuriate;
 
                     if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim)

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1555,7 +1555,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Jolt into Verproc", "Replaces Jolt with Verstone/Verfire, when proc is available and won't cause severe imbalance", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
         RedMageJoltVerprocCombo = 13021,
 
-        [CustomComboInfo("Lucid Dreaming Feature", "Add Lucid Dreaming to 2-sec spells when below threshold.", RDM.JobID, 0, "Jolt / Verfire / Verstone / Verthunder II / Veraero II -> Lucid Dreaming", "OOM? Git gud.")]
+        [CustomComboInfo("Lucid Dreaming Feature", "Add Lucid Dreaming to Veraero, Verthunder and Impact when below threshold.", RDM.JobID, 0, "Veraero / Verthunder / Impact -> Lucid Dreaming", "OOM? Git gud.")]
         RedMageLucidOnJolt = 13022,
 
         #endregion


### PR DESCRIPTION
I played a few dungeons with RDM and while it was functional, there were some quirks that I wanted to clean up.

RDM Lucid Dreaming Feature
 - Moved from [Jolt I/II, Verstone, Verfire, Veraero II, Verthunder II] to [Veraero I/III, Verthunder I/III and Scatter/Impact].
 - Disabled the feature during your Melee combo so it doesn't interfere with the buttons.
 - Lucid Dreaming will now appear for the entire weave window, even when your MP regens above the threshold.

WAR Bug Fix (https://github.com/Nik-Potokar/XIVSlothCombo/issues/405)
 - Infuriate will now only appear during the weave window.