### PR TITLE
Final 6.1 Part 1 update

### DIFF
--- a/XIVSlothCombo/Combos/ADV.cs
+++ b/XIVSlothCombo/Combos/ADV.cs
@@ -41,18 +41,18 @@ namespace XIVSlothComboPlugin.Combos
                         Dalamud.Logging.PluginLog.Debug($"TARGET STATUS CHECK: {chara.Name} -> {status.StatusId}");
                     }
                 }
+                foreach (var status in (LocalPlayer as BattleChara).StatusList)
+                {
+                    Dalamud.Logging.PluginLog.Debug($"SELF STATUS CHECK: {LocalPlayer.Name} -> {status.StatusId}");
+                }
 
                 Dalamud.Logging.PluginLog.Debug($"TARGET OBJECT KIND: {LocalPlayer.TargetObject?.ObjectKind}");
                 Dalamud.Logging.PluginLog.Debug($"PLAYER OBJECT KIND: {LocalPlayer.ObjectKind}");
                 Dalamud.Logging.PluginLog.Debug($"TARGET IS BATTLE CHARA: {LocalPlayer.TargetObject is BattleChara}");
                 Dalamud.Logging.PluginLog.Debug($"PLAYER IS BATTLE CHARA: {LocalPlayer is BattleChara}");
+                Dalamud.Logging.PluginLog.Debug($"IN MELEE RANGE: {InMeleeRange()}");
+                Dalamud.Logging.PluginLog.Debug($"LAST COMBO MOVE: {lastComboActionID}");
 
-
-
-                foreach (var status in (LocalPlayer as BattleChara).StatusList)
-                {
-                    Dalamud.Logging.PluginLog.Debug($"SELF STATUS CHECK: {LocalPlayer.Name} -> {status.StatusId}");
-                }
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Combos/ADV.cs
+++ b/XIVSlothCombo/Combos/ADV.cs
@@ -1,4 +1,6 @@
-﻿namespace XIVSlothComboPlugin.Combos
+﻿using Dalamud.Game.ClientState.Objects.Types;
+
+namespace XIVSlothComboPlugin.Combos
 {
     internal static class ADV
     {
@@ -25,5 +27,36 @@
             public const byte
                 Placeholder = 0;
         }
+#if DEBUG
+        internal class DEBUG : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DEBUG;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+            {
+                if (LocalPlayer.TargetObject is BattleChara chara)
+                {
+                    foreach (var status in chara.StatusList)
+                    {
+                        Dalamud.Logging.PluginLog.Debug($"TARGET STATUS CHECK: {chara.Name} -> {status.StatusId}");
+                    }
+                }
+
+                Dalamud.Logging.PluginLog.Debug($"TARGET OBJECT KIND: {LocalPlayer.TargetObject?.ObjectKind}");
+                Dalamud.Logging.PluginLog.Debug($"PLAYER OBJECT KIND: {LocalPlayer.ObjectKind}");
+                Dalamud.Logging.PluginLog.Debug($"TARGET IS BATTLE CHARA: {LocalPlayer.TargetObject is BattleChara}");
+                Dalamud.Logging.PluginLog.Debug($"PLAYER IS BATTLE CHARA: {LocalPlayer is BattleChara}");
+
+
+
+                foreach (var status in (LocalPlayer as BattleChara).StatusList)
+                {
+                    Dalamud.Logging.PluginLog.Debug($"SELF STATUS CHECK: {LocalPlayer.Name} -> {status.StatusId}");
+                }
+                return actionID;
+            }
+        }
+#endif
+
     }
 }

--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -386,6 +386,7 @@ namespace XIVSlothComboPlugin.Combos
                 var minorarcanaCD = GetCooldown(AST.MinorArcana);
                 var drawCD = GetCooldown(AST.Draw);
                 var actionIDCD = GetCooldown(actionID);
+                var lucidMPThreshold = Service.Configuration.GetCustomIntValue(AST.Config.ASTLucidDreamingFeature);
 
                 if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
                 {
@@ -411,7 +412,7 @@ namespace XIVSlothComboPlugin.Combos
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= 24)
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= 8000 && fallmalefic.CooldownRemaining > 0.2 && level >= 24)
+                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2 && level >= 24)
                         return AST.LucidDreaming;
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
@@ -500,6 +501,7 @@ namespace XIVSlothComboPlugin.Combos
                 var minorarcanaCD = GetCooldown(AST.MinorArcana);
                 var drawCD = GetCooldown(AST.Draw);
                 var actionIDCD = GetCooldown(actionID);
+                var lucidMPThreshold = Service.Configuration.GetCustomIntValue(AST.Config.ASTLucidDreamingFeature);
 
                 if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
                 {
@@ -530,7 +532,7 @@ namespace XIVSlothComboPlugin.Combos
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= 24)
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= 8000 && actionIDCD.CooldownRemaining > 0.2 && level >= 24)
+                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && actionIDCD.CooldownRemaining > 0.2 && level >= 24)
                         return AST.LucidDreaming;
                 }
             }
@@ -572,7 +574,7 @@ namespace XIVSlothComboPlugin.Combos
                 var minorarcanaCD = GetCooldown(AST.MinorArcana);
                 var drawCD = GetCooldown(AST.Draw);
                 var actionIDCD = GetCooldown(actionID);
-
+                var lucidMPThreshold = Service.Configuration.GetCustomIntValue(AST.Config.ASTLucidDreamingFeature);
 
 
                 if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
