### PR TITLE
Fixes

### DIFF
--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -107,7 +107,7 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             if (IsEnabled(CustomComboPreset.DarkEoSPoolOption) && gauge.ShadowTimeRemaining >= 1 && (gauge.HasDarkArts || LocalPlayer.CurrentMp > (mpRemaining + 3000)) && level >= DRK.Levels.EdgeOfDarkness && CanDelayedWeave(actionID))
                                 return OriginalHook(DRK.EdgeOfDarkness);
-                            if (LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10)
+                            if (gauge.HasDarkArts || LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10)
                             {
                                 if (level >= DRK.Levels.EdgeOfDarkness)
                                     return OriginalHook(DRK.EdgeOfDarkness);

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -107,7 +107,7 @@ namespace XIVSlothComboPlugin.Combos
                         if (level >= GNB.Levels.NoMercy && IsOffCooldown(GNB.NoMercy))
                         {
                             if (level >= GNB.Levels.BurstStrike && 
-                                ((gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.Bloodfest) < 2) || (gauge.Ammo == 2 && IsOnCooldown(GNB.GnashingFang)) || gauge.Ammo == GNB.MaxCartridges(level))) //cartridges unlocked
+                                ((gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.Bloodfest) < 1.5) || (gauge.Ammo == 2 && IsOnCooldown(GNB.GnashingFang)) || gauge.Ammo == GNB.MaxCartridges(level))) //cartridges unlocked
                                 return GNB.NoMercy;
                             if (level < GNB.Levels.BurstStrike) //no cartridges unlocked
                                 return GNB.NoMercy;
@@ -187,10 +187,11 @@ namespace XIVSlothComboPlugin.Combos
                     if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.GnashingFang)
                     {
                         if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 &&
-                            (gauge.Ammo == GNB.MaxCartridges(level) && IsOffCooldown(GNB.NoMercy) || //Regular 60 second GF/NM timing
-                            (gauge.Ammo > 0 && GetCooldownRemainingTime(GNB.NoMercy) > 17) || //Regular 30 second window                                                                        
-                            (gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.Bloodfest) < 2 && GetCooldownRemainingTime(GNB.NoMercy) < 2) || //1 ammo but Bloodfest ready during NM
-                            (gauge.Ammo == 3 && GetCooldownRemainingTime(GNB.NoMercy) < 2))) //3 ammo and NM nearly ready
+                            (gauge.Ammo == GNB.MaxCartridges(level) && GetCooldownRemainingTime(GNB.NoMercy) > 55 || //Regular 60 second GF/NM timing
+                            (gauge.Ammo > 0 && GetCooldownRemainingTime(GNB.NoMercy) > 17 && GetCooldownRemainingTime(GNB.NoMercy) < 35) || //Regular 30 second window                                                                        
+                            (gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.Bloodfest) < 1 && GetCooldownRemainingTime(GNB.NoMercy) < 1) || //1 ammo but Bloodfest ready during NM
+                            (gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.NoMercy) > 55 && IsOffCooldown(GNB.Bloodfest)) || //Opener Conditions
+                            (gauge.Ammo == 3 && GetCooldownRemainingTime(GNB.NoMercy) < 1))) //3 ammo and NM nearly ready
                                 return GNB.GnashingFang;
                         if (gauge.AmmoComboStep is 1 or 2)
                             return OriginalHook(GNB.GnashingFang);

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -107,7 +107,7 @@ namespace XIVSlothComboPlugin.Combos
                         if (level >= GNB.Levels.NoMercy && IsOffCooldown(GNB.NoMercy))
                         {
                             if (level >= GNB.Levels.BurstStrike && 
-                                ((gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.Bloodfest) < 3.5) || (gauge.Ammo == 2 && IsOnCooldown(GNB.GnashingFang)) || gauge.Ammo == GNB.MaxCartridges(level))) //cartridges unlocked
+                                ((gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.Bloodfest) < 2) || (gauge.Ammo == 2 && IsOnCooldown(GNB.GnashingFang)) || gauge.Ammo == GNB.MaxCartridges(level))) //cartridges unlocked
                                 return GNB.NoMercy;
                             if (level < GNB.Levels.BurstStrike) //no cartridges unlocked
                                 return GNB.NoMercy;
