### PR TITLE
[SGE] Single and AoE heals

### DIFF
--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -21,8 +21,10 @@ namespace XIVSlothComboPlugin.Combos
             Haima = 24305,
             Panhaima = 24311,
             Holos = 24310,
+            EukrasianDiagnosis = 24291,
+            EukrasianPrognosis = 24292,
 
-            // DPS
+        // DPS
             Dosis1 = 24283,
             Dosis2 = 24306,
             Dosis3 = 24312,
@@ -46,6 +48,7 @@ namespace XIVSlothComboPlugin.Combos
             Kardia = 24285,
             Eukrasia = 24290,
             Rhizomata = 24309,
+            
 
             // Role
             Egeiro = 24287,
@@ -57,7 +60,10 @@ namespace XIVSlothComboPlugin.Combos
             public const ushort
                 Kardia = 2604,
                 Eukrasia = 2606,
-                Swiftcast = 167;
+                Swiftcast = 167,
+                EukrasianDiagnosis = 2607,
+                Kardion = 2872,
+                EukrasianPrognosis = 2609;
         }
 
         public static class Debuffs
@@ -73,12 +79,15 @@ namespace XIVSlothComboPlugin.Combos
             public const ushort
                 Dosis = 1,
                 Prognosis = 10,
+                Physis = 20,
                 Phlegma = 26,
                 Eukrasia = 30,
                 Soteria = 35,
                 Druochole = 45,
                 Kerachole = 50,
                 Ixochole = 52,
+                Zoe = 56,
+                Pepsis = 58,
                 Physis2 = 60,
                 Taurochole = 62,
                 Toxikon = 66,
@@ -99,8 +108,21 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
-                SGELucidDreamingFeature = "SGELucidDreamingFeature";
+                SGELucidDreamingFeature = "SGELucidDreamingFeature",
+
+                CustomZoe = "CustomZoe",
+                CustomHaima = "CustomHaima",
+                CustomKrasis = "CustomKrasis",
+                CustomPepsis = "CustomPepsis",
+                CustomSoteria = "CustomSoteria",
+                CustomIxochole = "CustomIxochole",
+                CustomDiagnosis = "CustomDiagnosis",
+                CustomKerachole = "CustomKerachole",
+                CustomRhizomata = "CustomRhizomata",
+                CustomDruochole = "CustomDruochole",
+                CustomTaurochole = "CustomTaurochole";
         }
+        
     }
 
     internal class SageKardiaFeature : CustomCombo
@@ -320,4 +342,149 @@ namespace XIVSlothComboPlugin.Combos
             return actionID;
         }
     }
