### PR TITLE
DRK ST Overhaul

### DIFF
--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -75,6 +75,8 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const string
                 DrkKeepPlungeCharges = "DrkKeepPlungeCharges";
+            public const string
+                DrkMPManagement = "DrkMPManagement";
         }
     }
 
@@ -90,6 +92,7 @@ namespace XIVSlothComboPlugin.Combos
                 var gauge = GetJobGauge<DRKGauge>();
                 var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
                 var plungeChargesRemaining = Service.Configuration.GetCustomIntValue(DRK.Config.DrkKeepPlungeCharges);
+                var mpRemaining = Service.Configuration.GetCustomIntValue(DRK.Config.DrkMPManagement);
 
                 if (IsEnabled(CustomComboPreset.DarkRangedUptimeFeature) && level >= DRK.Levels.Unmend)
                 {
@@ -208,6 +211,9 @@ namespace XIVSlothComboPlugin.Combos
                             if (IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption) && HasEffect(DRK.Buffs.Delirium) && GetBuffRemainingTime(DRK.Buffs.Delirium) <= 10 && GetBuffRemainingTime(DRK.Buffs.Delirium) > 0 ||
                                 (GetBuffStacks(DRK.Buffs.Delirium) > 0 && IsNotEnabled(CustomComboPreset.DelayedDeliriumFeatureOption)))
                                 return DRK.Bloodspiller;
+                            //Blood management before Delirium + Blood Weapon
+                            if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && gauge.Blood >= 50 && (GetCooldownRemainingTime(DRK.Delirium) < 6 || GetCooldownRemainingTime(DRK.BloodWeapon) < 6))
+                                return DRK.Bloodspiller;
                         }
 
                         // oGCDs
@@ -217,7 +223,7 @@ namespace XIVSlothComboPlugin.Combos
                             {
                                 if (IsEnabled(CustomComboPreset.DarkBloodWeaponOption) && IsOffCooldown(DRK.BloodWeapon) && level >= DRK.Levels.BloodWeapon)
                                     return DRK.BloodWeapon;
-                                if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && IsOffCooldown(DRK.Delirium) && level >= DRK.Levels.Delirium)
+                                if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && IsOffCooldown(DRK.Delirium) && level >= DRK.Levels.Delirium && gauge.Blood < 50)
                                     return DRK.Delirium;
                                 
                                 if (level >= DRK.Levels.Shadowbringer)
@@ -229,7 +235,7 @@ namespace XIVSlothComboPlugin.Combos
                                 
                                 if (IsEnabled(CustomComboPreset.DarkCnSFeature) && IsOffCooldown(DRK.CarveAndSpit) && level >= DRK.Levels.CarveAndSpit)
                                     return DRK.CarveAndSpit;
-                                if (IsEnabled(CustomComboPreset.DarkEoSPoolOption) && gauge.ShadowTimeRemaining >= 1 && LocalPlayer.CurrentMp > 3000 && level >= DRK.Levels.EdgeOfDarkness)
+                                if (IsEnabled(CustomComboPreset.DarkEoSPoolOption) && gauge.ShadowTimeRemaining >= 1 && LocalPlayer.CurrentMp > (mpRemaining + 3000) && level >= DRK.Levels.EdgeOfDarkness)
                                     return OriginalHook(DRK.EdgeOfDarkness);
                                 if (IsEnabled(CustomComboPreset.DRKLivingShadowFeature) && gauge.Blood >= 50 && IsOffCooldown(DRK.LivingShadow) && level >= DRK.Levels.LivingShadow)
                                     return DRK.LivingShadow;

--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -248,7 +248,7 @@ namespace XIVSlothComboPlugin.Combos
                                 if (level >= DRK.Levels.Plunge)
                                 {
                                     if ((IsEnabled(CustomComboPreset.DarkPlungeFeature) && GetRemainingCharges(DRK.Plunge) > plungeChargesRemaining && IsNotEnabled(CustomComboPreset.DarkPlungeBurstOption)) ||
-                                        (IsEnabled(CustomComboPreset.DarkPlungeBurstOption) && GetRemainingCharges(DRK.Plunge) > 0 && gauge.ShadowTimeRemaining > 0)) //burst feature
+                                        (IsEnabled(CustomComboPreset.DarkPlungeBurstOption) && GetRemainingCharges(DRK.Plunge) > 0 && (gauge.ShadowTimeRemaining > 1 || GetCooldownRemainingTime(DRK.Buffs.Delirium) > 10))) //burst feature
                                         return DRK.Plunge;
                                 }
 

