### PR TITLE
DRK oGCD Feature Bug Fixes || BLM AoE Combo Feature Fix and Enhancement || Tanks Double Reprisal Protection Feature

### DIFF
--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -95,6 +95,11 @@ namespace XIVSlothComboPlugin.Combos
                 Fire3 = 2000,
                 MaxMP = 10000;
         }
+        public static class Config
+        {
+            public const string
+                BlmPolygotsStored = "BlmPolygotsStored";
+        }
     }
 
     internal class BlackBlizzardFeature : CustomCombo
@@ -333,7 +338,21 @@ namespace XIVSlothComboPlugin.Combos
                 var thunder2Debuff = TargetHasEffect(BLM.Debuffs.Thunder2);
                 var thunder2Timer = FindTargetEffect(BLM.Debuffs.Thunder2);
                 var currentMP = LocalPlayer.CurrentMp;
+                var castingSpell = LocalPlayer.IsCasting;
+                var polyToStore = Service.Configuration.GetCustomIntValue(BLM.Config.BlmPolygotsStored);
 
+                if (IsEnabled(CustomComboPreset.BlackAoEFoulOption))
+                {
+                    if (gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && CanWeave(actionID) && lastComboMove == BLM.Foul && !castingSpell)
+                    {
+                        return BLM.Manafont;
+                    }
+
+                    if ((gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && gauge.PolyglotStacks >= polyToStore) || (GetCooldownRemainingTime(BLM.Manafont) >= 30 && gauge.PolyglotStacks > polyToStore))
+                    {
+                        return BLM.Foul;
+                    }
+                }
                 if (IsEnabled(CustomComboPreset.BlackAoEComboFeature))
                 {
                     if ((!gauge.InUmbralIce && !gauge.InAstralFire) || (gauge.InAstralFire && currentMP <= 100))
@@ -660,14 +679,14 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (level < BLM.Levels.Thunder3)
                         {
-                            if (lastComboMove != BLM.Thunder && thunderRecast(4) && currentMP >= BLM.MP.AspectThunder)
+                            if (lastComboMove != BLM.Thunder && thunderRecast(4) && currentMP >= BLM.MP.AspectThunder && !TargetHasEffect(BLM.Debuffs.Thunder2))
                             {
                                 return BLM.Thunder;
                             }
                         }
                         else
                         {
-                            if (lastComboMove != BLM.Thunder3 && thunder3Recast(4) && currentMP >= BLM.MP.AspectThunder)
+                            if (lastComboMove != BLM.Thunder3 && thunder3Recast(4) && currentMP >= BLM.MP.AspectThunder && !TargetHasEffect(BLM.Debuffs.Thunder2) && !TargetHasEffect(BLM.Debuffs.Thunder4))
                             {
                                 return BLM.Thunder3;
                             }

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -340,7 +340,7 @@ namespace XIVSlothComboPlugin.Combos
                 var currentMP = LocalPlayer.CurrentMp;
                 var polyToStore = Service.Configuration.GetCustomIntValue(BLM.Config.BlmPolygotsStored);
 
-                if (IsEnabled(CustomComboPreset.BlackAoEFoulOption))
+                if (IsEnabled(CustomComboPreset.BlackAoEFoulOption) && level >= BLM.Levels.Manafont && level >= BLM.Levels.Foul)
                 {
                     if (gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && CanWeave(actionID) && lastComboMove == BLM.Foul)
                     {

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -347,7 +347,7 @@ namespace XIVSlothComboPlugin.Combos
                         return BLM.Manafont;
                     }
 
-                    if ((gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && gauge.PolyglotStacks >= 1) || (GetCooldownRemainingTime(BLM.Manafont) >= 30 && gauge.PolyglotStacks > polyToStore))
+                    if ((gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && gauge.PolyglotStacks >= 1) || (IsOnCooldown(BLM.Manafont) && (GetCooldownRemainingTime(BLM.Manafont) >= 30 && gauge.PolyglotStacks > polyToStore)))
                     {
                         return BLM.Foul;
                     }

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -338,12 +338,11 @@ namespace XIVSlothComboPlugin.Combos
                 var thunder2Debuff = TargetHasEffect(BLM.Debuffs.Thunder2);
                 var thunder2Timer = FindTargetEffect(BLM.Debuffs.Thunder2);
                 var currentMP = LocalPlayer.CurrentMp;
-//                var castingSpell = LocalPlayer.IsCasting;
                 var polyToStore = Service.Configuration.GetCustomIntValue(BLM.Config.BlmPolygotsStored);
 
                 if (IsEnabled(CustomComboPreset.BlackAoEFoulOption))
                 {
-                    if (gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && CanWeave(actionID) && lastComboMove == BLM.Foul/* && !castingSpell*/)
+                    if (gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && CanWeave(actionID) && lastComboMove == BLM.Foul)
                     {
                         return BLM.Manafont;
                     }

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -338,17 +338,17 @@ namespace XIVSlothComboPlugin.Combos
                 var thunder2Debuff = TargetHasEffect(BLM.Debuffs.Thunder2);
                 var thunder2Timer = FindTargetEffect(BLM.Debuffs.Thunder2);
                 var currentMP = LocalPlayer.CurrentMp;
-                var castingSpell = LocalPlayer.IsCasting;
+//                var castingSpell = LocalPlayer.IsCasting;
                 var polyToStore = Service.Configuration.GetCustomIntValue(BLM.Config.BlmPolygotsStored);
 
                 if (IsEnabled(CustomComboPreset.BlackAoEFoulOption))
                 {
-                    if (gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && CanWeave(actionID) && lastComboMove == BLM.Foul && !castingSpell)
+                    if (gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && CanWeave(actionID) && lastComboMove == BLM.Foul/* && !castingSpell*/)
                     {
                         return BLM.Manafont;
                     }
 
-                    if ((gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && gauge.PolyglotStacks >= polyToStore) || (GetCooldownRemainingTime(BLM.Manafont) >= 30 && gauge.PolyglotStacks > polyToStore))
+                    if ((gauge.InAstralFire && currentMP <= 100 && IsOffCooldown(BLM.Manafont) && gauge.PolyglotStacks >= 1) || (GetCooldownRemainingTime(BLM.Manafont) >= 30 && gauge.PolyglotStacks > polyToStore))
                     {
                         return BLM.Foul;
                     }

--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -316,6 +316,7 @@ namespace XIVSlothComboPlugin.Combos
                 var gauge = GetJobGauge<DRKGauge>();
                 var livingshadowCD = GetCooldown(DRK.LivingShadow);
                 var saltedCD = GetCooldown(DRK.SaltedEarth);
+                var saltAndDarkCD = GetCooldown(DRK.SaltAndDarkness);
                 var actionIDCD = GetCooldown(actionID);
 
                 if (gauge.Blood >= 50 && !livingshadowCD.IsCooldown && level >= DRK.Levels.LivingShadow)
@@ -324,9 +325,9 @@ namespace XIVSlothComboPlugin.Combos
                     return DRK.SaltedEarth;
                 if (!actionIDCD.IsCooldown && level >= DRK.Levels.CarveAndSpit)
                     return actionID;
-                if (HasEffect(DRK.Buffs.SaltedEarth) && level >= DRK.Levels.SaltAndDarkness)
+                if (!saltAndDarkCD.IsCooldown && HasEffect(DRK.Buffs.SaltedEarth) && level >= DRK.Levels.SaltAndDarkness)
                     return DRK.SaltAndDarkness;
-                if (IsEnabled(CustomComboPreset.DarkShadowbringeroGCDFeature) && shbCD.CooldownRemaining < 60)
+                if (IsEnabled(CustomComboPreset.DarkShadowbringeroGCDFeature) && shbCD.CooldownRemaining < 60 && level >= DRK.Levels.Shadowbringer && gauge.DarksideTimeRemaining > 0)
                     return DRK.Shadowbringer;
 
             }

--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -19,6 +19,7 @@ namespace XIVSlothComboPlugin.Combos
             Bloodspiller = 7392,
             LowBlow = 7540,
             Interject = 7538,
+            Reprisal = 7535,
             FloodOfDarkness = 16466,
             EdgeOfDarkness = 16467,
             StalwartSoul = 16468,
@@ -43,7 +44,8 @@ namespace XIVSlothComboPlugin.Combos
 
         public static class Debuffs
         {
-            // public const short placeholder = 0;
+            public const ushort
+                Reprisal = 1193;
         }
 
         public static class Levels
@@ -350,6 +352,22 @@ namespace XIVSlothComboPlugin.Combos
                     return DRK.Interject;
             }
 
+            return actionID;
+        }
+    }
+    internal class DarkKnightReprisalProtection : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DarkKnightReprisalProtection;
+
+        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        {
+            if (actionID is DRK.Reprisal)
+            {
+                if (TargetHasEffect(DRK.Debuffs.Reprisal) && IsOffCooldown(DRK.Reprisal))
+                {
+                    return DRK.LowBlow;
+                }
+            }
             return actionID;
         }
     }

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -14,6 +14,7 @@ namespace XIVSlothComboPlugin.Combos
         public const uint
             LowBlow = 7540,
             Interject = 7538,