+
+    internal class SageSingleTargetHeal : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SageSingleTargetHealFeature;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            var zoeCD = GetCooldown(SGE.Zoe);
+            
+            var HaimaCD = GetCooldown(SGE.Haima);
+            var PepsisCD = GetCooldown(SGE.Pepsis);
+            var KrasisCD = GetCooldown(SGE.Krasis);
+            var SoteriaCD = GetCooldown(SGE.Soteria);
+            var RhizomataCD = GetCooldown(SGE.Rhizomata);
+            var DruocholeCD = GetCooldown(SGE.Druochole);
+            var TaurocholeCD = GetCooldown(SGE.Taurochole);
+            var Addersgall = GetJobGauge<SGEGauge>().Addersgall;
+
+            var Kardia = FindEffect(SGE.Buffs.Kardia);
+            var Kardion = FindTargetEffect(SGE.Buffs.Kardion);
+            var EukrasianDiagnosis = FindTargetEffect(SGE.Buffs.EukrasianDiagnosis);
+
+            
+            var CustomZoe = Service.Configuration.GetCustomIntValue(SGE.Config.CustomZoe);
+            var CustomHaima = Service.Configuration.GetCustomIntValue(SGE.Config.CustomHaima);
+            var CustomKrasis = Service.Configuration.GetCustomIntValue(SGE.Config.CustomKrasis);
+            var CustomPepsis = Service.Configuration.GetCustomIntValue(SGE.Config.CustomPepsis);
+            var CustomSoteria = Service.Configuration.GetCustomIntValue(SGE.Config.CustomSoteria);
+            var CustomDiagnosis = Service.Configuration.GetCustomIntValue(SGE.Config.CustomDiagnosis);
+            var CustomDruochole = Service.Configuration.GetCustomIntValue(SGE.Config.CustomDruochole);
+            var CustomTaurochole = Service.Configuration.GetCustomIntValue(SGE.Config.CustomTaurochole);
+
+            if (actionID == SGE.Diagnosis )
+            {
+
+                if (IsEnabled(CustomComboPreset.CustomDruocholeFeature) && DruocholeCD.CooldownRemaining == 0  &&  Addersgall >= 1 && level >= SGE.Levels.Druochole && EnemyHealthPercentage() <= CustomDruochole)
+                    return SGE.Druochole;
+
+                if (IsEnabled(CustomComboPreset.CustomTaurocholeFeature) && TaurocholeCD.CooldownRemaining == 0  &&  Addersgall >= 1 && level >= SGE.Levels.Taurochole && EnemyHealthPercentage() <= CustomTaurochole)
+                    return SGE.Taurochole;
+
+                if (IsEnabled(CustomComboPreset.RhizomataFeatureAoE) && RhizomataCD.CooldownRemaining == 0 && Addersgall == 0 && level >= SGE.Levels.Rhizomata)
+                    return SGE.Rhizomata;
+
+                if (IsEnabled(CustomComboPreset.AutoApplyKardia) && (Kardion is null) && (Kardia is null))
+                    return SGE.Kardia;
+
+                if (IsEnabled(CustomComboPreset.CustomSoteriaFeature) && (CurrentTarget.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.Player) && SoteriaCD.CooldownRemaining == 0 && level >= SGE.Levels.Soteria && EnemyHealthPercentage() <= CustomSoteria)
+                    return SGE.Soteria;
+
+                if (IsEnabled(CustomComboPreset.CustomZoeFeature) && (CurrentTarget.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.Player) && zoeCD.CooldownRemaining == 0 && level >= SGE.Levels.Zoe && EnemyHealthPercentage() <= CustomZoe)
+                    return SGE.Zoe;
+
+                if (IsEnabled(CustomComboPreset.CustomKrasisFeature) && (CurrentTarget.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.Player) && KrasisCD.CooldownRemaining == 0 && level >= SGE.Levels.Krasis && EnemyHealthPercentage() <= CustomKrasis)
+                    return SGE.Krasis;
+
+                if (IsEnabled(CustomComboPreset.CustomPepsisFeature) && (CurrentTarget.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.Player) && PepsisCD.CooldownRemaining == 0 && level >= SGE.Levels.Pepsis && EnemyHealthPercentage() <= CustomPepsis && EukrasianDiagnosis is not null)
+                    return SGE.Pepsis;
+
+                if (IsEnabled(CustomComboPreset.CustomHaimaFeature) && (CurrentTarget.ObjectKind == Dalamud.Game.ClientState.Objects.Enums.ObjectKind.Player) && HaimaCD.CooldownRemaining == 0  && level >= SGE.Levels.Haima && EnemyHealthPercentage() <= CustomHaima)
+                    return SGE.Haima;
+                
+                if (IsEnabled(CustomComboPreset.CustomEukrasianDiagnosisFeature) && EukrasianDiagnosis is null && EnemyHealthPercentage() <= CustomDiagnosis)
+                {
+                    if (!HasEffect(SGE.Buffs.Eukrasia))
+                        return SGE.Eukrasia;
+                    if (HasEffect(SGE.Buffs.Eukrasia))
+                        return SGE.EukrasianDiagnosis;
+                }
+            }
+            return actionID;
+        }
+    }
+
+    internal class SageAoEHeal : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SageAoEHealFeature;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+
+
+            var HolosCD = GetCooldown(SGE.Holos);
+            var PhysisCD = GetCooldown(SGE.Physis);
+            var PepsisCD = GetCooldown(SGE.Pepsis);
+            var Physis2CD = GetCooldown(SGE.Physis2);
+            var PanhaimaCD = GetCooldown(SGE.Panhaima);
+            var IxocholeCD = GetCooldown(SGE.Ixochole);
+            var RhizomataCD = GetCooldown(SGE.Rhizomata);
+            var KeracholeCD = GetCooldown(SGE.Kerachole);
+            
+            var Addersgall = GetJobGauge<SGEGauge>().Addersgall;
+            var EukrasianPrognosis = FindEffect(SGE.Buffs.EukrasianPrognosis);
+
+            if (actionID == SGE.Prognosis)
+            {
+                if (IsEnabled(CustomComboPreset.RhizomataFeatureAoE) && RhizomataCD.CooldownRemaining == 0 && Addersgall == 0 && level >= SGE.Levels.Rhizomata)
+                    return SGE.Rhizomata;
+
+                if (IsEnabled(CustomComboPreset.KeracholeFeature) && KeracholeCD.CooldownRemaining == 0 && Addersgall >= 1 && level >= SGE.Levels.Kerachole)
+                    return SGE.Kerachole;
+
+                if (IsEnabled(CustomComboPreset.IxocholeFeature) && IxocholeCD.CooldownRemaining == 0 && Addersgall >= 1 &&  level >= SGE.Levels.Ixochole)
+                    return SGE.Ixochole;
+
+                if (IsEnabled(CustomComboPreset.PhysisFeature))
+                {
+                    if (PhysisCD.CooldownRemaining == 0 && level >= SGE.Levels.Physis && level < SGE.Levels.Physis2)
+                        return SGE.Physis;
+                    if (Physis2CD.CooldownRemaining == 0 && level >= SGE.Levels.Physis2)
+                        return SGE.Physis2;
+                }
+
+                if (IsEnabled(CustomComboPreset.EukrasianPrognosisFeature) && EukrasianPrognosis is null)
+                {
+                    if (!HasEffect(SGE.Buffs.Eukrasia))
+                        return SGE.Eukrasia;
+                    if (HasEffect(SGE.Buffs.Eukrasia))
+                        return SGE.EukrasianPrognosis;
+                }
+
+                if (IsEnabled(CustomComboPreset.HolosFeature) && HolosCD.CooldownRemaining == 0 && level >= SGE.Levels.Holos)
+                    return SGE.Holos;
+
+                if (IsEnabled(CustomComboPreset.PanhaimaFeature) && PanhaimaCD.CooldownRemaining == 0 && level >= SGE.Levels.Panhaima)
+                    return SGE.Panhaima;
+
+                if (IsEnabled(CustomComboPreset.PepsisFeature) && PepsisCD.CooldownRemaining == 0 && level >= SGE.Levels.Pepsis && EukrasianPrognosis is not null)
+                    return SGE.Pepsis;
+
+            }
+            return actionID;
+        }
+    }
+
+
+
+
+
+
+
+
+
+
+
 }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -610,6 +610,31 @@ namespace XIVSlothComboPlugin
             if (preset == CustomComboPreset.SageLucidFeatureAdvTest)
                 ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGELucidDreamingFeature, "Set value for your MP to be at or under for this feature to work###SGE", 150, SliderIncrements.Hundreds);
 
