### PR TITLE
PVP Feature Solo Instance Check + MoTD Updates

### DIFF
--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -156,8 +156,8 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
-                SMNLucidDreamingFeature = "SMNLucidDreamingFeature";
-            public const string
+                SMNLucidDreamingFeature = "SMNLucidDreamingFeature",
+                SMNSearingLightChoice = "SMNSearingLightChoice",
                 SummonerPrimalChoice = "SummonerPrimalChoice";
         }
     }
@@ -191,7 +191,7 @@ namespace XIVSlothComboPlugin.Combos
             return actionID;
         }
     }
-    
+
     internal class SummonerEDFesterCombo : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerEDFesterCombo;
@@ -289,7 +289,7 @@ namespace XIVSlothComboPlugin.Combos
 
                             if (summonerPrimalChoice == 1)
                             {
-                                if (gauge.IsTitanReady && level >=SMN.Levels.SummonTopaz)
+                                if (gauge.IsTitanReady && level >= SMN.Levels.SummonTopaz)
                                     return OriginalHook(SMN.SummonTopaz);
 
                                 if (gauge.IsGarudaReady && level >= SMN.Levels.SummonEmerald)
@@ -312,8 +312,8 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(SMN.Aethercharge)) &&
                             (level >= SMN.Levels.Aethercharge && level < SMN.Levels.Bahamut || //Pre Bahamut Phase
-                            gauge.IsBahamutReady  && level >= SMN.Levels.Bahamut || //Bahamut Phase
-                            gauge.IsPhoenixReady  && level >= SMN.Levels.Phoenix)) //Phoenix Phase
+                            gauge.IsBahamutReady && level >= SMN.Levels.Bahamut || //Bahamut Phase
+                            gauge.IsPhoenixReady && level >= SMN.Levels.Phoenix)) //Phoenix Phase
                             return OriginalHook(SMN.Aethercharge);
 
                         if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID))
@@ -322,7 +322,7 @@ namespace XIVSlothComboPlugin.Combos
                                 return OriginalHook(SMN.AstralFlow);
 
                             if (IsOffCooldown(OriginalHook(SMN.EnkindleBahamut)) && level >= SMN.Levels.Bahamut && lastComboMove is SMN.AstralImpulse or SMN.FountainOfFire)
-                                return OriginalHook(SMN.EnkindleBahamut); 
+                                return OriginalHook(SMN.EnkindleBahamut);
                         }
 
                         if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption))
@@ -331,7 +331,7 @@ namespace XIVSlothComboPlugin.Combos
                                 return OriginalHook(SMN.AstralFlow);
                         }
                     }
-                    
+
                     if (IsEnabled(CustomComboPreset.SummonerRuin4ToRuin3Feature) && level >= SMN.Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(SMN.Buffs.FurtherRuin))
                         return SMN.Ruin4;
                 }
@@ -356,9 +356,20 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     if (CanSpellWeave(actionID))
                     {
+                        var searingChoice = Service.Configuration.GetCustomIntValue(SMN.Config.SMNSearingLightChoice);
+
                         // Searing
-                        if (IsEnabled(CustomComboPreset.BuffOnSimpleAoESummoner) && IsOffCooldown(SMN.SearingLight) && level >= SMN.Levels.SearingLight && gauge.IsBahamutReady && GetCooldownRemainingTime(SMN.SummonBahamut) >= 55)
+                        if (IsEnabled(CustomComboPreset.BuffOnSimpleAoESummoner) &&
+                            IsOffCooldown(SMN.SearingLight) &&
+                            level >= SMN.Levels.SearingLight &&
+                            (searingChoice == 0 ||
+                            (OriginalHook(SMN.Tridisaster) is SMN.AstralFlare && gauge.SummonTimerRemaining > 0 && searingChoice == 1) ||
+                            (OriginalHook(SMN.Tridisaster) is SMN.BrandOfPurgatory && gauge.SummonTimerRemaining > 0 && searingChoice == 2) ||
+                            (OriginalHook(SMN.PreciousBrilliance) is (SMN.RubyCata or SMN.RubyOutburst) && gauge.SummonTimerRemaining > 0 && searingChoice == 3) ||
+                            (OriginalHook(SMN.PreciousBrilliance) is (SMN.EmeraldCata or SMN.EmeraldOutburst) && gauge.SummonTimerRemaining > 0 && searingChoice == 4) ||
+                            (OriginalHook(SMN.PreciousBrilliance) is (SMN.TopazCata or SMN.TopazOutburst) && gauge.SummonTimerRemaining > 0 && searingChoice == 5)))
                             return SMN.SearingLight;
+
 
                         // ED & Fester
                         if (IsEnabled(CustomComboPreset.SummonerESAOEFeature))
@@ -374,6 +385,39 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
                     }
 
