### PR TITLE
PVP Updates + CN support for AST

### DIFF
--- a/XIVSlothCombo/Combos/ADV.cs
+++ b/XIVSlothCombo/Combos/ADV.cs
@@ -54,7 +54,9 @@ namespace XIVSlothComboPlugin.Combos
                     Dalamud.Logging.PluginLog.Debug($"PLAYER IS BATTLE CHARA: {LocalPlayer is BattleChara}");
                     Dalamud.Logging.PluginLog.Debug($"IN MELEE RANGE: {InMeleeRange()}");
                     Dalamud.Logging.PluginLog.Debug($"LAST COMBO MOVE: {lastComboActionID}");
-                    Dalamud.Logging.PluginLog.Debug($"IN PVP ZONE: {Service.ClientState.IsPvP}");
+                    Dalamud.Logging.PluginLog.Debug($"IN PVP ZONE: {InPvP()}");
+                    Dalamud.Logging.PluginLog.Debug($"ZONE: {Service.ClientState.TerritoryType}");
+
                 }
                 return actionID;
             }

--- a/XIVSlothCombo/Combos/ADV.cs
+++ b/XIVSlothCombo/Combos/ADV.cs
@@ -34,25 +34,28 @@ namespace XIVSlothComboPlugin.Combos
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (LocalPlayer.TargetObject is BattleChara chara)
+                if (InCombat())
                 {
-                    foreach (var status in chara.StatusList)
+                    if (LocalPlayer.TargetObject is BattleChara chara)
                     {
-                        Dalamud.Logging.PluginLog.Debug($"TARGET STATUS CHECK: {chara.Name} -> {status.StatusId}");
+                        foreach (var status in chara.StatusList)
+                        {
+                            Dalamud.Logging.PluginLog.Debug($"TARGET STATUS CHECK: {chara.Name} -> {status.StatusId}");
+                        }
                     }
-                }
-                foreach (var status in (LocalPlayer as BattleChara).StatusList)
-                {
-                    Dalamud.Logging.PluginLog.Debug($"SELF STATUS CHECK: {LocalPlayer.Name} -> {status.StatusId}");
-                }
+                    foreach (var status in (LocalPlayer as BattleChara).StatusList)
+                    {
+                        Dalamud.Logging.PluginLog.Debug($"SELF STATUS CHECK: {LocalPlayer.Name} -> {status.StatusId}");
+                    }
 
-                Dalamud.Logging.PluginLog.Debug($"TARGET OBJECT KIND: {LocalPlayer.TargetObject?.ObjectKind}");
-                Dalamud.Logging.PluginLog.Debug($"PLAYER OBJECT KIND: {LocalPlayer.ObjectKind}");
-                Dalamud.Logging.PluginLog.Debug($"TARGET IS BATTLE CHARA: {LocalPlayer.TargetObject is BattleChara}");
-                Dalamud.Logging.PluginLog.Debug($"PLAYER IS BATTLE CHARA: {LocalPlayer is BattleChara}");
-                Dalamud.Logging.PluginLog.Debug($"IN MELEE RANGE: {InMeleeRange()}");
-                Dalamud.Logging.PluginLog.Debug($"LAST COMBO MOVE: {lastComboActionID}");
-
+                    Dalamud.Logging.PluginLog.Debug($"TARGET OBJECT KIND: {LocalPlayer.TargetObject?.ObjectKind}");
+                    Dalamud.Logging.PluginLog.Debug($"PLAYER OBJECT KIND: {LocalPlayer.ObjectKind}");
+                    Dalamud.Logging.PluginLog.Debug($"TARGET IS BATTLE CHARA: {LocalPlayer.TargetObject is BattleChara}");
+                    Dalamud.Logging.PluginLog.Debug($"PLAYER IS BATTLE CHARA: {LocalPlayer is BattleChara}");
+                    Dalamud.Logging.PluginLog.Debug($"IN MELEE RANGE: {InMeleeRange()}");
+                    Dalamud.Logging.PluginLog.Debug($"LAST COMBO MOVE: {lastComboActionID}");
+                    Dalamud.Logging.PluginLog.Debug($"IN PVP ZONE: {Service.ClientState.IsPvP}");
+                }
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -1,4 +1,4 @@
-using Dalamud.Game.ClientState.JobGauge.Enums;
+﻿using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using System.Linq;
@@ -36,6 +36,7 @@ namespace XIVSlothComboPlugin.Combos
             LadyOfCrown = 7445,
             Divination = 16552,
             Lightspeed = 3606,