@@ -186,8 +186,11 @@ namespace XIVSlothComboPlugin.Combos
 
                     if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.GnashingFang)
                     {
-                        if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 && 
-                            gauge.Ammo > 0) //Conditions for No Mercy/Gnashing Fang timing
+                        if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 &&
+                            (gauge.Ammo == GNB.MaxCartridges(level) && IsOffCooldown(GNB.NoMercy) || //Regular 60 second GF/NM timing
+                            (gauge.Ammo > 0 && GetCooldownRemainingTime(GNB.NoMercy) > 17) || //Regular 30 second window                                                                        
+                            (gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.Bloodfest) < 2 && GetCooldownRemainingTime(GNB.NoMercy) < 2) || //1 ammo but Bloodfest ready during NM
+                            (gauge.Ammo == 3 && GetCooldownRemainingTime(GNB.NoMercy) < 2))) //3 ammo and NM nearly ready
                                 return GNB.GnashingFang;
                         if (gauge.AmmoComboStep is 1 or 2)
                             return OriginalHook(GNB.GnashingFang);

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -189,9 +189,8 @@ namespace XIVSlothComboPlugin.Combos
                         if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 &&
                             (gauge.Ammo == GNB.MaxCartridges(level) && GetCooldownRemainingTime(GNB.NoMercy) > 55 || //Regular 60 second GF/NM timing
                             (gauge.Ammo > 0 && GetCooldownRemainingTime(GNB.NoMercy) > 17 && GetCooldownRemainingTime(GNB.NoMercy) < 35) || //Regular 30 second window                                                                        
-                            (gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.Bloodfest) < 1 && GetCooldownRemainingTime(GNB.NoMercy) < 1) || //1 ammo but Bloodfest ready during NM
-                            (gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.NoMercy) > 55 && IsOffCooldown(GNB.Bloodfest)) || //Opener Conditions
-                            (gauge.Ammo == 3 && GetCooldownRemainingTime(GNB.NoMercy) < 1))) //3 ammo and NM nearly ready
+                            (gauge.Ammo == 3 && GetCooldownRemainingTime(GNB.Bloodfest) < 2 && GetCooldownRemainingTime(GNB.NoMercy) < 2) || //3 minute window
+                            (gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.NoMercy) > 55 && IsOffCooldown(GNB.Bloodfest)))) //Opener Conditions
                                 return GNB.GnashingFang;
                         if (gauge.AmmoComboStep is 1 or 2)
                             return OriginalHook(GNB.GnashingFang);
@@ -219,7 +218,7 @@ namespace XIVSlothComboPlugin.Combos
                             if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
                                 return GNB.Hypervelocity;
                             if (level >= GNB.Levels.BurstStrike && (gauge.Ammo == GNB.MaxCartridges(level) ||
-                                (IsEnabled(CustomComboPreset.GunbreakerBloodfestonST) && GetCooldownRemainingTime(GNB.Bloodfest) < 6 && gauge.Ammo != 0))) //Burns Ammo for Bloodfest
+                                (IsEnabled(CustomComboPreset.GunbreakerBloodfestonST) && GetCooldownRemainingTime(GNB.Bloodfest) < 6 && gauge.Ammo != 0 && IsOnCooldown(GNB.NoMercy)))) //Burns Ammo for Bloodfest
                                 return GNB.BurstStrike;
                         }
 

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -186,7 +186,8 @@ namespace XIVSlothComboPlugin.Combos
 
                     if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.GnashingFang)
                     {
-                        if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 && gauge.Ammo > 0)
+                        if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 && 
+                            gauge.Ammo > 0) //Conditions for No Mercy/Gnashing Fang timing
                                 return GNB.GnashingFang;
                         if (gauge.AmmoComboStep is 1 or 2)
                             return OriginalHook(GNB.GnashingFang);
@@ -365,6 +366,8 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID == GNB.BurstStrike)
             {
                 var gauge = GetJobGauge<GNBGauge>().Ammo;
+                if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
+                    return GNB.Hypervelocity;
                 if (gauge == 0 && level >= GNB.Levels.Bloodfest)
                     return GNB.Bloodfest;
             }

--- a/XIVSlothCombo/Combos/SAM.cs
+++ b/XIVSlothCombo/Combos/SAM.cs
@@ -191,8 +191,7 @@ namespace XIVSlothComboPlugin.Combos
                     //Stops waste if you use Iaijutsu or Ogi and you've got a Kaeshi ready
                     if (!inOpener)
                     {
-                        if (IsEnabled(CustomComboPreset.SamuraiOgiNamikiriSTFeature) && gauge.Kaeshi == Kaeshi.NAMIKIRI)
-                            return OriginalHook(SAM.OgiNamikiri);
+
                         if (IsEnabled(CustomComboPreset.IaijutsuSTFeature) && (gauge.Kaeshi == Kaeshi.GOKEN || gauge.Kaeshi == Kaeshi.SETSUGEKKA))
                             return OriginalHook(SAM.TsubameGaeshi);
                     }
