### PR TITLE
SAM and WAR Features

### DIFF
--- a/XIVSlothCombo/Combos/ALL.cs
+++ b/XIVSlothCombo/Combos/ALL.cs
@@ -9,6 +9,7 @@ namespace XIVSlothComboPlugin.Combos
         public const uint
             Rampart = 7531,
             SecondWind = 7541,
+            TrueNorth = 7546,
             Addle = 7560,
             Swiftcast = 7561,
             LucidDreaming = 7562,
@@ -44,7 +45,8 @@ namespace XIVSlothComboPlugin.Combos
                 Swiftcast = 167,
                 Rampart = 1191,
                 Peloton = 1199,
-                LucidDreaming = 1204;
+                LucidDreaming = 1204,
+                TrueNorth = 1250;
         }
 
         public static class Debuffs
@@ -81,7 +83,8 @@ namespace XIVSlothComboPlugin.Combos
                 Feint = 22,
                 HeadGraze = 24,
                 Rescue = 48,
-                Shirk = 48;
+                Shirk = 48,
+                TrueNorth = 50;
         }
     }
 

--- a/XIVSlothCombo/Combos/SAM.cs
+++ b/XIVSlothCombo/Combos/SAM.cs
@@ -99,6 +99,8 @@ namespace XIVSlothComboPlugin.Combos
             public const string
                 SamKenkiOvercapAmount = "SamKenkiOvercapAmount";
             public const string
+                SamAOEKenkiOvercapAmount = "SamAOEKenkiOvercapAmount";
+            public const string
                 SamFillerCombo = "SamFillerCombo";
         }
     }
@@ -114,8 +116,14 @@ namespace XIVSlothComboPlugin.Combos
                 var gauge = GetJobGauge<SAMGauge>();
                 var SamKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamKenkiOvercapAmount);
 
-                if (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount && CanWeave(actionID) && level >= SAM.Levels.Shinten)
+                if (CanWeave(actionID))
+                {
+                    if (IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) && GetBuffStacks(SAM.Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
+                        return All.TrueNorth;
+                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount && level >= SAM.Levels.Shinten)
                         return SAM.Shinten;
+                }
+
                 if (HasEffect(SAM.Buffs.MeikyoShisui))
                     return SAM.Yukikaze;
 
@@ -191,7 +199,8 @@ namespace XIVSlothComboPlugin.Combos
                     //Stops waste if you use Iaijutsu or Ogi and you've got a Kaeshi ready
                     if (!inOpener)
                     {
-
+                        if (IsEnabled(CustomComboPreset.SamuraiOgiNamikiriSTFeature) && (gauge.Kaeshi == Kaeshi.NAMIKIRI))
+                            return OriginalHook(SAM.TsubameGaeshi);
                         if (IsEnabled(CustomComboPreset.IaijutsuSTFeature) && (gauge.Kaeshi == Kaeshi.GOKEN || gauge.Kaeshi == Kaeshi.SETSUGEKKA))
                             return OriginalHook(SAM.TsubameGaeshi);
                     }