+            Redraw = 3593,
 
             // aoes
             Gravity = 3615,
@@ -82,7 +83,8 @@ namespace XIVSlothComboPlugin.Combos
             HoroscopeHelios = 1891,
             AspectedBenefic = 835,
             NeutralSect = 1892,
-            NeutralSectShield = 1921;
+            NeutralSectShield = 1921,
+            ClarifyingDraw = 2713;
         }
 
         public static class Debuffs
@@ -166,6 +168,56 @@ namespace XIVSlothComboPlugin.Combos
                 Sage = "sage",
                 Conjurer = "conjurer";
         }
+
+        public static class MeleeCardTargetsCN
+        {
+            public const string
+                Monk = "武僧",
+                Dragoon = "龙骑士",
+                Ninja = "忍者",
+                Reaper = "钐镰客",
+                Samurai = "武士",
+                Pugilist = "格斗家",
+                Lancer = "枪术师",
+                Rogue = "双剑师";
+        }
+
+        public static class RangedCardTargetsCN
+        {
+            public const string
+                Bard = "吟游诗人",
+                Machinist = "机工士",
+                Dancer = "舞者",
+                RedMage = "赤魔法师",
+                BlackMage = "黑魔法师",
+                Summoner = "召唤师",
+                BlueMage = "青魔法师",
+                Archer = "弓箭手",
+                Thaumaturge = "咒术师",
+                Arcanist = "秘术师";
+
+        }
+
+        public static class TankCardTargetsCN
+        {
+            public const string
+                Paladin = "骑士",
+                Warrior = "战士",
+                DarkKnight = "暗黑骑士",
+                Gunbreaker = "绝枪战士",
+                Gladiator = "剑术师",
+                Marauder = "斧术师";
+        }
+
+        public static class HealerCardTargetsCN
+        {
+            public const string
+                WhiteMage = "白魔法师",
+                Astrologian = "占星术士",
+                Scholar = "学者",
+                Sage = "贤者",
+                Conjurer = "幻术师";
+        }
     }
 
     internal class AstrologianCardsOnDrawFeaturelikewhat : CustomCombo
@@ -179,12 +231,18 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var gauge = GetJobGauge<ASTGauge>();
                 var haveCard = HasEffect(AST.Buffs.Balance) || HasEffect(AST.Buffs.Bole) || HasEffect(AST.Buffs.Arrow) || HasEffect(AST.Buffs.Spear) || HasEffect(AST.Buffs.Ewer) || HasEffect(AST.Buffs.Spire);