@@ -603,7 +605,7 @@ namespace XIVSlothComboPlugin.Combos
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= 24)
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= 8000 && fallmalefic.CooldownRemaining > 0.2 && level >= 24)
+                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2 && level >= 24)
                         return AST.LucidDreaming;
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
@@ -655,7 +657,7 @@ namespace XIVSlothComboPlugin.Combos
                 var MaxHpValue = Service.Configuration.EnemyHealthMaxHp;
                 var PercentageHpValue = Service.Configuration.EnemyHealthPercentage;
                 var CurrentHpValue = Service.Configuration.EnemyCurrentHp;
-
+                var lucidMPThreshold = Service.Configuration.GetCustomIntValue(AST.Config.ASTLucidDreamingFeature);
 
                 if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
                 {
@@ -681,7 +683,7 @@ namespace XIVSlothComboPlugin.Combos
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= 24)
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= 8000 && fallmalefic.CooldownRemaining > 0.4 && level >= 24)
+                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.4 && level >= 24)
                         return AST.LucidDreaming;
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)

--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -475,6 +475,22 @@ namespace XIVSlothComboPlugin.Combos
         }
     }
 
+    internal class NinHuraijinArmorCrush : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinHuraijinArmorCrush;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID == NIN.Huraijin)
+            {
+                if (lastComboMove == NIN.GustSlash)
+                    return NIN.ArmorCrush;
+            }
+
+            return actionID;
+        }
+    }
+
 
     internal class NinjaHideMugFeature : CustomCombo
     {

--- a/XIVSlothCombo/Combos/WHM.cs
+++ b/XIVSlothCombo/Combos/WHM.cs
@@ -193,6 +193,7 @@ namespace XIVSlothComboPlugin.Combos
                     var diaDebuff = FindTargetEffect(WHM.Debuffs.Dia);
                     var aero1Debuff = FindTargetEffect(WHM.Debuffs.Aero);
                     var aero2Debuff = FindTargetEffect(WHM.Debuffs.Aero2);
+                    var lucidMPThreshold = Service.Configuration.GetCustomIntValue(WHM.Config.WHMLucidDreamingFeature);
 
                     if (CanSpellWeave(actionID))
                     {
@@ -200,7 +201,7 @@ namespace XIVSlothComboPlugin.Combos
                                 return WHM.PresenceOfMind;
                         if (IsEnabled(CustomComboPreset.WHMAssizeFeature) && level >= WHM.Levels.Assize && IsOffCooldown(WHM.Assize))
                                 return WHM.Assize;
-                        if (IsEnabled(CustomComboPreset.WHMLucidDreamingFeature) && IsOffCooldown(WHM.LucidDreaming) && LocalPlayer.CurrentMp <= 8000)
+                        if (IsEnabled(CustomComboPreset.WHMLucidDreamingFeature) && IsOffCooldown(WHM.LucidDreaming) && LocalPlayer.CurrentMp <= lucidMPThreshold)
                                 return WHM.LucidDreaming;
                     }
 

--- a/XIVSlothCombo/CombosPVP/BRDPVP.cs
+++ b/XIVSlothCombo/CombosPVP/BRDPVP.cs
@@ -14,11 +14,11 @@ namespace XIVSlothComboPlugin.Combos
             ApexArrow = 29393,
             SilentNocturne = 29395,
             EmpyrealArrow = 29398,
-            RepellingShot = 0,
-            WardensPaean = 0,
+            RepellingShot = 29399,
+            WardensPaean = 29400,
             PitchPerfect = 29392,
             BlastArrow = 29394,
-            FinalFantasia = 0;
+            FinalFantasia = 29401;
 
 
         public static class Buffs

--- a/XIVSlothCombo/CombosPVP/MCHPVP.cs
+++ b/XIVSlothCombo/CombosPVP/MCHPVP.cs
@@ -62,7 +62,7 @@ namespace XIVSlothComboPlugin.Combos
                     return OriginalHook(MCHPVP.HeatBlast);
 
                 if ((HasEffect(MCHPVP.Buffs.DrillPrimed) || HasEffect(MCHPVP.Buffs.ChainSawPrimed)) && 
-                    !HasEffect(MCHPVP.Buffs.Analysis) && analysisStacks > 0 && IsOnCooldown(MCHPVP.Wildfire))
+                    !HasEffect(MCHPVP.Buffs.Analysis) && analysisStacks > 0)
                     return OriginalHook(MCHPVP.Analysis);
 
                 if (HasEffect(MCHPVP.Buffs.Analysis) && HasEffect(MCHPVP.Buffs.DrillPrimed) && bigDamageStacks > 0)

--- a/XIVSlothCombo/CombosPVP/MCHPVP.cs
+++ b/XIVSlothCombo/CombosPVP/MCHPVP.cs
@@ -53,7 +53,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                if (globalAction != actionID) return globalAction; return PVPCommon.Recuperate;
+                if (globalAction != actionID) return globalAction;
 
                 if (canWeave && HasEffect(MCHPVP.Buffs.Overheated) && IsOffCooldown(MCHPVP.Wildfire))
                     return OriginalHook(MCHPVP.Wildfire);

