### PR TITLE
LucidDreaming (6.1) Updates & Phlegma Cleanup

### DIFF
--- a/XIVSlothCombo/Combos/ALL.cs
+++ b/XIVSlothCombo/Combos/ALL.cs
@@ -6,6 +6,7 @@
 
         public const uint
             Swiftcast = 7561,
+            LucidDreaming = 7562,
             Resurrection = 173,
             Verraise = 7523,
             Raise = 125,
@@ -23,6 +24,7 @@
         {
             public const ushort
                 Weakness = 43,
+                LucidDreaming = 1204,
                 Swiftcast = 167;
         }
 
@@ -35,6 +37,7 @@
         public static class Levels
         {
             public const byte
+                LucidDreaming = 14,
                 Raise = 12;
         }
     }

--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -21,7 +21,6 @@ namespace XIVSlothComboPlugin.Combos
             MinorArcana = 7443,
             SleeveDraw = 7448,
             Malefic4 = 16555,
-            LucidDreaming = 7562,
             Ascend = 3603,
             Swiftcast = 7561,
             CrownPlay = 25869,
@@ -508,7 +507,7 @@ namespace XIVSlothComboPlugin.Combos
                 var combust2Debuff = FindTargetEffect(AST.Debuffs.Combust2);
                 var combust1Debuff = FindTargetEffect(AST.Debuffs.Combust1);
                 var gauge = GetJobGauge<ASTGauge>();
-                var lucidDreaming = GetCooldown(AST.LucidDreaming);
+                var lucidDreaming = GetCooldown(All.LucidDreaming);
                 var fallmalefic = GetCooldown(AST.FallMalefic);
                 var minorarcanaCD = GetCooldown(AST.MinorArcana);
                 var drawCD = GetCooldown(AST.Draw);
@@ -537,10 +536,10 @@ namespace XIVSlothComboPlugin.Combos
                     if (gauge.DrawnCrownCard == CardType.NONE && incombat && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
                         return AST.MinorArcana;
                 }
-                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= 24)
+                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2 && level >= 24)
-                        return AST.LucidDreaming;
+                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2)
+                        return All.LucidDreaming;
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
                 {
@@ -628,7 +627,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
                 var gauge = GetJobGauge<ASTGauge>();
-                var lucidDreaming = GetCooldown(AST.LucidDreaming);
+                var lucidDreaming = GetCooldown(All.LucidDreaming);
                 var minorarcanaCD = GetCooldown(AST.MinorArcana);
                 var drawCD = GetCooldown(AST.Draw);
                 var actionIDCD = GetCooldown(actionID);
@@ -661,10 +660,10 @@ namespace XIVSlothComboPlugin.Combos
                     if (gauge.DrawnCrownCard == CardType.NONE && incombat && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
                         return AST.MinorArcana;
                 }
-                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= 24)
+                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && actionIDCD.CooldownRemaining > 0.2 && level >= 24)
-                        return AST.LucidDreaming;
+                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && actionIDCD.CooldownRemaining > 0.2 )
+                        return All.LucidDreaming;
                 }
             }
             return actionID;
@@ -700,7 +699,7 @@ namespace XIVSlothComboPlugin.Combos
                 var combust2Debuff = FindTargetEffect(AST.Debuffs.Combust2);
                 var combust1Debuff = FindTargetEffect(AST.Debuffs.Combust1);
                 var gauge = GetJobGauge<ASTGauge>();
-                var lucidDreaming = GetCooldown(AST.LucidDreaming);
+                var lucidDreaming = GetCooldown(All.LucidDreaming);
                 var fallmalefic = GetCooldown(AST.FallMalefic);
                 var minorarcanaCD = GetCooldown(AST.MinorArcana);
                 var drawCD = GetCooldown(AST.Draw);
@@ -734,10 +733,10 @@ namespace XIVSlothComboPlugin.Combos
                     if (gauge.DrawnCrownCard == CardType.NONE && incombat && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
                         return AST.MinorArcana;
                 }
