### PR TITLE
Various fixes and adjustments

### DIFF
--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -109,7 +109,6 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const string
                 TrickCooldownRemaining = "TrickCooldownRemaining",
-                HutonRemainingTimer = "HutonRemainingTimer",
                 HutonRemainingArmorCrush = "HutonRemainingArmorCrush",
                 MugNinkiGauge = "MugNinkiGauge";
         }

--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -142,8 +142,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (IsEnabled(CustomComboPreset.NinjaHuraijinFeature) && level >= NIN.Levels.Huraijin)
                 {
                     var gauge = GetJobGauge<NINGauge>();
-                    var timer = Service.Configuration.GetCustomIntValue(NIN.Config.HutonRemainingTimer);
-                    if (gauge.HutonTimer <= timer)
+                    if (gauge.HutonTimer <= 0)
                         return NIN.Huraijin;
                 }
 

--- a/XIVSlothCombo/Combos/WHM.cs
+++ b/XIVSlothCombo/Combos/WHM.cs
@@ -193,6 +193,7 @@ namespace XIVSlothComboPlugin.Combos
                     var diaDebuff = FindTargetEffect(WHM.Debuffs.Dia);
                     var aero1Debuff = FindTargetEffect(WHM.Debuffs.Aero);
                     var aero2Debuff = FindTargetEffect(WHM.Debuffs.Aero2);
+                    var lucidThreshold = Service.Configuration.GetCustomIntValue(WHM.Config.WHMLucidDreamingFeature);
 
                     if (CanSpellWeave(actionID))
                     {
@@ -200,7 +201,7 @@ namespace XIVSlothComboPlugin.Combos
                                 return WHM.PresenceOfMind;
                         if (IsEnabled(CustomComboPreset.WHMAssizeFeature) && level >= WHM.Levels.Assize && IsOffCooldown(WHM.Assize))
                                 return WHM.Assize;
-                        if (IsEnabled(CustomComboPreset.WHMLucidDreamingFeature) && IsOffCooldown(WHM.LucidDreaming) && LocalPlayer.CurrentMp <= 8000)
+                        if (IsEnabled(CustomComboPreset.WHMLucidDreamingFeature) && IsOffCooldown(WHM.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold)
                                 return WHM.LucidDreaming;
                     }
 

--- a/XIVSlothCombo/Combos/WHM.cs
+++ b/XIVSlothCombo/Combos/WHM.cs
@@ -69,6 +69,7 @@ namespace XIVSlothComboPlugin.Combos
                 Assize = 56,
                 ThinAir = 58,
                 Dia = 72,
+                AfflatusMisery = 74,
                 AfflatusRapture = 76;
         }
 
@@ -194,15 +195,16 @@ namespace XIVSlothComboPlugin.Combos
                     var aero1Debuff = FindTargetEffect(WHM.Debuffs.Aero);
                     var aero2Debuff = FindTargetEffect(WHM.Debuffs.Aero2);
                     var lucidThreshold = Service.Configuration.GetCustomIntValue(WHM.Config.WHMLucidDreamingFeature);
+                    var gauge = GetJobGauge<WHMGauge>();
 
                     if (CanSpellWeave(actionID))
                     {
                         if (IsEnabled(CustomComboPreset.WHMPresenceOfMindFeature) && level >= WHM.Levels.PresenceOfMind && IsOffCooldown(WHM.PresenceOfMind))
-                                return WHM.PresenceOfMind;
+                            return WHM.PresenceOfMind;
                         if (IsEnabled(CustomComboPreset.WHMAssizeFeature) && level >= WHM.Levels.Assize && IsOffCooldown(WHM.Assize))
-                                return WHM.Assize;
+                            return WHM.Assize;
                         if (IsEnabled(CustomComboPreset.WHMLucidDreamingFeature) && IsOffCooldown(WHM.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold)
-                                return WHM.LucidDreaming;
+                            return WHM.LucidDreaming;
                     }
 
                     if (IsEnabled(CustomComboPreset.WHMDotMainComboFeature) && inCombat)
@@ -225,6 +227,12 @@ namespace XIVSlothComboPlugin.Combos
                                 return WHM.Dia;
                         }
                     }