--- a/XIVSlothCombo/CombosPVP/NINPVP.cs
+++ b/XIVSlothCombo/CombosPVP/NINPVP.cs
@@ -1,0 +1,158 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XIVSlothComboPlugin;
+using XIVSlothComboPlugin.Combos;
+
+namespace XIVSlothComboPlugin
+{
+    internal static class NINPVP
+    {
+        public const byte ClassID = 18;
+        public const byte JobID = 30;
+
+        internal const uint
+            SpinningEdge = 29500,
+            GustSlash = 29501,
+            AeolianEdge = 29502,
+            FumaShuriken = 29505,
+            Mug = 29509,
+            ThreeMudra = 29507,
+            Bunshin = 29511,
+            Shukuchi = 29513,
+            SeitonTenchu = 29515,
+            ForkedRaiju = 29510,
+            FleetingRaiju = 29707,
+            HyoshoRanryu = 29506,
+            GokaMekkyaku = 29504,
+            Meisui = 29508,
+            Huton = 29512,
+            Doton = 29514,
+            Assassinate = 29503;
+
+        internal class Buffs
+        {
+            internal const ushort
+                ThreeMudra = 1317,
+                Hidden = 1316,
+                Bunshin = 2010,
+                ShadeShift = 2011;
+        }
+
+        internal class Debuffs
+        {
+            internal const ushort
+                SealedHyoshoRanryu = 3194,
+                SealedGokaMekkyaku = 3193,
+                SealedHuton = 3196,
+                SealedDoton = 3187,
+                SeakedForkedRaiju = 3195,
+                SealedMeisui = 3198;
+        }
+    }
+
+    internal class NINBurstMode : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NINBurstMode;
+
+        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        {
+            if (actionID is NINPVP.SpinningEdge or NINPVP.AeolianEdge or NINPVP.GustSlash)
+            {
+                uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+
+                if (globalAction != actionID) return globalAction;
+
+                var threeMudrasCD = GetCooldown(NINPVP.ThreeMudra);
+                var fumaCD = GetCooldown(NINPVP.FumaShuriken);
+                var bunshinStacks = HasEffect(NINPVP.Buffs.Bunshin) ? GetBuffStacks(NINPVP.Buffs.Bunshin) : 0;
+                bool raijuLocked = HasEffect(NINPVP.Debuffs.SeakedForkedRaiju);
+                bool meisuiLocked = HasEffect(NINPVP.Debuffs.SealedMeisui);
+                bool hyoshoLocked = HasEffect(NINPVP.Debuffs.SealedHyoshoRanryu);
+                bool dotonLocked = HasEffect(NINPVP.Debuffs.SealedDoton);
+                bool gokaLocked = HasEffect(NINPVP.Debuffs.SealedGokaMekkyaku);
+                bool hutonLocked = HasEffect(NINPVP.Debuffs.SealedHuton);
+                bool mudraMode = HasEffect(NINPVP.Buffs.ThreeMudra);
+
+                if (HasEffect(NINPVP.Buffs.Hidden))
+                    return OriginalHook(NINPVP.Assassinate);
+
+                if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown)
+                    return NINPVP.Mug;
+
+                if (!GetCooldown(NINPVP.Bunshin).IsCooldown)
+                    return NINPVP.Bunshin;
+
+                if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
+                    return OriginalHook(NINPVP.ThreeMudra);
+
+                if (mudraMode && !raijuLocked)
+                    return OriginalHook(NINPVP.ForkedRaiju);
+
+                if (mudraMode && !hyoshoLocked)
+                    return OriginalHook(NINPVP.HyoshoRanryu);
+
+                if (!InMeleeRange() && GetCooldown(NINPVP.FumaShuriken).RemainingCharges > 0)
+                    return OriginalHook(NINPVP.FumaShuriken);
+
+                
+
+            }
+
+            return actionID;
+        }
+    }
+
+    internal class NINAoEBurstMode : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NINAoEBurstMode;
+
+        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        {
+            if (actionID is NINPVP.FumaShuriken)
+            {
+                uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+
+                if (globalAction != actionID) return globalAction;
+
+                var threeMudrasCD = GetCooldown(NINPVP.ThreeMudra);
+                var fumaCD = GetCooldown(NINPVP.FumaShuriken);
+                var bunshinStacks = HasEffect(NINPVP.Buffs.Bunshin) ? GetBuffStacks(NINPVP.Buffs.Bunshin) : 0;
+                bool raijuLocked = HasEffect(NINPVP.Debuffs.SeakedForkedRaiju);
+                bool meisuiLocked = HasEffect(NINPVP.Debuffs.SealedMeisui);
+                bool hyoshoLocked = HasEffect(NINPVP.Debuffs.SealedHyoshoRanryu);
+                bool dotonLocked = HasEffect(NINPVP.Debuffs.SealedDoton);
+                bool gokaLocked = HasEffect(NINPVP.Debuffs.SealedGokaMekkyaku);
+                bool hutonLocked = HasEffect(NINPVP.Debuffs.SealedHuton);
+                bool mudraMode = HasEffect(NINPVP.Buffs.ThreeMudra);
+
+                if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown)
+                    return NINPVP.Mug;
+
+                if (!GetCooldown(NINPVP.Bunshin).IsCooldown)
+                    return NINPVP.Bunshin;
+
+                if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
+                    return OriginalHook(NINPVP.ThreeMudra);
+
+                if (mudraMode && !dotonLocked)
+                    return OriginalHook(NINPVP.Doton);
+
+                if (mudraMode && !gokaLocked)
+                    return OriginalHook(NINPVP.GokaMekkyaku);
+
+                if (lastComboActionID == NINPVP.GustSlash)
+                    return NINPVP.AeolianEdge;
+
+                if (lastComboActionID == NINPVP.SpinningEdge)
+                    return NINPVP.GustSlash;
+
+                return NINPVP.SpinningEdge;
+            }
+
+            return actionID;
+        }
+    }
+}

--- a/XIVSlothCombo/CombosPVP/NINPVP.cs
+++ b/XIVSlothCombo/CombosPVP/NINPVP.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using XIVSlothComboPlugin;
-using XIVSlothComboPlugin.Combos;
+﻿using XIVSlothComboPlugin.Combos;
 
 namespace XIVSlothComboPlugin
 {
@@ -75,29 +69,31 @@ namespace XIVSlothComboPlugin
                 bool gokaLocked = HasEffect(NINPVP.Debuffs.SealedGokaMekkyaku);
                 bool hutonLocked = HasEffect(NINPVP.Debuffs.SealedHuton);
                 bool mudraMode = HasEffect(NINPVP.Buffs.ThreeMudra);
+                bool canWeave = CanWeave(actionID);
 
                 if (HasEffect(NINPVP.Buffs.Hidden))
                     return OriginalHook(NINPVP.Assassinate);
 
-                if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown)
-                    return NINPVP.Mug;
+                if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown && canWeave)
+                    return OriginalHook(NINPVP.Mug);
 
