### PR TITLE
[SGE] Code Refactor & Combo Organization

### DIFF
--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -228,10 +228,9 @@ namespace XIVSlothComboPlugin.Combos
 
                 //Eukrasian Dosis.
                 //If we're too low level to use Eukrasia, we can stop here.
-                if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && (level >= SGE.Levels.Eukrasia))
+                if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && (level >= SGE.Levels.Eukrasia) && CurrentTarget is not null)
                 {
                     var OurTarget = CurrentTarget;
-                    if (OurTarget is null) return actionID;
                     //Check if our Target is there and not an enemy
                     if ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy)
                     {

--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -74,7 +74,7 @@ namespace XIVSlothComboPlugin.Combos
             EukrasianDosis3 = 2616;
         }
 
-        public static class Levels //Per 6.0 Patch https://na.finalfantasyxiv.com/jobguide/sage/
+        public static class Levels //Per 6.1 Patch https://na.finalfantasyxiv.com/jobguide/sage/
         {
             public const byte
                 Dosis = 1,
@@ -113,112 +113,87 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
-				        //GUI Customization Storage Names
-                CustomSGELucidDreaming = "CustomSGELucidDreaming",
-                CustomZoe = "CustomZoe",
-                CustomHaima = "CustomHaima",
-                CustomKrasis = "CustomKrasis",
-                CustomPepsis = "CustomPepsis",
-                CustomSoteria = "CustomSoteria",
-                CustomIxochole = "CustomIxochole",
-                CustomDiagnosis = "CustomDiagnosis",
-                CustomKerachole = "CustomKerachole",
-                CustomRhizomata = "CustomRhizomata",
-                CustomDruochole = "CustomDruochole",
-                CustomTaurochole = "CustomTaurochole";
+                //GUI Customization Storage Names
+                SGE_ST_Lucid = "SGE_ST_Lucid",
+                SGE_ST_Heal_Zoe = "SGE_ST_Heal_Zoe",
+                SGE_ST_Heal_Haima = "SGE_ST_Heal_Haima",
+                SGE_ST_Heal_Krasis = "SGE_ST_Heal_Krasis",
+                SGE_ST_Heal_Pepsis = "SGE_ST_Heal_Pepsis",
+                SGE_ST_Heal_Soteria = "SGE_ST_Heal_Soteria",
+                SGE_ST_Heal_Diagnosis = "SGE_ST_Heal_Diagnosis",
+                SGE_ST_Heal_Druochole = "SGE_ST_Heal_Druochole",
+                SGE_ST_Heal_Taurochole = "SGE_ST_Heal_Taurochole";
         }
     }
 
+    
     //SageKardiaFeature
-    //Soteria becomes Kardia when Kardia's Buff is not active and Soteria is on cooldown.
-    internal class SageKardiaFeature : CustomCombo
+    //Soteria becomes Kardia when Kardia's Buff is not active or Soteria is on cooldown.
+    internal class SageSoteriaKardia : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SageKardiaFeature;
-
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Kardia;
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is SGE.Soteria)
-            {
-                var soteriaCD = GetCooldown(SGE.Soteria);
-
-                if (HasEffect(SGE.Buffs.Kardia) && !soteriaCD.IsCooldown)
-                    return SGE.Soteria;
-
-                return SGE.Kardia;
-            }
-
-            return actionID;
+            if (actionID is SGE.Soteria && 
+                (!HasEffect(SGE.Buffs.Kardia) || IsOnCooldown(SGE.Soteria)) ) return SGE.Kardia;
+            else return actionID;
         }
     }
 
     //SageRhizomataFeature
     //Replaces all Addersgal using Abilities (Taurochole/Druochole/Ixochole/Kerachole) with Rhizomata if out of stacks of Addersgall
     //(Scholar speak: Replaces all Aetherflow abilities with Aetherflow when out)
-    internal class SageRhizomataFeature : CustomCombo
+    internal class SageRhizomata : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SageRhizomataFeature;
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Rhizo;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is SGE.Taurochole or SGE.Druochole or SGE.Ixochole or SGE.Kerachole)
-            {
-                if (level >= SGE.Levels.Rhizomata && GetJobGauge<SGEGauge>().Addersgall == 0)
-                        return SGE.Rhizomata;
-            }
-
-            return actionID;
+            if (actionID is SGE.Taurochole or SGE.Druochole or SGE.Ixochole or SGE.Kerachole &&
+                level >= SGE.Levels.Rhizomata &&
+                GetJobGauge<SGEGauge>().Addersgall == 0
+               ) return SGE.Rhizomata;
+            else return actionID;
         }
     }
-    //SageTauroDruoFeature
-    //Replaces Taurochole with Druocole when Taurochole is on cooldown or unavailable.
-    //(As of 6.0) Taurochole (single target massive insta heal w/ cooldown), Druochole (Single target insta heal)
-    internal class SageTauroDruoFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SageTauroDruoFeature;
 
+    //Druochole Upgrade to Taurochole (like a trait upgrade)
+    //Replaces Druocole with Taurochole when Taurochole is available
+    //(As of 6.0) Taurochole (single target massive insta heal w/ cooldown), Druochole (Single target insta heal)
+    internal class SageDruoTauro : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauro;
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is SGE.Taurochole)
-            {
-                var taurocholeCD = GetCooldown(SGE.Taurochole);
-
-                if (taurocholeCD.CooldownRemaining > 0 || level < SGE.Levels.Taurochole)
-                    return SGE.Druochole;
-            }
-
-            return actionID;
+            if (actionID is SGE.Druochole && level >= SGE.Levels.Taurochole && IsOffCooldown(SGE.Taurochole)) return SGE.Taurochole;
+            else return actionID;
         }
     }
 
     //Phlegma Replacement Feature