+            Reprisal = 7535,
             KeenEdge = 16137,
             NoMercy = 16138,
             BrutalShell = 16139,
@@ -53,7 +54,8 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const ushort
                 BowShock = 1838,
-                SonicBreak = 1837;
+                SonicBreak = 1837,
+                Reprisal = 1193;
         }
 
         public static class Levels
@@ -361,6 +363,22 @@ namespace XIVSlothComboPlugin.Combos
                     return GNB.Interject;
             }
 
+            return actionID;
+        }
+    }
+    internal class GunbreakerReprisalProtection : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerReprisalProtection;
+
+        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        {
+            if (actionID is GNB.Reprisal)
+            {
+                if (TargetHasEffect(GNB.Debuffs.Reprisal) && IsOffCooldown(GNB.Reprisal))
+                {
+                    return GNB.LowBlow;
+                }
+            }
             return actionID;
         }
     }

--- a/XIVSlothCombo/Combos/PLD.cs
+++ b/XIVSlothCombo/Combos/PLD.cs
@@ -22,6 +22,7 @@ namespace XIVSlothComboPlugin.Combos
             Requiescat = 7383,
             HolySpirit = 7384,
             Interject = 7538,
+            Reprisal = 7535,
             Prominence = 16457,
             HolyCircle = 16458,
             Confiteor = 16459,
