### PR TITLE
[RDM] Couple enhancements

### DIFF
--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -1202,7 +1202,7 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is RDM.Verthunder or RDM.Veraero or RDM.Scatter or RDM.Verthunder3 or RDM.Veraero3 or RDM.Impact)
+            if (actionID is RDM.Verthunder or RDM.Veraero or RDM.Scatter or RDM.Verthunder3 or RDM.Veraero3 or RDM.Impact or RDM.Jolt or RDM.Jolt2)
             {
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(RDM.Config.RdmLucidMpThreshold);
 

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -868,7 +868,7 @@ namespace XIVSlothComboPlugin.Combos
                         return RDM.ContreSixte;
                 }
 
-                if ((lastComboMove is RDM.Riposte or RDM.EnchantedRiposte) && gauge.WhiteMana >= 30 && gauge.BlackMana >= 30)
+                if ((lastComboMove is RDM.Riposte or RDM.EnchantedRiposte) && gauge.WhiteMana >= 30 && gauge.BlackMana >= 30 && (gauge.ManaStacks == 1 || level < RDM.Levels.ManaStack))
                 {
                     if (level >= RDM.Levels.Zwerchhau)
                         return OriginalHook(RDM.Zwerchhau);
@@ -877,7 +877,7 @@ namespace XIVSlothComboPlugin.Combos
                         return RDM.EnchantedRiposte;
                 }
 
-                if ((lastComboMove is RDM.Zwerchhau or RDM.EnchantedRiposte) && gauge.WhiteMana >= 15 && gauge.BlackMana >= 15)
+                if ((lastComboMove is RDM.Zwerchhau or RDM.EnchantedRiposte) && gauge.WhiteMana >= 15 && gauge.BlackMana >= 15 && (gauge.ManaStacks == 2 || level < RDM.Levels.ManaStack))
                 {
                     if (level >= RDM.Levels.Redoublement)
                         return OriginalHook(RDM.Redoublement);
@@ -1097,17 +1097,15 @@ namespace XIVSlothComboPlugin.Combos
                 }
 
                 if (!HasEffect(RDM.Buffs.Dualcast) && level >= RDM.Levels.Moulinet &&
-                    lastComboMove is not RDM.Verholy or RDM.Verflare or RDM.Scorch)
-                {
-                    if (gauge.WhiteMana >= 20 && gauge.BlackMana >= 20 && lastComboMove == RDM.Moulinet &&
-                        lastComboMove is not (RDM.Verholy or RDM.Verflare or RDM.Scorch) && (gauge.ManaStacks != 3 || level < RDM.Levels.ManaStack))
+                    lastComboMove is not (RDM.Verholy or RDM.Verflare or RDM.Scorch))
+                    {
+                    if (gauge.WhiteMana >= 20 && gauge.BlackMana >= 20 && (gauge.ManaStacks == 2 || level < RDM.Levels.ManaStack))
                         return RDM.EnchantedMoulinet;
 
-                    if (gauge.WhiteMana >= 40 && gauge.BlackMana >= 40 && lastComboMove == RDM.Moulinet &&
-                        lastComboMove is not (RDM.Verholy or RDM.Verflare or RDM.Scorch) && (gauge.ManaStacks != 3 || level < RDM.Levels.ManaStack))
+                    if (gauge.WhiteMana >= 40 && gauge.BlackMana >= 40 && (gauge.ManaStacks == 1 || level < RDM.Levels.ManaStack))
                         return RDM.EnchantedMoulinet;
 
-                    if (gauge.WhiteMana >= 60 && gauge.BlackMana >= 60 && InMeleeRange())
+                    if (gauge.WhiteMana >= 60 && gauge.BlackMana >= 60 && InMeleeRange() && (gauge.ManaStacks == 0 || level < RDM.Levels.ManaStack))
                         return RDM.EnchantedMoulinet;
                 }
 
@@ -1202,7 +1200,7 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is RDM.Verthunder or RDM.Veraero or RDM.Scatter or RDM.Verthunder3 or RDM.Veraero3 or RDM.Impact or RDM.Jolt or RDM.Jolt2)
+            if (actionID is RDM.Verthunder or RDM.Veraero or RDM.Scatter or RDM.Verthunder3 or RDM.Veraero3 or RDM.Verthunder2 or RDM.Veraero2 or RDM.Impact or RDM.Jolt or RDM.Jolt2)
             {
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(RDM.Config.RdmLucidMpThreshold);
 
@@ -1211,7 +1209,7 @@ namespace XIVSlothComboPlugin.Combos
                     showLucid = true;
                 }
 
