### PR TITLE
[PvP] DNC Added, others refactored

### DIFF
--- a/XIVSlothCombo/CombosPVP/BRDPVP.cs
+++ b/XIVSlothCombo/CombosPVP/BRDPVP.cs
@@ -1,7 +1,3 @@
-using Dalamud.Game.ClientState.JobGauge.Enums;
-using Dalamud.Game.ClientState.JobGauge.Types;
-using Dalamud.Game.ClientState.Objects.Types;
-
 namespace XIVSlothComboPlugin.Combos
 {
     internal static class BRDPvP
@@ -20,7 +16,6 @@ namespace XIVSlothComboPlugin.Combos
             BlastArrow = 29394,
             FinalFantasia = 29401;
 
-
         public static class Buffs
         {
             public const ushort
@@ -29,7 +24,6 @@ namespace XIVSlothComboPlugin.Combos
                 Repertoire = 3137,
                 BlastArrowReady = 3142;
         }
-
 
         internal class BurstShotFeaturePVP : CustomCombo
         {
@@ -41,15 +35,15 @@ namespace XIVSlothComboPlugin.Combos
                 if (actionID == BRDPvP.PowerfulShot)
                 {
                     var canWeave = CanWeave(actionID);
-                    //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                    //if (globalAction != actionID) return globalAction;
+                    if (canWeave)
+                    {
+                        if (GetCooldown(BRDPvP.EmpyrealArrow).RemainingCharges == 3)
+                            return OriginalHook(BRDPvP.EmpyrealArrow);
 
-                    if (GetCooldown(BRDPvP.EmpyrealArrow).RemainingCharges == 3 && canWeave)
-                        return OriginalHook(BRDPvP.EmpyrealArrow);
-
-                    if (!GetCooldown(BRDPvP.SilentNocturne).IsCooldown && canWeave)
-                        return OriginalHook(BRDPvP.SilentNocturne);
+                        if (!GetCooldown(BRDPvP.SilentNocturne).IsCooldown)
+                            return OriginalHook(BRDPvP.SilentNocturne);
+                    }
 
                     if (HasEffect(BRDPvP.Buffs.BlastArrowReady))
                         return OriginalHook(BRDPvP.BlastArrow);
@@ -60,7 +54,6 @@ namespace XIVSlothComboPlugin.Combos
                     if (!GetCooldown(BRDPvP.ApexArrow).IsCooldown)
                         return OriginalHook(BRDPvP.ApexArrow);
 
-
                     return OriginalHook(BRDPvP.PowerfulShot);
                 }
                 
@@ -68,5 +61,4 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
     }
-    
 }

