### PR TITLE
Fixes

### DIFF
--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -273,12 +273,19 @@ namespace XIVSlothComboPlugin.Combos
                         //Delirium Features
                         if (level >= DRK.Levels.Delirium && IsEnabled(CustomComboPreset.DeliriumFeature) && IsEnabled(CustomComboPreset.DarkMainComboCDsGroup))
                         {
-                            if (IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption) && 
-                                ((gauge.ShadowTimeRemaining > 1 && GetBuffRemainingTime(DRK.Buffs.Delirium) <= 10 && GetBuffRemainingTime(DRK.Buffs.Delirium) > 0) || (HasEffect(DRK.Buffs.Delirium) && GetCooldownRemainingTime(DRK.LivingShadow) >50)) || //Delayed Delirium Conditions
-                                (GetBuffStacks(DRK.Buffs.Delirium) > 0 && IsNotEnabled(CustomComboPreset.DelayedDeliriumFeatureOption))) //regular delirium
+                            //Regular Delirium
+                            if (GetBuffStacks(DRK.Buffs.Delirium) > 0 && (level < DRK.Levels.LivingShadow || IsNotEnabled(CustomComboPreset.DelayedDeliriumFeatureOption)))
                                 return DRK.Bloodspiller;
+
+                            //Delayed Delirium
+                            if (IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption) &&
+                                ((gauge.ShadowTimeRemaining > 1 && GetBuffRemainingTime(DRK.Buffs.Delirium) <= 10 && GetBuffRemainingTime(DRK.Buffs.Delirium) > 0) ||
+                                (HasEffect(DRK.Buffs.Delirium) && GetCooldownRemainingTime(DRK.LivingShadow) > 50)))
+
+                                return DRK.Bloodspiller;
+
                             //Blood management before Delirium
-                            if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && ((gauge.Blood >= 50 && GetCooldownRemainingTime(DRK.BloodWeapon) < 6 && GetCooldownRemainingTime(DRK.Delirium) > 0) || (IsOffCooldown(DRK.Delirium) && gauge.Blood >=50)))
+                            if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && ((gauge.Blood >= 50 && GetCooldownRemainingTime(DRK.BloodWeapon) < 6 && GetCooldownRemainingTime(DRK.Delirium) > 0) || (IsOffCooldown(DRK.Delirium) && gauge.Blood >= 50)))
                                 return DRK.Bloodspiller;
                         }
 

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -312,7 +312,7 @@ namespace XIVSlothComboPlugin.Combos
                 var rageThreshold = Service.Configuration.GetCustomIntValue(WAR.Config.WarInfuriateRange);
                 var hasNascent = HasEffect(WAR.Buffs.NascentChaos);
 