-                if (showLucid && CanSpellWeave(actionID) && HasCondition(ConditionFlag.InCombat) && IsOffCooldown(All.LucidDreaming) 
+                if (showLucid && CanSpellWeave(actionID) && HasCondition(ConditionFlag.InCombat) && IsOffCooldown(All.LucidDreaming) && !HasEffect(RDM.Buffs.Dualcast) 
                     && lastComboMove != RDM.EnchantedRiposte && lastComboMove != RDM.EnchantedZwerchhau 
                     && lastComboMove != RDM.EnchantedRedoublement && lastComboMove != RDM.Verflare 
                     && lastComboMove != RDM.Verholy && lastComboMove != RDM.Scorch) // Change abilities to Lucid Dreaming for entire weave window

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -64,6 +64,7 @@ namespace XIVSlothComboPlugin.Combos
             public const byte
                 Jolt = 2,
                 Verthunder = 4,
+                CorpsACorps = 6,
                 Veraero = 10,
                 Verthunder2 = 18,
                 Veraero2 = 22,
@@ -146,21 +147,25 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID is RDM.Redoublement or RDM.Riposte or RDM.Zwerchhau)
             {
                 var gauge = GetJobGauge<RDMGauge>();
-                var engagementCD = GetCooldown(RDM.Engagement);
                 var canWeave = CanWeave(OriginalHook(actionID));
 
-               if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
-               {
+                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && canWeave && GetCooldownRemainingTime(RDM.Engagement) < 35 &&
+                     InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte) && level >= RDM.Levels.Engagement && !HasEffect(RDM.Buffs.Dualcast))
+                    return RDM.Engagement;
+
+                if (IsEnabled(CustomComboPreset.RedMageCorpsACorpsFeature) && canWeave && GetCooldownRemainingTime(RDM.Corpsacorps) < 35 &&
+                    ((InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte)) ||
+                     (IsEnabled(CustomComboPreset.RedMageCorpsACorpsPullFeature) &&
+                     gauge.BlackMana >= 50 && gauge.WhiteMana >= 50)) && level >= RDM.Levels.CorpsACorps && !HasEffect(RDM.Buffs.Dualcast))
+                    return RDM.Corpsacorps;
+
+                if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
+                {
                     if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
                         return RDM.Fleche;
 
                     if (level >= RDM.Levels.ContreSixte && IsOffCooldown(RDM.ContreSixte))
                         return RDM.ContreSixte;
-               }
-
-                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && canWeave && engagementCD.CooldownRemaining < 35 && InMeleeRange())
-                {
-                    return RDM.Engagement;
                 }
 
                 if (IsEnabled(CustomComboPreset.RedMageMeleeComboPlus))
@@ -604,9 +609,18 @@ namespace XIVSlothComboPlugin.Combos
                 int white = gauge.WhiteMana;
                 int blackThreshold = white + IMBALANCE_DIFF_MAX;
                 int whiteThreshold = black + IMBALANCE_DIFF_MAX;
-                var engagementCD = GetCooldown(RDM.Engagement);
                 var canWeave = CanWeave(OriginalHook(actionID));
-                
+
+                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && canWeave && GetCooldownRemainingTime(RDM.Engagement) < 35 &&
+                    InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte) && level >= RDM.Levels.Engagement && !HasEffect(RDM.Buffs.Dualcast))
+                    return RDM.Engagement;
+
+                if (IsEnabled(CustomComboPreset.RedMageCorpsACorpsFeature) && canWeave && GetCooldownRemainingTime(RDM.Corpsacorps) < 35 &&
+                    ((InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte)) ||
+                     (IsEnabled(CustomComboPreset.RedMageCorpsACorpsPullFeature) &&
+                     gauge.BlackMana >= 60 && gauge.WhiteMana >= 60)) && level >= RDM.Levels.CorpsACorps && !HasEffect(RDM.Buffs.Dualcast))
+                    return RDM.Corpsacorps;
+
                 if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
                 {
                     if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
@@ -615,9 +629,6 @@ namespace XIVSlothComboPlugin.Combos
                     if (level >= RDM.Levels.ContreSixte && IsOffCooldown(RDM.ContreSixte))
                         return RDM.ContreSixte;
                 }
-
-                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && canWeave && engagementCD.CooldownRemaining < 35 && InMeleeRange())
-                    return RDM.Engagement;
 
                 if (lastComboMove is RDM.Scorch && level >= RDM.Levels.Resolution)
                     return RDM.Resolution;