--- a/XIVSlothCombo/CombosPVP/DNCPVP.cs
+++ b/XIVSlothCombo/CombosPVP/DNCPVP.cs
@@ -1,0 +1,83 @@
+using XIVSlothComboPlugin.Combos;
+
+namespace XIVSlothComboPlugin
+{
+    internal static class DNCPVP
+    {
+        public const byte JobID = 38;
+
+        internal const uint
+            FountainCombo = 54,
+            Cascade = 29416,
+            Fountain = 29417,
+            ReverseCascade = 29418,
+            Fountainfall = 29419,
+            SaberDance = 29420,
+            StarfallDance = 29421,
+            HoningDance = 29422,
+            HoningOvation = 29470,
+            FanDance = 29428,
+            CuringWaltz = 29429,
+            EnAvant = 29430,
+            ClosedPosition = 29431,
+            Contradance = 29432;
+
+        internal class Buffs
+        {
+            internal const ushort
+                EnAvant = 2048,
+                FanDance = 2052,
+                Bladecatcher = 3159,
+                FlourishingSaberDance = 3160,
+                StarfallDance = 3161,
+                HoningDance = 3162,
+                Acclaim = 3163,
+                HoningOvation = 3164;
+        }
+    }
+
+    internal class DNCBurstMode : CustomCombo // Burst Mode
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNCBurstMode;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            // Start by replacing the base actions of the combo, NOT the "combo" itself in-game!
+            if (actionID is DNCPVP.Cascade or DNCPVP.Fountain or DNCPVP.ReverseCascade or DNCPVP.Fountainfall)
+            {
+                bool starfallDanceReady = !GetCooldown(DNCPVP.StarfallDance).IsCooldown;
+                bool starfallDance = HasEffect(DNCPVP.Buffs.StarfallDance);
+                bool enAvant = HasEffect(DNCPVP.Buffs.EnAvant);
+                var enAvantCharges = GetCooldown(DNCPVP.EnAvant).RemainingCharges;
+                bool curingWaltzReady = !GetCooldown(DNCPVP.CuringWaltz).IsCooldown;
+                bool honingDanceReady = !GetCooldown(DNCPVP.HoningDance).IsCooldown;
+                // var acclaimStacks = FindEffect(DNCPVP.Buffs.Acclaim).StackCount;
+                bool canWeave = CanWeave(actionID);
+                var HP = PlayerHealthPercentageHp();
+
+                if (canWeave)
+                {
+                    // Curing Waltz Burst Option
+                    if (IsEnabled(CustomComboPreset.DNCCuringWaltzOption) && curingWaltzReady && HP <= 50) // Add slider to this next
+                        return OriginalHook(DNCPVP.CuringWaltz);
+
+                    // Fan Dance weaved on Main Combo
+                    if (IsOffCooldown(DNCPVP.FanDance))
+                        return OriginalHook(DNCPVP.FanDance);
+                }
+
+                // Starfall Dance on Main Combo
+                if (!starfallDance && starfallDanceReady)
+                    return OriginalHook(DNCPVP.StarfallDance);
+
+                // En Avant Overcap Protection Option
+                if (IsEnabled(CustomComboPreset.DNCEnAvantOvercapOption) && !enAvant && enAvantCharges == 4) // Probably just remove this altogether it's stupid
+                    return OriginalHook(DNCPVP.EnAvant);
+
+                return OriginalHook(DNCPVP.Cascade);
+            }
+
+            return actionID;
+        }
+    }
+}

--- a/XIVSlothCombo/CombosPVP/DNCPVP.cs
+++ b/XIVSlothCombo/CombosPVP/DNCPVP.cs
@@ -58,7 +58,7 @@ namespace XIVSlothComboPlugin
                 if (canWeave)
                 {
                     // Curing Waltz Burst Option
-                    if (IsEnabled(CustomComboPreset.DNCCuringWaltzOption) && curingWaltzReady && HP <= 50) // Add slider to this next
+                    if (IsEnabled(CustomComboPreset.DNCCuringWaltzOption) && curingWaltzReady && HP <= 60) // Add slider to this next
                         return OriginalHook(DNCPVP.CuringWaltz);
 
                     // Fan Dance weaved on Main Combo

--- a/XIVSlothCombo/CombosPVP/MCHPVP.cs
+++ b/XIVSlothCombo/CombosPVP/MCHPVP.cs
@@ -20,7 +20,6 @@ namespace XIVSlothComboPlugin.Combos
             Analysis = 29414,
             MarksmanSpite = 29415;
 
-
         public static class Buffs
         {
             public const ushort
@@ -39,22 +38,19 @@ namespace XIVSlothComboPlugin.Combos
                 Wildfire = 1323;
         }
     }
+
     internal class HeatedCleanShotFeature : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCHBurstMode;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == MCHPVP.BlastCharge )
