### PR TITLE
Tanks: Reprisal Feature Beautification ★ MNK Feature restored ★ Added check 'CanSpellWeave(actionID)' and cleanup on RDM

### DIFF
--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -392,7 +392,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID is DRK.Reprisal)
             {
-                if (TargetHasEffectAny(DRK.Debuffs.Reprisal))
+                if (TargetHasEffectAny(DRK.Debuffs.Reprisal) && IsOffCooldown(DRK.Reprisal))
                     return WHM.Stone1;
             }
             return actionID;

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -383,7 +383,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID is GNB.Reprisal)
             {
-                if (TargetHasEffectAny(GNB.Debuffs.Reprisal))
+                if (TargetHasEffectAny(GNB.Debuffs.Reprisal) && IsOffCooldown(GNB.Reprisal))
                     return WHM.Stone1;
             }
             return actionID;

--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -20,8 +20,9 @@ namespace XIVSlothComboPlugin.Combos
             PerfectBalance = 69,
             TrueStrike = 54,
             LegSweep = 7863,
+            Meditation = 3546,
             HowlingFist = 25763,
-            Enlightenment = 25763,
+            Enlightenment = 16474,
             MasterfulBlitz = 25764,
             ElixirField = 3545,
             FlintStrike = 25882,
@@ -420,6 +421,24 @@ namespace XIVSlothComboPlugin.Combos
                     return MNK.Brotherhood;
 
                 return MNK.RiddleOfFire;
+            }
+            return actionID;
+        }
+    }
+    internal class MonkHowlingFistMeditationFeature : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MonkHowlingFistMeditationFeature;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == MNK.HowlingFist || actionID == MNK.Enlightenment)
+            {
+                var gauge = GetJobGauge<MNKGauge>();
+
+                if (gauge.Chakra < 5)
+                {
+                    return MNK.Meditation;
+                }
             }
             return actionID;
         }

--- a/XIVSlothCombo/Combos/PLD.cs
+++ b/XIVSlothCombo/Combos/PLD.cs
@@ -488,7 +488,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID is PLD.Reprisal)
             {
-                if (TargetHasEffectAny(PLD.Debuffs.Reprisal))
+                if (TargetHasEffectAny(PLD.Debuffs.Reprisal) && IsOffCooldown(PLD.Reprisal))
                     return WHM.Stone1;
             }
             return actionID;

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -1153,26 +1153,21 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID is RDM.Verthunder or RDM.Veraero or RDM.Scatter or RDM.Verthunder3 or RDM.Veraero3 or RDM.Impact)
             {
-                var canWeave = CanWeave(actionID);
-                var castingSpell = LocalPlayer.IsCasting;
-                var inCombat = HasCondition(ConditionFlag.InCombat);
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(RDM.Config.RdmLucidMpThreshold);
 
-                if (!canWeave || !inCombat || IsOnCooldown(RDM.LucidDreaming) || lastComboMove == RDM.EnchantedRedoublement || lastComboMove == RDM.Verflare || lastComboMove == RDM.Verholy || lastComboMove == RDM.Scorch) // Reset following weave window or exit combat if enemy dies
-                {
-                    showLucid = false;
-                    return actionID;
-                }
-
-                if (level >= RDM.Levels.LucidDreaming && IsOffCooldown(RDM.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold) // Check to show Lucid Dreaming
+                if (level >= RDM.Levels.LucidDreaming && LocalPlayer.CurrentMp <= lucidThreshold) // Check to show Lucid Dreaming
                 {
                     showLucid = true;
                 }
 
-                if (showLucid && canWeave && !castingSpell) // Change abilities to Lucid Dreaming for entire weave window
+                if (showLucid && CanSpellWeave(actionID) && HasCondition(ConditionFlag.InCombat) && IsOffCooldown(RDM.LucidDreaming) 
+                    && lastComboMove != RDM.EnchantedRiposte && lastComboMove != RDM.EnchantedZwerchhau 
+                    && lastComboMove != RDM.EnchantedRedoublement && lastComboMove != RDM.Verflare 
+                    && lastComboMove != RDM.Verholy && lastComboMove != RDM.Scorch) // Change abilities to Lucid Dreaming for entire weave window
                 {
                     return RDM.LucidDreaming;
                 }
+                showLucid = false;
             }
             return actionID;
         }

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -337,7 +337,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID is WAR.Reprisal)
             {
-                if (TargetHasEffectAny(WAR.Debuffs.Reprisal))
+                if (TargetHasEffectAny(WAR.Debuffs.Reprisal) && IsOffCooldown(WAR.Reprisal))
                     return WHM.Stone1;
             }
             return actionID;

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -473,6 +473,24 @@ namespace XIVSlothComboPlugin.Combos
 
         /// <summary>
         /// Checks if the provided action ID has cooldown remaining enough to weave against it
+        /// without causing clipping and checks if you're casting a spell to make it mage friendly
+        /// </summary>
+        /// <param name="actionID">Action ID to check.</param>
+        /// <param name="weaveTime">Time when weaving window is over. Defaults to 0.7.</param>
+        /// <returns>True or false.</returns>
+        protected static bool CanSpellWeave(uint actionID, double weaveTime = 0.7)
+        {
+            var castingSpell = LocalPlayer.IsCasting;
+
+            if (GetCooldown(actionID).CooldownRemaining > weaveTime && !castingSpell)
+            {
+                return true;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the provided action ID has cooldown remaining enough to weave against it
         /// at the later half of the gcd without causing clipping (aka Delayed Weaving)
         /// </summary>
         /// <param name="actionID">Action ID to check.</param>


### PR DESCRIPTION
Tanks: No longer shows Stone when Reprisal is on CD
MNK: Meditation on Howling Fist/Enlightenment Feature restored (Was it supposed to be removed?)
⇒ In response to: https://github.com/Nik-Potokar/XIVSlothCombo/issues/435
RDM: Code cleanup on Lucid Dreaming feature
Framework: New check 'CanSpellWeave(actionID)' to check weave window and if a spell is being cast