-                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= 24)
+                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2 && level >= 24)
-                        return AST.LucidDreaming;
+                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2)
+                        return All.LucidDreaming;
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
                 {
@@ -780,7 +779,7 @@ namespace XIVSlothComboPlugin.Combos
                 var combust2Debuff = FindTargetEffect(AST.Debuffs.Combust2);
                 var combust1Debuff = FindTargetEffect(AST.Debuffs.Combust1);
                 var gauge = GetJobGauge<ASTGauge>();
-                var lucidDreaming = GetCooldown(AST.LucidDreaming);
+                var lucidDreaming = GetCooldown(All.LucidDreaming);
                 var fallmalefic = GetCooldown(AST.FallMalefic);
                 var minorarcanaCD = GetCooldown(AST.MinorArcana);
                 var drawCD = GetCooldown(AST.Draw);
@@ -812,10 +811,10 @@ namespace XIVSlothComboPlugin.Combos
                     if (gauge.DrawnCrownCard == CardType.NONE && lastComboMove == OriginalHook(actionID) && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.4 && level >= 70)
                         return AST.MinorArcana;
                 }
-                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= 24)
+                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.4 && level >= 24)
-                        return AST.LucidDreaming;
+                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.4)
+                        return All.LucidDreaming;
                 }
                 if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
                 {

--- a/XIVSlothCombo/Combos/BLU.cs
+++ b/XIVSlothCombo/Combos/BLU.cs
@@ -32,7 +32,6 @@ namespace XIVSlothComboPlugin.Combos
             Devour = 18320,
             Offguard = 11411,
             BadBreath = 11388,
-            LucidDreaming = 7562,
             MagicHammer = 18305,
             WhiteKnightsTour = 18310,
             BlackKnightsTour = 18311,
@@ -68,7 +67,7 @@ namespace XIVSlothComboPlugin.Combos
         public static class Levels
         {
             public const byte
-                LucidDreaming = 24;
+                Placeholder = 1;
         }
     }
 
@@ -236,7 +235,7 @@ namespace XIVSlothComboPlugin.Combos
                 var devourCD = GetCooldown(BLU.Devour);
                 var offguardDebuff = FindTargetEffect(BLU.Debuffs.Offguard);
                 var offguardCD = GetCooldown(BLU.Offguard);
-                var lucidCD = GetCooldown(BLU.LucidDreaming);
+                var lucidCD = GetCooldown(All.LucidDreaming);
 
                 if (offguardDebuff is null && !offguardCD.IsCooldown)
                     return BLU.Offguard;
@@ -244,8 +243,8 @@ namespace XIVSlothComboPlugin.Combos
                     return BLU.BadBreath;
                 if (!devourCD.IsCooldown && HasEffect(BLU.Buffs.TankMimicry))
                     return BLU.Devour;
-                if (!lucidCD.IsCooldown && LocalPlayer.CurrentMp <= 9000)
-                    return BLU.LucidDreaming;
+                if (!lucidCD.IsCooldown && LocalPlayer.CurrentMp <= 9000 & level >= All.Levels.LucidDreaming)
+                    return All.LucidDreaming;
             }
 
             return actionID;

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -43,8 +43,7 @@ namespace XIVSlothComboPlugin.Combos
             Acceleration = 7518,
             Swiftcast = 7561,
             Manafication = 7521,
