### PR TITLE
AST and WHM level checks for Aspected Helios and Medica 2

### DIFF
--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -103,6 +103,7 @@ namespace XIVSlothComboPlugin.Combos
                 MinorArcana = 50,
                 Draw = 30,
                 AspectedBenefic = 34,
+                AspectedHelios = 42,
                 CrownPlay = 70,
                 CelestialOpposition = 60,
                 CelestialIntersection = 74,
@@ -515,6 +516,9 @@ namespace XIVSlothComboPlugin.Combos
                 var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
                 var gauge = GetJobGauge<ASTGauge>();
 
+                if (level < AST.Levels.AspectedHelios)
+                    return AST.Helios;
+
                 if (IsEnabled(CustomComboPreset.AstrologianLazyLadyFeature))
                 {
                     if (gauge.DrawnCrownCard == CardType.LADY && incombat && level >= AST.Levels.CrownPlay)
@@ -529,7 +533,9 @@ namespace XIVSlothComboPlugin.Combos
                     if (horoscopeCD.CooldownRemaining == 0 && level >= AST.Levels.Horoscope)
                         return AST.Horoscope;
 
-                    if (!HasEffect(AST.Buffs.AspectedHelios) && HasEffect(AST.Buffs.Horoscope) || HasEffect(AST.Buffs.NeutralSect) && !HasEffect(AST.Buffs.NeutralSectShield))
+                    if ((!HasEffect(AST.Buffs.AspectedHelios) && level >= AST.Levels.AspectedHelios)
+                         || HasEffect(AST.Buffs.Horoscope)
+                         || (HasEffect(AST.Buffs.NeutralSect) && !HasEffect(AST.Buffs.NeutralSectShield)))
                         return AST.AspectedHelios;
 
                     if (HasEffect(AST.Buffs.HoroscopeHelios))

--- a/XIVSlothCombo/Combos/WHM.cs
+++ b/XIVSlothCombo/Combos/WHM.cs
@@ -68,6 +68,7 @@ namespace XIVSlothComboPlugin.Combos
                 PresenceOfMind = 30,
                 Cure2 = 30,
                 Aero2 = 46,
+                Medica2 = 50,
                 AfflatusSolace = 52,
                 Assize = 56,
                 ThinAir = 58,
@@ -272,6 +273,8 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     var gauge = GetJobGauge<WHMGauge>();
                     var medica2Buff = FindEffect(WHM.Buffs.Medica2);
+                    if (level < WHM.Levels.Medica2)
+                        return WHM.Medica1;
                     if (IsEnabled(CustomComboPreset.WhiteMageAfflatusMiseryMedicaFeature) && gauge.BloodLily == 3)
                         return WHM.AfflatusMisery;
                     if (IsEnabled(CustomComboPreset.WhiteMageAfflatusRaptureMedicaFeature) && level >= WHM.Levels.AfflatusRapture && gauge.Lily > 0 && medica2Buff.RemainingTime > 2)


### PR DESCRIPTION
[AST] Aspected Helios becomes Helios when under the level required for Aspected Helios
[AST] Made sure Aspected Helios, Horoscope and Neutral Sect play nicely together.

[WHM] Medica 2 becomes Medica 1 when under the level required for Medica 2
