### PR TITLE
[BRD] PvP making the weave window longer

### DIFF
--- a/XIVSlothCombo/CombosPVP/BRDPVP.cs
+++ b/XIVSlothCombo/CombosPVP/BRDPVP.cs
@@ -40,7 +40,7 @@ namespace XIVSlothComboPlugin.Combos
                 
                 if (actionID == BRDPvP.PowerfulShot)
                 {
-                    var canWeave = CanWeave(actionID);
+                    var canWeave = CanWeave(actionID, 0.5);
                     //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
                     //if (globalAction != actionID) return globalAction;


### PR DESCRIPTION
### BRD
- PVP
   - Made the weave window longer to account for the cast/recast speed buff.