-            Embolden = 7520,
-            LucidDreaming = 7562;
+            Embolden = 7520;
 
         public static class Buffs
         {
@@ -70,7 +69,6 @@ namespace XIVSlothComboPlugin.Combos
                 Veraero = 10,
                 Verthunder2 = 18,
                 Veraero2 = 22,
-                LucidDreaming = 24,
                 Verraise = 64,
                 Zwerchhau = 35,
                 Swiftcast = 18,
@@ -1183,17 +1181,17 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(RDM.Config.RdmLucidMpThreshold);
 
-                if (level >= RDM.Levels.LucidDreaming && LocalPlayer.CurrentMp <= lucidThreshold) // Check to show Lucid Dreaming
+                if (level >= All.Levels.LucidDreaming && LocalPlayer.CurrentMp <= lucidThreshold) // Check to show Lucid Dreaming
                 {
                     showLucid = true;
                 }
 
-                if (showLucid && CanSpellWeave(actionID) && HasCondition(ConditionFlag.InCombat) && IsOffCooldown(RDM.LucidDreaming) 
+                if (showLucid && CanSpellWeave(actionID) && HasCondition(ConditionFlag.InCombat) && IsOffCooldown(All.LucidDreaming) 
                     && lastComboMove != RDM.EnchantedRiposte && lastComboMove != RDM.EnchantedZwerchhau 
                     && lastComboMove != RDM.EnchantedRedoublement && lastComboMove != RDM.Verflare 
                     && lastComboMove != RDM.Verholy && lastComboMove != RDM.Scorch) // Change abilities to Lucid Dreaming for entire weave window
                 {
-                    return RDM.LucidDreaming;
+                    return All.LucidDreaming;
                 }
                 showLucid = false;
             }

--- a/XIVSlothCombo/Combos/SCH.cs
+++ b/XIVSlothCombo/Combos/SCH.cs
@@ -48,7 +48,6 @@ namespace XIVSlothComboPlugin.Combos
             // Role
             Swiftcast = 7561,
             Resurrection = 173,
-            LucidDreaming = 7562,
             Esuna = 5768;
 
         public static class Buffs
@@ -242,20 +241,19 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var actionIDCD = GetCooldown(actionID);
                 var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var lucidDreaming = GetCooldown(SCH.LucidDreaming);
                 var biolysis = FindTargetEffect(SCH.Debuffs.Biolysis);
                 var bio1 = FindTargetEffect(SCH.Debuffs.Bio1);
                 var bio2 = FindTargetEffect(SCH.Debuffs.Bio2);
                 var chainBuff = GetCooldown(SCH.ChainStratagem);
                 var chainTarget = TargetHasEffect(SCH.Debuffs.ChainStratagem);
-                var canWeave = CanWeave(actionID);
-                var lucidMPThreshold = Service.Configuration.GetCustomIntValue(SCH.Config.ScholarLucidDreaming);
 
-                if (IsEnabled(CustomComboPreset.ScholarLucidDPSFeature))
+                if (IsEnabled(CustomComboPreset.ScholarLucidDPSFeature) && level >= All.Levels.LucidDreaming)
                 {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && canWeave)
-                        return SCH.LucidDreaming;
+                    var lucidMPThreshold = Service.Configuration.GetCustomIntValue(SCH.Config.ScholarLucidDreaming);
+                    if ( IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidMPThreshold && CanSpellWeave(actionID) )
+                        return All.LucidDreaming;
                 }
