### PR TITLE
Actual fix for child conflicts + Issues Button

### DIFF
--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -170,7 +170,7 @@ namespace XIVSlothComboPlugin
 
 
 
-            ImGui.BeginChild("scrolling", new Vector2(0, -1), true);
+            ImGui.BeginChild("scrolling", new Vector2(0, -30), true);
 
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0, 5));
 
@@ -222,8 +222,13 @@ namespace XIVSlothComboPlugin
             }
 
             ImGui.PopStyleVar();
-
             ImGui.EndChild();
+
+            
+            if (ImGui.Button("Got an issue? Click this button and report it!"))
+            {
+                Util.OpenLink("https://github.com/Nik-Potokar/XIVSlothCombo/issues");
+            }
 
         }
 
@@ -380,7 +385,7 @@ namespace XIVSlothComboPlugin
                             }
                             if (conflictOriginals.Any(x => Service.Configuration.IsEnabled(x)))
                             {
-                                Service.Configuration.EnabledActions.Remove(preset);
+                                Service.Configuration.EnabledActions.Remove(childPreset);
                                 Service.Configuration.Save();
                             }
                             else

--- a/XIVSlothCombo/ConfigWindowFunctions.cs
+++ b/XIVSlothCombo/ConfigWindowFunctions.cs
@@ -12,6 +12,15 @@ namespace XIVSlothComboPlugin.ConfigFunctions
 {
     public static class ConfigWindowFunctions
     {
+        /// <summary>
+        /// Draws a slider that lets the user set a given value for their feature.
+        /// </summary>
+        /// <param name="minValue">The absolute minimum value you'll let the user pick.</param>
+        /// <param name="maxValue">The absolute maximum value you'll let the user pick.</param>
+        /// <param name="config">The config ID.</param>
+        /// <param name="sliderDescription">Description of the slider. Appends to the right of the slider.</param>
+        /// <param name="itemWidth">How long the slider should be.</param>
+        /// <param name="sliderIncrement">How much you want the user to increment the slider by. Uses SliderIncrements as a preset.</param>
         public static void DrawSliderInt(int minValue, int maxValue, string config, string sliderDescription, float itemWidth = 150, uint sliderIncrement = SliderIncrements.Ones)
         {
             var output = Service.Configuration.GetCustomIntValue(config, minValue);
@@ -40,6 +49,14 @@ namespace XIVSlothComboPlugin.ConfigFunctions
             ImGui.Spacing();
         }
 
+        /// <summary>
+        /// Draws a slider that lets the user set a given value for their feature.
+        /// </summary>
+        /// <param name="minValue">The absolute minimum value you'll let the user pick.</param>
+        /// <param name="maxValue">The absolute maximum value you'll let the user pick.</param>
+        /// <param name="config">The config ID.</param>
+        /// <param name="sliderDescription">Description of the slider. Appends to the right of the slider.</param>
+        /// <param name="itemWidth">How long the slider should be.</param>
         public static void DrawSliderFloat(float minValue, float maxValue, string config, string sliderDescription, float itemWidth = 150)
         {
             var output = Service.Configuration.GetCustomConfigValue(config, minValue);
@@ -56,6 +73,15 @@ namespace XIVSlothComboPlugin.ConfigFunctions
             ImGui.Spacing();
         }
 
+        /// <summary>
+        /// Draws a checkbox intended to be linked to other checkboxes sharing the same config value.
+        /// </summary>
+        /// <param name="config">The config ID.</param>
+        /// <param name="checkBoxName">The name of the feature.</param>
+        /// <param name="checkboxDescription">The description of the feature.</param>
+        /// <param name="outputValue">If the user ticks this box, this is the value the config will be set to.</param>
+        /// <param name="itemWidth"></param>
+        /// <param name="descriptionColor"></param>
         public static void DrawRadioButton(string config, string checkBoxName, string checkboxDescription, int outputValue, float itemWidth = 150, Vector4 descriptionColor = new Vector4())
         {
             ImGui.Indent();


### PR DESCRIPTION
Fixes hide conflicting combos with child presets (again).

Adds a button at the bottom of the window that opens up the Github issues page.