### PR TITLE
NIN & AST Updates

### DIFF
--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -274,6 +274,8 @@ namespace XIVSlothComboPlugin.Combos
     internal class AstrologianCardsOnDrawFeaturelikewhat : CustomCombo
     {
         private new bool GetTarget = true;
+
+        private GameObject? CurrentTarget;
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianCardsOnDrawFeaturelikewhat;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
@@ -304,6 +306,8 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (GetTarget || (IsEnabled(CustomComboPreset.AstrologianTargetLock)))
                             SetTarget();
+                        
+                            
                     }
 
                     return OriginalHook(AST.Play);
@@ -312,7 +316,10 @@ namespace XIVSlothComboPlugin.Combos
                 if (!GetTarget && (IsEnabled(CustomComboPreset.AstReFocusFeature) || IsEnabled(CustomComboPreset.AstReTargetFeature)))
                 {
                     if (IsEnabled(CustomComboPreset.AstReTargetFeature))
-                        TargetObject(TargetType.LastTarget);
+                    {
+                        Dalamud.Logging.PluginLog.Debug("Previous?");
+                        TargetObject(CurrentTarget);
+                    }
                     
 
                     if (IsEnabled(CustomComboPreset.AstReFocusFeature))
@@ -331,7 +338,7 @@ namespace XIVSlothComboPlugin.Combos
             var gauge = GetJobGauge<ASTGauge>();
             if (gauge.DrawnCard.Equals(CardType.NONE)) return false;
             var cardDrawn = gauge.DrawnCard;
-
+            if (GetTarget) CurrentTarget = LocalPlayer.TargetObject;
             //Checks for trusts then normal parties
             int maxPartySize = GetPartySlot(5) == null ? 4 : 8;
             if (GetPartyMembers().Length > 0) maxPartySize = GetPartyMembers().Length;

--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -111,7 +111,9 @@ namespace XIVSlothComboPlugin.Combos
                 TrickCooldownRemaining = "TrickCooldownRemaining",
                 HutonRemainingTimer = "HutonRemainingTimer",
                 HutonRemainingArmorCrush = "HutonRemainingArmorCrush",
-                MugNinkiGauge = "MugNinkiGauge";
+                MugNinkiGauge = "MugNinkiGauge",
+                NinkiBhavaPooling = "NinkiBhavaPooling",
+                NinkiBunshinPooling = "NinkiBunshinPooling";
         }
     }
 
@@ -225,6 +227,8 @@ namespace XIVSlothComboPlugin.Combos
                 var gauge = GetJobGauge<NINGauge>();
                 var bunshinCD = GetCooldown(NIN.Bunshin);
                 var trickCDThreshold = Service.Configuration.GetCustomIntValue(NIN.Config.TrickCooldownRemaining);
+                var ninkiBhavaPooling = Service.Configuration.GetCustomIntValue(NIN.Config.NinkiBhavaPooling);
+                var ninkiBunshinPooling = Service.Configuration.GetCustomIntValue(NIN.Config.NinkiBunshinPooling);
 
                 if (OriginalHook(NIN.Ninjutsu) is NIN.Rabbit) return OriginalHook(NIN.Ninjutsu);
 
@@ -305,14 +309,30 @@ namespace XIVSlothComboPlugin.Combos
                         return NIN.Jin;
                 }
 
+                if (!IsEnabled(CustomComboPreset.NinNinkiBunshinPooling))
+                {
+                    if (gauge.Ninki >= 50 && !bunshinCD.IsCooldown && canWeave && level >= NIN.Levels.Bunshin)
+                        return NIN.Bunshin;
+                }
+                else
+                {
+                    if (gauge.Ninki >= ninkiBunshinPooling && !bunshinCD.IsCooldown && canWeave && level >= NIN.Levels.Bunshin)
+                        return NIN.Bunshin;
+                }
 
-                if (gauge.Ninki >= 50 && !bunshinCD.IsCooldown && canWeave && level >= NIN.Levels.Bunshin)
-                    return NIN.Bunshin;
                 if (HasEffect(NIN.Buffs.PhantomReady) && level >= NIN.Levels.PhantomKamaitachi)
                     return NIN.PhantomKamaitachi;
 
-                if (gauge.Ninki >= 50 && canWeave && level >= 68)
-                    return NIN.Bhavacakra;
+                if (!IsEnabled(CustomComboPreset.NinNinkiBhavacakraPooling))
+                {
+                    if (gauge.Ninki >= 50 && canWeave && level >= NIN.Levels.Bhavacakra)
+                        return NIN.Bhavacakra;
+                }
+                else
+                {
+                    if (gauge.Ninki >= ninkiBhavaPooling && canWeave && level >= NIN.Levels.Bhavacakra)
+                        return NIN.Bhavacakra;
+                }
 
 
                 if (level >= NIN.Levels.Assassinate)