@@ -673,7 +684,6 @@ namespace XIVSlothComboPlugin.Combos
                 RDMGauge gauge = GetJobGauge<RDMGauge>();
                 int black = gauge.BlackMana;
                 int white = gauge.WhiteMana;
-                var engagementCD = GetCooldown(RDM.Engagement);
                 var canWeave = CanWeave(actionID);
 
 
@@ -839,6 +849,16 @@ namespace XIVSlothComboPlugin.Combos
                     }
                 }
 
+                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && canWeave && GetCooldownRemainingTime(RDM.Engagement) < 35 &&
+                    InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte) && level >= RDM.Levels.Engagement && !HasEffect(RDM.Buffs.Dualcast))
+                    return RDM.Engagement;
+
+                if (IsEnabled(CustomComboPreset.RedMageCorpsACorpsFeature) && canWeave && GetCooldownRemainingTime(RDM.Corpsacorps) < 35 &&
+                    ((InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte)) || 
+                     (IsEnabled(CustomComboPreset.RedMageCorpsACorpsPullFeature) && 
+                     gauge.BlackMana >= 50 && gauge.WhiteMana >= 50)) && level >= RDM.Levels.CorpsACorps && !HasEffect(RDM.Buffs.Dualcast))
+                    return RDM.Corpsacorps;
+
                 if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave)
                 {
                     if (level >= RDM.Levels.Fleche && IsOffCooldown(RDM.Fleche))
@@ -847,10 +867,6 @@ namespace XIVSlothComboPlugin.Combos
                     if (level >= RDM.Levels.ContreSixte && IsOffCooldown(RDM.ContreSixte))
                         return RDM.ContreSixte;
                 }
-
-                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && canWeave && engagementCD.CooldownRemaining < 35 &&
-                    InMeleeRange() && level >= RDM.Levels.Engagement)
-                    return RDM.Engagement;
 
                 if ((lastComboMove is RDM.Riposte or RDM.EnchantedRiposte) && gauge.WhiteMana >= 30 && gauge.BlackMana >= 30)
                 {
@@ -1060,6 +1076,16 @@ namespace XIVSlothComboPlugin.Combos
                     SimpleRedMage.inOpener = false;
                     SimpleRedMage.step = 0;
                 }
