### PR TITLE
NINPVP: Sealed Doton DebuffID Fix

### DIFF
--- a/XIVSlothCombo/CombosPVP/NINPVP.cs
+++ b/XIVSlothCombo/CombosPVP/NINPVP.cs
@@ -41,7 +41,7 @@ namespace XIVSlothComboPlugin
                 SealedHyoshoRanryu = 3194,
                 SealedGokaMekkyaku = 3193,
                 SealedHuton = 3196,
-                SealedDoton = 3187,
+                SealedDoton = 3197,
                 SeakedForkedRaiju = 3195,
                 SealedMeisui = 3198;
         }


### PR DESCRIPTION
Bug fix for NIN PVP AOE. Wrong Debuff ID was checked for Sealed Doton (Fix tested by Ari)