@@ -325,15 +345,15 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (comboTime > 0f)
                 {
-                    if (lastComboMove == NIN.SpinningEdge && level >= 4)
+                    if (lastComboMove == NIN.SpinningEdge && level >= NIN.Levels.GustSlash)
                         return NIN.GustSlash;
 
 
-                    if (lastComboMove == NIN.GustSlash && level >= 20 && gauge.HutonTimer < 15000 && level >= 54)
+                    if (lastComboMove == NIN.GustSlash && gauge.HutonTimer < 15000 && level >= NIN.Levels.ArmorCrush)
                         return NIN.ArmorCrush;
 
 
-                    if (lastComboMove == NIN.GustSlash && level >= 26)
+                    if (lastComboMove == NIN.GustSlash && level >= NIN.Levels.AeolianEdge)
                         return NIN.AeolianEdge;
 
                 }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -267,6 +267,23 @@ namespace XIVSlothComboPlugin
 
             #endregion
 
+            #region Message of the Day
+            var motd = Service.Configuration.HideMessageOfTheDay;
+            if (ImGui.Checkbox("Hide Message of the Day", ref motd))
+            {
+                Service.Configuration.HideMessageOfTheDay = motd;
+                Service.Configuration.Save();
+            }
+            if (ImGui.IsItemHovered())
+            {
+                ImGui.BeginTooltip();
+                ImGui.TextUnformatted("Disables the Message of the Day message in your chat when you login.");
+                ImGui.EndTooltip();
+            }
+            ImGui.NextColumn();
+
+            #endregion
+
             ImGui.EndChild();
         }
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -704,10 +704,16 @@ namespace XIVSlothComboPlugin
             
 
             if (preset == CustomComboPreset.NinAeolianMugFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, NIN.Config.MugNinkiGauge, "Set the amount of Ninki to be at or under for this feature (level 66 onwards)");
+                ConfigWindowFunctions.DrawSliderInt(0, 100, NIN.Config.MugNinkiGauge, $"Set the amount of Ninki to be at or under for this feature (level {NIN.TraitLevels.Shukiho} onwards)");
 
             if (preset == CustomComboPreset.NinjaArmorCrushOnMainCombo)
                 ConfigWindowFunctions.DrawSliderInt(0, 30, NIN.Config.HutonRemainingArmorCrush, "Set the amount of time remaining on Huton the feature\nshould wait before using Armor Crush", 200);
+
+            if (preset == CustomComboPreset.NinNinkiBhavacakraPooling)
+                ConfigWindowFunctions.DrawSliderInt(50, 100, NIN.Config.NinkiBhavaPooling, "The minimum value of Ninki to have before spending.");
+
+            if (preset == CustomComboPreset.NinNinkiBunshinPooling)
+                ConfigWindowFunctions.DrawSliderInt(50, 100, NIN.Config.NinkiBunshinPooling, "The minimum value of Ninki to have before spending.");
 
             #endregion
             // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -217,7 +217,7 @@ namespace XIVSlothComboPlugin
 
         [ConflictingCombos(AstReFocusFeature)]
         [ParentCombo(AstrologianCardsOnDrawFeaturelikewhat)]
-        [CustomComboInfo("Target Previous Feature", "Once you've played your card, switch back to your previously selected target.", AST.JobID)]
+        [CustomComboInfo("Target Previous Feature", "Once you've played your card, switch back to your previously manually selected target. (May also be who you played the card on)", AST.JobID)]
         AstReTargetFeature = 1033,
 
         [ConflictingCombos(AstReTargetFeature)]
@@ -1380,6 +1380,14 @@ namespace XIVSlothComboPlugin
 
         [CustomComboInfo("Huraijin / Armor Crush Combo", "Replace Huraijin with Armor Crush after using Gust Slash", NIN.JobID, 8)]
         NinHuraijinArmorCrush = 10032,
+
+        [ParentCombo(NinSimpleSingleTarget)]
+        [CustomComboInfo("Ninki Pooling Feature - Bunshin", "Allows you to have a minimum amount of Ninki saved before spending on Bunshin.", NIN.JobID)]
+        NinNinkiBunshinPooling = 10033,
+
+        [ParentCombo(NinSimpleSingleTarget)]
+        [CustomComboInfo("Ninki Pooling Feature - Bhavacakra", "Allows you to have a minimum amount of Ninki saved before spending on Bhavacakra.", NIN.JobID)]
+        NinNinkiBhavacakraPooling = 10034,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/PluginConfiguration.cs
+++ b/XIVSlothCombo/PluginConfiguration.cs
@@ -169,6 +169,8 @@ namespace XIVSlothComboPlugin
 
         public bool SpecialEvent { get; set; } = false;
 
+        public bool HideMessageOfTheDay { get; set; } = false;
+
         [JsonProperty]
         public Dictionary<string, byte[]> ImageCache { get; set; } = new();
 


### PR DESCRIPTION
[NIN]
Added 2 Ninki pooling features on `Simple Single Target`. #589 

[AST]
Reworked and fixed `Target Previous Feature` due to patch update. Now switches back to your last manually selected target once the card is played. #588 

[General]
Adds `Sloth Message of the Day` that gets printed to the chatbox upon login or reload plugin.