@@ -279,7 +278,7 @@ namespace XIVSlothComboPlugin.Combos
                             bool oddMinute = GetCooldownRemainingTime(SAM.Ikishoten) < 60 && gauge.Sen == Sen.NONE && !meikyoBuff && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) > 45;
                             bool evenMinute = !meikyoBuff && GetCooldownRemainingTime(SAM.Ikishoten) > 60 && gauge.Sen == Sen.NONE && GetRemainingCharges(SAM.TsubameGaeshi) == 0 && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) > 42 && gauge.Kenki > 15;
 
-                            if (GetDebuffRemainingTime(SAM.Debuffs.Higanbana) < 30)
+                            if (GetDebuffRemainingTime(SAM.Debuffs.Higanbana) < 40)
                             {
                                 if (inOddFiller || inEvenFiller)
                                 {
@@ -294,7 +293,9 @@ namespace XIVSlothComboPlugin.Combos
 
                             if (inEvenFiller)
                             {
-                                if ((InMeleeRange() && GetCooldownRemainingTime(SAM.Gyoten) > 1) ||IsOnCooldown(SAM.Hagakure))
+                                if (InMeleeRange() && !HasEffect(SAM.Buffs.EnhancedEnpi))
+                                    inEvenFiller = false;
+                                if (IsOnCooldown(SAM.Hagakure))
                                     inEvenFiller = false;
 
                                 if (SamFillerCombo == 2)
@@ -366,7 +367,7 @@ namespace XIVSlothComboPlugin.Combos
                                         return SAM.Gekko;
                                     if (lastComboMove == SAM.Hakaze)
                                         return SAM.Jinpu;
-                                    if (!HasEffect(SAM.Buffs.EnhancedEnpi) && GetCooldownRemainingTime(SAM.Yaten) > 1)
+                                    if ((InMeleeRange() && !HasEffect(SAM.Buffs.EnhancedEnpi) && IsOnCooldown(SAM.Gyoten)))
                                         return SAM.Hakaze;
                                     if (HasEffect(SAM.Buffs.EnhancedEnpi))
                                         return SAM.Enpi;
@@ -399,7 +400,7 @@ namespace XIVSlothComboPlugin.Combos
                                         return SAM.Senei;
                                     if (IsEnabled(CustomComboPreset.SeneiBurstFeature))
                                     {
-                                        if (hasDied || nonOpener || (gauge.Kaeshi == Kaeshi.SETSUGEKKA && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) <= 10) || GetCooldownRemainingTime(SAM.Ikishoten) <= 90)
+                                        if (hasDied || nonOpener || GetCooldownRemainingTime(SAM.Ikishoten) <= 90 || (gauge.Kaeshi == Kaeshi.SETSUGEKKA && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) <= 10))
                                             return SAM.Senei;
                                     }
                                 }
@@ -446,15 +447,17 @@ namespace XIVSlothComboPlugin.Combos
                             }
 
                             //Ogi Namikiri Features
-                            if (IsEnabled(CustomComboPreset.SamuraiOgiNamikiriSTFeature) && level >= SAM.Levels.OgiNamikiri && (gauge.Kaeshi == Kaeshi.NAMIKIRI) || (!this.IsMoving && HasEffect(SAM.Buffs.OgiNamikiriReady)))
+                            if (IsEnabled(CustomComboPreset.SamuraiOgiNamikiriSTFeature) && level >= SAM.Levels.OgiNamikiri)
                             {
-                                if (IsNotEnabled(CustomComboPreset.OgiNamikiriinBurstFeature))
-                                    return OriginalHook(SAM.OgiNamikiri);
-                                if (IsEnabled(CustomComboPreset.OgiNamikiriinBurstFeature))
+                                if ((!this.IsMoving && HasEffect(SAM.Buffs.OgiNamikiriReady)) || gauge.Kaeshi == Kaeshi.NAMIKIRI)
                                 {
-                                    if (hasDied || nonOpener || (meikyostacks == 1 && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) >= 45) ||
-                                        GetBuffRemainingTime(SAM.Buffs.OgiNamikiriReady) <= 10)
+                                    if (IsNotEnabled(CustomComboPreset.OgiNamikiriinBurstFeature))
                                         return OriginalHook(SAM.OgiNamikiri);
+                                    if (IsEnabled(CustomComboPreset.OgiNamikiriinBurstFeature))
+                                    {
+                                        if (hasDied || nonOpener || (meikyostacks == 1 && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) >= 45 && HasEffect(SAM.Buffs.MeikyoShisui)) || GetCooldownRemainingTime(SAM.Ikishoten) <= 105)
+                                            return OriginalHook(SAM.OgiNamikiri);
+                                    }
                                 }
                             }
                         }