--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -295,46 +295,35 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID == DRK.StalwartSoul)
             {
                 var gauge = GetJobGauge<DRKGauge>();
-                var deliriumTime = FindEffect(DRK.Buffs.Delirium);
-                var actionIDCD = GetCooldown(actionID);
-                if (IsEnabled(CustomComboPreset.DarkManaOvercapAoEFeature))
-                {
-                    if (LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10)
-                    {
-                        var gcd = GetCooldown(actionID);
-                        if (level >= DRK.Levels.FloodOfDarkness && gcd.IsCooldown)
-                            return OriginalHook(DRK.FloodOfDarkness);
 
+                if (CanWeave(actionID))
+                {
+                    if (IsEnabled(CustomComboPreset.DarkManaOvercapAoEFeature) && level >= DRK.Levels.FloodOfDarkness && (LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10))
+                            return OriginalHook(DRK.FloodOfDarkness);
+                    if (gauge.DarksideTimeRemaining > 0)
+                    {
+                        if (IsEnabled(CustomComboPreset.DRKStalwartabyssalDrainFeature) && level >= DRK.Levels.AbyssalDrain && IsOffCooldown(DRK.AbyssalDrain) && PlayerHealthPercentageHp() <= 60)
+                            return DRK.AbyssalDrain;
+                        if (IsEnabled(CustomComboPreset.DRKStalwartShadowbringerFeature) && level >= DRK.Levels.Shadowbringer && GetRemainingCharges(DRK.Shadowbringer) > 0)
+                            return DRK.Shadowbringer;
                     }
                 }
-                if (IsEnabled(CustomComboPreset.DRKStalwartabyssalDrainFeature) && level >= DRK.Levels.AbyssalDrain)
-                {
-                    if (actionIDCD.IsCooldown && IsOffCooldown(DRK.AbyssalDrain) && PlayerHealthPercentageHp() <= 60)
-                        return DRK.AbyssalDrain;
-                }
-                if (IsEnabled(CustomComboPreset.DRKStalwartShadowbringerFeature) && level >= DRK.Levels.Shadowbringer)
-                {
-                    if (actionIDCD.IsCooldown && GetRemainingCharges(DRK.Shadowbringer) > 0 && gauge.DarksideTimeRemaining > 0)
-                        return DRK.Shadowbringer;
-                }
-                if (IsEnabled(CustomComboPreset.DRKOvercapFeature))
-                {
-                    if (lastComboMove == DRK.Unleash && gauge.Blood >= 90)
-                        return DRK.Quietus;
-                }
+
                 if (IsEnabled(CustomComboPreset.DeliriumFeature))
                 {
-                    if (level >= DRK.Levels.Quietus && level >= DRK.Levels.Delirium && HasEffect(DRK.Buffs.Delirium))
-                        return DRK.Quietus;
-                }
-                if (HasEffect(DRK.Buffs.Delirium) && deliriumTime.RemainingTime <= 10 && deliriumTime.RemainingTime > 0 && IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption))
-                {
-                    if (level >= DRK.Levels.Quietus && level >= DRK.Levels.Delirium)
+                    if (level >= DRK.Levels.Delirium && HasEffect(DRK.Buffs.Delirium) && gauge.DarksideTimeRemaining > 0)
                         return DRK.Quietus;
                 }
 
-                if (comboTime > 0 && lastComboMove == DRK.Unleash && level >= DRK.Levels.StalwartSoul)
-                    return DRK.StalwartSoul;
+                if (comboTime > 0)
+                {
+                    if (lastComboMove == DRK.Unleash && level >= DRK.Levels.StalwartSoul)
+                    {
+                        if (IsEnabled(CustomComboPreset.DRKOvercapFeature) && gauge.Blood >= 90 && level >= DRK.Levels.Quietus && gauge.DarksideTimeRemaining > 0)
+                            return DRK.Quietus;
+                        return DRK.StalwartSoul;
+                    }
+                }
 
                 return DRK.Unleash;
             }

--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -248,7 +248,7 @@ namespace XIVSlothComboPlugin.Combos
                                 if (level >= DRK.Levels.Plunge)
                                 {
                                     if ((IsEnabled(CustomComboPreset.DarkPlungeFeature) && GetRemainingCharges(DRK.Plunge) > plungeChargesRemaining && IsNotEnabled(CustomComboPreset.DarkPlungeBurstOption)) ||
-                                        (IsEnabled(CustomComboPreset.DarkPlungeBurstOption) && GetRemainingCharges(DRK.Plunge) > 0 && (gauge.ShadowTimeRemaining > 1 || GetCooldownRemainingTime(DRK.Buffs.Delirium) > 10))) //burst feature
+                                        (IsEnabled(CustomComboPreset.DarkPlungeBurstOption) && GetRemainingCharges(DRK.Plunge) > 0 && (gauge.ShadowTimeRemaining > 1 || GetCooldownRemainingTime(DRK.Buffs.Delirium) > 50))) //burst feature
                                         return DRK.Plunge;
                                 }
 