-                if (!GetCooldown(NINPVP.Bunshin).IsCooldown)
-                    return NINPVP.Bunshin;
+                if (!GetCooldown(NINPVP.Bunshin).IsCooldown && canWeave)
+                    return OriginalHook(NINPVP.Bunshin);
 
-                if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
+                if (threeMudrasCD.RemainingCharges > 0 && !mudraMode && canWeave)
                     return OriginalHook(NINPVP.ThreeMudra);
-
-                if (mudraMode && !raijuLocked)
-                    return OriginalHook(NINPVP.ForkedRaiju);
 
                 if (mudraMode && !hyoshoLocked)
                     return OriginalHook(NINPVP.HyoshoRanryu);
 
-                if (!InMeleeRange() && GetCooldown(NINPVP.FumaShuriken).RemainingCharges > 0)
-                    return OriginalHook(NINPVP.FumaShuriken);
+                if (mudraMode && !raijuLocked && bunshinStacks > 0)
+                    return OriginalHook(NINPVP.ForkedRaiju);
 
-                
+                if (mudraMode && !hutonLocked)
+                    return NINPVP.Huton;
+
+                if (fumaCD.RemainingCharges > 0)
+                    return OriginalHook(NINPVP.FumaShuriken);
 
             }
 
@@ -111,7 +107,7 @@ namespace XIVSlothComboPlugin
 
         protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
         {
-            if (actionID is NINPVP.FumaShuriken)
+            if (actionID == NINPVP.FumaShuriken)
             {
                 uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
@@ -127,14 +123,15 @@ namespace XIVSlothComboPlugin
                 bool gokaLocked = HasEffect(NINPVP.Debuffs.SealedGokaMekkyaku);
                 bool hutonLocked = HasEffect(NINPVP.Debuffs.SealedHuton);
                 bool mudraMode = HasEffect(NINPVP.Buffs.ThreeMudra);
+                bool canWeave = CanWeave(actionID);
 
-                if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown)
+                if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown && canWeave)
                     return NINPVP.Mug;
 
-                if (!GetCooldown(NINPVP.Bunshin).IsCooldown)
+                if (!GetCooldown(NINPVP.Bunshin).IsCooldown && canWeave)
                     return NINPVP.Bunshin;
 
-                if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
+                if (threeMudrasCD.RemainingCharges > 0 && !mudraMode && canWeave)
                     return OriginalHook(NINPVP.ThreeMudra);
 
                 if (mudraMode && !dotonLocked)
@@ -143,13 +140,20 @@ namespace XIVSlothComboPlugin
                 if (mudraMode && !gokaLocked)
                     return OriginalHook(NINPVP.GokaMekkyaku);
 
-                if (lastComboActionID == NINPVP.GustSlash)
-                    return NINPVP.AeolianEdge;
+                if (fumaCD.RemainingCharges > 0)
+                    return OriginalHook(NINPVP.FumaShuriken);
 
-                if (lastComboActionID == NINPVP.SpinningEdge)
-                    return NINPVP.GustSlash;
+                if (InMeleeRange())
+                {
+                    if (lastComboActionID == NINPVP.GustSlash)
+                        return OriginalHook(NINPVP.AeolianEdge);
 
-                return NINPVP.SpinningEdge;
+                    if (lastComboActionID == NINPVP.SpinningEdge)
+                        return OriginalHook(NINPVP.GustSlash);
+
+
+                    return OriginalHook(NINPVP.SpinningEdge);
+                }
             }
 
             return actionID;

--- a/XIVSlothCombo/CombosPVP/SGEPVP.cs
+++ b/XIVSlothCombo/CombosPVP/SGEPVP.cs
@@ -1,0 +1,76 @@
+﻿using XIVSlothComboPlugin.Combos;
+
+namespace XIVSlothComboPlugin
+{
+    internal static class SGEPVP
+    {
+        internal const uint
+            Dosis = 29256,
+            Phlegma = 29259,
+            Pneuma = 29260,
+            Eukrasia = 29258,
+            Icarus = 29261,
+            Toxikon = 29262,
+            Kardia = 29264,
+            EukrasianDosis = 29257,
+            Toxicon2 = 29263;
+
+        internal class Debuffs
+        {
+            internal const ushort
+                EukrasianDosis = 3108,
+                Toxicon = 3113;
+        }
+
+        internal class Buffs
+        {
+            internal const ushort
+                Kardia = 2871,
+                Kardion = 2872,
+                Eukrasia = 3107,
+                Addersting = 3115,
+                Haima = 3110,
+                Haimatinon = 3111;
+        }
+
+    }
+
+
+    internal class SGEBurstMode : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGEBurstMode;
+
+        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        {
+            if (actionID == SGEPVP.Dosis)
+            {
+                uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+
+                if (globalAction != actionID) return globalAction;
+
+                if (!HasEffectAny(SGEPVP.Buffs.Kardia))
+                    return SGEPVP.Kardia;
+
+                if (!GetCooldown(SGEPVP.Pneuma).IsCooldown)
+                    return SGEPVP.Pneuma;
+
+                if (InMeleeRange() && !HasEffect(SGEPVP.Buffs.Eukrasia) && GetCooldown(SGEPVP.Phlegma).RemainingCharges > 0)
+                    return SGEPVP.Phlegma;
+
+                if (HasEffect(SGEPVP.Buffs.Addersting) && !HasEffect(SGEPVP.Buffs.Eukrasia))
+                    return SGEPVP.Toxicon2;
+
+                if (!TargetHasEffectAny(SGEPVP.Debuffs.EukrasianDosis) && GetCooldown(SGEPVP.Eukrasia).RemainingCharges > 0 && !HasEffect(SGEPVP.Buffs.Eukrasia))
+                    return SGEPVP.Eukrasia;
+
+                if (HasEffect(SGEPVP.Buffs.Eukrasia))
+                    return OriginalHook(SGEPVP.Dosis);
+
+                if (!TargetHasEffect(SGEPVP.Debuffs.Toxicon) && GetCooldown(SGEPVP.Toxikon).RemainingCharges > 0)
+                    return OriginalHook(SGEPVP.Toxikon);
+
+            }
+            return actionID;
+        }
+    }
+}

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -855,7 +855,28 @@ namespace XIVSlothComboPlugin
             // ====================================================================================
             #region PVP VALUES
             if (preset == CustomComboPreset.PVPEmergencyHeals)