-    //Can replace Zero Charges/Stacks of Phlegma with Toxikon (if you can use it) or Dyskrasia 
-    internal class SagePhlegmaFeature : CustomCombo
+    //Replaces Zero Charges/Stacks of Phlegma with Toxikon (if you can use it) or Dyskrasia 
+    internal class SageAoEPhlegma : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SagePhlegmaFeature;
-
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_Phlegma;
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             if (actionID is SGE.Phlegma or SGE.Phlegma2 or SGE.Phlegma3)
             {
-                if ((IsEnabled(CustomComboPreset.SagePhlegmaToxikonFeature)   && level >= SGE.Levels.Toxikon)   || 
-                    (IsEnabled(CustomComboPreset.SagePhlegmaDyskrasiaFeature) && level >= SGE.Levels.Dyskrasia))
-
+                if (IsEnabled(CustomComboPreset.SGE_AoE_Toxikon) ||
+                    IsEnabled(CustomComboPreset.SGE_AoE_Dyskrasia))
                 {
-                    //If not targetting anything, use Dyskrasia Option if selected
-                    if ( IsEnabled(CustomComboPreset.SagePhlegmaDyskrasiaFeature) && (!HasTarget()) ) return OriginalHook(SGE.Dyskrasia);
-
                     //Check for "out of Phlegma stacks" 
-                    if (GetCooldown(OriginalHook(SGE.Phlegma)).RemainingCharges == 0) {
-                        //and if we have Adderstings to use for Toxikon
-                        //Has Priority over Dyskrasia
-                        if ( IsEnabled(CustomComboPreset.SagePhlegmaToxikonFeature) && (level >= SGE.Levels.Toxikon) && (GetJobGauge<SGEGauge>().Addersting > 0) )
-                        {
-                            return OriginalHook(SGE.Toxikon);  //OriginalHook used so game can use Toxikon 1 & 2
-                        }
-                        if ( IsEnabled(CustomComboPreset.SagePhlegmaDyskrasiaFeature) && level >= SGE.Levels.Dyskrasia ) 
-                        {
+                    if (GetCooldown(OriginalHook(SGE.Phlegma)).RemainingCharges == 0)
+                    {
+                        //Toxikon Checks
+                        if (IsEnabled(CustomComboPreset.SGE_AoE_Toxikon) &&
+                             level >= SGE.Levels.Toxikon &&
+                             GetJobGauge<SGEGauge>().Addersting > 0 &&
+                             HasBattleTarget() //Checking for a enemy target, hopefully allows a fallback to Dyskrasia (run and gun) if enabled, or targetting players
+                           ) return OriginalHook(SGE.Toxikon);  //OriginalHook used so game can use Toxikon 1 & 2
+
+                        if (IsEnabled(CustomComboPreset.SGE_AoE_Dyskrasia) && level >= SGE.Levels.Dyskrasia)
                             return OriginalHook(SGE.Dyskrasia); //OriginalHook used so game can use Dyskrasia 1 & 2
-                        }
                     }
                 }
             }
@@ -229,86 +204,71 @@ namespace XIVSlothComboPlugin.Combos
     //SageDPSFeature
     //Replaces Dosis with Eukrasia when the debuff on the target is < 3 seconds or not existing
     //Lucid Dreaming optional
-    internal class SageDPSFeature : CustomCombo
+    internal class SageSTDosis : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SageDPSFeature;
-
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_Dosis;
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is SGE.Dosis1 or SGE.Dosis2 or SGE.Dosis3)
+            if (actionID is SGE.Dosis1 or SGE.Dosis2 or SGE.Dosis3 &&
+               HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
             {
-                if (HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
-                {
+                //20220424 Tsusai: Lucid moved to the top (higher priority) similar to SCH
+                //Lucid should be usable incombat without a target
+                if (IsEnabled(CustomComboPreset.SGE_ST_Lucid) &&
+                    level >= All.Levels.LucidDreaming &&
+                    IsOffCooldown(All.LucidDreaming) &&
+                    LocalPlayer.CurrentMp <= GetComboSlider(SGE.Config.SGE_ST_Lucid)
+                   ) return All.LucidDreaming;
 
-                    //20220424 Tsusai: Lucid moved to the top (higher priority) similar to SCH
-                    //Lucid should be usable incombat without a target
-                    if (IsEnabled(CustomComboPreset.SageLucidFeature) && level >= All.Levels.LucidDreaming)
+                //If we're too low level to use Eukrasia, we can stop here.
+                if (level >= SGE.Levels.Eukrasia)
+                {
+                    var OurTarget = CurrentTarget;
+                    //Check if our Target is there and not an enemy
+                    if ((OurTarget is not null) && ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy))
                     {
-                        //Get slider configuration
-                        int MinMP = Service.Configuration.GetCustomIntValue(SGE.Config.CustomSGELucidDreaming, 8000);
-                        //Can we use?
-                        if (IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= MinMP && CanSpellWeave(actionID))
-                            return All.LucidDreaming;
+                        //If ToT is enabled, Check if ToT is not null
+                        if ((IsEnabled(CustomComboPreset.SGE_ST_DosisToT)) &&
+                            (CurrentTarget.TargetObject is not null) &&
+                            ((CurrentTarget.TargetObject as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy))
+                            //Set Ourtarget as the Target of Target
+                            OurTarget = CurrentTarget.TargetObject;
+                        //Our Target of Target wasn't hostile, our target isn't hostile, time to exit, nothing to check debuff on, fuck this shit we're out
+                        else return actionID;
                     }
 
-                    //If we're too low level to use Eukrasia, we can stop here.
-                    if (level >= SGE.Levels.Eukrasia)
+                    //Determine which Dosis debuff to check
+                    var DosisDebuffID = level switch
                     {
-                        var OurTarget = CurrentTarget;
-                        //Check if our Target is there and not an enemy
-                        if ((OurTarget is not null) && ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy))
+                        //Using FindEffect b/c we have a custom Target variable
+                        >= SGE.Levels.Dosis3 => FindEffect(SGE.Debuffs.EukrasianDosis3, OurTarget, LocalPlayer?.ObjectId),
+                        >= SGE.Levels.Dosis2 => FindEffect(SGE.Debuffs.EukrasianDosis2, OurTarget, LocalPlayer?.ObjectId),
+                        //Ekrasia Dosis unlocks with Eukrasia, checked at the start
+                        _ => FindEffect(SGE.Debuffs.EukrasianDosis1, OurTarget, LocalPlayer?.ObjectId),
+                    };
+
+                    if (HasEffect(SGE.Buffs.Eukrasia))
+                        return OriginalHook(SGE.Dosis1); //OriginalHook will autoselect the correct Dosis for us
+
+                    //Got our Debuff for our level, check for it and procede 
+                    if ((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3))
+                    {
+                        //Advanced Options Enabled to procede with auto-Eukrasia
+                        //Incompatible with ToT due to Enemy checks that are using CurrentTarget.
+                        if (IsEnabled(CustomComboPreset.SGE_ST_DosisAdv))
                         {
-                            //If ToT is enabled, Check if ToT is not null
-                            if ((IsEnabled(CustomComboPreset.SageDPSFeatureToT)) &&
-                                (CurrentTarget.TargetObject is not null) &&
-                                ((CurrentTarget.TargetObject as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy))
-                                //Set Ourtarget as the Target of Target
-                                OurTarget = CurrentTarget.TargetObject;
-                            //Our Target of Target wasn't hostile, our target isn't hostile, time to exit, nothing to check debuff on, fuck this shit we're out
-                            else return actionID;
-                        }
-
-
-                        //Eukrasian Dosis var
-                        Dalamud.Game.ClientState.Statuses.Status? DosisDebuffID;
-
-                        //Find which version of Eukrasian Dosis we need 
-                        //Tsusai Devnote: VS's code suggestion would use an older C# style, and might confuse a beginner...like me
-                        switch (level)
-                        {
-                            case >= SGE.Levels.Dosis3: //Using FindEffect b/c we have a custom Target variable
-                                DosisDebuffID = FindEffect(SGE.Debuffs.EukrasianDosis3, OurTarget, LocalPlayer?.ObjectId); 
-                                break;
-                            case >= SGE.Levels.Dosis2:
-                                DosisDebuffID = FindEffect(SGE.Debuffs.EukrasianDosis2, OurTarget, LocalPlayer?.ObjectId);
-                                break;
-                            default: //Ekrasia Dosis unlocks with Eukrasia, checked at the start
-                                DosisDebuffID = FindEffect(SGE.Debuffs.EukrasianDosis1, OurTarget, LocalPlayer?.ObjectId);
-                                break;
-                        }
-                        if (HasEffect(SGE.Buffs.Eukrasia))
-                            return OriginalHook(SGE.Dosis1); //OriginalHook will autoselect the correct Dosis for us
-
-                        //Got our Debuff for our level, check for it and procede 
-                        if ((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3))
-                        {
-                            //Advanced Test Options Enabled to procede with auto-Eukrasia
-                            //Incompatible with ToT due to Enemy checks that are using CurrentTarget.
-                            if (IsEnabled(CustomComboPreset.SageDPSFeatureAdvTest))
+                            var MaxHpValue = Service.Configuration.EnemyHealthMaxHp;
+                            var PercentageHpValue = Service.Configuration.EnemyHealthPercentage;
+                            var CurrentHpValue = Service.Configuration.EnemyCurrentHp;
+                            if ((DosisDebuffID is null && EnemyHealthMaxHp() > MaxHpValue && EnemyHealthPercentage() > PercentageHpValue) || 
+                                ((DosisDebuffID.RemainingTime <= 3) && EnemyHealthPercentage() > PercentageHpValue && EnemyHealthCurrentHp() > CurrentHpValue))
                             {
-                                var MaxHpValue = Service.Configuration.EnemyHealthMaxHp;
-                                var PercentageHpValue = Service.Configuration.EnemyHealthPercentage;
-                                var CurrentHpValue = Service.Configuration.EnemyCurrentHp;
-                                if ((DosisDebuffID is null && EnemyHealthMaxHp() > MaxHpValue && EnemyHealthPercentage() > PercentageHpValue) || 
-                                    ((DosisDebuffID.RemainingTime <= 3) && EnemyHealthPercentage() > PercentageHpValue && EnemyHealthCurrentHp() > CurrentHpValue))
-                                {
-                                    return SGE.Eukrasia;
-                                }
-                            }
-
-                            else //End Advanced Test Options. If it needs to be removed, leave the next line
                                 return SGE.Eukrasia;
+                            }
                         }
+
+                        else //End Advanced Options. If it needs to be removed, leave the next line
+                            return SGE.Eukrasia;
                     }
                 }
             }
@@ -317,89 +277,86 @@ namespace XIVSlothComboPlugin.Combos
     }
 
     //SageEgeiroFeature
-    //Swiftcast combos to Egeiro (Raise) while Swiftcast buff is active
-    internal class SageEgeiroFeature : CustomCombo
+    //Swiftcast combos to Egeiro (Raise) while Swiftcast is on cooldown
+    internal class SageRaise : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SageEgeiroFeature;
-
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Raise;
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is All.Swiftcast)
-            {
-                if (IsEnabled(CustomComboPreset.SageEgeiroFeature))
-                {
-                    if (HasEffect(All.Buffs.Swiftcast))
-                        return SGE.Egeiro;
-                }
-
-                return OriginalHook(All.Swiftcast);
-            }
-            return actionID;
+            if (actionID is All.Swiftcast && IsOnCooldown(All.Buffs.Swiftcast)) return SGE.Egeiro;
+            else return actionID;
         }
     }
 
     internal class SageSingleTargetHeal : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SageSingleTargetHealFeature;
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_Heal;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            var zoeCD = GetCooldown(SGE.Zoe);
-            var HaimaCD = GetCooldown(SGE.Haima);
-            var PepsisCD = GetCooldown(SGE.Pepsis);
-            var KrasisCD = GetCooldown(SGE.Krasis);
-            var SoteriaCD = GetCooldown(SGE.Soteria);
-            var RhizomataCD = GetCooldown(SGE.Rhizomata);
-            var DruocholeCD = GetCooldown(SGE.Druochole);
-            var TaurocholeCD = GetCooldown(SGE.Taurochole);
-            var Addersgall = GetJobGauge<SGEGauge>().Addersgall;
-            var Kardia = FindEffect(SGE.Buffs.Kardia);
-            var Kardion = FindTargetEffect(SGE.Buffs.Kardion);
-            var EukrasianDiagnosis = FindTargetEffect(SGE.Buffs.EukrasianDiagnosis);
-            var CustomZoe = Service.Configuration.GetCustomIntValue(SGE.Config.CustomZoe);
-            var CustomHaima = Service.Configuration.GetCustomIntValue(SGE.Config.CustomHaima);
-            var CustomKrasis = Service.Configuration.GetCustomIntValue(SGE.Config.CustomKrasis);
-            var CustomPepsis = Service.Configuration.GetCustomIntValue(SGE.Config.CustomPepsis);
-            var CustomSoteria = Service.Configuration.GetCustomIntValue(SGE.Config.CustomSoteria);
-            var CustomDiagnosis = Service.Configuration.GetCustomIntValue(SGE.Config.CustomDiagnosis);
-            var CustomDruochole = Service.Configuration.GetCustomIntValue(SGE.Config.CustomDruochole);
-            var CustomTaurochole = Service.Configuration.GetCustomIntValue(SGE.Config.CustomTaurochole);
-
             if (actionID is SGE.Diagnosis )
             {
+                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && 
+                    level >= SGE.Levels.Druochole &&
+                    IsOffCooldown(SGE.Druochole) &&
+                    GetJobGauge<SGEGauge>().Addersgall >= 1 && 
+                    EnemyHealthPercentage() <= GetComboSlider(SGE.Config.SGE_ST_Heal_Druochole)
+                   ) return SGE.Druochole;
 