--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -208,64 +208,66 @@ namespace XIVSlothComboPlugin.Combos
                         //Delirium Features
                         if (level >= DRK.Levels.Delirium && IsEnabled(CustomComboPreset.DeliriumFeature))
                         {
-                            if (IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption) && HasEffect(DRK.Buffs.Delirium) && GetBuffRemainingTime(DRK.Buffs.Delirium) <= 10 && GetBuffRemainingTime(DRK.Buffs.Delirium) > 0 ||
-                                (GetBuffStacks(DRK.Buffs.Delirium) > 0 && IsNotEnabled(CustomComboPreset.DelayedDeliriumFeatureOption)))
+                            if (IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption) && 
+                                ((gauge.ShadowTimeRemaining > 1 && GetBuffRemainingTime(DRK.Buffs.Delirium) <= 10 && GetBuffRemainingTime(DRK.Buffs.Delirium) > 0) || (HasEffect(DRK.Buffs.Delirium) && GetCooldownRemainingTime(DRK.LivingShadow) >50)) || //Delayed Delirium Conditions
+                                (GetBuffStacks(DRK.Buffs.Delirium) > 0 && IsNotEnabled(CustomComboPreset.DelayedDeliriumFeatureOption))) //regular delirium
                                 return DRK.Bloodspiller;
-                            //Blood management before Delirium + Blood Weapon
-                            if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && gauge.Blood >= 50 && (GetCooldownRemainingTime(DRK.Delirium) < 6 || GetCooldownRemainingTime(DRK.BloodWeapon) < 6))
+                            //Blood management before Delirium
+                            if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && gauge.Blood >= 50 && GetCooldownRemainingTime(DRK.Delirium) < 6 && GetCooldownRemainingTime(DRK.Delirium) > 0)
                                 return DRK.Bloodspiller;
+                        }
+
+                        //Mana Features
+                        if (IsEnabled(CustomComboPreset.DarkManaOvercapFeature) && CanWeave(actionID))
+                        {
+                            if (IsEnabled(CustomComboPreset.DarkEoSPoolOption) && gauge.ShadowTimeRemaining >= 1 && LocalPlayer.CurrentMp > (mpRemaining + 3000) && level >= DRK.Levels.EdgeOfDarkness)
+                                return OriginalHook(DRK.EdgeOfDarkness);
+                            if (LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10)
+                            {
+                                if (level >= DRK.Levels.EdgeOfDarkness)
+                                    return OriginalHook(DRK.EdgeOfDarkness);
+                                if (level >= DRK.Levels.FloodOfDarkness && level < DRK.Levels.EdgeOfDarkness)
+                                    return DRK.FloodOfDarkness;
+                            }
                         }
 
                         // oGCDs
-                        if (CanWeave(actionID))
+                        if (CanWeave(actionID) && (gauge.DarksideTimeRemaining > 0))
                         {
-                            if (gauge.DarksideTimeRemaining > 0)
+                            if (IsEnabled(CustomComboPreset.DarkBloodWeaponOption) && IsOffCooldown(DRK.BloodWeapon) && level >= DRK.Levels.BloodWeapon)
+                                return DRK.BloodWeapon;
+                            if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && IsOffCooldown(DRK.Delirium) && level >= DRK.Levels.Delirium && gauge.Blood < 50)
+                                return DRK.Delirium;
+
+                            if (level >= DRK.Levels.Shadowbringer && IsEnabled(CustomComboPreset.DarkShBFeature))
                             {
-                                if (IsEnabled(CustomComboPreset.DarkBloodWeaponOption) && IsOffCooldown(DRK.BloodWeapon) && level >= DRK.Levels.BloodWeapon)
-                                    return DRK.BloodWeapon;
-                                if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && IsOffCooldown(DRK.Delirium) && level >= DRK.Levels.Delirium && gauge.Blood < 50)
-                                    return DRK.Delirium;
-                                
-                                if (level >= DRK.Levels.Shadowbringer)
-                                {
-                                    if ((IsEnabled(CustomComboPreset.DarkShBFeature) && GetRemainingCharges(DRK.Shadowbringer) > 0 && IsNotEnabled(CustomComboPreset.DarkBurstShBOption)) ||
-                                        (IsEnabled(CustomComboPreset.DarkBurstShBOption) && GetRemainingCharges(DRK.Shadowbringer) > 0 && gauge.ShadowTimeRemaining > 0)) //burst feature
-                                        return DRK.Shadowbringer;
-                                }
-                                
-                                if (IsEnabled(CustomComboPreset.DarkCnSFeature) && IsOffCooldown(DRK.CarveAndSpit) && level >= DRK.Levels.CarveAndSpit)
-                                    return DRK.CarveAndSpit;
-                                if (IsEnabled(CustomComboPreset.DarkEoSPoolOption) && gauge.ShadowTimeRemaining >= 1 && LocalPlayer.CurrentMp > (mpRemaining + 3000) && level >= DRK.Levels.EdgeOfDarkness)
-                                    return OriginalHook(DRK.EdgeOfDarkness);
-                                if (IsEnabled(CustomComboPreset.DRKLivingShadowFeature) && gauge.Blood >= 50 && IsOffCooldown(DRK.LivingShadow) && level >= DRK.Levels.LivingShadow)
-                                    return DRK.LivingShadow;
-                                if (IsEnabled(CustomComboPreset.DarkSaltedEarthFeature) && level >= DRK.Levels.SaltedEarth)
-                                {
-                                    if (IsOffCooldown(DRK.SaltedEarth) || (HasEffect(DRK.Buffs.SaltedEarth) && IsOffCooldown(DRK.SaltAndDarkness) && level >= DRK.Levels.SaltAndDarkness))
-                                        return OriginalHook(DRK.SaltedEarth);
-                                }
-
-                                if (level >= DRK.Levels.Plunge)
-                                {
-                                    if ((IsEnabled(CustomComboPreset.DarkPlungeFeature) && GetRemainingCharges(DRK.Plunge) > plungeChargesRemaining && IsNotEnabled(CustomComboPreset.DarkPlungeBurstOption)) ||
-                                        (IsEnabled(CustomComboPreset.DarkPlungeBurstOption) && GetRemainingCharges(DRK.Plunge) > 0 && (gauge.ShadowTimeRemaining > 1 || GetCooldownRemainingTime(DRK.Buffs.Delirium) > 50))) //burst feature
-                                        return DRK.Plunge;
-                                }
-
+                                if ((GetRemainingCharges(DRK.Shadowbringer) > 0 && IsNotEnabled(CustomComboPreset.DarkBurstShBOption)) ||
+                                    (IsEnabled(CustomComboPreset.DarkBurstShBOption) && GetRemainingCharges(DRK.Shadowbringer) > 0 && gauge.ShadowTimeRemaining > 1)) //burst feature
+                                    return DRK.Shadowbringer;
                             }