+                var cardDrawn = gauge.DrawnCard;
 
                 if (!gauge.ContainsSeal(SealType.NONE) && IsEnabled(CustomComboPreset.AstrologianAstrodyneOnPlayFeature) && (gauge.DrawnCard != CardType.NONE || GetCooldown(AST.Draw).CooldownRemaining > 30))
                     return AST.Astrodyne;
 
                 if (haveCard)
                 {
+                    if (HasEffect(AST.Buffs.ClarifyingDraw) && IsEnabled(CustomComboPreset.AstRedrawFeature))
+                    {
+                        if ((cardDrawn == CardType.BALANCE && gauge.Seals.Contains(SealType.SUN)) || (cardDrawn == CardType.ARROW && gauge.Seals.Contains(SealType.MOON)) || (cardDrawn == CardType.SPEAR && gauge.Seals.Contains(SealType.CELESTIAL)) || (cardDrawn == CardType.BOLE && gauge.Seals.Contains(SealType.SUN)) || (cardDrawn == CardType.EWER && gauge.Seals.Contains(SealType.MOON)) || (cardDrawn == CardType.SPIRE && gauge.Seals.Contains(SealType.CELESTIAL)))
+                            return AST.Redraw;
+                    }
                     if (IsEnabled(CustomComboPreset.AstAutoCardTarget))
                     {
                         if (GetTarget || (IsEnabled(CustomComboPreset.AstrologianTargetLock)))
@@ -230,7 +288,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (cardDrawn is CardType.BALANCE or CardType.ARROW or CardType.SPEAR)
                 {
-                    if (typeof(AST.MeleeCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
+                    if (typeof(AST.MeleeCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.MeleeCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
                     {
                         TargetPartyMember(member);
                         GetTarget = false;
@@ -240,7 +298,7 @@ namespace XIVSlothComboPlugin.Combos
                 }
                 if (cardDrawn is CardType.BOLE or CardType.EWER or CardType.SPIRE)
                 {
-                    if (typeof(AST.RangedCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
+                    if (typeof(AST.RangedCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.RangedCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
                     {
                         TargetPartyMember(member);
                         GetTarget = false;
@@ -268,7 +326,7 @@ namespace XIVSlothComboPlugin.Combos
 
                     if (cardDrawn is CardType.BALANCE or CardType.ARROW or CardType.SPEAR)
                     {
-                        if (typeof(AST.TankCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
+                        if (typeof(AST.TankCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.TankCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
                         {
                             TargetPartyMember(member);
                             GetTarget = false;
@@ -278,7 +336,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
                     if (cardDrawn is CardType.BOLE or CardType.EWER or CardType.SPIRE)
                     {
-                        if (typeof(AST.HealerCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
+                        if (typeof(AST.HealerCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.HealerCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
                         {
                             TargetPartyMember(member);
                             GetTarget = false;

--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -109,6 +109,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const string
                 TrickCooldownRemaining = "TrickCooldownRemaining",
+                HutonRemainingTimer = "HutonRemainingTimer",
                 HutonRemainingArmorCrush = "HutonRemainingArmorCrush",
                 MugNinkiGauge = "MugNinkiGauge";
         }

--- a/XIVSlothCombo/CombosPVP/BRDPVP.cs
+++ b/XIVSlothCombo/CombosPVP/BRDPVP.cs
@@ -40,9 +40,9 @@ namespace XIVSlothComboPlugin.Combos
                 
                 if (actionID == BRDPvP.PowerfulShot)
                 {
-                    uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+                    //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                    if (globalAction != actionID) return globalAction;
+                    //if (globalAction != actionID) return globalAction;
 
                     if (GetCooldown(BRDPvP.EmpyrealArrow).RemainingCharges == 3)
                         return OriginalHook(BRDPvP.EmpyrealArrow);

--- a/XIVSlothCombo/CombosPVP/MCHPVP.cs
+++ b/XIVSlothCombo/CombosPVP/MCHPVP.cs
@@ -51,9 +51,9 @@ namespace XIVSlothComboPlugin.Combos
                 var analysisStacks = GetRemainingCharges(MCHPVP.Analysis);
                 var bigDamageStacks = GetRemainingCharges(OriginalHook(MCHPVP.Drill));
 
-                uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                if (globalAction != actionID) return globalAction;
+                //if (globalAction != actionID) return globalAction;
 
                 if (canWeave && HasEffect(MCHPVP.Buffs.Overheated) && IsOffCooldown(MCHPVP.Wildfire))
                     return OriginalHook(MCHPVP.Wildfire);

--- a/XIVSlothCombo/CombosPVP/NINPVP.cs
+++ b/XIVSlothCombo/CombosPVP/NINPVP.cs
@@ -55,9 +55,9 @@ namespace XIVSlothComboPlugin
         {
             if (actionID is NINPVP.SpinningEdge or NINPVP.AeolianEdge or NINPVP.GustSlash)
             {
-                uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                if (globalAction != actionID) return globalAction;
+                //if (globalAction != actionID) return globalAction;
 
                 var threeMudrasCD = GetCooldown(NINPVP.ThreeMudra);
                 var fumaCD = GetCooldown(NINPVP.FumaShuriken);
@@ -109,9 +109,9 @@ namespace XIVSlothComboPlugin
         {
             if (actionID == NINPVP.FumaShuriken)
             {
-                uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                if (globalAction != actionID) return globalAction;
+                //if (globalAction != actionID) return globalAction;
 
                 var threeMudrasCD = GetCooldown(NINPVP.ThreeMudra);
                 var fumaCD = GetCooldown(NINPVP.FumaShuriken);

--- a/XIVSlothCombo/CombosPVP/PVPCommon.cs
+++ b/XIVSlothCombo/CombosPVP/PVPCommon.cs
@@ -39,7 +39,7 @@ namespace XIVSlothComboPlugin
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (Execute() && Service.ClientState.IsPvP) return PVPCommon.Recuperate;
+                if (Execute() && InPvP()) return PVPCommon.Recuperate;
                 return actionID;
             }
 
@@ -66,7 +66,7 @@ namespace XIVSlothComboPlugin
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (Execute() && Service.ClientState.IsPvP) return PVPCommon.Guard;
+                if (Execute() && InPvP()) return PVPCommon.Guard;
                 return actionID;
             }
 
@@ -91,7 +91,7 @@ namespace XIVSlothComboPlugin
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (Execute() && Service.ClientState.IsPvP) return PVPCommon.Purify;
+                if (Execute() && InPvP()) return PVPCommon.Purify;
                 return actionID;
             }
 

--- a/XIVSlothCombo/CombosPVP/PVPCommon.cs
+++ b/XIVSlothCombo/CombosPVP/PVPCommon.cs
@@ -28,7 +28,8 @@ namespace XIVSlothComboPlugin
                 HalfAsleep = 3022,
                 Sleep = 1348,
                 DeepFreeze = 3219,
-                Heavy = 1344;
+                Heavy = 1344,
+                Unguarded = 3021;
         }
 
 
@@ -37,7 +38,7 @@ namespace XIVSlothComboPlugin
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PVPEmergencyHeals;
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
-            {   
+            {
                 if (TargetHasEffect(BRDPvP.Buffs.Repertoire)) { }
                 return actionID;
             }
@@ -74,6 +75,7 @@ namespace XIVSlothComboPlugin
                 var threshold = Service.Configuration.GetCustomIntValue(PVPCommon.Config.EmergencyGuardThreshold);
                 var remainingPercentage = (float)LocalPlayer.CurrentHp / (float)jobMaxHp;
 
+                if (HasEffectAny(PVPCommon.Debuffs.Unguarded)) return false;
                 if (GetCooldown(PVPCommon.Guard).IsCooldown) return false;
                 if (remainingPercentage * 100 > threshold) return false;
 

--- a/XIVSlothCombo/CombosPVP/PVPCommon.cs
+++ b/XIVSlothCombo/CombosPVP/PVPCommon.cs
@@ -39,7 +39,7 @@ namespace XIVSlothComboPlugin
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (TargetHasEffect(BRDPvP.Buffs.Repertoire)) { }
+                if (Execute() && Service.ClientState.IsPvP) return PVPCommon.Recuperate;
                 return actionID;
             }
 
@@ -66,6 +66,7 @@ namespace XIVSlothComboPlugin
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
+                if (Execute() && Service.ClientState.IsPvP) return PVPCommon.Guard;
                 return actionID;
             }
 
@@ -90,6 +91,7 @@ namespace XIVSlothComboPlugin
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
+                if (Execute() && Service.ClientState.IsPvP) return PVPCommon.Purify;
                 return actionID;
             }
 
@@ -113,24 +115,6 @@ namespace XIVSlothComboPlugin
             }
         }
 
-        internal class ExecutePVPGlobal : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; }
-
-            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
-            {
-                return actionID;
-            }
-
-            public static uint ExecuteGlobal(uint actionId)
-            {
-                if (IsEnabled(CustomComboPreset.PVPQuickPurify) && PVPCommon.QuickPurify.Execute()) return PVPCommon.Purify;
-                if (IsEnabled(CustomComboPreset.PVPEmergencyGuard) && PVPCommon.GlobalEmergencyGuard.Execute()) return PVPCommon.Guard;
-                if (IsEnabled(CustomComboPreset.PVPEmergencyHeals) && PVPCommon.GlobalEmergencyHeals.Execute()) return PVPCommon.Recuperate;
-
-                return actionId;
-            }
-        }
     }
 
 }

--- a/XIVSlothCombo/CombosPVP/PVPCommon.cs
+++ b/XIVSlothCombo/CombosPVP/PVPCommon.cs
@@ -76,7 +76,7 @@ namespace XIVSlothComboPlugin
                 var threshold = Service.Configuration.GetCustomIntValue(PVPCommon.Config.EmergencyGuardThreshold);
                 var remainingPercentage = (float)LocalPlayer.CurrentHp / (float)jobMaxHp;
 
-                if (HasEffectAny(PVPCommon.Debuffs.Unguarded)) return false;
+                if (HasEffectAny(PVPCommon.Debuffs.Unguarded) || HasEffect(WARPVP.Buffs.InnerRelease)) return false;
                 if (GetCooldown(PVPCommon.Guard).IsCooldown) return false;
                 if (remainingPercentage * 100 > threshold) return false;
 

--- a/XIVSlothCombo/CombosPVP/RDMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/RDMPVP.cs
@@ -56,9 +56,9 @@ namespace XIVSlothComboPlugin
         {
             if (actionID is RDMPVP.Verstone or RDMPVP.Verfire)
             {
-                uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                if (globalAction != actionID) return globalAction;
+                //if (globalAction != actionID) return globalAction;
 
                 if (!GetCooldown(RDMPVP.Frazzle).IsCooldown && HasEffect(RDMPVP.Buffs.BlackShift))
                     return OriginalHook(RDMPVP.Frazzle);

--- a/XIVSlothCombo/CombosPVP/SGEPVP.cs
+++ b/XIVSlothCombo/CombosPVP/SGEPVP.cs
@@ -44,9 +44,9 @@ namespace XIVSlothComboPlugin
         {
             if (actionID == SGEPVP.Dosis)
             {
-                uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                if (globalAction != actionID) return globalAction;
+                //if (globalAction != actionID) return globalAction;
 
                 if (!HasEffectAny(SGEPVP.Buffs.Kardia))
                     return SGEPVP.Kardia;

--- a/XIVSlothCombo/CombosPVP/WARPVP.cs
+++ b/XIVSlothCombo/CombosPVP/WARPVP.cs
@@ -37,9 +37,9 @@ namespace XIVSlothComboPlugin
         {
             if (actionID == WARPVP.HeavySwing)
             {
-                uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                if (globalAction != actionID) return globalAction;
+                //if (globalAction != actionID) return globalAction;
 
                 if (!GetCooldown(WARPVP.Bloodwhetting).IsCooldown)
                     return OriginalHook(WARPVP.Bloodwhetting);

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -688,10 +688,10 @@ namespace XIVSlothComboPlugin
             if (preset == CustomComboPreset.NinSimpleTrickFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 15, NIN.Config.TrickCooldownRemaining, "Set the amount of time in seconds for the feature to try and set up \nSuiton in advance of Trick Attack coming off cooldown");
 
-            /*
+            
             if (preset == CustomComboPreset.NinjaHuraijinFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 60, NIN.Config.HutonRemainingTimer, "Set the amount of time remaining on Huton the feature\nshould wait before using Huraijin", 200);
-            */
+            
 
             if (preset == CustomComboPreset.NinAeolianMugFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, NIN.Config.MugNinkiGauge, "Set the amount of Ninki to be at or under for this feature (level 66 onwards)");

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -803,5 +803,8 @@ namespace XIVSlothComboPlugin.Combos
             P7,
             P8
         }
+
+        protected static bool InPvP()
+            => Service.ClientState.IsPvP || Service.ClientState.TerritoryType == 250;
     }
 }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -204,8 +204,12 @@ namespace XIVSlothComboPlugin
         AstrologianTargetLock = 1030,
 
         [ParentCombo(AstAutoCardTarget)]
-        [CustomComboInfo("Add Tanks/Healers to Auto-Target", "Targets a tank or healer if no DPS remain for auto card target selection", AST.JobID)]
+        [CustomComboInfo("Add Tanks/Healers to Auto-Target", "Targets a tank or healer if no DPS remain for quick target selection", AST.JobID)]
         AstrologianTargetExtraFeature = 1031,
+
+        [ParentCombo(AstrologianCardsOnDrawFeaturelikewhat)]
+        [CustomComboInfo("Redraw Feature", "Sets Draw to Redraw if you pull a card with a seal you already have and you can use Redraw.", AST.JobID)]
+        AstRedrawFeature = 1032,
 
 
         #endregion

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -84,7 +84,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("DEBUG MODE", "OUTPUTS DEBUG INFO. PLEASE USE THE /XLDEV COMMAND AND OPEN THE LOG WINDOW AND SET LOG LEVEL TO DEBUG.", 0)]
         DEBUG = 99998,
 #endif
-#endregion
+        #endregion
         // ====================================================================================
         #region ADV
         #endregion
@@ -102,6 +102,7 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region ASTROLOGIAN
 
+        [ConflictingCombos(AstrologianAutoDrawFeature,AstrologianDpsAoEFeature)]
         [CustomComboInfo("Draw on Play", "Play turns into Draw when no card is drawn, as well as the usual Play behavior.", AST.JobID, 0, "Pot of Greed", "Draw some cards, or something. Idk, you're the one that chose to play AST.")]
         AstrologianCardsOnDrawFeaturelikewhat = 1000,
 
@@ -133,12 +134,14 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Aspected Helios Feature", "Replaces Aspected Helios whenever you are under Aspected Helios regen with Helios", AST.JobID, 0, "HELIOSCOPTER", "HELIOSCOPTER HELIOSCOPTER")]
         AstrologianHeliosFeature = 1010,
 
+        [ConflictingCombos(AstrologianCardsOnDrawFeaturelikewhat)]
         [CustomComboInfo("Auto Card Draw", "Adds Auto Card Draw Onto Main DPS Feature", AST.JobID, 0, "Kaiba Feature", "You just activated my trap card!")]
         AstrologianAutoDrawFeature = 1011,
 
         [CustomComboInfo("Auto Crown Card Draw", "Adds Auto Crown Card Draw Onto Main DPS Feature ", AST.JobID, 0, "Kaiba 2, Electric Boogaloo", "It's a trap!")]
         AstrologianAutoCrownDrawFeature = 1012,
 
+        [ConflictingCombos(AstrologianCardsOnDrawFeaturelikewhat)]
         [CustomComboInfo("AoE DPS Feature", "Adds AutoDraws/Astrodyne to the AoE Gravity combo", AST.JobID, 0, "A bowlful of cards", "Oops! All AoE!")]
         AstrologianDpsAoEFeature = 1013,
 


### PR DESCRIPTION
PVP global features now replaces every button and works on every job, regardless of individual job features.

Added CN client compatibility for the AST Quick Target features.

Added a `Redraw Feature` to the AST draw feature to attempt to optimize seal gains.

PVP Global Feature `Emergency Guard` now takes into consideration if under the debuff of WAR LB.

Wolves Den Pier now counts as a PVP zone, to enable global features in duels.

`JustUsed` now reverted back to previous, working state. (Fixes BRD simple opener issues)