-                if (IsEnabled(CustomComboPreset.CustomDruocholeFeature) && DruocholeCD.CooldownRemaining is 0 && Addersgall >= 1 && level >= SGE.Levels.Druochole && EnemyHealthPercentage() <= CustomDruochole)
-                    return SGE.Druochole;
+                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) &&
+                    level >= SGE.Levels.Taurochole && 
+                    IsOffCooldown(SGE.Taurochole) && 
+                    GetJobGauge<SGEGauge>().Addersgall >= 1 &&
+                    EnemyHealthPercentage() <= GetComboSlider(SGE.Config.SGE_ST_Heal_Taurochole)
+                   ) return SGE.Taurochole;
 
-                if (IsEnabled(CustomComboPreset.CustomTaurocholeFeature) && TaurocholeCD.CooldownRemaining is 0 && Addersgall >= 1 && level >= SGE.Levels.Taurochole && EnemyHealthPercentage() <= CustomTaurochole)
-                    return SGE.Taurochole;
+                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) &&
+                    level >= SGE.Levels.Rhizomata &&
+                    IsOffCooldown(SGE.Rhizomata) &&
+                    GetJobGauge<SGEGauge>().Addersgall is 0
+                   ) return SGE.Rhizomata;
 
-                if (IsEnabled(CustomComboPreset.RhizomataFeatureAoE) && RhizomataCD.CooldownRemaining is 0 && Addersgall is 0 && level >= SGE.Levels.Rhizomata)
-                    return SGE.Rhizomata;
-
-                if (IsEnabled(CustomComboPreset.AutoApplyKardia) && (Kardion is null) && (Kardia is null))
-                    return SGE.Kardia;
+                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Kardia) && 
+                    level >= SGE.Levels.Kardia &&
+                    FindEffect(SGE.Buffs.Kardia) is null &&
+                    FindTargetEffect(SGE.Buffs.Kardion) is null
+                   ) return SGE.Kardia;
 
                 if (CurrentTarget?.ObjectKind is ObjectKind.Player)
                 {
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) &&
+                        level >= SGE.Levels.Soteria &&
+                        IsOffCooldown(SGE.Soteria) && 
+                        EnemyHealthPercentage() <= GetComboSlider(SGE.Config.SGE_ST_Heal_Soteria)
+                       ) return SGE.Soteria;
 
-                    if (IsEnabled(CustomComboPreset.CustomSoteriaFeature) && SoteriaCD.CooldownRemaining is 0 && level >= SGE.Levels.Soteria && EnemyHealthPercentage() <= CustomSoteria)
-                        return SGE.Soteria;
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) &&
+                        level >= SGE.Levels.Zoe &&
+                        IsOffCooldown(SGE.Zoe) && 
+                        EnemyHealthPercentage() <= GetComboSlider(SGE.Config.SGE_ST_Heal_Zoe)
+                       ) return SGE.Zoe;
 
-                    if (IsEnabled(CustomComboPreset.CustomZoeFeature) && zoeCD.CooldownRemaining is 0 && level >= SGE.Levels.Zoe && EnemyHealthPercentage() <= CustomZoe)
-                        return SGE.Zoe;
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) &&
+                        level >= SGE.Levels.Krasis &&
+                        IsOffCooldown(SGE.Krasis) && EnemyHealthPercentage() <= GetComboSlider(SGE.Config.SGE_ST_Heal_Krasis)
+                       ) return SGE.Krasis;
 