+            if (actionID == MCHPVP.BlastCharge)
             {
-                var canWeave = CanWeave(actionID); 
+                var canWeave = CanWeave(actionID);
                 var analysisStacks = GetRemainingCharges(MCHPVP.Analysis);
                 var bigDamageStacks = GetRemainingCharges(OriginalHook(MCHPVP.Drill));
                 var overheated = HasEffect(MCHPVP.Buffs.Overheated);
-
-                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
-
-                //if (globalAction != actionID) return globalAction;
 
                 if (canWeave && HasEffect(MCHPVP.Buffs.Overheated) && IsOffCooldown(MCHPVP.Wildfire))
                     return OriginalHook(MCHPVP.Wildfire);
@@ -62,28 +58,28 @@ namespace XIVSlothComboPlugin.Combos
                 if (overheated)
                     return OriginalHook(MCHPVP.HeatBlast);
 
-                if ((HasEffect(MCHPVP.Buffs.DrillPrimed) || HasEffect(MCHPVP.Buffs.ChainSawPrimed)) && 
+                if ((HasEffect(MCHPVP.Buffs.DrillPrimed) || HasEffect(MCHPVP.Buffs.ChainSawPrimed)) &&
                     !HasEffect(MCHPVP.Buffs.Analysis) && analysisStacks > 0 && (!IsEnabled(CustomComboPreset.MCHAltDrill)
                     || IsOnCooldown(MCHPVP.Wildfire)) && !canWeave && !overheated && bigDamageStacks > 0)
                     return OriginalHook(MCHPVP.Analysis);
 
-                if (HasEffect(MCHPVP.Buffs.Analysis) && HasEffect(MCHPVP.Buffs.DrillPrimed) && bigDamageStacks > 0)
-                    return OriginalHook(MCHPVP.Drill);
+                if (bigDamageStacks > 0)
+                {
+                    if (HasEffect(MCHPVP.Buffs.Analysis) && HasEffect(MCHPVP.Buffs.DrillPrimed))
+                        return OriginalHook(MCHPVP.Drill);
 
-                if (HasEffect(MCHPVP.Buffs.BioblasterPrimed) && bigDamageStacks > 0 && GetTargetDistance() <= 12)
-                    return OriginalHook(MCHPVP.BioBlaster);
+                    if (HasEffect(MCHPVP.Buffs.BioblasterPrimed) && GetTargetDistance() <= 12)
+                        return OriginalHook(MCHPVP.BioBlaster);
 
-                if (HasEffect(MCHPVP.Buffs.AirAnchorPrimed) && bigDamageStacks > 0)
-                    return OriginalHook(MCHPVP.AirAnchor);
+                    if (HasEffect(MCHPVP.Buffs.AirAnchorPrimed))
+                        return OriginalHook(MCHPVP.AirAnchor);
 
-                if (HasEffect(MCHPVP.Buffs.Analysis) && HasEffect(MCHPVP.Buffs.ChainSawPrimed) && bigDamageStacks > 0)
-                    return OriginalHook(MCHPVP.ChainSaw);
-
-
+                    if (HasEffect(MCHPVP.Buffs.Analysis) && HasEffect(MCHPVP.Buffs.ChainSawPrimed))
+                        return OriginalHook(MCHPVP.ChainSaw);
+                }
             }
 
             return actionID;
         }
     }
-
 }

--- a/XIVSlothCombo/CombosPVP/NINPVP.cs
+++ b/XIVSlothCombo/CombosPVP/NINPVP.cs
@@ -55,10 +55,6 @@ namespace XIVSlothComboPlugin
         {
             if (actionID is NINPVP.SpinningEdge or NINPVP.AeolianEdge or NINPVP.GustSlash)
             {
-                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
-
-                //if (globalAction != actionID) return globalAction;
-
                 var threeMudrasCD = GetCooldown(NINPVP.ThreeMudra);
                 var fumaCD = GetCooldown(NINPVP.FumaShuriken);
                 var bunshinStacks = HasEffect(NINPVP.Buffs.Bunshin) ? GetBuffStacks(NINPVP.Buffs.Bunshin) : 0;
@@ -74,23 +70,29 @@ namespace XIVSlothComboPlugin
                 if (HasEffect(NINPVP.Buffs.Hidden))
                     return OriginalHook(NINPVP.Assassinate);
 
-                if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown && canWeave)
-                    return OriginalHook(NINPVP.Mug);
+                if (canWeave)
+                {
+                    if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown)
+                        return OriginalHook(NINPVP.Mug);
 
-                if (!GetCooldown(NINPVP.Bunshin).IsCooldown && canWeave)
-                    return OriginalHook(NINPVP.Bunshin);
+                    if (!GetCooldown(NINPVP.Bunshin).IsCooldown)
+                        return OriginalHook(NINPVP.Bunshin);
 
-                if (threeMudrasCD.RemainingCharges > 0 && !mudraMode && canWeave)
-                    return OriginalHook(NINPVP.ThreeMudra);
+                    if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
+                        return OriginalHook(NINPVP.ThreeMudra);
+                }
 