@@ -45,7 +46,8 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const ushort
                 BladeOfValor = 2721,
-                GoringBlade = 725;
+                GoringBlade = 725,
+                Reprisal = 1193;
         }
 
         public static class Levels
@@ -475,6 +477,22 @@ namespace XIVSlothComboPlugin.Combos
                     return PLD.LowBlow;
             }
 
+            return actionID;
+        }
+    }
+    internal class PaladinReprisalProtection : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinReprisalProtection;
+
+        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        {
+            if (actionID is PLD.Reprisal)
+            {
+                if (TargetHasEffect(PLD.Debuffs.Reprisal) && IsOffCooldown(PLD.Reprisal))
+                {
+                    return PLD.LowBlow;
+                }
+            }
             return actionID;
         }
     }

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -22,6 +22,7 @@ namespace XIVSlothComboPlugin.Combos
             Upheaval = 7387,
             LowBlow = 7540,
             Interject = 7538,
+            Reprisal = 7535,
             InnerRelease = 7389,
             RawIntuition = 3551,
             MythrilTempest = 16462,
@@ -44,7 +45,8 @@ namespace XIVSlothComboPlugin.Combos
 
         public static class Debuffs
         {
-            // public const short placeholder = 0;
+            public const ushort
+                Reprisal = 1193;
         }
 
         public static class Levels
@@ -325,6 +327,22 @@ namespace XIVSlothComboPlugin.Combos
                     return WAR.PrimalRend;
             }
 
+            return actionID;
+        }
+    }
+    internal class WarriorReprisalProtection : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorReprisalProtection;
+
+        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        {
+            if (actionID is WAR.Reprisal)
+            {
+                if (TargetHasEffect(WAR.Debuffs.Reprisal) && IsOffCooldown(WAR.Reprisal))
+                {
+                    return WAR.LowBlow;
+                }
+            }
             return actionID;
         }
     }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -427,6 +427,9 @@ namespace XIVSlothComboPlugin
             #endregion
             // ====================================================================================
             #region BLACK MAGE
+            
+            if (preset == CustomComboPreset.BlackAoEFoulOption && enabled)
+                ConfigWindowFunctions.DrawSliderInt(0, 2, BLM.Config.BlmPolygotsStored, "Number of Polygot charges to store.\n(2 = Only use Polygot with Manafont)");
 
             #endregion
             // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -702,7 +702,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Blood Weapon out of Combat Feature", "If TBN is used outside of combat, turns the main combo into Blood Weapon in preparation for the opener.", DRK.JobID, 0)]
         DarkBloodWeaponOpener = 5018,
 
-        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Trust action, Engage", DRK.JobID)]
+        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Low Blow when target already has the effect", DRK.JobID)]
         DarkKnightReprisalProtection = 5019,
 
         #endregion
@@ -952,7 +952,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Gnashing Fang Starter", "Begins Gnashing Fang on main combo.", GNB.JobID, 0)]
         GunbreakerGFStartonMain = 7019,
 