+
+                    if (IsEnabled(CustomComboPreset.WHMLilyOvercapFeature) && level >= WHM.Levels.AfflatusRapture && ((gauge.Lily == 3) || (gauge.Lily == 2 && gauge.LilyTimer >= 17000)))
+                                return WHM.AfflatusRapture;
+
+                    if (IsEnabled(CustomComboPreset.WHMAfflatusMiseryOGCDFeature) && level >= WHM.Levels.AfflatusMisery && gauge.BloodLily >= 3)
+                                return WHM.AfflatusMisery;
                 }
 
                 return actionID;

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -590,7 +590,7 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawSliderInt(0, 100, NIN.Config.MugNinkiGauge, "Set the amount of Ninki to be at or under for this feature (level 66 onwards)");
             
             if (preset == CustomComboPreset.NinjaArmorCrushOnMainCombo)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, NIN.Config.HutonRemainingArmorCrush, "Set the amount of time remaining on Huton the feature\nshould wait before using Armor Crush", 200);
+                ConfigWindowFunctions.DrawSliderInt(0, 30, NIN.Config.HutonRemainingArmorCrush, "Set the amount of time remaining on Huton the feature\nshould wait before using Armor Crush", 200);
 
             #endregion
             // ====================================================================================

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -583,9 +583,6 @@ namespace XIVSlothComboPlugin
             if (preset == CustomComboPreset.NinSimpleTrickFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 15, NIN.Config.TrickCooldownRemaining, "Set the amount of time in seconds for the feature to try and set up \nSuiton in advance of Trick Attack coming off cooldown");
             
-            if (preset == CustomComboPreset.NinjaHuraijinFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 60, NIN.Config.HutonRemainingTimer, "Set the amount of time remaining on Huton the feature\nshould wait before using Huraijin", 200);
-            
             if (preset == CustomComboPreset.NinAeolianMugFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, NIN.Config.MugNinkiGauge, "Set the amount of Ninki to be at or under for this feature (level 66 onwards)");
             

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -499,9 +499,9 @@ namespace XIVSlothComboPlugin.Combos
         /// without causing clipping and checks if you're casting a spell to make it mage friendly
         /// </summary>
         /// <param name="actionID">Action ID to check.</param>
-        /// <param name="weaveTime">Time when weaving window is over. Defaults to 0.7.</param>
+        /// <param name="weaveTime">Time when weaving window is over. Defaults to 0.5.</param>
         /// <returns>True or false.</returns>
-        protected static bool CanSpellWeave(uint actionID, double weaveTime = 0.7)
+        protected static bool CanSpellWeave(uint actionID, double weaveTime = 0.5)
         {
             var castingSpell = LocalPlayer.IsCasting;
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2122,6 +2122,14 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Thin Air Raise Feature", "Adds Thin Air to the WHM Raise Feature/Alternative Feature", WHM.JobID, 0, "", "I can hardly breathe as it is!")]
         WHMThinAirFeature = 19014,
 
+        [ParentCombo(WHMCDsonMainComboGroup)]
+        [CustomComboInfo("Lily Overcap Protection", "Adds Afflatus Rapture (AoE Heal) to glare when at 3 lilies.", WHM.JobID, 0, "Feed the blood lily!", "Burn out the bad! Burn out the bad!")]
+        WHMLilyOvercapFeature = 19016,
+
+        [ParentCombo(WHMCDsonMainComboGroup)]
+        [CustomComboInfo("Adds Afflatus Misery to Glare/Stone", "Adds Afflatus Misery to Glare when Blood Lily is in full bloom.", WHM.JobID, 0, "Take this!", "**Throws Blood**")]
+        WHMAfflatusMiseryOGCDFeature = 19017,
+
         #endregion
         // ====================================================================================
         #region DOH


### PR DESCRIPTION
WHM: Lucid feature wasn't connected to slider.
NIN: Limited armor crush slider to 30 to prevent overcapping buff.
NIN: Removed slider on Hurajin, always DPS loss if not set to 0.
Framework: Lowered weave window on CanSpellWeave to help account for SPS builds. (https://github.com/Nik-Potokar/XIVSlothCombo/issues/490)
Note: CanSpellWeave change should be a temporary fix until we can set global variables.  Then we can make it a user input slider.

WHM: Lily Overcap Protection (Adds Afflatus Rapture AoE heal to Glare/Stone) (https://github.com/Nik-Potokar/XIVSlothCombo/issues/495)
WHM: Afflatus Misery on Glare/Stone option