@@ -405,6 +414,9 @@ namespace XIVSlothComboPlugin.Combos
                             //oGCDs
                             if (CanSpellWeave(actionID))
                             {
+                                if (IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) &&GetBuffStacks(SAM.Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
+                                    return All.TrueNorth;
+
                                 //Senei Features
                                 if (IsEnabled(CustomComboPreset.SeneionST) && gauge.Kenki >= 25 && IsOffCooldown(SAM.Senei) && level >= SAM.Levels.Senei)
                                 {
@@ -454,7 +466,7 @@ namespace XIVSlothComboPlugin.Combos
                             {
                                 if (gauge.Kaeshi == Kaeshi.SETSUGEKKA && level >= SAM.Levels.TsubameGaeshi && GetRemainingCharges(SAM.TsubameGaeshi) > 0)
                                     return OriginalHook(SAM.TsubameGaeshi);
-                                if (!this.IsMoving && (((oneSeal || oneSeal && meikyostacks == 2) && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) <= 10) || threeSeal))
+                                if (!this.IsMoving && (((oneSeal || oneSeal && meikyostacks == 2) && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) <= 10) || (threeSeal && level >= SAM.Levels.Setsugekka)))
                                     return OriginalHook(SAM.Iaijutsu);
                             }
 
@@ -522,8 +534,13 @@ namespace XIVSlothComboPlugin.Combos
 
             if (actionID == SAM.Kasha)
             {
-                if (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount && CanWeave(actionID) && level >= SAM.Levels.Shinten)
-                    return SAM.Shinten;
+                if (CanWeave(actionID))
+                {
+                    if (IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) && GetBuffStacks(SAM.Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
+                        return All.TrueNorth;
+                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount && level >= SAM.Levels.Shinten)
+                        return SAM.Shinten;
+                }
                 if (HasEffect(SAM.Buffs.MeikyoShisui))
                     return SAM.Kasha;
 
@@ -552,7 +569,7 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID == SAM.Mangetsu)
             {
                 var gauge = GetJobGauge<SAMGauge>();
-                var SamKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamKenkiOvercapAmount);
+                var SamAOEKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamAOEKenkiOvercapAmount);
 
                 //oGCD Features
                 if (CanSpellWeave(actionID))
@@ -561,7 +578,7 @@ namespace XIVSlothComboPlugin.Combos
                         return SAM.Guren;
                     if (IsEnabled(CustomComboPreset.SamuraiIkishotenonmaincombo) && gauge.Kenki <= 50 && IsOffCooldown(SAM.Ikishoten) && level >= SAM.Levels.Ikishoten)
                         return SAM.Ikishoten;
-                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeatureAoe) && gauge.Kenki >= SamKenkiOvercapAmount && level >= SAM.Levels.Kyuten)
+                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeatureAoe) && gauge.Kenki >= SamAOEKenkiOvercapAmount && level >= SAM.Levels.Kyuten)
                             return SAM.Kyuten;
                     if (IsEnabled(CustomComboPreset.SamuraiShoha2AOEFeature) && level >= SAM.Levels.Shoha2 && gauge.MeditationStacks == 3)
                         return SAM.Shoha2;
@@ -615,19 +632,56 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID == SAM.Oka)
             {
                 var gauge = GetJobGauge<SAMGauge>();
-                var SamKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamKenkiOvercapAmount);
+                var SamAOEKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamAOEKenkiOvercapAmount);
 
                 if (CanWeave(actionID))
                 {
-                    if (IsEnabled(CustomComboPreset.SamuraiIkishotenonmaincombo) && gauge.Kenki <= 50 && IsOffCooldown(SAM.Ikishoten) && level >= SAM.Levels.Ikishoten)
-                        return SAM.Ikishoten;
-
-                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeatureAoe) && gauge.Kenki >= SamKenkiOvercapAmount && level >= SAM.Levels.Kyuten)
+                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeatureAoe) && IsNotEnabled(CustomComboPreset.SamTwoTargetFeature) && gauge.Kenki >= SamAOEKenkiOvercapAmount && level >= SAM.Levels.Kyuten)
                             return SAM.Kyuten;
                 }
 
-                if (HasEffect(SAM.Buffs.MeikyoShisui))
+                if (HasEffect(SAM.Buffs.MeikyoShisui) && IsNotEnabled(CustomComboPreset.SamTwoTargetFeature))
                     return SAM.Oka;