--- a/XIVSlothCombo/Combos/SAM.cs
+++ b/XIVSlothCombo/Combos/SAM.cs
@@ -232,13 +232,15 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //GCDs
+                        if (twoSeal && lastComboMove == SAM.Yukikaze)
+                            return OriginalHook(SAM.Iaijutsu);
                         if (threeSeal && (GetRemainingCharges(SAM.MeikyoShisui) == 1 || !HasEffect(SAM.Buffs.OgiNamikiriReady)))
                             return OriginalHook(SAM.Iaijutsu);
                         if (oneSeal && !TargetHasEffect(SAM.Debuffs.Higanbana) && GetRemainingCharges(SAM.TsubameGaeshi) == 1)
                             return OriginalHook(SAM.Iaijutsu);
                         if (oneSeal && TargetHasEffect(SAM.Debuffs.Higanbana) && HasEffect(SAM.Buffs.OgiNamikiriReady))
                             return OriginalHook(SAM.OgiNamikiri);
-                        if (gauge.Kaeshi == Kaeshi.SETSUGEKKA)
+                        if (gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Kaeshi == Kaeshi.GOKEN)
                             return OriginalHook(SAM.TsubameGaeshi);
                         if (gauge.Kaeshi == Kaeshi.NAMIKIRI)
                             return OriginalHook(OriginalHook(SAM.OgiNamikiri));
@@ -262,6 +264,12 @@ namespace XIVSlothComboPlugin.Combos
                         if (GetRemainingCharges(SAM.TsubameGaeshi) == 0)
                         {
                             inOpener = false;
+                        }
+
+                        if (lastComboMove == SAM.Yukikaze && oneSeal)
+                        {
+                            inOpener = false;
+                            nonOpener = true;
                         }
                     }
 
@@ -297,6 +305,8 @@ namespace XIVSlothComboPlugin.Combos
                                     inEvenFiller = false;
                                 if (IsOnCooldown(SAM.Hagakure))
                                     inEvenFiller = false;
+                                if (hasDied)
+                                    inEvenFiller = false;
 
                                 if (SamFillerCombo == 2)
                                 {
@@ -329,6 +339,8 @@ namespace XIVSlothComboPlugin.Combos
                             if (inOddFiller)
                             {
                                 if (IsOnCooldown(SAM.Hagakure))
+                                    inOddFiller = false;
+                                if (hasDied)
                                     inOddFiller = false;
 
                                 if (SamFillerCombo == 1)

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -123,7 +123,6 @@ namespace XIVSlothComboPlugin.Combos
                         return WAR.PrimalRend;
 
                     if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.InnerBeast) ||
-                        (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.InnerChaos) ||
                         (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.InnerBeast &&
                         (IsOffCooldown(WAR.InnerRelease) || GetCooldown(WAR.InnerRelease).CooldownRemaining > 35 || HasEffect(WAR.Buffs.NascentChaos))))
                             return OriginalHook(WAR.InnerBeast);
@@ -210,9 +209,9 @@ namespace XIVSlothComboPlugin.Combos
 
                         if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady) && level >= WAR.Levels.PrimalRend)
                             return OriginalHook(WAR.PrimalRend);
+
                         if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.SteelCyclone) ||
-                            (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.SteelCyclone) ||
-                            (IsEnabled(CustomComboPreset.WarriorInnerChaosOption) && HasEffect(WAR.Buffs.NascentChaos) && level >= WAR.Levels.ChaoticCyclone))
+                            (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.SteelCyclone))
                                 return OriginalHook(WAR.SteelCyclone);
                     }
 
@@ -267,21 +266,6 @@ namespace XIVSlothComboPlugin.Combos
                 return OriginalHook(actionID);
 
 
-            }
-
-            return actionID;
-        }
-    }
-    internal class WarriorInfuriateFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorInfuriateFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == WAR.Infuriate)
-            {
-                if (HasEffect(WAR.Buffs.InnerRelease) || HasEffect(WAR.Buffs.NascentChaos))
-                    return OriginalHook(WAR.FellCleave);
             }
 
             return actionID;

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -122,10 +122,14 @@ namespace XIVSlothComboPlugin.Combos
                     if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady))
                         return WAR.PrimalRend;
 
