### PR TITLE
[MCH & BRD]  Some PVP and PVE fixes and tweaks

### DIFF
--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -97,7 +97,8 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
-                RagingJawsRenewTime = "ragingJawsRenewTime";
+                RagingJawsRenewTime = "ragingJawsRenewTime",
+                NoWasteHPPercentage = "noWasteHpPercentage";
         }
 
         internal static bool SongIsNotNone(Song value)
@@ -990,7 +991,8 @@ namespace XIVSlothComboPlugin.Combos
                     return BRD.HeadGraze;
                 }
                 
-                var isEnemyHealthHigh = IsEnabled(CustomComboPreset.BardSimpleRaidMode) ? true : CustomCombo.EnemyHealthPercentage() > 1;
+                var isEnemyHealthHigh = IsEnabled(CustomComboPreset.BardSimpleNoWasteMode) ?
+                    CustomCombo.EnemyHealthPercentage() > Service.Configuration.GetCustomFloatValue(BRD.Config.NoWasteHPPercentage) : true;
 
                 if (IsEnabled(CustomComboPreset.SimpleSongOption) && canWeave && isEnemyHealthHigh)
                 {
@@ -1150,7 +1152,7 @@ namespace XIVSlothComboPlugin.Combos
 
                     var ragingStrikesDuration = FindEffect(BRD.Buffs.RagingStrikes);
 
-                    var ragingJawsRenewTime = Service.Configuration.GetCustomConfigValue(BRD.Config.RagingJawsRenewTime);
+                    var ragingJawsRenewTime = Service.Configuration.GetCustomFloatValue(BRD.Config.RagingJawsRenewTime);
 
                     DotRecast poisonRecast = delegate (int duration)
                     {

--- a/XIVSlothCombo/Combos/MCH.cs
+++ b/XIVSlothCombo/Combos/MCH.cs
@@ -440,7 +440,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 }
 
-                if (canWeaveNormal && gauge.Heat >= 50 && !gauge.IsOverheated && openerFinished && IsOffCooldown(MCH.Wildfire) && level >= MCH.Levels.Wildfire &&
+                if (canWeaveNormal && gauge.Heat >= 50 && openerFinished && IsOffCooldown(MCH.Wildfire) && level >= MCH.Levels.Wildfire &&
                         IsEnabled(CustomComboPreset.MachinistSimpleWildCharge))
                 {
                     if (CombatEngageDuration().Minutes == 0 && GetRemainingCharges(MCH.Reassemble) == 0 && CanDelayedWeave(actionID) ) return MCH.Wildfire;

--- a/XIVSlothCombo/CombosPVP/MCHPVP.cs
+++ b/XIVSlothCombo/CombosPVP/MCHPVP.cs
@@ -50,6 +50,7 @@ namespace XIVSlothComboPlugin.Combos
                 var canWeave = CanWeave(actionID); 
                 var analysisStacks = GetRemainingCharges(MCHPVP.Analysis);
                 var bigDamageStacks = GetRemainingCharges(OriginalHook(MCHPVP.Drill));
+                var overheated = HasEffect(MCHPVP.Buffs.Overheated);
 
                 uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
@@ -58,24 +59,24 @@ namespace XIVSlothComboPlugin.Combos
                 if (canWeave && HasEffect(MCHPVP.Buffs.Overheated) && IsOffCooldown(MCHPVP.Wildfire))
                     return OriginalHook(MCHPVP.Wildfire);
 
-                if (HasEffect(MCHPVP.Buffs.Overheated))
+                if (overheated)
                     return OriginalHook(MCHPVP.HeatBlast);
 
                 if ((HasEffect(MCHPVP.Buffs.DrillPrimed) || HasEffect(MCHPVP.Buffs.ChainSawPrimed)) && 
                     !HasEffect(MCHPVP.Buffs.Analysis) && analysisStacks > 0 && (!IsEnabled(CustomComboPreset.MCHAltDrill)
-                    || IsOnCooldown(MCHPVP.Wildfire)))
+                    || IsOnCooldown(MCHPVP.Wildfire)) && !canWeave && !overheated && bigDamageStacks > 0)
                     return OriginalHook(MCHPVP.Analysis);
 
                 if (HasEffect(MCHPVP.Buffs.Analysis) && HasEffect(MCHPVP.Buffs.DrillPrimed) && bigDamageStacks > 0)
                     return OriginalHook(MCHPVP.Drill);
 
-                if (HasEffect(MCHPVP.Buffs.BioblasterPrimed) && bigDamageStacks > 0)
+                if (HasEffect(MCHPVP.Buffs.BioblasterPrimed) && bigDamageStacks > 0 && GetTargetDistance() <= 12)
                     return OriginalHook(MCHPVP.BioBlaster);
 
                 if (HasEffect(MCHPVP.Buffs.AirAnchorPrimed) && bigDamageStacks > 0)
                     return OriginalHook(MCHPVP.AirAnchor);
 
-                if (HasEffect(MCHPVP.Buffs.ChainSawPrimed) && bigDamageStacks > 0)
+                if (HasEffect(MCHPVP.Buffs.Analysis) && HasEffect(MCHPVP.Buffs.ChainSawPrimed) && bigDamageStacks > 0)
                     return OriginalHook(MCHPVP.ChainSaw);
 
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -597,7 +597,7 @@ namespace XIVSlothComboPlugin
             // ====================================================================================
             #region BARD
             if (preset == CustomComboPreset.BardSimpleRagingJaws)
-                ConfigWindowFunctions.DrawSliderFloat(0, 3, BRD.Config.RagingJawsRenewTime, "Remaining time (In seconds)");
+                ConfigWindowFunctions.DrawSliderInt(3, 5, BRD.Config.RagingJawsRenewTime, "Remaining time (In seconds)");
 
             if (preset == CustomComboPreset.BardSimpleNoWasteMode)
                 ConfigWindowFunctions.DrawSliderInt(1, 5, BRD.Config.NoWasteHPPercentage, "Remaining target HP percentage");

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -599,6 +599,9 @@ namespace XIVSlothComboPlugin
             if (preset == CustomComboPreset.BardSimpleRagingJaws)
                 ConfigWindowFunctions.DrawSliderFloat(0, 3, BRD.Config.RagingJawsRenewTime, "Remaining time (In seconds)");
 
+            if (preset == CustomComboPreset.BardSimpleNoWasteMode)
+                ConfigWindowFunctions.DrawSliderInt(1, 5, BRD.Config.NoWasteHPPercentage, "Remaining target HP percentage");
+
             #endregion
             // ====================================================================================
             #region DANCER

--- a/XIVSlothCombo/ConfigWindowFunctions.cs
+++ b/XIVSlothCombo/ConfigWindowFunctions.cs
@@ -59,14 +59,14 @@ namespace XIVSlothComboPlugin.ConfigFunctions
         /// <param name="itemWidth">How long the slider should be.</param>
         public static void DrawSliderFloat(float minValue, float maxValue, string config, string sliderDescription, float itemWidth = 150)
         {
-            var output = Service.Configuration.GetCustomConfigValue(config, minValue);
+            var output = Service.Configuration.GetCustomFloatValue(config, minValue);
             var inputChanged = false;
             ImGui.PushItemWidth(itemWidth);
             inputChanged |= ImGui.SliderFloat(sliderDescription, ref output, minValue, maxValue);
 
             if (inputChanged)
             {
-                Service.Configuration.SetCustomConfigValue(config, output);
+                Service.Configuration.SetCustomFloatValue(config, output);
                 Service.Configuration.Save();
             }
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -407,8 +407,8 @@ namespace XIVSlothComboPlugin
         BardSimpleBuffsRadiantFeature = 3018,
 
         [ParentCombo(SimpleBardFeature)]
-        [CustomComboInfo("Simple Raid Mode", "Removes enemy health checking on mobs for buffs, dots and songs.", BRD.JobID, 0, "But Muh Parse", "Just slings all the shit, all the time!")]
-        BardSimpleRaidMode = 3019,
+        [CustomComboInfo("Simple No Waste Mode", "Adds enemy health checking on mobs for buffs, dots and songs.\nThey will not be reapplied if less than specified.", BRD.JobID, 0, "But Muh Parse", "Just slings all the shit, all the time!")]
+        BardSimpleNoWasteMode = 3019,
 
         [ParentCombo(SimpleBardFeature)]
         [CustomComboInfo("Simple Interrupt", "Uses interrupt during simple bard rotation if applicable", BRD.JobID, 0, "Simple Interr-", "Excuse me, I wa-")]

--- a/XIVSlothCombo/PluginConfiguration.cs
+++ b/XIVSlothCombo/PluginConfiguration.cs
@@ -177,7 +177,7 @@ namespace XIVSlothComboPlugin
         public Dictionary<string, byte[]> ImageCache { get; set; } = new();
 
         [JsonProperty]
-        private static Dictionary<string, float> CustomConfigValues { get; set; } = new Dictionary<string, float>();
+        private static Dictionary<string, float> CustomFloatValues { get; set; } = new Dictionary<string, float>();
 
         [JsonProperty]
         private static Dictionary<string, int> CustomIntValues { get; set; } = new Dictionary<string, int>();
@@ -187,18 +187,18 @@ namespace XIVSlothComboPlugin
 
         [JsonProperty]
         private static Dictionary<string, bool[]> CustomBoolArrayValues { get; set; } = new Dictionary<string, bool[]>();
-        public float GetCustomConfigValue(string config, float defaultMinValue = 0)
+        public float GetCustomFloatValue(string config, float defaultMinValue = 0)
         {
             float configValue;
 
-            if (!CustomConfigValues.TryGetValue(config, out configValue)) return defaultMinValue;
+            if (!CustomFloatValues.TryGetValue(config, out configValue)) return defaultMinValue;
 
             return configValue;
         }
 
-        public void SetCustomConfigValue(string config, float value)
+        public void SetCustomFloatValue(string config, float value)
         {
-            CustomConfigValues[config] = value;
+            CustomFloatValues[config] = value;
         }
 
         public int GetCustomIntValue(string config, int defaultMinVal = 0)


### PR DESCRIPTION
### MCH
- PVP
   - Fixed the use of analysis , was incorrectly using it with Bioblaster and spamming the casts;
   - Added a distance check for Bioblaster (12y);
- PVE
   - Made wilffire more responsive to apply the debuff, should feel better at the 2m windows;

### BRD
- PVE
   - Renamed Simple Raid Mode, to Simple No Waste Mode and added a slider for user to set the threshold [1:5] for the HP check to apply/reapply dots, songs and buffs;