### PR TITLE
[BRD] Protection correction for when you dont have songs going.

### DIFF
--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -1024,9 +1024,9 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             // Do logic to determine first song
 
-                            if (minuetOffCooldown || !(JustUsed(BRD.MagesBallad) || JustUsed(BRD.ArmysPaeon)) ) return BRD.WanderersMinuet;
-                            if (balladOffCooldown || !(JustUsed(BRD.WanderersMinuet) || JustUsed(BRD.ArmysPaeon)) ) return BRD.MagesBallad;
-                            if (paeonOffCooldown  || !(JustUsed(BRD.MagesBallad) || JustUsed(BRD.ArmysPaeon)) ) return BRD.ArmysPaeon;
+                            if (minuetOffCooldown && !(JustUsed(BRD.MagesBallad)        || JustUsed(BRD.ArmysPaeon)) )      return BRD.WanderersMinuet;
+                            if (balladOffCooldown && !(JustUsed(BRD.WanderersMinuet)    || JustUsed(BRD.ArmysPaeon)) )      return BRD.MagesBallad;
+                            if (paeonOffCooldown  && !(JustUsed(BRD.MagesBallad)        || JustUsed(BRD.WanderersMinuet)) ) return BRD.ArmysPaeon;
                         }
 
                         if (gauge.Song == Song.WANDERER)
@@ -1045,7 +1045,7 @@ namespace XIVSlothComboPlugin.Combos
 
                         if (gauge.Song == Song.MAGE)
                         {
-                            // Move to Army's Paeon if < 9 seconds left on song
+                            // Move to Army's Paeon if < 12 seconds left on song
                             if (songTimerInSeconds < 12 && paeonOffCooldown)
                             {
                                 return BRD.ArmysPaeon;
@@ -1054,7 +1054,7 @@ namespace XIVSlothComboPlugin.Combos
 
                         if (gauge.Song == Song.ARMY)
                         {
-                            // Move to Wanderer's Minuet if < 3 seconds left on song
+                            // Move to Wanderer's Minuet if < 3 seconds left on song or WM off CD
                             if (songTimerInSeconds < 3 || minuetOffCooldown)
                             {
                                 return BRD.WanderersMinuet;

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -496,7 +496,7 @@ namespace XIVSlothComboPlugin
             // ====================================================================================
             #region BARD
             if (preset == CustomComboPreset.BardSimpleRagingJaws)
-                ConfigWindowFunctions.DrawSliderFloat(0, 3, BRD.Config.RagingJawsRenewTime, "Remaining time (In seconds)");
+                ConfigWindowFunctions.DrawSliderFloat(3, 5, BRD.Config.RagingJawsRenewTime, "Remaining time (In seconds)");
 
             #endregion
             // ====================================================================================

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -435,7 +435,7 @@ namespace XIVSlothComboPlugin.Combos
         /// <param name="actionID">Action ID to check.</param>
         /// <returns>True or false.</returns>
         protected static bool JustUsed(uint actionID)
-            => GetCooldownRemainingTime(actionID) > (GetCooldown(actionID).CooldownTotal - 3);
+            => IsOnCooldown(actionID) && GetCooldownRemainingTime(actionID) > (GetCooldown(actionID).CooldownTotal - 3);
 
         /// <summary>
         /// Gets a value indicating whether an action has any available charges.


### PR DESCRIPTION
### BRD
   -  Remade protection for casting songs when no song is playing;
      - Some users reported they were double songing when no song was being used, should be solved.
   - Changed the time option of RagingJaws to be 3 to 5 seconds instead of 0 to 3 seconds. 