+            if (preset == CustomComboPreset.CustomSoteriaFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomSoteria, "Set HP percentage value for Soteria to trigger");
+           
+            if (preset == CustomComboPreset.CustomZoeFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomZoe, "Set HP percentage value for Zoe to trigger");
+
+            if (preset == CustomComboPreset.CustomPepsisFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomPepsis, "Set HP percentage value for Pepsis to trigger");
+
+            if (preset == CustomComboPreset.CustomTaurocholeFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomTaurochole, "Set HP percentage value for Taurochole to trigger");
+
+            if (preset == CustomComboPreset.CustomHaimaFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomHaima, "Set HP percentage value for Haima to trigger");
+
+            if (preset == CustomComboPreset.CustomKrasisFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomKrasis, "Set HP percentage value for Krasis to trigger");
+
+            if (preset == CustomComboPreset.CustomDruocholeFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomDruochole, "Set HP percentage value for Druochole to trigger");
+            
+            if (preset == CustomComboPreset.CustomEukrasianDiagnosisFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomDiagnosis, "Set HP percentage value for Eukrasian Diagnosis to trigger");
+
+
             #endregion
             // ====================================================================================
             #region SAMURAI

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1565,6 +1565,86 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Egeiro into Swiftcast Feature", "Changes Egiero to Swiftcast when Swiftcast is available.", SGE.JobID, 0, "Raise to Raise", "Swaps your raise with WHM's raise.\nDoesn't work any more. You're welcome")]
         SageAlternateEgeiroFeature = 14008,
 