-                    if (IsEnabled(CustomComboPreset.CustomKrasisFeature) && KrasisCD.CooldownRemaining is 0 && level >= SGE.Levels.Krasis && EnemyHealthPercentage() <= CustomKrasis)
-                        return SGE.Krasis;
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) &&
+                        level >= SGE.Levels.Pepsis && 
+                        IsOffCooldown(SGE.Pepsis) && EnemyHealthPercentage() <= GetComboSlider(SGE.Config.SGE_ST_Heal_Pepsis) &&
+                        FindTargetEffect(SGE.Buffs.EukrasianDiagnosis) is not null
+                       ) return SGE.Pepsis;
 
-                    if (IsEnabled(CustomComboPreset.CustomPepsisFeature) && PepsisCD.CooldownRemaining is 0 && level >= SGE.Levels.Pepsis && EnemyHealthPercentage() <= CustomPepsis && EukrasianDiagnosis is not null)
-                        return SGE.Pepsis;
-
-                    if (IsEnabled(CustomComboPreset.CustomHaimaFeature) && HaimaCD.CooldownRemaining is 0 && level >= SGE.Levels.Haima && EnemyHealthPercentage() <= CustomHaima)
-                        return SGE.Haima;
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) &&
+                        level >= SGE.Levels.Haima &&
+                        IsOffCooldown(SGE.Haima) && EnemyHealthPercentage() <= GetComboSlider(SGE.Config.SGE_ST_Heal_Haima)
+                       ) return SGE.Haima;
                 }
                 
-                if (IsEnabled(CustomComboPreset.CustomEukrasianDiagnosisFeature) && EukrasianDiagnosis is null && EnemyHealthPercentage() <= CustomDiagnosis && level >= SGE.Levels.Eukrasia)
+                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Diagnosis) &&
+                    level >= SGE.Levels.Eukrasia &&
+                    FindTargetEffect(SGE.Buffs.EukrasianDiagnosis) is null && 
+                    EnemyHealthPercentage() <= GetComboSlider(SGE.Config.SGE_ST_Heal_Diagnosis))
                 {
                     if (!HasEffect(SGE.Buffs.Eukrasia))
                         return SGE.Eukrasia;
@@ -412,42 +369,38 @@ namespace XIVSlothComboPlugin.Combos
 
     internal class SageAoEHeal : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SageAoEHealFeature;
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_Heal;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-
-            var HolosCD = GetCooldown(SGE.Holos);
-            var PhysisCD = GetCooldown(SGE.Physis);
-            var PepsisCD = GetCooldown(SGE.Pepsis);
-            var Physis2CD = GetCooldown(SGE.Physis2);
-            var PanhaimaCD = GetCooldown(SGE.Panhaima);
-            var IxocholeCD = GetCooldown(SGE.Ixochole);
-            var RhizomataCD = GetCooldown(SGE.Rhizomata);
-            var KeracholeCD = GetCooldown(SGE.Kerachole);
-            var Addersgall = GetJobGauge<SGEGauge>().Addersgall;
-            var EukrasianPrognosis = FindEffect(SGE.Buffs.EukrasianPrognosis);
-
             if (actionID is SGE.Prognosis)
             {
-                if (IsEnabled(CustomComboPreset.RhizomataFeatureAoE) && RhizomataCD.CooldownRemaining is 0 && Addersgall is 0 && level >= SGE.Levels.Rhizomata)
-                    return SGE.Rhizomata;
+                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) &&
+                    level >= SGE.Levels.Rhizomata &&
+                    IsOffCooldown(SGE.Rhizomata) &&
+                    GetJobGauge<SGEGauge>().Addersgall is 0 
+                   ) return SGE.Rhizomata;
 
-                if (IsEnabled(CustomComboPreset.KeracholeFeature) && KeracholeCD.CooldownRemaining is 0 && Addersgall >= 1 && level >= SGE.Levels.Kerachole)
-                    return SGE.Kerachole;
+                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) &&
+                    level >= SGE.Levels.Kerachole &&
+                    IsOffCooldown(SGE.Kerachole) && 
+                    GetJobGauge<SGEGauge>().Addersgall >= 1
+                   ) return SGE.Kerachole;
 
-                if (IsEnabled(CustomComboPreset.IxocholeFeature) && IxocholeCD.CooldownRemaining is 0 && Addersgall >= 1 &&  level >= SGE.Levels.Ixochole)
-                    return SGE.Ixochole;
+                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) &&
+                    level >= SGE.Levels.Ixochole &&
+                    IsOffCooldown(SGE.Ixochole) &&
+                    GetJobGauge<SGEGauge>().Addersgall >= 1                     
+                   ) return SGE.Ixochole;
 
-                if (IsEnabled(CustomComboPreset.PhysisFeature))
-                {
-                    if (PhysisCD.CooldownRemaining is 0 && level >= SGE.Levels.Physis && level < SGE.Levels.Physis2)
-                        return SGE.Physis;
-                    if (Physis2CD.CooldownRemaining is 0 && level >= SGE.Levels.Physis2)
-                        return SGE.Physis2;
-                }
+                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) &&
+                    level >= SGE.Levels.Physis &&
+                    IsOffCooldown(OriginalHook(SGE.Physis))
+                   ) return OriginalHook(SGE.Physis);
 
-                if (IsEnabled(CustomComboPreset.EukrasianPrognosisFeature) && EukrasianPrognosis is null && level >= SGE.Levels.Eukrasia)
+                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EkPrognosis) &&
+                    level >= SGE.Levels.Eukrasia &&
+                    FindEffect(SGE.Buffs.EukrasianPrognosis) is null)
                 {
                     if (!HasEffect(SGE.Buffs.Eukrasia))
                         return SGE.Eukrasia;
@@ -455,15 +408,21 @@ namespace XIVSlothComboPlugin.Combos
                         return SGE.EukrasianPrognosis;
                 }
 
-                if (IsEnabled(CustomComboPreset.HolosFeature) && HolosCD.CooldownRemaining is 0 && level >= SGE.Levels.Holos)
-                    return SGE.Holos;
+                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) &&
+                    level >= SGE.Levels.Holos &&
+                    IsOffCooldown(SGE.Holos)
+                   ) return SGE.Holos;
 
-                if (IsEnabled(CustomComboPreset.PanhaimaFeature) && PanhaimaCD.CooldownRemaining is 0 && level >= SGE.Levels.Panhaima)
-                    return SGE.Panhaima;
+                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) &&
+                    level >= SGE.Levels.Panhaima &&
+                    IsOffCooldown(SGE.Panhaima)
+                   ) return SGE.Panhaima;
 
-                if (IsEnabled(CustomComboPreset.PepsisFeature) && PepsisCD.CooldownRemaining is 0 && level >= SGE.Levels.Pepsis && EukrasianPrognosis is not null)
-                    return SGE.Pepsis;
-
+                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) &&
+                    level >= SGE.Levels.Pepsis &&
+                    IsOffCooldown(SGE.Pepsis) &&
+                    FindEffect(SGE.Buffs.EukrasianPrognosis) is not null
+                   ) return SGE.Pepsis;
             }
             return actionID;
         }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -774,33 +774,18 @@ namespace XIVSlothComboPlugin
             #endregion
             // ====================================================================================
             #region SAGE