+
+                if (IsEnabled(CustomComboPreset.RedMageEngagementFeature) && canWeave && GetCooldownRemainingTime(RDM.Engagement) < 35 &&
+                    InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte) && level >= RDM.Levels.Engagement && !HasEffect(RDM.Buffs.Dualcast))
+                    return RDM.Engagement;
+
+                if (IsEnabled(CustomComboPreset.RedMageCorpsACorpsFeature) && canWeave && GetCooldownRemainingTime(RDM.Corpsacorps) < 35 &&
+                    ((InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte)) ||
+                     (IsEnabled(CustomComboPreset.RedMageCorpsACorpsPullFeature) &&
+                     gauge.BlackMana >= 60 && gauge.WhiteMana >= 60)) && level >= RDM.Levels.CorpsACorps && !HasEffect(RDM.Buffs.Dualcast))
+                    return RDM.Corpsacorps;
 
                 if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
                 {

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1687,44 +1687,51 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Red Mage AoE Finisher", "Adds Finishers onto Moulinet and SmartCast AoE Feature.", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
         RedMageMeleeAoECombo = 13012,
 
-        [CustomComboInfo("Engagement Feature", "Adds Engagement in all melee combos. (Testing Only!)", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
+        [CustomComboInfo("Engagement Feature", "Adds Engagement in all melee combos.", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
         RedMageEngagementFeature = 13013,
 
+        [CustomComboInfo("Corps-a-Corps Feature", "Adds Corps-a-Corps in all melee combos.", RDM.JobID, 0, "Verraise -> Swiftcast", "Ah look, it's what you were always meant to do")]
+        RedMageCorpsACorpsFeature = 13014,
+
         [CustomComboInfo("Simple Red Mage Feature Single Target", "Combines Smartcast feature with melee combo on Verstone,Verfire or melee skills (This is not optimal until i find a solution for distance delay)", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
-        SimpleRedMage = 13014,
+        SimpleRedMage = 13015,
 
         [CustomComboInfo("Simple Red Mage Feature AoE", "Combines Smartcast AoE feature with melee AoE combo on Verthunder2/Veraero2 (This is not optimal until i find a solution for distance delay)", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
-        SimpleRedMageAoE = 13015,
+        SimpleRedMageAoE = 13016,
 
         [CustomComboInfo("Corps-A-corps/Displacement Feature", "Corps-A-corps becomes displacement when in melee range", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
-        RedMageMovementFeature = 13016,
+        RedMageMovementFeature = 13017,
 
         [ParentCombo(RedMageOgcdCombo)]
         [CustomComboInfo("oGCD Feature Everywhere", "Adds oGCD Feature to all other combos", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
-        RedMageOgcdComboOnCombos = 13017,
+        RedMageOgcdComboOnCombos = 13018,
 
         [ParentCombo(SimpleRedMage)]
         [CustomComboInfo("Verstone/Verfire Activation", "Add Acceleration and Swiftcast to Simple Red Mage to force activation of verstone or verfire effects when necessary.", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
-        SimpleRedMageFishing = 13018,
+        SimpleRedMageFishing = 13019,
 
         [ParentCombo(SimpleRedMageFishing)]
         [CustomComboInfo("Acceleration only", "Only use Acceleration to force verfire or verstone activations.", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
-        SimpleRedMageAccelOnlyFishing = 13019,
+        SimpleRedMageAccelOnlyFishing = 13020,
 
         [ParentCombo(SimpleRedMage)]
         [ConflictingCombos(RedMageVerprocOpenerSmartCastFeature)]
         [CustomComboInfo("Simple opener", "Do the optimal opener. [lv90 only]", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
-        SimpleRedMageOpener = 13020,
+        SimpleRedMageOpener = 13021,
 
         [ConflictingCombos(RedMageSmartSingleTargetCombo, RedMageVerprocCombo)]
         [CustomComboInfo("Jolt into Verproc", "Replaces Jolt with Verstone/Verfire, when proc is available and won't cause severe imbalance", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
-        RedMageJoltVerprocCombo = 13021,
+        RedMageJoltVerprocCombo = 13022,
 
         [CustomComboInfo("Lucid Dreaming Feature", "Add Lucid Dreaming to Veraero, Verthunder and Impact when below threshold.", RDM.JobID, 0, "Veraero / Verthunder / Impact -> Lucid Dreaming", "OOM? Git gud.")]
-        RedMageLucidOnJolt = 13022,
+        RedMageLucidOnJolt = 13023,
 
         [CustomComboInfo("RDM Alternative Raise Feature", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 0, "Swifty Verraise", "You're panicing right now, aren't you?")]
-        RedMageSwiftVerraise = 13023,
+        RedMageSwiftVerraise = 13024,
+
+        [ParentCombo(RedMageCorpsACorpsFeature)]
+        [CustomComboInfo("Pull to target", "When with enough mana to enter melee phase.", RDM.JobID, 0, "", "")]
+        RedMageCorpsACorpsPullFeature = 13025,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1723,7 +1723,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Jolt into Verproc", "Replaces Jolt with Verstone/Verfire, when proc is available and won't cause severe imbalance", RDM.JobID, 0, "Swiftcast -> Verraise", "Ah look, it's what you were always meant to do")]
         RedMageJoltVerprocCombo = 13022,
 
-        [CustomComboInfo("Lucid Dreaming Feature", "Add Lucid Dreaming to Veraero, Verthunder and Impact when below threshold.", RDM.JobID, 0, "Veraero / Verthunder / Impact -> Lucid Dreaming", "OOM? Git gud.")]
+        [CustomComboInfo("Lucid Dreaming Feature", "Add Lucid Dreaming to Veraero, Verthunder, Impact and Jolt when below threshold.", RDM.JobID, 0, "Veraero / Verthunder / Impact -> Lucid Dreaming", "OOM? Git gud.")]
         RedMageLucidOnJolt = 13023,
 
         [CustomComboInfo("RDM Alternative Raise Feature", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 0, "Swifty Verraise", "You're panicing right now, aren't you?")]


### PR DESCRIPTION
### RDM
- PVE
   - New feature
      - `Corps-a-Corps` feature to be used between melee GCDs , and an option to use to pull you to the target when ready to enter melee phase;
   - Tweaks
      - `Lucid Dreaming` feature changed to accommodate  AoE abilities for `Veraero` and `Verthunder` plus `jolt`;
      - Melee phases, its now possible to go from `ST` melee combo to  `AoE` and still get the finishers (of course breaking your melee combo but not losing your mana stacks) provide you have the mana for it;
         - `AoE` to `ST` is being considered but still not ETA;
         - Very niche, not optimal behavior , just use for trash and overworld things;