-                if (mudraMode && !hyoshoLocked)
-                    return OriginalHook(NINPVP.HyoshoRanryu);
+                if (mudraMode)
+                {
+                    if (!hyoshoLocked)
+                        return OriginalHook(NINPVP.HyoshoRanryu);
 
-                if (mudraMode && !raijuLocked && bunshinStacks > 0)
-                    return OriginalHook(NINPVP.ForkedRaiju);
+                    if (!raijuLocked && bunshinStacks > 0)
+                        return OriginalHook(NINPVP.ForkedRaiju);
 
-                if (mudraMode && !hutonLocked)
-                    return NINPVP.Huton;
+                    if (!hutonLocked)
+                        return NINPVP.Huton;
+                }
 
                 if (fumaCD.RemainingCharges > 0)
                     return OriginalHook(NINPVP.FumaShuriken);
@@ -109,10 +111,6 @@ namespace XIVSlothComboPlugin
         {
             if (actionID == NINPVP.FumaShuriken)
             {
-                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
-
-                //if (globalAction != actionID) return globalAction;
-
                 var threeMudrasCD = GetCooldown(NINPVP.ThreeMudra);
                 var fumaCD = GetCooldown(NINPVP.FumaShuriken);
                 var bunshinStacks = HasEffect(NINPVP.Buffs.Bunshin) ? GetBuffStacks(NINPVP.Buffs.Bunshin) : 0;
@@ -125,20 +123,26 @@ namespace XIVSlothComboPlugin
                 bool mudraMode = HasEffect(NINPVP.Buffs.ThreeMudra);
                 bool canWeave = CanWeave(actionID);
 
-                if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown && canWeave)
-                    return NINPVP.Mug;
+                if (canWeave)
+                {
+                    if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown)
+                        return NINPVP.Mug;
 
-                if (!GetCooldown(NINPVP.Bunshin).IsCooldown && canWeave)
-                    return NINPVP.Bunshin;
+                    if (!GetCooldown(NINPVP.Bunshin).IsCooldown)
+                        return NINPVP.Bunshin;
 
-                if (threeMudrasCD.RemainingCharges > 0 && !mudraMode && canWeave)
-                    return OriginalHook(NINPVP.ThreeMudra);
+                    if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
+                        return OriginalHook(NINPVP.ThreeMudra);
+                }
 
-                if (mudraMode && !dotonLocked)
-                    return OriginalHook(NINPVP.Doton);
+                if (mudraMode)
+                {
+                    if (!dotonLocked)
+                        return OriginalHook(NINPVP.Doton);
 
-                if (mudraMode && !gokaLocked)
-                    return OriginalHook(NINPVP.GokaMekkyaku);
+                    if (!gokaLocked)
+                        return OriginalHook(NINPVP.GokaMekkyaku);
+                }
 
                 if (fumaCD.RemainingCharges > 0)
                     return OriginalHook(NINPVP.FumaShuriken);
@@ -150,7 +154,6 @@ namespace XIVSlothComboPlugin
 
                     if (lastComboActionID == NINPVP.SpinningEdge)
                         return OriginalHook(NINPVP.GustSlash);
-
 
                     return OriginalHook(NINPVP.SpinningEdge);
                 }

--- a/XIVSlothCombo/CombosPVP/RDMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/RDMPVP.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using XIVSlothComboPlugin;
-using XIVSlothComboPlugin.Combos;
+﻿using XIVSlothComboPlugin.Combos;
 
 namespace XIVSlothComboPlugin
 {
@@ -31,7 +25,6 @@ namespace XIVSlothComboPlugin
             BlackShift = 29702,
             SouthernCross = 29704;
 
-
         public static class Buffs
         {
             public const ushort
@@ -43,9 +36,7 @@ namespace XIVSlothComboPlugin
                 EnchantedZwerchhau = 3235,
                 VermilionRadiance = 3233,
                 MagickBarrier = 3240;
-
         }
-
     }
 
     internal class RedMageBurstMode : CustomCombo