+                    //Demi
+                    if (IsEnabled(CustomComboPreset.SummonerDemiAoESummonsFeature))
+                    {
+                        if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(SMN.Aethercharge)) &&
+                            (level >= SMN.Levels.Aethercharge && level < SMN.Levels.Bahamut || //Pre Bahamut Phase
+                            gauge.IsBahamutReady && level >= SMN.Levels.Bahamut || //Bahamut Phase
+                            gauge.IsPhoenixReady && level >= SMN.Levels.Phoenix)) //Phoenix Phase
+                            return OriginalHook(SMN.Aethercharge);
+
+                    }
+
+                    //Demi Nuke
+                    if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID))
+                    {
+                        if (IsOffCooldown(OriginalHook(SMN.AstralFlow)) &&
+                            level >= SMN.Levels.AstralFlow &&
+                            (level < SMN.Levels.Bahamut || lastComboMove is SMN.AstralFlare) &&
+                            gauge.AttunmentTimerRemaining > 0)
+                            return OriginalHook(SMN.AstralFlow);
+                        if (IsOffCooldown(OriginalHook(SMN.EnkindleBahamut)) &&
+                            level >= SMN.Levels.Bahamut &&
+                            lastComboMove is SMN.AstralFlare or SMN.BrandOfPurgatory &&
+                            gauge.AttunmentTimerRemaining > 0)
+                            return OriginalHook(SMN.EnkindleBahamut);
+                    }
+
+                    //Demi Nuke 2: Electric Boogaloo
+                    if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption))
+                    {
+                        if (IsOffCooldown(OriginalHook(SMN.AstralFlow)) && lastComboMove is SMN.BrandOfPurgatory)
+                            return OriginalHook(SMN.AstralFlow);
+                    }
+
                     // Egis
                     if (IsEnabled(CustomComboPreset.EgisOnAOEFeature))
                     {
@@ -382,10 +426,7 @@ namespace XIVSlothComboPlugin.Combos
                             IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(SMN.Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == SMN.CrimsonCyclone)) //Ifrit
                             return OriginalHook(SMN.AstralFlow);
 
-                        if (IsEnabled(CustomComboPreset.SummonerEgiAttacksAOEFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
-                            return OriginalHook(SMN.PreciousBrilliance);
-
-                        if (gauge.SummonTimerRemaining == 0 && IsOnCooldown(SMN.SummonPhoenix) && IsOnCooldown(SMN.SummonBahamut))
+                        if (gauge.SummonTimerRemaining == 0)
                         {
                             if (gauge.IsTitanReady && level >= SMN.Levels.SummonTopaz)
                                 return OriginalHook(SMN.SummonTopaz);
@@ -396,29 +437,11 @@ namespace XIVSlothComboPlugin.Combos
                         }
                     }
 
-                    //Demi
-                    if (IsEnabled(CustomComboPreset.SummonerDemiAoESummonsFeature))
-                    {
-                        if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(SMN.Aethercharge)) &&
-                            (level >= SMN.Levels.Aethercharge && level < SMN.Levels.Bahamut || //Pre Bahamut Phase
-                            gauge.IsBahamutReady && level >= SMN.Levels.Bahamut || //Bahamut Phase
-                            gauge.IsPhoenixReady && level >= SMN.Levels.Phoenix)) //Phoenix Phase
-                            return OriginalHook(SMN.Aethercharge);
+                    //Precious Brilliance
+                    if (IsEnabled(CustomComboPreset.SummonerEgiAttacksAOEFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
+                        return OriginalHook(SMN.PreciousBrilliance);
 
-                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID))
-                        {
-                            if (IsOffCooldown(OriginalHook(SMN.AstralFlow)) && level >= SMN.Levels.AstralFlow && (level < SMN.Levels.Bahamut || lastComboMove is SMN.AstralFlare))
-                                return OriginalHook(SMN.AstralFlow);
-                            if (IsOffCooldown(OriginalHook(SMN.EnkindleBahamut)) && level >= SMN.Levels.Bahamut && lastComboMove is SMN.AstralFlare or SMN.BrandOfPurgatory)
-                                return OriginalHook(SMN.EnkindleBahamut);
-                        }
-                        
-                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption))
-                        {
-                            if (IsOffCooldown(OriginalHook(SMN.AstralFlow)) && lastComboMove is SMN.BrandOfPurgatory)
-                                return OriginalHook(SMN.AstralFlow);
-                        }
-                    }
+
 
                     if (IsEnabled(CustomComboPreset.SummonerRuin4ToTridisasterFeature) && level >= SMN.Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(SMN.Buffs.FurtherRuin))
                         return SMN.Ruin4;