-                    if (InCombat() && rageGauge.BeastGauge <= rageThreshold && GetCooldown(WAR.Infuriate).RemainingCharges > 0 && !hasNascent && level >= WAR.Levels.Infuriate)
+                    if (InCombat() && rageGauge.BeastGauge <= rageThreshold && GetCooldown(WAR.Infuriate).RemainingCharges > 0 && !hasNascent && level >= WAR.Levels.Infuriate && CanWeave(actionID))
                         return OriginalHook(WAR.Infuriate);
             }
 

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -139,7 +139,7 @@ namespace XIVSlothComboPlugin.Combos
 
                     if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsPath)
                     {
-                        if (IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= WAR.Levels.InnerBeast && HasEffectAny(WAR.Buffs.SurgingTempest) && gauge >= 90)
+                        if (IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= WAR.Levels.InnerBeast && (level < WAR.Levels.StormsEye || HasEffectAny(WAR.Buffs.SurgingTempest)) && gauge >= 90)
                             return OriginalHook(WAR.InnerBeast);
                         if ((GetBuffRemainingTime(WAR.Buffs.SurgingTempest) <= surgingThreshold) && level >= WAR.Levels.StormsEye)
                             return WAR.StormsEye;

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -702,29 +702,11 @@ namespace XIVSlothComboPlugin
             #endregion
             // ====================================================================================
             #region PALADIN
-            if (preset == CustomComboPreset.PaladinFightOrFlightFeature)
-            {
-                var CustomGCDValueHigh = Service.Configuration.CustomGCDValueHigh;
-                var CustomGCDValueLow = Service.Configuration.CustomGCDValueLow;
+            if (preset == CustomComboPreset.PaladinAtonementFeature && enabled)
+                ConfigWindowFunctions.DrawSliderInt(2, 3, PLD.Config.PLDAtonementCharges, "How many Atonements to cast right before FoF (Atonement Drop)?");
 
-                var inputChanged = false;
-                ImGui.PushItemWidth(75);
-                inputChanged |= ImGui.InputFloat("Input Custom GCD Value For a Skill to be used in-between the GCD Value Low", ref CustomGCDValueHigh);
-                inputChanged |= ImGui.InputFloat("Input Custom GCD Value For a Skill to be used in-between the GCD Value High", ref CustomGCDValueLow);
-
-
-
-
-                if (inputChanged)
-                {
-                    Service.Configuration.CustomGCDValueHigh = CustomGCDValueHigh;
-                    Service.Configuration.CustomGCDValueLow = CustomGCDValueLow;
-
-                    Service.Configuration.Save();
-                }
-
-                ImGui.Spacing();
-            }
+            if (preset == CustomComboPreset.PaladinInterveneFeature && enabled)
+                ConfigWindowFunctions.DrawSliderInt(0, 1, PLD.Config.PLDKeepInterveneCharges, "How many charges to keep ready? (0 = Use All)");
 
             //if (preset == CustomComboPreset.SkillCooldownRemaining)
             //{

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -645,6 +645,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Buffs on Main Combo", "Collection of Buffs to add to Main Combo", DRK.JobID)]
         DarkMainComboBuffsGroup = 5098,
 
+        [ConflictingCombos(DarkoGCDFeature)]
         [ParentCombo(DarkSouleaterCombo)]
         [CustomComboInfo("CDs on Main Combo", "Collection of CDs to add to Main Combo", DRK.JobID)]
         DarkMainComboCDsGroup = 5099,
@@ -671,6 +672,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("EoS Overcap Feature", "Uses EoS if you are above 8.5k mana or Darkside is about to expire (10sec or less)", DRK.JobID, 0, "Something about mana", "You're basically a black mage! Well done!")]
         DarkManaOvercapFeature = 5005,
 
+        [ConflictingCombos(DarkMainComboCDsGroup)]
         [CustomComboInfo("oGCD Feature", "Adds Living Shadow > Salted Earth > Carve And Spit > Salt And Darkness to Carve And Spit and Abysal Drain", DRK.JobID, 0, "", "Just does your whole job for you, really")]
         DarkoGCDFeature = 5006,
 

--- a/XIVSlothCombo/PluginConfiguration.cs
+++ b/XIVSlothCombo/PluginConfiguration.cs
@@ -163,10 +163,6 @@ namespace XIVSlothComboPlugin
 
         public float EnemyCurrentHp { get; set; } = 0;
 
-        public float CustomGCDValueHigh { get; set; } = 0;
-
-        public float CustomGCDValueLow { get; set; } = 0;
-
         public float SkillCooldownRemaining { get; set; } = 0;
 
         public int MudraPathSelection { get; set; } = 0;


### PR DESCRIPTION
DRK: oGCD Feature is now flagged as a conflicting feature with CDs on Main Combo to stop interaction with Carve and Spit
DRK: Delayed Delirium fix for sub level 80
WAR: Infuriate on Fell Cleave fix to stop interaction on Main Combo
WAR: Overcap Fix for sub level 50
PLD: Reverting ConfigWindow settings back as the new update reverted them back to pre slider days.