+        [ConflictingCombos(SageRhizomataFeature, SageTauroDruoFeature)]
+        [CustomComboInfo("Sage Single Target Heal Feature", "Changes Diagnosis. You must target a party member (including yourself) for some features to work.", SGE.JobID, 0)]
+        SageSingleTargetHealFeature = 14011,
+
+        [ConflictingCombos(SageRhizomataFeature, SageTauroDruoFeature)]
+        [CustomComboInfo("Sage AoE Heal Feature", "Changes Prognosis. Customize your AoE healing to your liking", SGE.JobID, 0)]
+        SageAoEHealFeature = 14012,
+
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Apply Kardia", "Applies Kardia to your target if it's not applied to anyone else.", SGE.JobID, 0)]
+        AutoApplyKardia = 14013,
+
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Eukrasian Diagnosis Feature", "Diagnosis becomes Eukrasian Diagnosis if the shield is not applied to the target.", SGE.JobID, 0)]
+        CustomEukrasianDiagnosisFeature = 14014,
+
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Custom Soteria Feature", "Applies Soteria when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
+        CustomSoteriaFeature = 14015,
+        
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Custom Zoe Feature", "Applies Zoe when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
+        CustomZoeFeature = 14016,
+
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Custom Pepsis Feature", "Triggers Pepsis if a shield is present and the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
+        CustomPepsisFeature = 14017,
+
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Custom Taurochole Feature", "Adds Taurochole when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
+        CustomTaurocholeFeature = 14018,
+
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Custom Haima Feature", "Adds Haima when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
+        CustomHaimaFeature = 14019,
+
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Custom Rhizomata Feature", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 0)]
+        RhizomataFeature = 14020,
+        
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Custom Krasis Feature", "Applies Krasis when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
+        CustomKrasisFeature = 14021,
+
+        [ParentCombo(SageAoEHealFeature)]
+        [CustomComboInfo("Physis Feature", "Adds Physis.", SGE.JobID, 0)]
+        PhysisFeature = 14022,
+
+        [ParentCombo(SageAoEHealFeature)]
+        [CustomComboInfo("Eukrasian Prognosis Feature", "Prognosis becomes Eukrasian Prognosis if the shield is not applied.", SGE.JobID, 0)]
+        EukrasianPrognosisFeature = 14023,
+
+        [ParentCombo(SageAoEHealFeature)]
+        [CustomComboInfo("Holos Feature", "Adds Holos.", SGE.JobID, 0)]
+        HolosFeature = 14024,
+
+        [ParentCombo(SageAoEHealFeature)]
+        [CustomComboInfo("Panhaima Feature", "Adds Panhaima.", SGE.JobID, 0)]
+        PanhaimaFeature = 14025,
+
+        [ParentCombo(SageAoEHealFeature)]
+        [CustomComboInfo("Pepsis Feature", "Triggers Pepsis if a shield is present.", SGE.JobID, 0)]
+        PepsisFeature = 14026,
+
+        [ParentCombo(SageAoEHealFeature)]
+        [CustomComboInfo("Ixochole Feature", "Adds Ixochole", SGE.JobID, 0)]
+        IxocholeFeature = 14027,
+
+        [ParentCombo(SageAoEHealFeature)]
+        [CustomComboInfo("Kerachole Feature", "Adds Kerachole", SGE.JobID, 0)]
+        KeracholeFeature = 14028,
+
+        [ParentCombo(SageAoEHealFeature)]
+        [CustomComboInfo("Rhizomata Feature", "Adds Rhizomata when Addersgall is 0", SGE.JobID, 0)]
+        RhizomataFeatureAoE = 14029,
+
+        [ParentCombo(SageSingleTargetHealFeature)]
+        [CustomComboInfo("Druochole Feature", "Adds Druochole when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
+        CustomDruocholeFeature = 14030,
+                
         #endregion
         // ====================================================================================
         #region SAMURAI


### PR DESCRIPTION
Customizable Single Target Heal
The user can create a custom skill priority by adjusting the HP% values.
Some features only work if there is a target selected

- Adds Kardia to the selected target if absent
- Adds Eukrasian Diagnosis when the target's HP reaches the specified percentage; 
- Eukrasian Shield is only applied if the target selected doesn't have the shield applied.
- Adds Soteria Diagnosis when the target's HP reaches the specified percentage.
- Adds Zoe Diagnosis when the target's HP reaches the specified percentage.
- Triggers Pepsis  when the target's HP reaches the specified percentage.
- Adds Taurochole when the target's HP reaches the specified percentage.
- Adds Haima when the target's HP reaches the specified percentage.
- Adds Rhizomata when the Addersgall reaches 0.
- Adds Krasis when the target's HP reaches the specified percentage.
- Adds Druochole when the target's HP reaches the specified percentage



Simple AoE Healing

User can pick and chose which AoE skills to add
- Adds Eukrasian Prognosis if the shield is not applied.
- Adds Holos.
- Adds Panhaima
- Triggers Pepsis if a shield is present.
- Adds Ixochole
- Adds Kerachole 
- Adds Rhizomata when the Addersgall reaches 0.