-                    if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.InnerBeast) ||
-                        (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.InnerBeast &&
-                        (IsOffCooldown(WAR.InnerRelease) || GetCooldown(WAR.InnerRelease).CooldownRemaining > 35 || HasEffect(WAR.Buffs.NascentChaos))))
+                    if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && level >= WAR.Levels.InnerBeast)
+                    {
+                        if (gauge >= 50 && (IsOffCooldown(WAR.InnerRelease) || GetCooldownRemainingTime(WAR.InnerRelease) > 35 || HasEffect(WAR.Buffs.NascentChaos)))
                             return OriginalHook(WAR.InnerBeast);
+                        if (HasEffect(WAR.Buffs.InnerRelease))
+                            return OriginalHook(WAR.InnerBeast);
+                    }
+
                 }
 
                 if (comboTime > 0)
@@ -161,9 +165,6 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID == WAR.StormsEye)
                 {
-                    if (IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease))
-                        return OriginalHook(WAR.FellCleave);
-
                     if (comboTime > 0)
                     {
                         if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim)
@@ -209,10 +210,8 @@ namespace XIVSlothComboPlugin.Combos
 
                         if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady) && level >= WAR.Levels.PrimalRend)
                             return OriginalHook(WAR.PrimalRend);
-
-                        if ((IsEnabled(CustomComboPreset.WarriorInnerReleaseFeature) && HasEffect(WAR.Buffs.InnerRelease) && level >= WAR.Levels.SteelCyclone) ||
-                            (IsEnabled(CustomComboPreset.WarriorSpenderOption) && gauge >= 50 && level >= WAR.Levels.SteelCyclone))
-                                return OriginalHook(WAR.SteelCyclone);
+                        if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && level >= WAR.Levels.SteelCyclone && (gauge >= 50 || HasEffect(WAR.Buffs.InnerRelease)))
+                            return OriginalHook(WAR.SteelCyclone);
                     }
 
                     if (comboTime > 0)

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2195,12 +2195,6 @@ namespace XIVSlothComboPlugin
         WarriorOrogenyFeature = 18009,
 
         [ParentCombo(WarriorStormsPathCombo)]
-        [ConflictingCombos(WarriorSpenderOption)]
-        [CustomComboInfo("Inner Chaos option", "Adds Inner Chaos to Storms Path Combo and Chaotic Cyclone to Overpower Combo if you are buffed with Nascent Chaos.\nRequires Storms Path Combo and Overpower Combo", WAR.JobID, 0, "", "THE EYE OF THE TIGERRRRR")]
-        WarriorInnerChaosOption = 18010,
-
-        [ParentCombo(WarriorStormsPathCombo)]
-        [ConflictingCombos(WarriorInnerChaosOption)]
         [CustomComboInfo("Fell Cleave/Decimate Option", "Adds Fell Cleave to main combo when gauge is at 50 or more and adds Decimate to the AoE combo .\nWill use Inner Chaos/Chaotic Cyclone if Infuriate is used.\nWill begin pooling resources when Inner Release is under 30s", WAR.JobID, 0, "", "MORE CLEAVE!")]
         WarriorSpenderOption = 18011,
 
@@ -2215,9 +2209,6 @@ namespace XIVSlothComboPlugin
         [ParentCombo(WarriorMythrilTempestCombo)]
         [CustomComboInfo("Inner Release AOE Feature", "Adds Inner Release to Storm's Path Combo.", WAR.JobID, 0)]
         WarriorIRonAOE = 18014,
-
-        [CustomComboInfo("Infuriate Feature", "Replaces Infuriate with Fell Cleave when under Inner Release buff.\nReplaces Infuriate with Inner Chaos When under Nascent Chaos buff", WAR.JobID, 0, "Cleave of annoyance", "Infuriating stuff, if you ask me. Truly chaotic.")]
-        WarriorInfuriateFeature = 18015,
 
         [ParentCombo(WarriorStormsPathCombo)]
         [CustomComboInfo("Tomahawk Uptime Feature", "Replace Storm's Path Combo Feature with Tomahawk when you are out of range.", WAR.JobID, 0, "Tomahawk!", "You heard me! Tomahawk! Ka-chow!")]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1853,7 +1853,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Samurai Overcap Feature", "Adds Shinten onto main combo when Kenki is at the selected amount or more", SAM.JobID, 0, "Wink emoji Overcap Feature 1", "Kinky.")]
         SamuraiOvercapFeature = 15001,
 