+
+                //Two Target Rotation
+                if (IsEnabled(CustomComboPreset.SamTwoTargetFeature))
+                {
+                    if (CanSpellWeave(actionID))
+                    {
+                        if (level >= SAM.Levels.Senei && gauge.Kenki >= 25 && IsOffCooldown(SAM.Senei))
+                            return SAM.Senei;
+                        if (level >= SAM.Levels.Shinten && gauge.Kenki >= 25)
+                            return SAM.Shinten;
+                        if (level >= SAM.Levels.Shoha && gauge.MeditationStacks == 3)
+                            return SAM.Shoha;
+                    }
+
+                    if (HasEffect(SAM.Buffs.MeikyoShisui))
+                    {
+                        if (gauge.Sen.HasFlag(Sen.SETSU) == false && level >= SAM.Levels.Yukikaze)
+                            return SAM.Yukikaze;
+                        if (gauge.Sen.HasFlag(Sen.GETSU) == false && level >= SAM.Levels.Mangetsu)
+                            return SAM.Mangetsu;
+                        if (gauge.Sen.HasFlag(Sen.KA) == false && level >= SAM.Levels.Oka)
+                            return SAM.Oka;
+                    }
+
+                    if (level >= SAM.Levels.TsubameGaeshi && gauge.Kaeshi == Kaeshi.SETSUGEKKA && GetRemainingCharges(SAM.TsubameGaeshi) > 0)
+                        return OriginalHook(SAM.TsubameGaeshi);
+                    if (level >= SAM.Levels.Setsugekka && OriginalHook(SAM.Iaijutsu) == SAM.Setsugekka)
+                        return OriginalHook(SAM.Iaijutsu);
+
+                    if (comboTime > 0)
+                    {
+                        if (lastComboMove == SAM.Hakaze && level >= SAM.Levels.Yukikaze)
+                            return SAM.Yukikaze;
+                        if (lastComboMove is SAM.Fuko or SAM.Fuga && gauge.Sen.HasFlag(Sen.GETSU) == false && level >= SAM.Levels.Mangetsu)
+                            return SAM.Mangetsu;
+                    }
+
+                    if (gauge.Sen.HasFlag(Sen.SETSU) == false)
+                        return SAM.Hakaze;
+                }
 
                 if (comboTime > 0 && level >= SAM.Levels.Oka)
                 {

--- a/XIVSlothCombo/Combos/SAM.cs
+++ b/XIVSlothCombo/Combos/SAM.cs
@@ -169,6 +169,9 @@ namespace XIVSlothComboPlugin.Combos
                         return SAM.Enpi;
                 }
 
+                if (CanSpellWeave(actionID) && IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) && GetBuffStacks(SAM.Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
+                    return All.TrueNorth;
+
                 if (!InCombat())
                 {
                     hasDied = false;
@@ -414,9 +417,6 @@ namespace XIVSlothComboPlugin.Combos
                             //oGCDs
                             if (CanSpellWeave(actionID))
                             {
-                                if (IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) &&GetBuffStacks(SAM.Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
-                                    return All.TrueNorth;
-
                                 //Senei Features
                                 if (IsEnabled(CustomComboPreset.SeneionST) && gauge.Kenki >= 25 && IsOffCooldown(SAM.Senei) && level >= SAM.Levels.Senei)
                                 {

--- a/XIVSlothCombo/Combos/SAM.cs
+++ b/XIVSlothCombo/Combos/SAM.cs
@@ -592,7 +592,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 if (IsEnabled(CustomComboPreset.TenkaGokenAOEFeature) && level >= SAM.Levels.TenkaGoken)
                 {
-                    if (!this.IsMoving && (OriginalHook(SAM.Iaijutsu) == SAM.TenkaGoken || OriginalHook(SAM.Iaijutsu) == SAM.Setsugekka))
+                    if (!this.IsMoving && (OriginalHook(SAM.Iaijutsu) == SAM.TenkaGoken || (OriginalHook(SAM.Iaijutsu) == SAM.Setsugekka && level >= SAM.Levels.Setsugekka)))
                         return OriginalHook(SAM.Iaijutsu);
                     if ((gauge.Kaeshi == Kaeshi.GOKEN || gauge.Kaeshi == Kaeshi.SETSUGEKKA) && level >= SAM.Levels.TsubameGaeshi && GetRemainingCharges(SAM.TsubameGaeshi) > 0)
                         return OriginalHook(SAM.TsubameGaeshi);

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -119,8 +119,13 @@ namespace XIVSlothComboPlugin.Combos
                             return WAR.Onslaught;
                     }
 
-                    if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady))
+                    if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady) && level >= WAR.Levels.PrimalRend)
+                    {
+                        if (IsEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature) && (GetTargetDistance() <= 1 || GetBuffRemainingTime(WAR.Buffs.PrimalRendReady) <= 10))
+                            return WAR.PrimalRend;
+                        if (IsNotEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature))
                         return WAR.PrimalRend;