-            if (preset == CustomComboPreset.SGE_ST_DosisAdv)
-            {
-                var MaxHpValue = Service.Configuration.EnemyHealthMaxHp;
-                var PercentageHpValue = Service.Configuration.EnemyHealthPercentage;
-                var CurrentHpValue = Service.Configuration.EnemyCurrentHp;
+            
+            if (preset == CustomComboPreset.SGE_ST_Dosis_EDosisHPPer)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Dosis_EDosisHPPer, "");
 
-                var inputChanged = false;
-                ImGui.PushItemWidth(75);
-                inputChanged |= ImGui.InputFloat("Input Target MAX Hp  (If targets MAX Hp is BELOW this value it will not use DoT)", ref MaxHpValue);
-                inputChanged |= ImGui.InputFloat("Input Current Enemy Hp (Flat Value) (If targets Current HP is BELOW this value it will not use DoT)", ref CurrentHpValue);
-                inputChanged |= ImGui.InputFloat("Input Current Enemy % Hp (If targets Current % Hp is BELOW this value it will not use DoT)", ref PercentageHpValue);
+            if (preset == CustomComboPreset.SGE_ST_Dosis_Lucid)
+                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_Dosis_Lucid, "", 150, SliderIncrements.Hundreds);
 
+            if (preset == CustomComboPreset.SGE_ST_Dosis_Toxikon)
+                ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show when moving only", "", 1);
 
-                if (inputChanged)
-                {
-                    Service.Configuration.EnemyHealthMaxHp = MaxHpValue;
-                    Service.Configuration.EnemyHealthPercentage = PercentageHpValue;
-                    Service.Configuration.EnemyCurrentHp = CurrentHpValue;
-
-                    Service.Configuration.Save();
-                }
-
-                ImGui.Spacing();
-            }
-
-            if (preset == CustomComboPreset.SGE_ST_Lucid)
-                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_Lucid, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);
+            if (preset == CustomComboPreset.SGE_ST_Dosis_Toxikon)
+                ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show at all times", "", 2);
 
             if (preset == CustomComboPreset.SGE_ST_Heal_Soteria)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Soteria, "Set HP percentage value for Soteria to trigger");

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -774,7 +774,7 @@ namespace XIVSlothComboPlugin
             #endregion
             // ====================================================================================
             #region SAGE
-            if (preset == CustomComboPreset.SageDPSFeatureAdvTest)
+            if (preset == CustomComboPreset.SGE_ST_DosisAdv)
             {
                 var MaxHpValue = Service.Configuration.EnemyHealthMaxHp;
                 var PercentageHpValue = Service.Configuration.EnemyHealthPercentage;
@@ -799,32 +799,32 @@ namespace XIVSlothComboPlugin
                 ImGui.Spacing();
             }
 
-            if (preset == CustomComboPreset.SageLucidFeature)
-                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.CustomSGELucidDreaming, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);
+            if (preset == CustomComboPreset.SGE_ST_Lucid)
+                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_Lucid, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);
 
-            if (preset == CustomComboPreset.CustomSoteriaFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomSoteria, "Set HP percentage value for Soteria to trigger");
+            if (preset == CustomComboPreset.SGE_ST_Heal_Soteria)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Soteria, "Set HP percentage value for Soteria to trigger");
 
-            if (preset == CustomComboPreset.CustomZoeFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomZoe, "Set HP percentage value for Zoe to trigger");
+            if (preset == CustomComboPreset.SGE_ST_Heal_Zoe)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Zoe, "Set HP percentage value for Zoe to trigger");
 
-            if (preset == CustomComboPreset.CustomPepsisFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomPepsis, "Set HP percentage value for Pepsis to trigger");
+            if (preset is CustomComboPreset.SGE_ST_Heal_Pepsis)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Pepsis, "Set HP percentage value for Pepsis to trigger");
 
-            if (preset == CustomComboPreset.CustomTaurocholeFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomTaurochole, "Set HP percentage value for Taurochole to trigger");
+            if (preset == CustomComboPreset.SGE_ST_Heal_Taurochole)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Taurochole, "Set HP percentage value for Taurochole to trigger");
 
-            if (preset == CustomComboPreset.CustomHaimaFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomHaima, "Set HP percentage value for Haima to trigger");
+            if (preset == CustomComboPreset.SGE_ST_Heal_Haima)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Haima, "Set HP percentage value for Haima to trigger");
 
-            if (preset == CustomComboPreset.CustomKrasisFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomKrasis, "Set HP percentage value for Krasis to trigger");
+            if (preset == CustomComboPreset.SGE_ST_Heal_Krasis)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Krasis, "Set HP percentage value for Krasis to trigger");
 
-            if (preset == CustomComboPreset.CustomDruocholeFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomDruochole, "Set HP percentage value for Druochole to trigger");
+            if (preset == CustomComboPreset.SGE_ST_Heal_Druochole)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Druochole, "Set HP percentage value for Druochole to trigger");
 
-            if (preset == CustomComboPreset.CustomEukrasianDiagnosisFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.CustomDiagnosis, "Set HP percentage value for Eukrasian Diagnosis to trigger");
+            if (preset == CustomComboPreset.SGE_ST_Heal_Diagnosis)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Diagnosis, "Set HP percentage value for Eukrasian Diagnosis to trigger");
 
 
             #endregion

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -719,7 +719,7 @@ namespace XIVSlothComboPlugin.Combos
 
         }
 
-        protected static int GetComboSlider(string SliderID)
+        protected static int GetOptionValue(string SliderID)
         {
             return Service.Configuration.GetCustomIntValue(SliderID);
         }

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -719,6 +719,11 @@ namespace XIVSlothComboPlugin.Combos
 
         }
 