+
                 if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= SCH.Levels.Biolysis && incombat)
                 {
                     if ((biolysis is null) || (biolysis.RemainingTime <= 3))

--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -50,11 +50,10 @@ namespace XIVSlothComboPlugin.Combos
             Kardia = 24285,
             Eukrasia = 24290,
             Rhizomata = 24309,
-            
+
             // Role
             Egeiro = 24287,
-            Swiftcast = 7561,
-            LucidDreaming = 7562;
+            Swiftcast = 7561;
 
         public static class Buffs
         {
@@ -84,7 +83,6 @@ namespace XIVSlothComboPlugin.Combos
                 Prognosis = 10,
                 Egeiro = 12,
                 Physis = 20,
-                LucidDreaming = 24,
                 Phlegma = 26,
                 Eukrasia = 30, //includes Dosis, Diagnosis, & Prognosis
                 Soteria = 35,
@@ -210,18 +208,8 @@ namespace XIVSlothComboPlugin.Combos
                     //If not targetting anything, use Dyskrasia Option if selected
                     if ( IsEnabled(CustomComboPreset.SagePhlegmaDyskrasiaFeature) && (!HasTarget()) ) return OriginalHook(SGE.Dyskrasia);
 
-                    uint Phlegma; //Phlegma placeholder
-                    //Find which version of Phlegma based on player's level that we need to update with
-                    //Phlegma unlocks before Dyskrasia & Toxikon (checked above), we'll always have P1 available
-                    switch (level)
-                    {
-                        case >= (byte)SGE.Levels.Phlegma3: Phlegma = SGE.Phlegma3; break;
-                        case >= (byte)SGE.Levels.Phlegma2: Phlegma = SGE.Phlegma2; break;
-                        default : Phlegma = SGE.Phlegma; break;
-                }
-
                     //Check for "out of Phlegma stacks" 
-                    if (GetCooldown(Phlegma).RemainingCharges == 0) {
+                    if (GetCooldown(OriginalHook(SGE.Phlegma)).RemainingCharges == 0) {
                         //and if we have Adderstings to use for Toxikon
                         //Has Priority over Dyskrasia
                         if ( IsEnabled(CustomComboPreset.SagePhlegmaToxikonFeature) && (level >= SGE.Levels.Toxikon) && (GetJobGauge<SGEGauge>().Addersting > 0) )
@@ -252,6 +240,18 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
                 {
+
+                    //20220424 Tsusai: Lucid moved to the top (higher priority) similar to SCH
+                    //Lucid should be usable incombat without a target
+                    if (IsEnabled(CustomComboPreset.SageLucidFeature) && level >= All.Levels.LucidDreaming)
+                    {
+                        //Get slider configuration
+                        int MinMP = Service.Configuration.GetCustomIntValue(SGE.Config.CustomSGELucidDreaming, 8000);
+                        //Can we use?
+                        if (IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= MinMP && CanSpellWeave(actionID))
+                            return All.LucidDreaming;
+                    }
+
                     //If we're too low level to use Eukrasia, we can stop here.
                     if (level >= SGE.Levels.Eukrasia)
                     {
@@ -310,16 +310,6 @@ namespace XIVSlothComboPlugin.Combos
                             else //End Advanced Test Options. If it needs to be removed, leave the next line
                                 return SGE.Eukrasia;
                         }
-                    }
-
-                    //Lucid should be usable outside of whatever is targetted
-                    if (IsEnabled(CustomComboPreset.SageLucidFeature) && level >= SGE.Levels.LucidDreaming)
-                    {
-                        var lucidDreaming = GetCooldown(SGE.LucidDreaming);
-                        //Get slider configuration
-                        int MinMP = Service.Configuration.GetCustomIntValue("CustomSGELucidDreaming", 8000);
-                        if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= MinMP && CanWeave(actionID))
-                            return SGE.LucidDreaming;
                     }
                 }
             }

--- a/XIVSlothCombo/Combos/WHM.cs
+++ b/XIVSlothCombo/Combos/WHM.cs
@@ -13,7 +13,6 @@ namespace XIVSlothComboPlugin.Combos
             Cure2 = 135,
             AfflatusSolace = 16531,
             AfflatusRapture = 16534,
-            LucidDreaming = 7562,
             Raise = 125,
             Swiftcast = 7561,
             AfflatusMisery = 16535,
@@ -236,8 +235,8 @@ namespace XIVSlothComboPlugin.Combos
                             return WHM.PresenceOfMind;
                         if (IsEnabled(CustomComboPreset.WHMAssizeFeature) && level >= WHM.Levels.Assize && IsOffCooldown(WHM.Assize))
                             return WHM.Assize;
-                        if (IsEnabled(CustomComboPreset.WHMLucidDreamingFeature) && IsOffCooldown(WHM.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold)
-                            return WHM.LucidDreaming;
+                        if (IsEnabled(CustomComboPreset.WHMLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
+                            return All.LucidDreaming;
                     }
 
                     if (IsEnabled(CustomComboPreset.WHMDotMainComboFeature) && inCombat)


### PR DESCRIPTION
ALL: Added Lucid Dreaming info. Lucid Dreaming was lowered to level 14.
AST/BLU/RDM/SCH/SGE: Updated Lucid Dreaming calls to use All.LucidDreaming. SCH/SGE CanWeave upgraded to CanSpellWeave.
AST: Removed redundant level checks against LucidDreaming, but file overall needs a good looking over/refactor
SGE: DPSFeature - Prioritized Lucid Dreaming.
SGE: PhlegmaFeature - Simplified code provided from Taurenkey