+                    }
 
                     if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && level >= WAR.Levels.InnerBeast)
                     {
@@ -209,7 +214,13 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady) && level >= WAR.Levels.PrimalRend)
-                            return OriginalHook(WAR.PrimalRend);
+                        {
+                            if (IsEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature) && (GetTargetDistance() <= 3 || GetBuffRemainingTime(WAR.Buffs.PrimalRendReady) <= 10))
+                                return WAR.PrimalRend;
+                            if (IsNotEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature))
+                                return WAR.PrimalRend;
+                        }
+
                         if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && level >= WAR.Levels.SteelCyclone && (gauge >= 50 || HasEffect(WAR.Buffs.InnerRelease)))
                             return OriginalHook(WAR.SteelCyclone);
                     }

--- a/XIVSlothCombo/CombosPVP/SAMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/SAMPVP.cs
@@ -1,0 +1,85 @@
+﻿namespace XIVSlothComboPlugin.Combos
+{
+    internal static class SAMPvP
+    {
+        public const byte JobID = 34;
+
+        public const uint
+            KashakCombo = 58,
+            Yukikaze = 29523,
+            Gekko = 29524,
+            Kasha = 29525,
+            Hyosetsu = 29526,
+            Mangetsu = 29527,
+            Oka = 29528,
+            OgiNamikiri = 29530,
+            Soten = 29532,
+            Chiten = 29533,
+            Mineuchi = 29535,
+            MeikyoShisui = 29536,
+            Midare = 29529,
+            Kaeshi = 29531;
+
+        public static class Buffs
+        {
+            public const ushort
+                Placeholder = 1;
+        }
+
+        public static class Config
+        {
+            public const string
+                SamSotenCharges = "SamSotenCharges";
+        }
+
+        internal class SAMBurstMode : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SAMBurstMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+
+                if (actionID == SAMPvP.MeikyoShisui)
+                {
+                    var sotenCharges = Service.Configuration.GetCustomIntValue(SAMPvP.Config.SamSotenCharges);
+                    //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+
+                    if (IsOffCooldown(SAMPvP.MeikyoShisui))
+                        return OriginalHook(SAMPvP.MeikyoShisui);
+                    if (IsEnabled(CustomComboPreset.SAMBurstChitenFeature) && IsOffCooldown(SAMPvP.Chiten))
+                        return OriginalHook(SAMPvP.Chiten);
+                    if (GetCooldownRemainingTime(SAMPvP.Soten) < 1 && CanWeave(SAMPvP.Yukikaze))
+                        return OriginalHook(SAMPvP.Soten);
+                    if (OriginalHook(SAMPvP.MeikyoShisui) == SAMPvP.Midare)
+                        return OriginalHook(SAMPvP.MeikyoShisui);
+                    if (IsEnabled(CustomComboPreset.SAMBurstStunFeature) && IsOffCooldown(SAMPvP.Mineuchi))
+                        return OriginalHook(SAMPvP.Mineuchi);
+                    if (IsOffCooldown(SAMPvP.OgiNamikiri))
+                        return OriginalHook(SAMPvP.OgiNamikiri);
+                    if (GetRemainingCharges(SAMPvP.Soten) > sotenCharges)
+                        return OriginalHook(SAMPvP.Soten);
+                    if (OriginalHook(SAMPvP.OgiNamikiri) == SAMPvP.Kaeshi)
+                        return OriginalHook(SAMPvP.OgiNamikiri);
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class SAMGapCloserFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SAMGapCloserFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is SAMPvP.Yukikaze or SAMPvP.Gekko or SAMPvP.Kasha or SAMPvP.Hyosetsu or SAMPvP.Mangetsu or SAMPvP.Oka)
+                {
+                    if (!InMeleeRange() && GetRemainingCharges(SAMPvP.Soten) > 0)
+                        return OriginalHook(SAMPvP.Soten);
+                }
+
+                return actionID;
+            }
+        }
+    }
+}

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -831,9 +831,9 @@ namespace XIVSlothComboPlugin
             // ====================================================================================
             #region SAMURAI
             if (preset == CustomComboPreset.SamuraiOvercapFeature && enabled)