-                        }
+
+                            if (IsEnabled(CustomComboPreset.DarkCnSFeature) && IsOffCooldown(DRK.CarveAndSpit) && level >= DRK.Levels.CarveAndSpit)
+                                return DRK.CarveAndSpit;
+
+                            if (IsEnabled(CustomComboPreset.DRKLivingShadowFeature) && gauge.Blood >= 50 && IsOffCooldown(DRK.LivingShadow) && level >= DRK.Levels.LivingShadow)
+                                return DRK.LivingShadow;
+                            if (IsEnabled(CustomComboPreset.DarkSaltedEarthFeature) && level >= DRK.Levels.SaltedEarth)
+                            {
+                                if (IsOffCooldown(DRK.SaltedEarth) || (HasEffect(DRK.Buffs.SaltedEarth) && IsOffCooldown(DRK.SaltAndDarkness) && level >= DRK.Levels.SaltAndDarkness))
+                                    return OriginalHook(DRK.SaltedEarth);
+                            }
+
+                            if (level >= DRK.Levels.Plunge && IsEnabled(CustomComboPreset.DarkPlungeFeature))
+                            {
+                                if ((GetRemainingCharges(DRK.Plunge) > plungeChargesRemaining && IsNotEnabled(CustomComboPreset.DarkPlungeBurstOption)) ||
+                                    (IsEnabled(CustomComboPreset.DarkPlungeBurstOption) && GetRemainingCharges(DRK.Plunge) > 0 && (gauge.ShadowTimeRemaining > 1 || GetCooldownRemainingTime(DRK.Buffs.Delirium) > 50))) //burst feature
+                                    return DRK.Plunge;
+                            }
+                        }                      
 
                         // 1-2-3 combo
                         if (comboTime > 0)
                         {
-                            if (IsEnabled(CustomComboPreset.DarkManaOvercapFeature) && (LocalPlayer.CurrentMp > 8500) && CanWeave(actionID))
-                            {
-                                if (level >= DRK.Levels.EdgeOfDarkness)
-                                    return DRK.EdgeOfShadow;
-                                if (level >= DRK.Levels.FloodOfDarkness && level < DRK.Levels.EdgeOfDarkness)
-                                    return DRK.FloodOfDarkness;
-                            }
-
                             if (lastComboMove == DRK.HardSlash && level >= DRK.Levels.SyphonStrike)
                                 return DRK.SyphonStrike;
 

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -180,7 +180,7 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
                             return GNB.Hypervelocity;
-                        if ((gauge.Ammo != 0) && level >= GNB.Levels.BurstStrike)
+                        if (IsEnabled(CustomComboPreset.GunbreakerBSinNMFeature) && (gauge.Ammo != 0) && level >= GNB.Levels.BurstStrike)
                             return GNB.BurstStrike;
                     }
 

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -91,7 +91,6 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (IsEnabled(CustomComboPreset.WarriorStormsPathCombo) && actionID == WAR.StormsPath)
             {
-                var stormseyeBuff = FindEffectAny(WAR.Buffs.SurgingTempest);
                 var gauge = GetJobGauge<WARGauge>().BeastGauge;
                 var surgingThreshold = Service.Configuration.GetCustomIntValue(WAR.Config.WarSurgingRefreshRange);
                 var onslaughtChargesRemaining = Service.Configuration.GetCustomIntValue(WAR.Config.WarKeepOnslaughtCharges);
@@ -140,7 +139,7 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= WAR.Levels.InnerBeast && HasEffectAny(WAR.Buffs.SurgingTempest) && gauge >= 90)
                             return OriginalHook(WAR.InnerBeast);