-                ConfigWindowFunctions.DrawSliderInt(1, 100, PVPCommon.Config.EmergencyHealThreshold, "Set the percentage to be at or under for the feature to kick in.\n100% is considered to start at 15,000 less than your max HP to prevent wastage.");
+            {
+                var pc = Service.ClientState.LocalPlayer;
+                if (pc != null)
+                {
+                    var maxHP = Service.ClientState.LocalPlayer?.MaxHp <= 15000 ? 0 : Service.ClientState.LocalPlayer.MaxHp - 15000;
+                    if (maxHP > 0)
+                    {
+                        var setting = Service.Configuration.GetCustomIntValue(PVPCommon.Config.EmergencyHealThreshold);
+                        var hpThreshold = ((float)maxHP / 100 * setting);
+
+                        ConfigWindowFunctions.DrawSliderInt(1, 100, PVPCommon.Config.EmergencyHealThreshold, $"Set the percentage to be at or under for the feature to kick in.\n100% is considered to start at 15,000 less than your max HP to prevent wastage.\nHP Value to be at or under: {hpThreshold}");
+                    }
+                    else
+                    {
+                        ConfigWindowFunctions.DrawSliderInt(1, 100, PVPCommon.Config.EmergencyHealThreshold, "Set the percentage to be at or under for the feature to kick in.\n100% is considered to start at 15,000 less than your max HP to prevent wastage.");
+                    }
+                }
+                else
+                {
+                    ConfigWindowFunctions.DrawSliderInt(1, 100, PVPCommon.Config.EmergencyHealThreshold, "Set the percentage to be at or under for the feature to kick in.\n100% is considered to start at 15,000 less than your max HP to prevent wastage.");
+                }
+            }
 
             if (preset == CustomComboPreset.PVPEmergencyGuard)
                 ConfigWindowFunctions.DrawSliderInt(1, 100, PVPCommon.Config.EmergencyGuardThreshold, "Set the percentage to be at or under for the feature to kick in.");

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -90,7 +90,6 @@ namespace XIVSlothComboPlugin
         }
         public override void Draw()
         {
-
             if (ImGui.BeginTabBar("SlothBar"))
             {
                 if (ImGui.BeginTabItem("Combos/Features"))
@@ -280,6 +279,8 @@ namespace XIVSlothComboPlugin
 
                 if (ImGui.CollapsingHeader(jobName))
                 {
+                    if (jobName == "All Jobs" && !Service.Configuration.EnableSecretCombos) ImGui.Text("This section currently only contains PVP features at present.");
+
                     foreach (var (preset, info) in this.groupedPresets[jobName])
                     {
                         if (Service.Configuration.HideConflictedCombos)

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -549,7 +549,6 @@ namespace XIVSlothComboPlugin.Combos
         {
             var distance = GetTargetDistance();
 
-            Dalamud.Logging.PluginLog.Debug(distance.ToString());   
             if (distance == 0)
                 return true;
 
@@ -625,31 +624,7 @@ namespace XIVSlothComboPlugin.Combos
             return false;
         }
 
-        protected static string CorrectPositional()
-        {
-            if (CurrentTarget is null)
-                return "NO TARGET";
-            if (CurrentTarget is not BattleChara chara)
-                return "INVALID TARGET";
-
-            //Do simple rotation check, hitbox later
-            var rotationalDiff = CurrentTarget.Rotation - LocalPlayer.Rotation;
-            var degrees = RadiansToDegrees(rotationalDiff);
-
-            return "";
-        }
-
-        private static float RadiansToDegrees(float d)
-        {
-            return Convert.ToSingle(d * (180 / Math.PI));
-        }
-        public static class Positionals
-        {
-            public const string
-                Rear = "Rear",
-                Flank = "Flank",
-                Front = "Front";
-        }
+        
         /// <summary>
         /// Gets the party list
         /// </summary>

--- a/XIVSlothCombo/CustomComboCache.cs
+++ b/XIVSlothCombo/CustomComboCache.cs
@@ -74,7 +74,6 @@ namespace XIVSlothComboPlugin
 
             foreach (var status in chara.StatusList)
             {
-
                 if (status.StatusId == statusID && (!sourceID.HasValue || status.SourceID == 0 || status.SourceID == InvalidObjectID || status.SourceID == sourceID))
                     return this.statusCache[key] = status;
             }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -80,7 +80,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Disabled", "This should not be used.", ADV.JobID)]
         Disabled = 99999,
 
-        #endregion
+#if DEBUG
+        [CustomComboInfo("DEBUG MODE", "OUTPUTS DEBUG INFO. PLEASE USE THE /XLDEV COMMAND AND OPEN THE LOG WINDOW AND SET LOG LEVEL TO DEBUG.", 0)]
+        DEBUG = 99998,
+#endif
+#endregion
         // ====================================================================================
         #region ADV
         #endregion
@@ -2254,6 +2258,14 @@ namespace XIVSlothComboPlugin
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Heavy Swing into an all-in-one damage button.", WARPVP.JobID)]
         WARBurstMode = 80019,
+
+        [SecretCustomCombo]
+        [CustomComboInfo("Burst Mode", "Turns Aeolian Edge Combo into an all-in-one damage button.", NINPVP.JobID)]
+        NINBurstMode = 80020,
+
+        [SecretCustomCombo]
+        [CustomComboInfo("AoE Burst Mode", "Turns Fuma Shuriken into an all-in-one AoE damage button.", NINPVP.JobID)]
+        NINAoEBurstMode = 80021,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1226,11 +1226,11 @@ namespace XIVSlothComboPlugin
         #region NINJA
 
         [ConflictingCombos(NinSimpleSingleTarget)]
-        [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain.", NIN.JobID, 0, "One, Two, Three", "It's a Ninja's life for me")]
+        [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain.", NIN.JobID, 3, "One, Two, Three", "It's a Ninja's life for me")]
         NinjaArmorCrushCombo = 10000,
 
         [ConflictingCombos(NinSimpleSingleTarget)]
-        [CustomComboInfo("Aeolian Edge Combo", "Replace Aeolian Edge with its combo chain.", NIN.JobID, 0, "Edgy Edge Combo", "Knife go stab")]
+        [CustomComboInfo("Aeolian Edge Combo", "Replace Aeolian Edge with its combo chain.", NIN.JobID, 2, "Edgy Edge Combo", "Knife go stab")]
         NinjaAeolianEdgeCombo = 10001,
 
         //[CustomComboInfo("Simple AoE", "Replaces Death Blossom with the AoE rotation.", NIN.JobID)]
@@ -1239,76 +1239,76 @@ namespace XIVSlothComboPlugin
         //[CustomComboInfo("Dream to Assassinate", "Replace Dream Within a Dream with Assassinate when Assassinate Ready.", NIN.JobID)]
         //NinjaAssassinateFeature = 10003,
 
-        [CustomComboInfo("Kassatsu to Trick", "Replaces Kassatsu with Trick Attack while Suiton or Hidden is up.\nCooldown tracking plugin recommended.", NIN.JobID, 0, "Katsu Curry to Trick", "This is how we eat at a restaurant and don't pay the bill.\nRUN!")]
+        [CustomComboInfo("Kassatsu to Trick", "Replaces Kassatsu with Trick Attack while Suiton or Hidden is up.\nCooldown tracking plugin recommended.", NIN.JobID, 4, "Katsu Curry to Trick", "This is how we eat at a restaurant and don't pay the bill.\nRUN!")]
         NinjaKassatsuTrickFeature = 10004,
 
-        [CustomComboInfo("Ten Chi Jin to Meisui", "Replaces Ten Chi Jin (the move) with Meisui while Suiton is up.\nCooldown tracking plugin recommended.", NIN.JobID, 0, "Ten Chin Scratches to Chop-Suey", "Does something, probably.\nHow do you deal with all these attack names?")]
+        [CustomComboInfo("Ten Chi Jin to Meisui", "Replaces Ten Chi Jin (the move) with Meisui while Suiton is up.\nCooldown tracking plugin recommended.", NIN.JobID, 5, "Ten Chin Scratches to Chop-Suey", "Does something, probably.\nHow do you deal with all these attack names?")]
         NinjaTCJMeisuiFeature = 10005,
 
-        [CustomComboInfo("Kassatsu Chi/Jin Feature", "Replaces Chi with Jin while Kassatsu is up if you have Enhanced Kassatsu.", NIN.JobID, 0, "", "Swaps your Katsu curry with a Chi Chin-scratch.")]
+        [CustomComboInfo("Kassatsu Chi/Jin Feature", "Replaces Chi with Jin while Kassatsu is up if you have Enhanced Kassatsu.", NIN.JobID, 6, "", "Swaps your Katsu curry with a Chi Chin-scratch.")]
         NinjaKassatsuChiJinFeature = 10006,
 
-        [CustomComboInfo("Hide to Mug", "Replaces Hide with Mug while in combat.", NIN.JobID, 0, "Stand and Deliver", "John Cena is a thief, now?")]
+        [CustomComboInfo("Hide to Mug", "Replaces Hide with Mug while in combat.", NIN.JobID, 7, "Stand and Deliver", "John Cena is a thief, now?")]
         NinjaHideMugFeature = 10007,
 
-        [CustomComboInfo("Aeolian to Ninjutsu Feature", "Replaces Aeolian Edge (combo) with Ninjutsu if any Mudra are used.", NIN.JobID, 0, "Hand signs and all that", "Do the Naruto thing, I think.\nIdk I don't watch anime, sorry")]
+        [CustomComboInfo("Aeolian to Ninjutsu Feature", "Replaces Aeolian Edge (combo) with Ninjutsu if any Mudra are used.", NIN.JobID, 8, "Hand signs and all that", "Do the Naruto thing, I think.\nIdk I don't watch anime, sorry")]
         NinjaNinjutsuFeature = 10008,
 
         [ConflictingCombos(NinSimpleSingleTarget)]
-        [CustomComboInfo("GCDs to Ninjutsu Feature", "Every GCD combo becomes Ninjutsu while Mudras are being used.", NIN.JobID, 0, "Full-on Sign Language", "NOW you're really communicating with the party.")]
+        [CustomComboInfo("GCDs to Ninjutsu Feature", "Every GCD combo becomes Ninjutsu while Mudras are being used.", NIN.JobID, 9, "Full-on Sign Language", "NOW you're really communicating with the party.")]
         NinjaGCDNinjutsuFeature = 10009,
 
-        [CustomComboInfo("Huraijin / Raiju Feature", "Replaces Huraijin with Forked and Fleeting Raiju when available.", NIN.JobID, 0, "Pikachu / Raichu Feature", "Does something? Maybe? Evolutions? Combos? Probably.")]
+        [CustomComboInfo("Huraijin / Raiju Feature", "Replaces Huraijin with Forked and Fleeting Raiju when available.", NIN.JobID, 10, "Pikachu / Raichu Feature", "Does something? Maybe? Evolutions? Combos? Probably.")]
         NinjaHuraijinRaijuFeature = 10010,
 
         [ParentCombo(NinjaHuraijinRaijuFeature)]
-        [CustomComboInfo("Huraijin / Raiju Feature Option 1", "Replaces Huraijin with Fleeting Raiju when available.", NIN.JobID, 0, "Pikachu / Raichu Option 1", "Does the same thing probably, who knows.")]
+        [CustomComboInfo("Huraijin / Raiju Feature Option 1", "Replaces Huraijin with Fleeting Raiju when available.", NIN.JobID, 11, "Pikachu / Raichu Option 1", "Does the same thing probably, who knows.")]
         NinjaHuraijinRaijuFeature1 = 10011,
 
         [ParentCombo(NinjaHuraijinRaijuFeature)]
-        [CustomComboInfo("Huraijin / Raiju Feature Option 2", "Replaces Huraijin with Forked Raiju when available.", NIN.JobID, 0, "Pikachu / Raichu Option 2", "What we DO know, is that all NIN mains just slam their heads on the keyboard to do combos, anyway.")]
+        [CustomComboInfo("Huraijin / Raiju Feature Option 2", "Replaces Huraijin with Forked Raiju when available.", NIN.JobID, 12, "Pikachu / Raichu Option 2", "What we DO know, is that all NIN mains just slam their heads on the keyboard to do combos, anyway.")]
         NinjaHuraijinRaijuFeature2 = 10012,
 
         [ParentCombo(NinjaAeolianEdgeCombo)]
-        [CustomComboInfo("Armor Crush Feature", "Adds Armor Crush onto main combo.", NIN.JobID, 0, "", "Act like you can crush armor with your kitchen knives or whatever.")]
+        [CustomComboInfo("Armor Crush Feature", "Adds Armor Crush onto main combo.", NIN.JobID, 13, "", "Act like you can crush armor with your kitchen knives or whatever.")]
         NinjaArmorCrushOnMainCombo = 10013,
 
         [ParentCombo(NinjaAeolianEdgeCombo)]
-        [CustomComboInfo("Raiju Feature", "Adds Fleeting Raiju to Aeolian Edge Combo.", NIN.JobID, 0, "Raichu Feature", "Thunderbolt!")]
+        [CustomComboInfo("Raiju Feature", "Adds Fleeting Raiju to Aeolian Edge Combo.", NIN.JobID, 14, "Raichu Feature", "Thunderbolt!")]
         NinjaFleetingRaijuFeature = 10014,
 
         [ParentCombo(NinjaAeolianEdgeCombo)]
-        [CustomComboInfo("HuraijinToMainCombo", "Adds Huraijin to main combo if Huton buff is not present", NIN.JobID, 0, "", "Smells like a hurricane. No idea.")]
+        [CustomComboInfo("HuraijinToMainCombo", "Adds Huraijin to main combo if Huton buff is not present", NIN.JobID, 15, "", "Smells like a hurricane. No idea.")]
         NinjaHuraijinFeature = 10015,
 
         [ParentCombo(NinjaAeolianEdgeCombo)]
-        [CustomComboInfo("BunshinOnMainCombo", "Adds Bunshin whenever its off cd and you have gauge for it on main combo.", NIN.JobID, 0, "What do you call a Viera that's been cut off at the knees?", "Bun-shin KEK")]
+        [CustomComboInfo("BunshinOnMainCombo", "Adds Bunshin whenever its off cd and you have gauge for it on main combo.", NIN.JobID, 16, "What do you call a Viera that's been cut off at the knees?", "Bun-shin KEK")]
         NinjaBunshinFeature = 10016,
 
         [ParentCombo(NinjaAeolianEdgeCombo)]
-        [CustomComboInfo("BavacakraOnMainCombo", "Adds Bavacakra you have gauge for it on main combo.", NIN.JobID, 0, "BAKLAVA!", "BAKLAVA!")]
+        [CustomComboInfo("BavacakraOnMainCombo", "Adds Bavacakra you have gauge for it on main combo.", NIN.JobID, 17, "BAKLAVA!", "BAKLAVA!")]
         NinjaBhavacakraFeature = 10017,
 
         [ParentCombo(NinjaAeolianEdgeCombo)]
-        [CustomComboInfo("Throwing Dagger Uptime Feature", "Replace Aeolian Edge with Throwing Daggers when targer is our of range.", NIN.JobID, 0, "", "Would probably make more sense for NIN to be a Ranged DPS, anyway.")]
+        [CustomComboInfo("Throwing Dagger Uptime Feature", "Replace Aeolian Edge with Throwing Daggers when targer is our of range.", NIN.JobID, 18, "", "Would probably make more sense for NIN to be a Ranged DPS, anyway.")]
         NinjaRangedUptimeFeature = 10018,
 
-        [CustomComboInfo("Simple Mudras", "Simplify the mudra casting to avoid failing.", NIN.JobID, 0, "Simple Murder", "Murder, made simple. For the everyday user.")]
+        [CustomComboInfo("Simple Mudras", "Simplify the mudra casting to avoid failing.", NIN.JobID, 19, "Simple Murder", "Murder, made simple. For the everyday user.")]
         NinjaSimpleMudras = 10020,
 
         [ParentCombo(NinjaTCJMeisuiFeature)]
-        [CustomComboInfo("Ten Chi Jin Feature", "Turns Ten Chi Jin (the move) into Ten, Chi, and Jin.", NIN.JobID, 0, "", "Does literally nothing. Ever")]
+        [CustomComboInfo("Ten Chi Jin Feature", "Turns Ten Chi Jin (the move) into Ten, Chi, and Jin.", NIN.JobID, 20, "", "Does literally nothing. Ever")]
         NinTCJFeature = 10021,
 
         [ConflictingCombos(NinjaArmorCrushCombo, NinjaAeolianEdgeCombo, NinjaGCDNinjutsuFeature)]
-        [CustomComboInfo("Simple Ninja Single Target", "Turns Spinning Edge into a one-button full single target rotation.\nUses Ninjitsus, applies Trick Attack and uses Armor Crush to upkeep Huton buff.\nConflicts with a lot of features. Please only use this and the AoE version and disable all other Ninja features.", NIN.JobID, 0, "", "")]
+        [CustomComboInfo("Simple Ninja Single Target", "Turns Spinning Edge into a one-button full single target rotation.\nUses Ninjitsus, applies Trick Attack and uses Armor Crush to upkeep Huton buff.", NIN.JobID, 0, "", "")]
         NinSimpleSingleTarget = 10022,
 
-        [CustomComboInfo("Simple Ninja AoE", "Turns Death Blossom into a one-button full AoE rotation.\nApplies Doton but will only use Ninjitsus if under the effect of Kassatsu or have 2 charges to ensure more Doton uptime.", NIN.JobID, 0, "Dote-on AoE", "Uses /dote on every target.")]
+        [CustomComboInfo("Simple Ninja AoE", "Turns Death Blossom into a one-button full AoE rotation.", NIN.JobID, 1, "Dote-on AoE", "Uses /dote on every target.")]
         NinSimpleAoE = 10023,
 
         [ParentCombo(NinSimpleSingleTarget)]
-        [CustomComboInfo("Include Trick Attack", "Add or disable Trick Attack as part of the feature.", NIN.JobID, 0, "Surprise!", "It's like the Uno Reverse card of XIV!")]
+        [CustomComboInfo("Include Trick Attack", "Add or disable Trick Attack as part of the feature.", NIN.JobID, 1, "Surprise!", "It's like the Uno Reverse card of XIV!")]
         NinSimpleTrickFeature = 10024,
 
         [ParentCombo(NinjaAeolianEdgeCombo)]
@@ -1336,8 +1336,11 @@ namespace XIVSlothComboPlugin
         NinSimpleAoeBunshin = 10030,
 
         [ParentCombo(NinSimpleSingleTarget)]
-        [CustomComboInfo("Add Mug", "Adds Mug to this Simple Feature.", NIN.JobID)]
+        [CustomComboInfo("Add Mug", "Adds Mug to this Simple Feature.", NIN.JobID, 2)]
         NinSimpleMug = 10031,
+
+        [CustomComboInfo("Huraijin / Armor Crush Combo", "Replace Huraijin with Armor Crush after using Gust Slash", NIN.JobID, 8)]
+        NinHuraijinArmorCrush = 10032,
 
         #endregion
         // ====================================================================================
@@ -2259,13 +2262,19 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Burst Mode", "Turns Heavy Swing into an all-in-one damage button.", WARPVP.JobID)]
         WARBurstMode = 80019,
 
+        [ConflictingCombos(NINAoEBurstMode)]
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Aeolian Edge Combo into an all-in-one damage button.", NINPVP.JobID)]
         NINBurstMode = 80020,
 
+        [ConflictingCombos(NINBurstMode)]
         [SecretCustomCombo]
         [CustomComboInfo("AoE Burst Mode", "Turns Fuma Shuriken into an all-in-one AoE damage button.", NINPVP.JobID)]
         NINAoEBurstMode = 80021,
+
+        [SecretCustomCombo]
+        [CustomComboInfo("Burst Mode", "Turns Dosis III into an all-in-one damage button.", SGE.JobID)]
+        SGEBurstMode = 80022,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
Changelog for big 6.1 update (Part 1 cause it's soooo big it needs longer to cook).

PVP
- Removes all old PVP features due to redundancy.
- New PVP features for BRD, MCH, RDM, WAR, NIN & SGE added plus common actions for all of them.
- Adds Emergency Heals, Guard and Quick Purify features to be used in tandem with the previously mentioned PVP features.

Framework:
- The configuration window has been redesigned to fit a neater tabbed style.
- `Adventurer` renamed to `All Jobs`
- Developers can now target specific party members easier. Also works in Trusts (big bonus).
- New UI templates to accomodate the targeting update: Job Grid, Role Grids. Both have multiple choice and single choice variants.
- `Debug Mode` added to the `Adventurer` tab to allow developers more ready access to certain things such as statuses, distances and object types.
- Fixed a bug in `InMeleeRange` which didn't consider other players as valid targets.
- Removed redundant boolean argument for `InMeleeRange`.

PVE
- AST has received a big glow-up in the form of targeting QoL and their cards. `Draw on Play` now has new suboptions with `Quick Target Cards` and the suboption to that for `Keep Target Locked` and `Add Tanks/Healers to Auto-Target`
- Fixed the `Lucid Dreaming` slider features for AST & WHM.
- NIN has been adjusted slightly to accomodate the recent 6.1 updates. `Mug` is now optional on the `Simple Ninja Single Target` feature and the order has been adjusted to put it earlier in the feature.
- `Huraijin / Armor Crush Combo` has been added to NIN as per my statement in #494.