-        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Trust action, Engage", GNB.JobID)]
+        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Low Blow when target already has the effect", GNB.JobID)]
         GunbreakerReprisalProtection = 7020,
 
         #endregion
@@ -1365,7 +1365,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("AOE Expiacion / Circle of Scorn Feature", "Adds Expiacion and Circle of Scorn onto the main AOE combo during weave windows", PLD.JobID, 0, "", "")]
         PaladinAoEExpiacionScornFeature = 11024,
 
-        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Trust action, Engage", PLD.JobID)]
+        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Low Blow when target already has the effect", PLD.JobID)]
         PaladinReprisalProtection = 11025,
 
         #endregion
@@ -2031,7 +2031,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Infuriate on Storm's Path", "Adds Infuriate to Storm's Path Combo when gauge is below 50 and not under Inner Release.", WAR.JobID)]
         WarriorInfuriateonST = 18021,
 
-        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Trust action, Engage", WAR.JobID)]
+        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Low Blow when target already has the effect", WAR.JobID)]
         WarriorReprisalProtection = 18022,
 
         #endregion

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -702,6 +702,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Blood Weapon out of Combat Feature", "If TBN is used outside of combat, turns the main combo into Blood Weapon in preparation for the opener.", DRK.JobID, 0)]
         DarkBloodWeaponOpener = 5018,
 
+        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Trust action, Engage", DRK.JobID)]
+        DarkKnightReprisalProtection = 5019,
+
         #endregion
         // ====================================================================================
         #region DRAGOON
@@ -948,6 +951,9 @@ namespace XIVSlothComboPlugin
         [ParentCombo(GunbreakerGnashingFangOnMain)]
         [CustomComboInfo("Gnashing Fang Starter", "Begins Gnashing Fang on main combo.", GNB.JobID, 0)]
         GunbreakerGFStartonMain = 7019,
+
+        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Trust action, Engage", GNB.JobID)]
+        GunbreakerReprisalProtection = 7020,
 
         #endregion
         // ====================================================================================
@@ -1358,6 +1364,9 @@ namespace XIVSlothComboPlugin
         [ParentCombo(PaladinProminenceCombo)]
         [CustomComboInfo("AOE Expiacion / Circle of Scorn Feature", "Adds Expiacion and Circle of Scorn onto the main AOE combo during weave windows", PLD.JobID, 0, "", "")]
         PaladinAoEExpiacionScornFeature = 11024,
+
+        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Trust action, Engage", PLD.JobID)]
+        PaladinReprisalProtection = 11025,
 
         #endregion
         // ====================================================================================
@@ -2021,6 +2030,9 @@ namespace XIVSlothComboPlugin
         [ParentCombo(WarriorStormsPathCombo)]
         [CustomComboInfo("Infuriate on Storm's Path", "Adds Infuriate to Storm's Path Combo when gauge is below 50 and not under Inner Release.", WAR.JobID)]
         WarriorInfuriateonST = 18021,
+
+        [CustomComboInfo("Double Reprisal Protection", "Replaces Reprisal with Trust action, Engage", WAR.JobID)]
+        WarriorReprisalProtection = 18022,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -273,6 +273,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Simple Fire3 Opener - 1 Triplecast", "Modifies the Simple Fire3 Opener to only use 1 Triplecast.", BLM.JobID, 0, "", "")]
         BlackSimpleAltOpenerFeature = 2019,
 
+        [ParentCombo(BlackAoEComboFeature)]
+        [CustomComboInfo("Foul / Manafont to Flare Option", "Adds foul when available during Astral Fire. Weaves manafont after foul for additional Flare", BLM.JobID, 0, "", "")]
+        BlackAoEFoulOption = 2020,
+
         #endregion
         // ====================================================================================
         #region BLUE MAGE


### PR DESCRIPTION
DRK: Fix for Shadowbringer ability preventing use of Abyssal Drain on oGCD Feature (https://github.com/Nik-Potokar/XIVSlothCombo/issues/423)
DRK: Fix for Salt and Darkness preventing use of Shadowbringer on oGCD Feature
BLM: Fix for Thunder issue when switching from AoE Combo Feature to Simple BLM (https://github.com/Nik-Potokar/XIVSlothCombo/issues/403)
BLM: Added option to AoE Combo Feature to include Foul and Manafont-to-Flare for additional damage (https://github.com/Nik-Potokar/XIVSlothCombo/issues/403 and https://github.com/Nik-Potokar/XIVSlothCombo/issues/381)
DRK / GNB / PLD / WAR: Double Reprisal Protection Feature (https://github.com/Nik-Potokar/XIVSlothCombo/issues/329)