-                        if ((!HasEffectAny(WAR.Buffs.SurgingTempest) || stormseyeBuff.RemainingTime <= surgingThreshold) && level >= WAR.Levels.StormsEye)
+                        if ((!HasEffectAny(WAR.Buffs.SurgingTempest) || GetBuffRemainingTime(WAR.Buffs.SurgingTempest) <= surgingThreshold) && level >= WAR.Levels.StormsEye)
                             return WAR.StormsEye;
                         return WAR.StormsPath;
                     }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -151,6 +151,24 @@ namespace XIVSlothComboPlugin
                 ImGui.EndTooltip();
             }
 
+            float offset = (float)Service.Configuration.MeleeOffset;
+
+            var inputChangedeth = false;
+            inputChangedeth |= ImGui.InputFloat("Melee Distance Offset", ref offset);
+
+            if (inputChangedeth)
+            {
+                Service.Configuration.MeleeOffset = (double)offset;
+                Service.Configuration.Save();
+            }
+
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.TextUnformatted("Offset of melee check distance for features that use it. For those who don't want to immediately use their ranged attack if the boss walks slightly out of range.");
+                ImGui.EndTooltip();
+            }
+
             var slothIrl = isAprilFools ? Service.Configuration.AprilFoolsSlothIrl : false;
             if (isAprilFools)
             {

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -464,6 +464,8 @@ namespace XIVSlothComboPlugin
             #endregion
             // ====================================================================================
             #region DARK KNIGHT
+            if (preset == CustomComboPreset.DarkEoSPoolOption && enabled)
+                ConfigWindowFunctions.DrawSliderInt(0, 3000, DRK.Config.DrkMPManagement, "How much MP to save (0 = Use All)");
             if (preset == CustomComboPreset.DarkPlungeFeature && enabled)
                 ConfigWindowFunctions.DrawSliderInt(0, 1, DRK.Config.DrkKeepPlungeCharges, "How many charges to keep ready? (0 = Use All)");
             #endregion

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -464,7 +464,8 @@ namespace XIVSlothComboPlugin
             #endregion
             // ====================================================================================
             #region DARK KNIGHT
-
+            if (preset == CustomComboPreset.DarkPlungeFeature && enabled)
+                ConfigWindowFunctions.DrawSliderInt(0, 1, DRK.Config.DrkKeepPlungeCharges, "How many charges to keep ready? (0 = Use All)");
             #endregion
             // ====================================================================================
             #region DRAGOON
@@ -472,7 +473,8 @@ namespace XIVSlothComboPlugin
             #endregion
             // ====================================================================================
             #region GUNBREAKER
-
+            if (preset == CustomComboPreset.GunbreakerRoughDivideFeature && enabled)
+                ConfigWindowFunctions.DrawSliderInt(0, 1, GNB.Config.GnbKeepRoughDivideCharges, "How many charges to keep ready? (0 = Use All)");
             #endregion
             // ====================================================================================
             #region MACHINIST

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -505,7 +505,7 @@ namespace XIVSlothComboPlugin.Combos
             if (distance == 0)
                 return true;
 
-            if (distance > 3)
+            if (distance > 3 + Service.Configuration.MeleeOffset)
                 return false;
 
             return true;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -656,14 +656,8 @@ namespace XIVSlothComboPlugin
         DarkShadowbringeroGCDFeature = 5007,
 
         [ParentCombo(DarkSouleaterCombo)]
-        [ConflictingCombos(DarkPlungeFeatureOption)]
-        [CustomComboInfo("Plunge Feature", "Adds Plunge onto main combo whenever its available (Uses all stacks).", DRK.JobID, 0, "", "Take the plunge. All the way!")]
+        [CustomComboInfo("Plunge Feature", "Adds Plunge onto main combo whenever its available and Darkside is up.", DRK.JobID, 0, "", "Take the plunge. All the way!")]
         DarkPlungeFeature = 5008,
-
-        [ParentCombo(DarkSouleaterCombo)]
-        [ConflictingCombos(DarkPlungeFeature)]
-        [CustomComboInfo("Plunge Option", "Adds Plunge onto main combo whenever its available (Leaves 1 stack).", DRK.JobID, 0, "", "Take the plunge. Or, just dip your toes in. Whatever.")]
-        DarkPlungeFeatureOption = 5009,
 
         [ParentCombo(DeliriumFeature)]
         [CustomComboInfo("Delayed Delirium Feature", "Delays Bloodspiller by 2 GCDs when Delirium is used. Useful for feeding into raid buffs at level 90.", DRK.JobID, 0)]
@@ -697,6 +691,38 @@ namespace XIVSlothComboPlugin
         [ParentCombo(DarkOpenerFeature)]
         [CustomComboInfo("Blood Weapon out of Combat Feature", "If TBN is used outside of combat, turns the main combo into Blood Weapon in preparation for the opener.", DRK.JobID, 0)]
         DarkBloodWeaponOpener = 5018,
+
+        [ParentCombo(DarkPlungeFeature)]
+        [CustomComboInfo("Plunge Burst Option", "Pools Plunge to use during even minute window bursts.", DRK.JobID, 0)]
+        DarkPlungeBurstOption = 5019,
+
+        [ParentCombo(DarkManaOvercapFeature)]
+        [CustomComboInfo("EoS Burst Option", "Uses all remaining blood gauge during even minute window bursts.", DRK.JobID, 0)]
+        DarkEoSPoolOption = 5020,
+
+        [ParentCombo(DarkSouleaterCombo)]
+        [CustomComboInfo("Salted Earth Feature", "Adds Salted Earth on Main Combo while Darkside is up, will use Salt and Darkness if unlocked.", DRK.JobID, 0)]
+        DarkSaltedEarthFeature = 5021,
+
+        [ParentCombo(DarkSouleaterCombo)]
+        [CustomComboInfo("Carve and Spit Feature", "Adds Carve and Spit on Main Combo while Darkside is up.", DRK.JobID, 0)]
+        DarkCnSFeature = 5022,
+
+        [ParentCombo(DarkSouleaterCombo)]
+        [CustomComboInfo("Shadowbringer Feature", "Adds Shadowbringer on Main Combo while Darkside is up. Will use all stacks on CD.", DRK.JobID, 0)]
+        DarkShBFeature = 5023,
+
+        [ParentCombo(DarkShBFeature)]
+        [CustomComboInfo("Shadowbringer Burst Option", "Pools Shadowbringer to use during even minute window bursts.", DRK.JobID, 0)]
+        DarkBurstShBOption = 5024,
+
+        [ParentCombo(DeliriumFeature)]
+        [CustomComboInfo("Delirium on CD", "Adds Delirium to Main Combo on CD and when Darkside is up.", DRK.JobID, 0)]
+        DarkDeliriumOnCD = 5025,
+
+        [ParentCombo(DarkSouleaterCombo)]
+        [CustomComboInfo("Blood Weapon on CD", "Adds Blood Weapon to Main Combo on CD and when Darkside is up.", DRK.JobID, 0)]
+        DarkBloodWeaponOption = 5026,
 
         #endregion
         // ====================================================================================
@@ -878,26 +904,24 @@ namespace XIVSlothComboPlugin
         GunbreakerGnashingFangOnMain = 7001,
 
         [ParentCombo(GunbreakerSolidBarrelCombo)]
-        [CustomComboInfo("Sonic Break/Bow Shock/Blasting Zone on Main Combo", "Adds Sonic Break/Bow Shock/Blasting Zone on main combo when under No Mercy buff", GNB.JobID, 0, "Gee Whiz!", "Mom, I can't manage my oGCDs!")]
+        [CustomComboInfo("CDs on Main Combo", "Adds various CDs to the Main Combo when under No Mercy or when No Mercy is on cooldown", GNB.JobID, 0, "Gee Whiz!", "Mom, I can't manage my oGCDs!")]
         GunbreakerCDsOnMainComboFeature = 7002,
+
+        [ParentCombo(GunbreakerCDsOnMainComboFeature)]
+        [CustomComboInfo("Danger Zone/Blasting Zone on Main Combo", "Adds Danger Zone/Blasting Zone to the Main Combo", GNB.JobID, 0)]
+        GunbreakerDZOnMainComboFeature = 7005,
 
         [ParentCombo(GunbreakerSolidBarrelCombo)]
         [CustomComboInfo("Double Down on Main Combo", "Adds Double Down on main combo when under No Mercy buff", GNB.JobID, 0, "ALL the deeps", "For when you're both feeling merciless and are stuffed full of powder. BANG!")]
         GunbreakerDDonMain = 7003,
 
         [ParentCombo(GunbreakerSolidBarrelCombo)]
-        [ConflictingCombos(GunbreakerRoughDivide2StackOption)]
-        [CustomComboInfo("Rough Divide Option (Leaves 1 Stack)", "Adds Rough Divide onto main combo whenever it's available (Leaves 1 stack).", GNB.JobID, 0, "Divide... Roughly", "Ayo pour one out for the homie Squall")]
-        GunbreakerRoughDivide1StackOption = 7004,
+        [CustomComboInfo("Rough Divide Option", "Adds Rough Divide onto main combo whenever it's available.", GNB.JobID, 0, "Divide... Roughly", "Ayo pour one out for the homie Squall")]
+        GunbreakerRoughDivideFeature = 7004,
 
         [ParentCombo(GunbreakerDemonSlaughterCombo)]
         [CustomComboInfo("Bow Shock on AoE Feature", "Adds Bow Shock onto the aoe combo when it's off cooldown. Recommended to use with Gnashing Fang features.", GNB.JobID, 0, "AoE cattleprod enabler")]
         GunbreakerBowShockFeature = 7017,
-        
-        [ConflictingCombos(GunbreakerRoughDivide1StackOption)]
-        [ParentCombo(GunbreakerSolidBarrelCombo)]
-        [CustomComboInfo("Rough Divide Option (Uses all stacks)", "Adds Rough Divide onto main combo whenever its available (Uses all stacks).", GNB.JobID, 0, "Divide... Rougher!", "Ayo pour two out for the homie Squall")]
-        GunbreakerRoughDivide2StackOption = 7005,
 
         [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain.", GNB.JobID, 0, "dEmOn SlAuGhTeR", "Demon Slaughter? Really? What is this, RPR?")]
         GunbreakerDemonSlaughterCombo = 7006,
@@ -944,6 +968,17 @@ namespace XIVSlothComboPlugin
         [ParentCombo(GunbreakerGnashingFangOnMain)]
         [CustomComboInfo("Gnashing Fang Starter", "Begins Gnashing Fang on main combo.", GNB.JobID, 0)]
         GunbreakerGFStartonMain = 7019,
+
+        [ParentCombo(GunbreakerCDsOnMainComboFeature)]
+        [CustomComboInfo("Bow Shock on Main Combo", "Adds Bow Shock to the Main Combo", GNB.JobID, 0)]
+        GunbreakerBSOnMainComboFeature = 7020,
+
+        [ParentCombo(GunbreakerCDsOnMainComboFeature)]
+        [CustomComboInfo("Sonic Break on Main Combo", "Adds Sonic Break to the Main Combo", GNB.JobID, 0)]
+        GunbreakerSBOnMainComboFeature = 7021,
+
+        [CustomComboInfo("Sonic Break/Bow Shock on NM", "Adds Sonic Break and Bow Shock to No Mercy when NM is on CD", GNB.JobID, 0)]
+        GunbreakerCDsonNMFeature = 7022,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -983,6 +983,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Sonic Break/Bow Shock on NM", "Adds Sonic Break and Bow Shock to No Mercy when NM is on CD", GNB.JobID, 0)]
         GunbreakerCDsonNMFeature = 7022,
 
+        [ParentCombo(GunbreakerCDsOnMainComboFeature)]
+        [CustomComboInfo("Burst Strike on Main Combo", "Adds Burst Strike to Main Combo when under No Mercy and Gnashing Fang is over.", GNB.JobID, 0)]
+        GunbreakerBSinNMFeature = 7023,
+        
         #endregion
         // ====================================================================================
         #region MACHINIST

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -696,7 +696,7 @@ namespace XIVSlothComboPlugin
         DarkBloodWeaponOpener = 5018,
 
         [ParentCombo(DarkPlungeFeature)]
-        [CustomComboInfo("Plunge Burst Option", "Pools Plunge to use during even minute window bursts.", DRK.JobID, 0)]
+        [CustomComboInfo("Plunge Burst Option", "Pools Plunge to use during minute window bursts.", DRK.JobID, 0)]
         DarkPlungeBurstOption = 5019,
 
         [ParentCombo(DarkManaOvercapFeature)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -661,7 +661,7 @@ namespace XIVSlothComboPlugin
         DarkPlungeFeature = 5008,
 
         [ParentCombo(DeliriumFeature)]
-        [CustomComboInfo("Delayed Delirium Feature", "Delays Bloodspiller by 2 GCDs when Delirium is used. Useful for feeding into raid buffs at level 90.", DRK.JobID, 0)]
+        [CustomComboInfo("Delayed Delirium Feature", "Delays Bloodspiller by 2 GCDs when Delirium is used during even windows, uses it regularly during odd windows. Useful for feeding into raid buffs at level 90.", DRK.JobID, 0)]
         DelayedDeliriumFeatureOption = 5010,
 
         [ParentCombo(DarkSouleaterCombo)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -697,7 +697,7 @@ namespace XIVSlothComboPlugin
         DarkPlungeBurstOption = 5019,
 
         [ParentCombo(DarkManaOvercapFeature)]
-        [CustomComboInfo("EoS Burst Option", "Uses all remaining blood gauge during even minute window bursts.", DRK.JobID, 0)]
+        [CustomComboInfo("EoS Burst Option", "Uses EoS until chosen MP limit is reached during even minute window bursts.", DRK.JobID, 0)]
         DarkEoSPoolOption = 5020,
 
         [ParentCombo(DarkSouleaterCombo)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -627,7 +627,7 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region DARK KNIGHT
 
-        [CustomComboInfo("Souleater Combo", "Replace Souleater with its combo chain.", DRK.JobID, 0, "Fetch me their souls!", "Heheheheheh")]
+        [CustomComboInfo("Souleater Combo", "Replace Souleater with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Simple Dark Knight)", DRK.JobID, 0, "Fetch me their souls!", "Heheheheheh")]
         DarkSouleaterCombo = 5000,
 
         [CustomComboInfo("Stalwart Soul Combo", "Replace Stalwart Soul with its combo chain.", DRK.JobID, 0, "", "Ugly name for an ugly job")]
@@ -642,7 +642,7 @@ namespace XIVSlothComboPlugin
         DRKOvercapFeature = 5003,
 
         [ParentCombo(DarkSouleaterCombo)]
-        [CustomComboInfo("Living Shadow Feature", "Living shadow will now be on main combo if its not on CD and you have gauge for it.", DRK.JobID, 0, "", "Trick everyone into thinking a party member is standing where they shouldn't be!")]
+        [CustomComboInfo("Living Shadow Feature", "Living Shadow will now be on main combo if its not on CD and you have gauge for it.", DRK.JobID, 0, "", "Trick everyone into thinking a party member is standing where they shouldn't be!")]
         DRKLivingShadowFeature = 5004,
 
         [ParentCombo(DarkSouleaterCombo)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -720,7 +720,7 @@ namespace XIVSlothComboPlugin
         DarkBurstShBOption = 5024,
 
         [ParentCombo(DeliriumFeature)]
-        [CustomComboInfo("Delirium on CD", "Adds Delirium to Main Combo on CD and when Darkside is up.", DRK.JobID, 0)]
+        [CustomComboInfo("Delirium on CD", "Adds Delirium to Main Combo on CD and when Darkside is up. Will also spend 50 blood gauge if Delirium is nearly ready to protect from overcap.", DRK.JobID, 0)]
         DarkDeliriumOnCD = 5025,
 
         [ParentCombo(DarkSouleaterCombo)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -637,6 +637,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Delirium Feature", "Replace Souleater and Stalwart Soul with Bloodspiller and Quietus when Delirium is active.", DRK.JobID, 0, "", "Delirium is what you have if you choose to play DRK.\nDoc's words, not mine")]
         DeliriumFeature = 5002,
 
+        [ParentCombo(DarkStalwartSoulCombo)]
         [CustomComboInfo("Dark Knight Gauge Overcap Feature", "Replace AoE combo with gauge spender if you are about to overcap.", DRK.JobID, 0, "", "Hey big spenderrrrr")]
         DRKOvercapFeature = 5003,
 
@@ -670,9 +671,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Interrupt Feature", "Replaces Low Blow with Interject when target can be interrupted .", DRK.JobID, 0, "Lower blow", "Blow, but low.")]
         DarkKnightInterruptFeature = 5012,
 
+        [ParentCombo(DarkStalwartSoulCombo)]
         [CustomComboInfo("Abyssal Drain Feature", "Adds abyssal drain to the AoE Combo when you fall below 60 percent hp.", DRK.JobID, 0, "", "Even the un-cool kids got heals these days")]
         DRKStalwartabyssalDrainFeature = 5013,
 
+        [ParentCombo(DarkStalwartSoulCombo)]
         [CustomComboInfo("AoE Shadowbringer Feature", "Adds Shadowbringer to the AoE Combo.", DRK.JobID, 0, "", "Wasn't this last expansion?")]
         DRKStalwartShadowbringerFeature = 5014,
 

--- a/XIVSlothCombo/PluginConfiguration.cs
+++ b/XIVSlothCombo/PluginConfiguration.cs
@@ -82,6 +82,11 @@ namespace XIVSlothComboPlugin
         };
 
         /// <summary>
+        /// Gets or sets the offset of the melee range check. Default is 0.
+        /// </summary>
+        public double MeleeOffset { get; set; } = 0;
+
+        /// <summary>
         /// Save the configuration to disk.
         /// </summary>
         public void Save()


### PR DESCRIPTION
GNB, DRK: Added sliders to gap closer options
GNB: Separated CDs into individual toggles, added DoT skills to NM feature
DRK: Refactored Souleater Combo
DRK: Added Delirium, Shadowbringer, Carve and Spit, Blood Weapon to Main Combo. Added burst features to pool some skills for even minute window bursts. With all options selected will turn Main Combo to Simple DRK.
DRK: Cleaned up Opener, removed flags related to resources. Will be able to enter Opener from outside of combat without any reliance on any resources.
DRK: Added slider for EoS MP Dump.
DRK: AoE refactoring
Framework: Added global Melee Distance Offset