### PR TITLE
[MCH & RDM] RDM fix and MCH Enhancement

### DIFF
--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -1078,10 +1078,12 @@ namespace XIVSlothComboPlugin.Combos
                 if (!HasEffect(RDM.Buffs.Dualcast) && level >= RDM.Levels.Moulinet &&
                     lastComboMove is not RDM.Verholy or RDM.Verflare or RDM.Scorch)
                 {
-                    if (gauge.WhiteMana >= 20 && gauge.BlackMana >= 20 && lastComboMove == RDM.Moulinet)
+                    if (gauge.WhiteMana >= 20 && gauge.BlackMana >= 20 && lastComboMove == RDM.Moulinet &&
+                        lastComboMove is not (RDM.Verholy or RDM.Verflare or RDM.Scorch) && (gauge.ManaStacks != 3 || level < RDM.Levels.ManaStack))
                         return RDM.EnchantedMoulinet;
 
-                    if (gauge.WhiteMana >= 40 && gauge.BlackMana >= 40 && lastComboMove == RDM.Moulinet)
+                    if (gauge.WhiteMana >= 40 && gauge.BlackMana >= 40 && lastComboMove == RDM.Moulinet &&
+                        lastComboMove is not (RDM.Verholy or RDM.Verflare or RDM.Scorch) && (gauge.ManaStacks != 3 || level < RDM.Levels.ManaStack))
                         return RDM.EnchantedMoulinet;
 
                     if (gauge.WhiteMana >= 60 && gauge.BlackMana >= 60 && InMeleeRange())

--- a/XIVSlothCombo/CombosPVP/MCHPVP.cs
+++ b/XIVSlothCombo/CombosPVP/MCHPVP.cs
@@ -1,5 +1,3 @@
-using Dalamud.Game.ClientState.JobGauge.Types;
-
 namespace XIVSlothComboPlugin.Combos
 {
     internal static class MCHPVP
@@ -58,14 +56,16 @@ namespace XIVSlothComboPlugin.Combos
                 if (overheated)
                     return OriginalHook(MCHPVP.HeatBlast);
 
-                if ((HasEffect(MCHPVP.Buffs.DrillPrimed) || HasEffect(MCHPVP.Buffs.ChainSawPrimed)) &&
+                if ((HasEffect(MCHPVP.Buffs.DrillPrimed) || 
+                    (HasEffect(MCHPVP.Buffs.ChainSawPrimed) && !IsEnabled(CustomComboPreset.MCHAltAnalysis)) ||
+                    (HasEffect(MCHPVP.Buffs.AirAnchorPrimed) && IsEnabled(CustomComboPreset.MCHAltAnalysis))) &&
                     !HasEffect(MCHPVP.Buffs.Analysis) && analysisStacks > 0 && (!IsEnabled(CustomComboPreset.MCHAltDrill)
                     || IsOnCooldown(MCHPVP.Wildfire)) && !canWeave && !overheated && bigDamageStacks > 0)
                     return OriginalHook(MCHPVP.Analysis);
 
                 if (bigDamageStacks > 0)
                 {
-                    if (HasEffect(MCHPVP.Buffs.Analysis) && HasEffect(MCHPVP.Buffs.DrillPrimed))
+                    if (HasEffect(MCHPVP.Buffs.DrillPrimed))
                         return OriginalHook(MCHPVP.Drill);
 
                     if (HasEffect(MCHPVP.Buffs.BioblasterPrimed) && GetTargetDistance() <= 12)
@@ -74,7 +74,7 @@ namespace XIVSlothComboPlugin.Combos
                     if (HasEffect(MCHPVP.Buffs.AirAnchorPrimed))
                         return OriginalHook(MCHPVP.AirAnchor);
 
-                    if (HasEffect(MCHPVP.Buffs.Analysis) && HasEffect(MCHPVP.Buffs.ChainSawPrimed))
+                    if (HasEffect(MCHPVP.Buffs.ChainSawPrimed))
                         return OriginalHook(MCHPVP.ChainSaw);
                 }
             }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2427,11 +2427,16 @@ namespace XIVSlothComboPlugin
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Blast Charge into an all-in-one damage button.", MCHPVP.JobID)]
         MCHBurstMode = 80010,
+       
+            [SecretCustomCombo]
+            [ParentCombo(MCHBurstMode)]
+            [CustomComboInfo("Alternate Drill Mode", "Saves drill for use after wildfire.", MCHPVP.JobID)]
+            MCHAltDrill = 80011,
 
-        [SecretCustomCombo]
-        [ParentCombo(MCHBurstMode)]
-        [CustomComboInfo("Alternate Drill Mode", "Saves drill for use after wildfire.", MCHPVP.JobID)]
-        MCHAltDrill = 80011,
+            [SecretCustomCombo]
+            [ParentCombo(MCHBurstMode)]
+            [CustomComboInfo("Alternate Analysis Mode", "Uses analysis with Air Anchor instead of Chain Saw.", MCHPVP.JobID)]
+            MCHAltAnalysis = 80012,
 
         // BRD
         [SecretCustomCombo]


### PR DESCRIPTION
### RDM
- PVE
   - Solved Simple RDM AoE stuck on melee when at 3 mana stacks and mana was 40/40 or 20/20.
      - Note: I forgot this fix on the last one when I fixed Simple ST, my bad :O

### MCH
- PVP
   - Added the option to use Analysis on Air Anchor instead of Chain Saw, for a more CCish gameplay.