-        [CustomComboInfo("Samurai AoE Overcap Feature", "Adds Guren>Kyuten onto main AoE combos when Kenki is at the selected amount or more", SAM.JobID, 0, "Wink emoji Overcap Feature 3", "Kinkier")]
+        [CustomComboInfo("Samurai AoE Overcap Feature", "Adds Kyuten onto main AoE combos when Kenki is at the selected amount or more", SAM.JobID, 0, "Wink emoji Overcap Feature 3", "Kinkier")]
         SamuraiOvercapFeatureAoe = 15002,
 
         //Main Combo Features

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1874,7 +1874,7 @@ namespace XIVSlothComboPlugin
 
             [ConflictingCombos(SamuraiYatenFeature)]
             [ParentCombo(SamuraiGekkoCombo)]
-            [CustomComboInfo("Level 90 Samurai Opener", "Adds the Level 90 Opener to the Main Combo.\nOpener triggered by using Meikyo Shisui before combat. If you have any Sen, Hagakure will be used to clear them.\nWill work at any levels of Kenki, requires 2 charges of Meikyo Shisui and all CDs ready. If conditions aren't met it will skip into the regular rotation.", SAM.JobID, 0)]
+            [CustomComboInfo("Level 90 Samurai Opener", "Adds the Level 90 Opener to the Main Combo.\nOpener triggered by using Meikyo Shisui before combat. If you have any Sen, Hagakure will be used to clear them.\nWill work at any levels of Kenki, requires 2 charges of Meikyo Shisui and all CDs ready. If conditions aren't met it will skip into the regular rotation. \nIf the Opener is interrupted, it will exit the opener via a Goken and a Kaeshi: Goken at the end or via the last Yukikaze. If the latter, CDs will be used on cooldown regardless of burst options.", SAM.JobID, 0)]
             SamuraiOpenerFeature = 15007,
 
             [ConflictingCombos(SamuraiYatenFeature)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2175,10 +2175,6 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Warrior Gauge Overcap Feature", "Replace Single target or AoE combo with gauge spender if you are about to overcap and are before a step of a combo that would generate beast gauge", WAR.JobID, 0, "", "Taming the beast... for now.")]
         WarriorGaugeOvercapFeature = 18003,
 
-        [ParentCombo(WarriorStormsPathCombo)]
-        [CustomComboInfo("Inner Release Feature", "Replace Single target and AoE combo with Fell Cleave/Decimate during Inner Release", WAR.JobID, 0, "", "Unleash your deepest thoughts and feelings upon the party. They'll love it!")]
-        WarriorInnerReleaseFeature = 18004,
-
         [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76", WAR.JobID, 0, "Nasty-ass Flash", "Jeez. Keep it to yourself.")]
         WarriorNascentFlashFeature = 18005,
 
@@ -2195,7 +2191,7 @@ namespace XIVSlothComboPlugin
         WarriorOrogenyFeature = 18009,
 
         [ParentCombo(WarriorStormsPathCombo)]
-        [CustomComboInfo("Fell Cleave/Decimate Option", "Adds Fell Cleave to main combo when gauge is at 50 or more and adds Decimate to the AoE combo .\nWill use Inner Chaos/Chaotic Cyclone if Infuriate is used.\nWill begin pooling resources when Inner Release is under 30s", WAR.JobID, 0, "", "MORE CLEAVE!")]
+        [CustomComboInfo("Fell Cleave/Decimate Option", "Adds Fell Cleave to main combo when gauge is at 50 or more and adds Decimate to the AoE combo .\nWill use Inner Chaos/Chaotic Cyclone if Infuriate is used and Fell Cleave/Steel Cyclone during Inner Release.\nWill begin pooling resources when Inner Release is under 30s", WAR.JobID, 0, "", "MORE CLEAVE!")]
         WarriorSpenderOption = 18011,
 
         [ParentCombo(WarriorStormsPathCombo)]


### PR DESCRIPTION
SAM: Adjusted Filler Combo Timers, Adjusted burst Ogi Namikiri conditions
GNB: Adjusted windows for NM and Gnashing Fang Starter
WAR: Removed Inner Release Feature and consolidated it into Fell/Cleave Decimate Option.
WAR: Removed Infuriate Feature and Inner Chaos Option
DRK: Forgot Dark Arts check for regular EoS