+        protected static int GetComboSlider(string SliderID)
+        {
+            return Service.Configuration.GetCustomIntValue(SliderID);
+        }
+
         protected unsafe static FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject* GetTarget(TargetType target)
         {
             GameObject? o = null;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -106,7 +106,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Global Healer Features", "Features and options involving shared role actions for Healers.\nCollapsing this category does NOT disable the features inside.", ADV.JobID)]
         AllHealerFeatures = 100098,
 
-            [ConflictingCombos(AstrologianAscendFeature, SchRaiseFeature, SageEgeiroFeature, WHMRaiseFeature)]
+            [ConflictingCombos(AstrologianAscendFeature, SchRaiseFeature, SGE_Raise, WHMRaiseFeature)]
             [ParentCombo(AllHealerFeatures)]
             [CustomComboInfo("Healer: Raise Feature", "Changes the class' Raise Ability into Swiftcast.", ADV.JobID)]
             AllHealerRaiseFeature = 100010,
@@ -1730,130 +1730,138 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region SAGE
 
-        [CustomComboInfo("Soteria into Kardia Feature", "Soteria turns into Kardia when not active or Soteria is on-cooldown.", SGE.JobID, 0, "Spoopy into Kpoopy", "Don't forget your danc- uh, heal partner!")]
-        SageKardiaFeature = 14000,
+        //SAGE_FEATURE_NUMBERING
+        //Numbering Scheme: 14[Section][Feature Number][Sub-Feature]
+        //Example: 14110 (Section 1: DPS, Feature Number 1, Sub-feature 0)
+        //New features should be added to the appropriate sections.
 
-        [CustomComboInfo("Rhizomata Feature#", "Replaces Taurochole, Druochole, Ixochole and Kerachole with Rhizomata when Addersgall is empty.", SGE.JobID, 0, "Rhizomatato", "Can't quite manage that gauge? Neither can we.")]
-        SageRhizomataFeature = 14001,
+        //SECTION_1_DPS
+        [CustomComboInfo("Dosis DPS Enhancements", "Replaces Dosis with Eukrasia Dosis", SGE.JobID, 110)]
+        SGE_ST_Dosis = 14110,
 
-        [CustomComboInfo("Taurochole into Druochole Feature", "Replaces Taurochole with Druochole when Taurochole is on cooldown.", SGE.JobID, 0, "This for that", "They do the same thing, really. If you close your eyes.")]
-        SageTauroDruoFeature = 14002,
+            [ParentCombo(SGE_ST_Dosis)]
+            [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to Dosis when MP drops below slider value", SGE.JobID, 111)]
+            SGE_ST_Lucid = 14111,
 
-        [CustomComboInfo("Phlegma into X Feature", "Does nothing on it's own, must choose any/all sub-features!", SGE.JobID, 0, "", "Phlegmaballs.")]
-        SagePhlegmaFeature = 14031,
+            [ParentCombo(SGE_ST_Dosis)]
+            [ConflictingCombos(SGE_ST_DosisToT)]
+            [CustomComboInfo("Fine Tune Dosis", "Input some values to your liking.", SGE.JobID, 112)]
+            SGE_ST_DosisAdv = 14112,
 
-        [ParentCombo(SagePhlegmaFeature)]
-        [CustomComboInfo("Phlegma into Toxikon Feature", "Phlegma turns into Toxikon when you are out of Phlegma charges and have Addersting.\nTakes priority over the Phlegma into Dyskrasia Feature.", SGE.JobID, 0, "", "Changes Phlegma to Toxikon, purely because the name is awful.")]
-        SagePhlegmaToxikonFeature = 14003,
+            [ParentCombo(SGE_ST_Dosis)]
+            [ConflictingCombos(SGE_ST_DosisAdv)]
+            [CustomComboInfo("Target of Target Dosis", "Target of Target checking for Dosis", SGE.JobID, 113)]
+            SGE_ST_DosisToT = 14113,
 
-        [ParentCombo(SagePhlegmaFeature)]
-        [CustomComboInfo("Phlegma into Dyskrasia Feature", "Phlegma turns into Dyskrasia when you are out of charges.", SGE.JobID, 0, "", "Again, Phlegma is the worst skill name in the game. GET RID!")]
-        SagePhlegmaDyskrasiaFeature = 14004,
+        [CustomComboInfo("Phlegma DPS Enhancements", "Replaces Phlegma with suboptions when on cooldown", SGE.JobID, 121, "", "Phlegmaballs.")]
+        SGE_AoE_Phlegma = 14121,
 
-        [CustomComboInfo("Dosis DPS Feature", "Adds Eukrasia and Eukrasian Dosis on one combo button.", SGE.JobID, 0, "", "Oh look, you're basically WHM now!")]
-        SageDPSFeature = 14005,
+            [ParentCombo(SGE_AoE_Phlegma)]
+            [CustomComboInfo("Toxikon", "Use Toxikon when you have Addersting charges\nTakes priority over Dyskrasia", SGE.JobID, 122, "", "Changes Phlegma to Toxikon, purely because the name is awful.")]
+            SGE_AoE_Toxikon = 14122,
 
-        [ParentCombo(SageDPSFeature)]
-        [ConflictingCombos(SageDPSFeatureToT)]
-        [CustomComboInfo("Fine Tune Dosis", "Input some values to your liking.", SGE.JobID, 0, "", "NERD")]
-        SageDPSFeatureAdvTest = 14009,
+            [ParentCombo(SGE_AoE_Phlegma)]
+            [CustomComboInfo("Dyskrasia", "Use Dyskrasia (even without a target selected)", SGE.JobID, 123, "", "Again, Phlegma is the worst skill name in the game. GET RID!")]
+            SGE_AoE_Dyskrasia = 14123,
 
-        [ParentCombo(SageDPSFeature)]
-        [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming into the Dosis DPS feature at slider value or less.", SGE.JobID, 0, "Muh piety", "Never run out of steam!")]
-        SageLucidFeature = 14006,
 
-        [ParentCombo(SageDPSFeature)]
-        [ConflictingCombos(SageDPSFeatureAdvTest)]
-        [CustomComboInfo("Target of Target Dosis", "Target of Target checking for Dosis", SGE.JobID, 0, "", "NERD")]
-        SageDPSFeatureToT = 14032,
+        //SECTION_2_Healing
+        [ConflictingCombos(SGE_Rhizo, SGE_DruoTauro)]
+        [CustomComboInfo("Diagnosis Simple Single Target Heal", "Changes Diagnosis. You must target a party member (including yourself) for some features to work.", SGE.JobID, 210)]
+        SGE_ST_Heal = 14210,
 
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Apply Kardia", "Applies Kardia to your target if it's not applied to anyone else.", SGE.JobID, 211)]
+            SGE_ST_Heal_Kardia = 14211,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Eukrasian Diagnosis", "Diagnosis becomes Eukrasian Diagnosis if the shield is not applied to the target.", SGE.JobID, 212)]
+            SGE_ST_Heal_Diagnosis = 14212,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Soteria", "Applies Soteria when the selected target is at or above the set HP percentage.", SGE.JobID, 213)]
+            SGE_ST_Heal_Soteria = 14213,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Zoe", "Applies Zoe when the selected target is at or above the set HP percentage.", SGE.JobID, 214)]
+            SGE_ST_Heal_Zoe = 14214,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Pepsis###ST", "Triggers Pepsis if a shield is present and the selected target is at or above the set HP percentage.", SGE.JobID, 215)]
+            SGE_ST_Heal_Pepsis = 14215,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Taurochole", "Adds Taurochole when the selected target is at or above the set HP percentage.", SGE.JobID, 216)]
+            SGE_ST_Heal_Taurochole = 14216,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Haima", "Adds Haima when the selected target is at or above the set HP percentage.", SGE.JobID, 217)]
+            SGE_ST_Heal_Haima = 14217,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Rhizomata###SGEST", "Adds Rhizomata when Addersgall is 0", SGE.JobID, 218)]
+            SGE_ST_Heal_Rhizomata = 14218,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Krasis", "Applies Krasis when the selected target is at or above the set HP percentage.", SGE.JobID, 219)]
+            SGE_ST_Heal_Krasis = 14219,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Druochole", "Adds Druochole when the selected target is at or above the set HP percentage.", SGE.JobID, 2110)]
+            SGE_ST_Heal_Druochole = 142110,
+
+        [ConflictingCombos(SGE_Rhizo, SGE_DruoTauro)]
+        [CustomComboInfo("Sage Simple AoE Heal", "Changes Prognosis. Customize your AoE healing to your liking", SGE.JobID, 220)]
+        SGE_AoE_Heal = 14220,
+
+            [ParentCombo(SGE_AoE_Heal)]
+            [CustomComboInfo("Physis", "Adds Physis.", SGE.JobID, 221)]
+            SGE_AoE_Heal_Physis = 14221,
+
+            [ParentCombo(SGE_AoE_Heal)]
+            [CustomComboInfo("Eukrasian Prognosis", "Prognosis becomes Eukrasian Prognosis if the shield is not applied.", SGE.JobID, 222)]
+            SGE_AoE_Heal_EkPrognosis = 14222,
+
+            [ParentCombo(SGE_AoE_Heal)]
+            [CustomComboInfo("Holos", "Adds Holos.", SGE.JobID, 223)]
+            SGE_AoE_Heal_Holos = 14223,
+
+            [ParentCombo(SGE_AoE_Heal)]
+            [CustomComboInfo("Panhaima", "Adds Panhaima.", SGE.JobID, 224)]
+            SGE_AoE_Heal_Panhaima = 14224,
+
+            [ParentCombo(SGE_AoE_Heal)]
+            [CustomComboInfo("Pepsis##AoE", "Triggers Pepsis if a shield is present.", SGE.JobID, 225)]
+            SGE_AoE_Heal_Pepsis = 14225,
+
+            [ParentCombo(SGE_AoE_Heal)]
+            [CustomComboInfo("Ixochole", "Adds Ixochole", SGE.JobID, 226)]
+            SGE_AoE_Heal_Ixochole = 14226,
+
+            [ParentCombo(SGE_AoE_Heal)]
+            [CustomComboInfo("Kerachole", "Adds Kerachole", SGE.JobID, 227)]
+            SGE_AoE_Heal_Kerachole = 14227,
+
+            [ParentCombo(SGE_AoE_Heal)]
+            [CustomComboInfo("Rhizomata###SGEAOE", "Adds Rhizomata when Addersgall is 0", SGE.JobID, 228)]
+            SGE_AoE_Heal_Rhizomata = 14228,
+
+
+        [CustomComboInfo("Rhizomata", "Replaces Addersgall skills with Rhizomata when empty.", SGE.JobID, 230)]
+        SGE_Rhizo = 14230,
+
+        [CustomComboInfo("Upgrade Druochole to Taurochole", "Upgrades Druochole to Taurochole when Taurochole is available", SGE.JobID, 240)]
+        SGE_DruoTauro = 14240,
+
+        //SECTION_3_Utility
         [ConflictingCombos(AllHealerRaiseFeature)]
-        [CustomComboInfo("SGE Alternative Raise Feature", "Changes Swiftcast to Egeiro when under the effect of Swiftcast.", SGE.JobID, 0, "Swiftcast to Swiftcast", "GET BACK TO DOING DAMAGE")]
-        SageEgeiroFeature = 14007,
+        [CustomComboInfo("Swiftcast Raise Combo", "Changes Swiftcast to Egeiro while Swiftcast is on cooldown.", SGE.JobID, 310)]
+        SGE_Raise = 14310,
 
-        [ConflictingCombos(SageRhizomataFeature, SageTauroDruoFeature)]
-        [CustomComboInfo("Sage Single Target Heal Feature", "Changes Diagnosis. You must target a party member (including yourself) for some features to work.", SGE.JobID, 0)]
-        SageSingleTargetHealFeature = 14011,
+        [CustomComboInfo("Soteria into Kardia", "Soteria turns into Kardia when not active or Soteria is on-cooldown.", SGE.JobID, 320)]
+        SGE_Kardia = 14320,
 
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Apply Kardia", "Applies Kardia to your target if it's not applied to anyone else.", SGE.JobID, 0)]
-        AutoApplyKardia = 14013,
-
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Eukrasian Diagnosis Feature", "Diagnosis becomes Eukrasian Diagnosis if the shield is not applied to the target.", SGE.JobID, 0)]
-        CustomEukrasianDiagnosisFeature = 14014,
-
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Custom Soteria Feature", "Applies Soteria when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
-        CustomSoteriaFeature = 14015,
-
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Custom Zoe Feature", "Applies Zoe when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
-        CustomZoeFeature = 14016,
-
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Custom Pepsis Feature", "Triggers Pepsis if a shield is present and the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
-        CustomPepsisFeature = 14017,
-
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Custom Taurochole Feature", "Adds Taurochole when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
-        CustomTaurocholeFeature = 14018,
-
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Custom Haima Feature", "Adds Haima when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
-        CustomHaimaFeature = 14019,
-
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Custom Rhizomata Feature", "Adds Rhizomata when Addersgall is 0", SGE.JobID, 0)]
-        RhizomataFeature = 14020,
-
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Custom Krasis Feature", "Applies Krasis when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
-        CustomKrasisFeature = 14021,
-
-        [ParentCombo(SageSingleTargetHealFeature)]
-        [CustomComboInfo("Druochole Feature", "Adds Druochole when the selected target is at or above the set HP percentage.", SGE.JobID, 0)]
-        CustomDruocholeFeature = 14030,
-
-        [ConflictingCombos(SageRhizomataFeature, SageTauroDruoFeature)]
-        [CustomComboInfo("Sage AoE Heal Feature", "Changes Prognosis. Customize your AoE healing to your liking", SGE.JobID, 0)]
-        SageAoEHealFeature = 14012,
-
-        [ParentCombo(SageAoEHealFeature)]
-        [CustomComboInfo("Physis Feature", "Adds Physis.", SGE.JobID, 0)]
-        PhysisFeature = 14022,
-
-        [ParentCombo(SageAoEHealFeature)]
-        [CustomComboInfo("Eukrasian Prognosis Feature", "Prognosis becomes Eukrasian Prognosis if the shield is not applied.", SGE.JobID, 0)]
-        EukrasianPrognosisFeature = 14023,
-
-        [ParentCombo(SageAoEHealFeature)]
-        [CustomComboInfo("Holos Feature", "Adds Holos.", SGE.JobID, 0)]
-        HolosFeature = 14024,
-
-        [ParentCombo(SageAoEHealFeature)]
-        [CustomComboInfo("Panhaima Feature", "Adds Panhaima.", SGE.JobID, 0)]
-        PanhaimaFeature = 14025,
-
-        [ParentCombo(SageAoEHealFeature)]
-        [CustomComboInfo("Pepsis Feature", "Triggers Pepsis if a shield is present.", SGE.JobID, 0)]
-        PepsisFeature = 14026,
-
-        [ParentCombo(SageAoEHealFeature)]
-        [CustomComboInfo("Ixochole Feature", "Adds Ixochole", SGE.JobID, 0)]
-        IxocholeFeature = 14027,
-
-        [ParentCombo(SageAoEHealFeature)]
-        [CustomComboInfo("Kerachole Feature", "Adds Kerachole", SGE.JobID, 0)]
-        KeracholeFeature = 14028,
-
-        [ParentCombo(SageAoEHealFeature)]
-        [CustomComboInfo("Rhizomata Feature", "Adds Rhizomata when Addersgall is 0", SGE.JobID, 0)]
-        RhizomataFeatureAoE = 14029,
-
-        //20220420: Last ID Used is 14032
-
-
+        
         #endregion
         // ====================================================================================
         #region SAMURAI

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1740,7 +1740,7 @@ namespace XIVSlothComboPlugin
         SGE_ST_Dosis = 14110,
 
             [ParentCombo(SGE_ST_Dosis)]
-            [CustomComboInfo("Lucid Dreaming", "Adds Lucid Dreaming to Dosis when MP drops below slider value", SGE.JobID, 111)]
+            [CustomComboInfo("Lucid Dreaming###SGEST", "Adds Lucid Dreaming to Dosis when MP drops below slider value", SGE.JobID, 111)]
             SGE_ST_Dosis_Lucid = 14111,
 
             [ParentCombo(SGE_ST_Dosis)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1736,33 +1736,45 @@ namespace XIVSlothComboPlugin
         //New features should be added to the appropriate sections.
 
         //SECTION_1_DPS
-        [CustomComboInfo("Dosis DPS Enhancements", "Replaces Dosis with Eukrasia Dosis", SGE.JobID, 110)]
+        [CustomComboInfo("Single Target DPS Enhancements", "Replaces Dosis with options below", SGE.JobID, 110)]
         SGE_ST_Dosis = 14110,
 
             [ParentCombo(SGE_ST_Dosis)]
-            [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to Dosis when MP drops below slider value", SGE.JobID, 111)]
-            SGE_ST_Lucid = 14111,
+            [CustomComboInfo("Lucid Dreaming", "Adds Lucid Dreaming to Dosis when MP drops below slider value", SGE.JobID, 111)]
+            SGE_ST_Dosis_Lucid = 14111,
 
             [ParentCombo(SGE_ST_Dosis)]
-            [ConflictingCombos(SGE_ST_DosisToT)]
-            [CustomComboInfo("Fine Tune Dosis", "Input some values to your liking.", SGE.JobID, 112)]
-            SGE_ST_DosisAdv = 14112,
+            [CustomComboInfo("Eukrasian Dosis", "Automatic DoT Uptime", SGE.JobID, 112)]
+            SGE_ST_Dosis_EDosis = 14112,
+
+                [ParentCombo(SGE_ST_Dosis_EDosis)]
+                [ConflictingCombos(SGE_ST_Dosis_EDosisToT)]
+                [CustomComboInfo("Enemy HP%% Limiter", "Stop using Eukrasian Dosis when Enemy HP%% is below this value:", SGE.JobID, 1121)]
+                SGE_ST_Dosis_EDosisHPPer = 141121,
+
+                [ParentCombo(SGE_ST_Dosis_EDosis)]
+                [ConflictingCombos(SGE_ST_Dosis_EDosisHPPer)]
+                [CustomComboInfo("Target of Target Dosis", "Target of Target checking for Dosis", SGE.JobID, 1122)]
+                SGE_ST_Dosis_EDosisToT = 141122,
 
             [ParentCombo(SGE_ST_Dosis)]
-            [ConflictingCombos(SGE_ST_DosisAdv)]
-            [CustomComboInfo("Target of Target Dosis", "Target of Target checking for Dosis", SGE.JobID, 113)]
-            SGE_ST_DosisToT = 14113,
+            [CustomComboInfo("Toxikon###SGEST", "Use Toxikon when you have Addersting charges", SGE.JobID, 113)]
+            SGE_ST_Dosis_Toxikon = 14113,
 
-        [CustomComboInfo("Phlegma DPS Enhancements", "Replaces Phlegma with suboptions when on cooldown", SGE.JobID, 121, "", "Phlegmaballs.")]
+        [CustomComboInfo("AoE DPS Enhancements", "Replaces Phlegma with suboptions when on cooldown", SGE.JobID, 121, "", "Phlegmaballs.")]
         SGE_AoE_Phlegma = 14121,
 
             [ParentCombo(SGE_AoE_Phlegma)]
-            [CustomComboInfo("Toxikon", "Use Toxikon when you have Addersting charges\nTakes priority over Dyskrasia", SGE.JobID, 122, "", "Changes Phlegma to Toxikon, purely because the name is awful.")]
-            SGE_AoE_Toxikon = 14122,
+            [CustomComboInfo("Toxikon###SGEAoE", "Use Toxikon when you have Addersting charges\nTakes priority over Dyskrasia SubOption", SGE.JobID, 122, "", "Changes Phlegma to Toxikon, purely because the name is awful.")]
+            SGE_AoE_Phlegma_Toxikon = 14122,
 
             [ParentCombo(SGE_AoE_Phlegma)]
-            [CustomComboInfo("Dyskrasia", "Use Dyskrasia (even without a target selected)", SGE.JobID, 123, "", "Again, Phlegma is the worst skill name in the game. GET RID!")]
-            SGE_AoE_Dyskrasia = 14123,
+            [CustomComboInfo("Dyskrasia", "Use Dyskrasia", SGE.JobID, 123, "", "Again, Phlegma is the worst skill name in the game. GET RID!")]
+            SGE_AoE_Phlegma_Dyskrasia = 14123,
+
+                [ParentCombo(SGE_AoE_Phlegma_Dyskrasia)]
+                [CustomComboInfo("Targetless Mode", "Prioritize Dyskrasia when no target is selected\nIgnores Phlegma Charges", SGE.JobID, 1231, "", "Again, Phlegma is the worst skill name in the game. GET RID!")]
+                SGE_AoE_Phlegma_Dyskrasia_NoTarget = 141231,
 
 
         //SECTION_2_Healing
@@ -1787,7 +1799,7 @@ namespace XIVSlothComboPlugin
             SGE_ST_Heal_Zoe = 14214,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Pepsis###ST", "Triggers Pepsis if a shield is present and the selected target is at or above the set HP percentage.", SGE.JobID, 215)]
+            [CustomComboInfo("Pepsis###SGEST", "Triggers Pepsis if a shield is present and the selected target is at or above the set HP percentage.", SGE.JobID, 215)]
             SGE_ST_Heal_Pepsis = 14215,
 
             [ParentCombo(SGE_ST_Heal)]
@@ -1831,7 +1843,7 @@ namespace XIVSlothComboPlugin
             SGE_AoE_Heal_Panhaima = 14224,
 
             [ParentCombo(SGE_AoE_Heal)]
-            [CustomComboInfo("Pepsis##AoE", "Triggers Pepsis if a shield is present.", SGE.JobID, 225)]
+            [CustomComboInfo("Pepsis##SGEAoE", "Triggers Pepsis if a shield is present.", SGE.JobID, 225)]
             SGE_AoE_Heal_Pepsis = 14225,
 
             [ParentCombo(SGE_AoE_Heal)]
@@ -1847,7 +1859,7 @@ namespace XIVSlothComboPlugin
             SGE_AoE_Heal_Rhizomata = 14228,
 
 
-        [CustomComboInfo("Rhizomata", "Replaces Addersgall skills with Rhizomata when empty.", SGE.JobID, 230)]
+        [CustomComboInfo("Rhizomata Helper", "Replaces Addersgall skills with Rhizomata when empty.", SGE.JobID, 230)]
         SGE_Rhizo = 14230,
 
         [CustomComboInfo("Upgrade Druochole to Taurochole", "Upgrades Druochole to Taurochole when Taurochole is available", SGE.JobID, 240)]


### PR DESCRIPTION
- CustomComboPreset.cs & SGE.cs: Refactored/reordered/renumbered Sage using NikkoXIV's RDM prototype design
- CustomComboPreset.cs: Changed Sage feature names and descriptions
- CustomCombo: Added GetOptionValue (shorthand for Service.Configuration.GetCustomIntValue(), for sliders and radiobuttons) **Desperately needs a better name**
- ConfigWindow: Removed integer boxes for Flat HP checks. Enemy HP Percent changed to slider
- SGE-SageSoteriaKardia: Combined nested ifs by inversing buff and cooldown checks
- SGE-SageRhizomata: Combined nested Ifs
- SGE-SageDruoTauro: Reversed Tauro and Druo. Behavior is the same (uses Tauro when it can). Works more like native XIV trait that upgrades Druo to Tauro, vs degrading Tauro to Druo (better for leveling)
- SGE-SageAoEPhlegma: Cleaned up if checking priority. Changed Toxikon to check for target. Dyskrasia has an optional no-target feature (if you need to run and spam Dyskrasia without a targetting/target moving camera)
- SGE-SageSTDosis: Eukrasian Dosis is now a suboption. Toxikon added as a suboption. Can be set to show when usable or just when moving. Re-added no target exit (sorry). Cleaned up Lucid Dreaming checking code thanks to GetOptionValue. Simplified debuff check so VS would stfu about making it better. 
- SGE-SageRaise: Checking if Swiftcast is on cooldown instead of buff. Allows for hard casting raise after the buff wears off.
- SGE-SageSingleTargetHeal & SageAoEHeal: Code optimization. Previously would constantly be checking cooldowns and slider values for all suboptions, even if all suboptions were off. CDs/Buffs/Debuffs moved into each suboption's code. For each suboption, EnabledComboPreset and Level checks are now prioritized in the if statement before suboption specific things are checked (if it's not enabled or you can't use it, don't grab API data).