--- a/XIVSlothCombo/CombosPVP/WARPVP.cs
+++ b/XIVSlothCombo/CombosPVP/WARPVP.cs
@@ -32,7 +32,9 @@ namespace XIVSlothComboPlugin
         {
             if (actionID is WARPVP.HeavySwing or WARPVP.Maim or WARPVP.StormsPath)
             {
-                if (!GetCooldown(WARPVP.Bloodwhetting).IsCooldown)
+                var canWeave = CanWeave(actionID);
+
+                if (!GetCooldown(WARPVP.Bloodwhetting).IsCooldown && canWeave)
                     return OriginalHook(WARPVP.Bloodwhetting);
 
                 if (!InMeleeRange() && !GetCooldown(WARPVP.Blota).IsCooldown)
@@ -41,7 +43,7 @@ namespace XIVSlothComboPlugin
                 if (!GetCooldown(WARPVP.PrimalRend).IsCooldown)
                     return OriginalHook(WARPVP.PrimalRend);
 
-                if (!GetCooldown(WARPVP.Onslaught).IsCooldown)
+                if (!GetCooldown(WARPVP.Onslaught).IsCooldown && canWeave)
                     return OriginalHook(WARPVP.Onslaught);
 
                 if (InMeleeRange())
@@ -49,10 +51,9 @@ namespace XIVSlothComboPlugin
                     if (HasEffect(WARPVP.Buffs.NascentChaos))
                         return OriginalHook(WARPVP.Bloodwhetting);
 
-                    if (!GetCooldown(WARPVP.Orogeny).IsCooldown)
+                    if (!GetCooldown(WARPVP.Orogeny).IsCooldown && canWeave)
                         return OriginalHook(WARPVP.Orogeny);
 
-                    return OriginalHook(WARPVP.HeavySwing);
                 }
             }
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -861,6 +861,15 @@ namespace XIVSlothComboPlugin
             // ====================================================================================
             #region SUMMONER
 
+            if (preset == CustomComboPreset.BuffOnSimpleAoESummoner)
+            {
+                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SMNSearingLightChoice, "Option 1", "Use Searing Light on cooldown, regardless of phase.", 0);
+                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SMNSearingLightChoice, "Option 2", "Use Searing Light only in Bahamut phase.", 1);
+                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SMNSearingLightChoice, "Option 3", "Use Searing Light only in Phoenix phase.", 2);
+                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SMNSearingLightChoice, "Option 4", "Use Searing Light only in Ifrit phase.", 3);
+                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SMNSearingLightChoice, "Option 5", "Use Searing Light only in Garuda phase.", 4);
+                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SMNSearingLightChoice, "Option 6", "Use Searing Light only in Titan phase.", 5);
+            }
             if (preset == CustomComboPreset.SummonerEgiSummonsonMainFeature)
                 ConfigWindowFunctions.DrawRadioButton(SMN.Config.SummonerPrimalChoice,"Titan","Summons Titan first, Garuda second, Ifrit third", 1);
 

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -794,11 +794,11 @@ namespace XIVSlothComboPlugin.Combos
         protected static bool InPvP()
             => Service.ClientState.IsPvP ||
             Service.ClientState.TerritoryType == 250 || //Wolves Den
-            Service.ClientState.TerritoryType == 376 || //Borderland Ruins
-            Service.ClientState.TerritoryType == 431 || //Seal Rock
-            Service.ClientState.TerritoryType == 554 || //Fields of Glory
-            Service.ClientState.TerritoryType == 888 || //Onsal Hakair
-            Service.ClientState.TerritoryType == 729 || //Astragalos
-            Service.ClientState.TerritoryType == 791;   //Hidden Gorge
+            (Service.ClientState.TerritoryType == 376 && Service.PartyList.Count() > 1) || //Borderland Ruins
+            (Service.ClientState.TerritoryType == 431 && Service.PartyList.Count() > 1) || //Seal Rock
+            (Service.ClientState.TerritoryType == 554 && Service.PartyList.Count() > 1) || //Fields of Glory
+            (Service.ClientState.TerritoryType == 888 && Service.PartyList.Count() > 1) || //Onsal Hakair
+            (Service.ClientState.TerritoryType == 729 && Service.PartyList.Count() > 1) || //Astragalos
+            (Service.ClientState.TerritoryType == 791 && Service.PartyList.Count() > 1);   //Hidden Gorge
     }
 }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2055,8 +2055,8 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Demi Attacks on Main Combo", "Adds Astral Flow to the Main Combo.", SMN.JobID, 0, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
         SummonerSingleTargetDemiFeature = 17002,
 