-                ConfigWindowFunctions.DrawSliderInt(0, 85, SAM.Config.SamKenkiOvercapAmount, "Set the Kenki overcap amount.");
+                ConfigWindowFunctions.DrawSliderInt(0, 85, SAM.Config.SamKenkiOvercapAmount, "Set the Kenki overcap amount for ST combos.");
             if (preset == CustomComboPreset.SamuraiOvercapFeatureAoe && enabled)
-                ConfigWindowFunctions.DrawSliderInt(0, 85, SAM.Config.SamKenkiOvercapAmount, "Set the Kenki overcap amount.");
+                ConfigWindowFunctions.DrawSliderInt(0, 85, SAM.Config.SamAOEKenkiOvercapAmount, "Set the Kenki overcap amount for AOE combos.");
             //Fillers
             if (preset == CustomComboPreset.SamuraiFillersonMainCombo)
                 ConfigWindowFunctions.DrawRadioButton(SAM.Config.SamFillerCombo, "2.14+", "2 Filler GCDs", 1);

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -834,6 +834,8 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawSliderInt(0, 85, SAM.Config.SamKenkiOvercapAmount, "Set the Kenki overcap amount for ST combos.");
             if (preset == CustomComboPreset.SamuraiOvercapFeatureAoe && enabled)
                 ConfigWindowFunctions.DrawSliderInt(0, 85, SAM.Config.SamAOEKenkiOvercapAmount, "Set the Kenki overcap amount for AOE combos.");
+            if (preset == CustomComboPreset.SAMBurstMode && enabled)
+                ConfigWindowFunctions.DrawSliderInt(0, 2, SAMPvP.Config.SamSotenCharges, "How many charges of Soten to keep ready? (0 = Use All).");
             //Fillers
             if (preset == CustomComboPreset.SamuraiFillersonMainCombo)
                 ConfigWindowFunctions.DrawRadioButton(SAM.Config.SamFillerCombo, "2.14+", "2 Filler GCDs", 1);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1895,7 +1895,7 @@ namespace XIVSlothComboPlugin
             SamuraiGekkoCDs = 15099,
 
                 [ParentCombo(SamuraiGekkoCDs)]
-                [CustomComboInfo("Ikishoten on Main Combo", "Adds Ikishoten to Single Target/AoE combos when at or below 50 Kenki.\nWill dump Kenki at 10 seconds left to allow Ikishoten to be used.", SAM.JobID, 0, "Gauge pls", "You heard me. Gauge pls")]
+                [CustomComboInfo("Ikishoten on Main Combo", "Adds Ikishoten to Gekko and Mangetsu combos when at or below 50 Kenki.\nWill dump Kenki at 10 seconds left to allow Ikishoten to be used.", SAM.JobID, 0, "Gauge pls", "You heard me. Gauge pls")]
                 SamuraiIkishotenonmaincombo = 15009,
 
                 [ParentCombo(SamuraiGekkoCDs)]
@@ -1965,6 +1965,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Oka Combo", "Replace Oka with its combo chain.", SAM.JobID, 0, "Okeh Combo", "Okeh")]
         SamuraiOkaCombo = 15026,
 