@@ -56,9 +47,6 @@ namespace XIVSlothComboPlugin
         {
             if (actionID is RDMPVP.Verstone or RDMPVP.Verfire)
             {
-                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
-
-                //if (globalAction != actionID) return globalAction;
 
                 if (!GetCooldown(RDMPVP.Frazzle).IsCooldown && HasEffect(RDMPVP.Buffs.BlackShift))
                     return OriginalHook(RDMPVP.Frazzle);
@@ -69,24 +57,19 @@ namespace XIVSlothComboPlugin
                 if (!InMeleeRange() && GetCooldown(RDMPVP.CorpsACorps).RemainingCharges > 0 && !GetCooldown(RDMPVP.EnchantedRiposte).IsCooldown)
                     return OriginalHook(RDMPVP.CorpsACorps);
 
-                if (InMeleeRange() && !GetCooldown(RDMPVP.EnchantedRiposte).IsCooldown)
-                    return OriginalHook(RDMPVP.EnchantedRiposte);
+                if (InMeleeRange())
+                {
+                    if (!GetCooldown(RDMPVP.EnchantedRiposte).IsCooldown || lastComboActionID == RDMPVP.EnchantedRiposte || lastComboActionID == RDMPVP.EnchantedZwerchhau)
+                        return OriginalHook(RDMPVP.EnchantedRiposte);
 
-                if (InMeleeRange() && lastComboActionID == RDMPVP.EnchantedRiposte)
-                    return OriginalHook(RDMPVP.EnchantedRiposte);
-
-                if (InMeleeRange() && lastComboActionID == RDMPVP.EnchantedZwerchhau)
-                    return OriginalHook(RDMPVP.EnchantedRiposte);
-
-                if (InMeleeRange() && lastComboActionID == RDMPVP.EnchantedRedoublement && GetCooldown(RDMPVP.Displacement).RemainingCharges > 0)
-                    return OriginalHook(RDMPVP.Displacement);
+                    if (lastComboActionID == RDMPVP.EnchantedRedoublement && GetCooldown(RDMPVP.Displacement).RemainingCharges > 0)
+                        return OriginalHook(RDMPVP.Displacement);
+                }
 
                 if (HasEffect(RDMPVP.Buffs.VermilionRadiance))
                     return OriginalHook(RDMPVP.EnchantedRiposte);
 
-
                 return OriginalHook(RDMPVP.Verstone);
-
             }
 
             return actionID;

--- a/XIVSlothCombo/CombosPVP/WARPVP.cs
+++ b/XIVSlothCombo/CombosPVP/WARPVP.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using XIVSlothComboPlugin.Combos;
+﻿using XIVSlothComboPlugin.Combos;
 
 namespace XIVSlothComboPlugin
 {
@@ -37,10 +32,6 @@ namespace XIVSlothComboPlugin
         {
             if (actionID == WARPVP.HeavySwing)
             {
-                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
-
-                //if (globalAction != actionID) return globalAction;
-
                 if (!GetCooldown(WARPVP.Bloodwhetting).IsCooldown)
                     return OriginalHook(WARPVP.Bloodwhetting);
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -622,6 +622,10 @@ namespace XIVSlothComboPlugin
 
 
             }
+
+            if (preset == CustomComboPreset.DNCCuringWaltzOption)
+                ConfigWindowFunctions.DrawSliderInt(0, 90, DNCPVP.Config.DNCWaltzThreshold, "Set a HP percentage value. Caps at 90 to prevent waste.###DNC", 150, SliderIncrements.Ones);
+
             #endregion
             // ====================================================================================
             #region DARK KNIGHT

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2347,40 +2347,74 @@ namespace XIVSlothComboPlugin
         //[CustomComboInfo("BlackEnochianPVPFeature", "Enochian Stance Switcher", BLMPVP.JobID)]
         //BlackEnochianPVPFeature = 80016,
 
+        // MCH
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Blast Charge into an all-in-one damage button.", MCHPVP.JobID)]
         MCHBurstMode = 80010,
         
-        [SecretCustomCombo]
-        [ParentCombo(MCHBurstMode)]
-        [CustomComboInfo("Alternate Drill Mode", "Saves drill for use after wildfire.", MCHPVP.JobID)]
-        MCHAltDrill = 80011,
-
+            [SecretCustomCombo]
+            [ParentCombo(MCHBurstMode)]
+            [CustomComboInfo("Alternate Drill Mode", "Saves drill for use after wildfire.", MCHPVP.JobID)]
+            MCHAltDrill = 80011,
+        
+        // BRD
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Powerful Shot into an all-in-one damage button.", BRDPvP.JobID)]
-        BRDBurstMode = 80017,
+        BRDBurstMode = 80020,
 
+        // RDM
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Verstone/Verfire into an all-in-one damage button.", RDMPVP.JobID)]
-        RDMBurstMode = 80018,
+        RDMBurstMode = 80030,
 
+        // WAR
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Heavy Swing into an all-in-one damage button.", WARPVP.JobID)]
-        WARBurstMode = 80019,
+        WARBurstMode = 80040,
 
+        // NIN
         [ConflictingCombos(NINAoEBurstMode)]
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Aeolian Edge Combo into an all-in-one damage button.", NINPVP.JobID)]
-        NINBurstMode = 80020,
+        NINBurstMode = 80050,
 
         [ConflictingCombos(NINBurstMode)]
         [SecretCustomCombo]
         [CustomComboInfo("AoE Burst Mode", "Turns Fuma Shuriken into an all-in-one AoE damage button.", NINPVP.JobID)]
-        NINAoEBurstMode = 80021,
+        NINAoEBurstMode = 80051,
 
+        // SGE
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Dosis III into an all-in-one damage button.", SGE.JobID)]
-        SGEBurstMode = 80022,
+        SGEBurstMode = 80060,
+
+        // DNC
+        [SecretCustomCombo]
+        [CustomComboInfo("Burst Mode", "Turns Fountain Combo into an all-in-one damage button.", DNC.JobID)]
+        DNCBurstMode = 80070,
+
+            [SecretCustomCombo]
+            [ParentCombo(DNCBurstMode)]
+            [CustomComboInfo("Honing Dance Option", "Adds Honing Dance to the main combo when in melee range (for pack pushing, respects global offset).\nThis option prevents early use of Honing Ovation!\nKeep Honing Dance bound to another key if you want to end early.", DNC.JobID)]
+            DNCHoningDanceOption = 80071,
+
+            [SecretCustomCombo]
+            [ParentCombo(DNCBurstMode)]
+            [CustomComboInfo("Curing Waltz Burst Option", "Adds Curing Waltz to the main combo when available, and your HP is at or below the set percentage.", DNC.JobID)]
+            DNCCuringWaltzOption = 80072,
+
+            /*
+            [SecretCustomCombo] // I'm probably gonna remove this entirely
+            [ParentCombo(DNCBurstMode)]
+            [CustomComboInfo("En Avant Overcap Protection", "Adds En Avant to the main combo when you hit maximum stacks.\nNOT OPTIMAL, THIS MAY GET YOU KILLED", DNC.JobID)]
+            DNCEnAvantOvercapOption = 80073,
+            */
+        /*
+        // RPR
+        [SecretCustomCombo]
+        [CustomComboInfo("Burst Mode", "Turns Slice Combo into an all-in-one damage button.", RPR.JobID)]
+        RPRBurstMode = 80080,
+        */
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
[All PvP Jobs Below]
Removed unnecessary namespaces
Removed unnecessary whitespace
Removed deprecated globals code

[DNCPvP]
Added `Burst Mode`
Added `Honing Dance Option`
Added `Curing Waltz Option`

[RDMPvP]
Refactored melee actions
Removed deprecated globals code

[NINPvP]
Refactored `canWeave` actions
Refactored `mudraMode` actions

[WARPvP]
See "[All PvP Jobs Below]"

[BRDPvP]
Refactored `canWeave` actions

[MCHPvP]
Refactored `bigDamageStacks > 0` actions