-        [ParentCombo(SummonerDemiAoESummonsFeature)]
-        [CustomComboInfo("AOE Demi Attacks on AOE Combo", "Adds Astral Flare/Brand of Purgatory to the AOE Combo.", SMN.JobID, 0, "BRRRR", "Upgrade!")]
+        [ParentCombo(SummonerAOEComboFeature)]
+        [CustomComboInfo("AOE Demi Attacks on AOE Combo", "Adds Astral Flare/Brand of Purgatory to the AOE Combo.", SMN.JobID, 4, "BRRRR", "Upgrade!")]
         SummonerAOEDemiFeature = 17003,
 
         [ParentCombo(EgisOnRuinFeature)]
@@ -2107,7 +2107,7 @@ namespace XIVSlothComboPlugin
         SummonerEgiSummonsonMainFeature = 17016,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Energy Siphon/Painflare on Main Combo", "Adds Energy Siphon/Painflare to AOE Combo", SMN.JobID, 0, "", "We'll play the game for you. Shush, now")]
+        [CustomComboInfo("Energy Siphon/Painflare on Main Combo", "Adds Energy Siphon/Painflare to AOE Combo", SMN.JobID, 1, "", "We'll play the game for you. Shush, now")]
         SummonerESAOEFeature = 17017,
 
         [ParentCombo(SummonerMainComboFeature)]
@@ -2115,7 +2115,7 @@ namespace XIVSlothComboPlugin
         SearingLightonRuinFeature = 17018,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Searing Light AoE Option", "Adds Searing Light to the AOE Combo.", SMN.JobID, 0, "Our Eyes!", "Yay, we're all legally blind!")]
+        [CustomComboInfo("Searing Light AoE Option", "Adds Searing Light to the AOE Combo.", SMN.JobID, 2, "Our Eyes!", "Yay, we're all legally blind!")]
         BuffOnSimpleAoESummoner = 17019,
 
         [ParentCombo(SummonerMainComboFeature)]
@@ -2123,11 +2123,11 @@ namespace XIVSlothComboPlugin
         SummonerDemiSummonsFeature = 17020,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Demi Summons AOE Combo", "Adds Demi Summons to the AOE Combo.", SMN.JobID, 0, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
+        [CustomComboInfo("Demi Summons AOE Combo", "Adds Demi Summons to the AOE Combo.", SMN.JobID, 3, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
         SummonerDemiAoESummonsFeature = 17021,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Egi Summons on AOE Combo", "Adds Egi Summons to AOE Combo", SMN.JobID, 0, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
+        [CustomComboInfo("Egi Summons on AOE Combo", "Adds Egi Summons to AOE Combo", SMN.JobID, 5, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
         EgisOnAOEFeature = 17022,
 
         [ParentCombo(EgisOnRuinFeature)]
@@ -2144,8 +2144,8 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Pooled Festers Feature", "Pools Festers/Energy Drain for Searing Light/2 min windows.", SMN.JobID, 0)]
         SummonerEDPoolonMainFeature = 17025,
 
-        [ParentCombo(EgisOnAOEFeature)]
-        [CustomComboInfo("Precious Brilliance on AOE Combo", "Adds Egi attacks (Precious Brilliance) to AOE Combo.", SMN.JobID, 0)]
+        [ParentCombo(SummonerAOEComboFeature)]
+        [CustomComboInfo("Precious Brilliance on AOE Combo", "Adds Egi attacks (Precious Brilliance) to AOE Combo.", SMN.JobID, 6)]
         SummonerEgiAttacksAOEFeature = 17026,
 
         [ConflictingCombos(AllCasterRaiseFeature)]

--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -7,6 +7,7 @@ using Dalamud.Plugin;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Threading.Tasks;
 
 namespace XIVSlothComboPlugin
 {
@@ -55,8 +56,15 @@ namespace XIVSlothComboPlugin
                 ShowInHelp = true,
             });
 
+            Service.ClientState.Login += PrintLoginMessage;
+            
+        }
+
+        private void PrintLoginMessage(object? sender, EventArgs e)
+        {
             if (!Service.Configuration.HideMessageOfTheDay)
-            PrintMotD();
+                Task.Delay(TimeSpan.FromSeconds(3)).ContinueWith(task => PrintMotD());
+
         }
 
         private void PrintMotD()


### PR DESCRIPTION
[PVP]
Makes sure to disable the PVP flag if you don't have a party when on a Frontlines map (to bug fix any quests that take you to a solo instance on a Frontlines map). #599 
WAR Burst Mode now actually uses the full default combo and not just Heavy Swing. Plus tweaks to enable weaving. #606 

[SMN]
Mini-rework to the `Enable AOE Combo Features` to enable using summon abilities without requiring the summon egi feature enabled first.
Adds 6 options to the `Searing Light AoE option` to decide which phase to use the ability in.

[Plugin]
MOTD now fires off 3 seconds after logging in rather than right away.