+            [ParentCombo(SamuraiOkaCombo)]    
+            [CustomComboInfo("Oka Two Target Rotation Feature", "Adds the Yukikaze Combo, Mangetsu Combo, Senei, Shinten, and Shoha to Oka Combo.\nOptimal for two targets and when 86 and above.", SAM.JobID, 0)]
+            SamTwoTargetFeature = 150261,
+
         //CD Features
         [CustomComboInfo("Jinpu/Shifu Feature", "Replace Meikyo Shisui with Jinpu or Shifu depending on what is needed.", SAM.JobID, 0, "Jumpup/Sitdown", "Work those glutes.")]
         SamuraiJinpuShifuFeature = 15027,
@@ -2008,7 +2012,11 @@ namespace XIVSlothComboPlugin
         SamuraiYatenFeature = 15036,
         
         [CustomComboInfo("Ikishoten Namikiri Feature", "Replace Ikishoten with Ogi Namikiri and then Kaeshi Namikiri when available.\nIf you have full Meditation stacks, Ikishoten becomes Shoha while you have Ogi Namikiri ready.", SAM.JobID, 0, "Sticky-icky-shoten", "Wait, you guys use meditation?")]
-        SamuraiIkishotenNamikiriFeature = 150367,
+        SamuraiIkishotenNamikiriFeature = 15037,
+
+        [CustomComboInfo("True North Feature", "Adds True North on all ST Combos if Meikyo Shisui's buff is on you.", SAM.JobID, 0)]
+        SamuraiTrueNorthFeature = 15038,
+        
 
         #endregion
         // ====================================================================================
@@ -2235,6 +2243,11 @@ namespace XIVSlothComboPlugin
         [ParentCombo(WarriorInfuriateFellCleave)]
         [CustomComboInfo("Use Inner Release Stacks First", "Prevents the use of Infuriate while you have Inner Release stacks available.", WAR.JobID, 0, "Don't blow it all in one place.", "Save some for later.")]
         WarriorUseInnerReleaseFirst = 18022,
+
+        [ParentCombo(WarriorPrimalRendFeature)]
+        [CustomComboInfo("Primal Rend Melee Feature", "Uses Primal Rend when in the target's target ring (1 yalm) and closer otherwise will use it when buff is less than 10 seconds.", WAR.JobID, 0, "Don't blow it all in one place.", "Save some for later.")]
+        WarriorPrimalRendCloseRangeFeature = 18023,
+        
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2498,6 +2498,25 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Curing Waltz Burst Option", "Adds Curing Waltz to the main combo when available, and your HP is at or below the set percentage.", DNC.JobID)]
         DNCCuringWaltzOption = 80072,
 
+        // SAM
+
+        [SecretCustomCombo]
+        [CustomComboInfo("Burst Mode", "Adds Meikyo Shisui, Midare:Setsugekka, Ogi Namikiri, Kaeshi: Namikiri and Soten to Meikyo Shisui.", SAM.JobID)]
+        SAMBurstMode = 80080,
+
+            [SecretCustomCombo]
+            [ParentCombo(SAMBurstMode)]
+            [CustomComboInfo("Chiten to Burst Mode", "Adds Chiten to the Burst Mode.", SAM.JobID)]
+            SAMBurstChitenFeature = 80081,
+            [SecretCustomCombo]
+            [ParentCombo(SAMBurstMode)]
+            [CustomComboInfo("Mineuchi to Burst Mode", "Adds Mineuchi to the Burst Mode.", SAM.JobID)]
+            SAMBurstStunFeature = 80082,
+
+        [SecretCustomCombo]
+        [CustomComboInfo("Soten Gap Closer Feature", "Adds Soten when outside melee range to the Kasha Combo.", SAM.JobID)]
+        SAMGapCloserFeature = 80083,
+
         /*
         [SecretCustomCombo] // I'm probably gonna remove this entirely
         [ParentCombo(DNCBurstMode)]


### PR DESCRIPTION
SAM: Two Target Feature added to Oka Combo
SAM: True North Feature added
SAM: Separated sliders for AOE and ST overcap
SAM: Fixed Setsugekka level check for One Button Rotation
SAMPvP: Burst Mode and Gap Closer Features added
WAR: Added Primal Rend Melee Feature which activates Primal Rend when under the boss