### PR TITLE
RDM: Adjusting case of Corps-a-corps level check

### DIFF
--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -64,7 +64,7 @@ namespace XIVSlothComboPlugin.Combos
             public const byte
                 Jolt = 2,
                 Verthunder = 4,
-                CorpsACorps = 6,
+                Corpsacorps = 6,
                 Veraero = 10,
                 Verthunder2 = 18,
                 Veraero2 = 22,
@@ -156,7 +156,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (IsEnabled(CustomComboPreset.RedMageCorpsACorpsFeature) && canWeave && GetCooldownRemainingTime(RDM.Corpsacorps) < 35 &&
                     ((InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte)) ||
                      (IsEnabled(CustomComboPreset.RedMageCorpsACorpsPullFeature) &&
-                     gauge.BlackMana >= 50 && gauge.WhiteMana >= 50)) && level >= RDM.Levels.CorpsACorps && !HasEffect(RDM.Buffs.Dualcast))
+                     gauge.BlackMana >= 50 && gauge.WhiteMana >= 50)) && level >= RDM.Levels.Corpsacorps && !HasEffect(RDM.Buffs.Dualcast))
                     return RDM.Corpsacorps;
 
                 if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
@@ -618,7 +618,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (IsEnabled(CustomComboPreset.RedMageCorpsACorpsFeature) && canWeave && GetCooldownRemainingTime(RDM.Corpsacorps) < 35 &&
                     ((InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte)) ||
                      (IsEnabled(CustomComboPreset.RedMageCorpsACorpsPullFeature) &&
-                     gauge.BlackMana >= 60 && gauge.WhiteMana >= 60)) && level >= RDM.Levels.CorpsACorps && !HasEffect(RDM.Buffs.Dualcast))
+                     gauge.BlackMana >= 60 && gauge.WhiteMana >= 60)) && level >= RDM.Levels.Corpsacorps && !HasEffect(RDM.Buffs.Dualcast))
                     return RDM.Corpsacorps;
 
                 if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))
@@ -856,7 +856,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (IsEnabled(CustomComboPreset.RedMageCorpsACorpsFeature) && canWeave && GetCooldownRemainingTime(RDM.Corpsacorps) < 35 &&
                     ((InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte)) || 
                      (IsEnabled(CustomComboPreset.RedMageCorpsACorpsPullFeature) && 
-                     gauge.BlackMana >= 50 && gauge.WhiteMana >= 50)) && level >= RDM.Levels.CorpsACorps && !HasEffect(RDM.Buffs.Dualcast))
+                     gauge.BlackMana >= 50 && gauge.WhiteMana >= 50)) && level >= RDM.Levels.Corpsacorps && !HasEffect(RDM.Buffs.Dualcast))
                     return RDM.Corpsacorps;
 
                 if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave)
@@ -1084,7 +1084,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (IsEnabled(CustomComboPreset.RedMageCorpsACorpsFeature) && canWeave && GetCooldownRemainingTime(RDM.Corpsacorps) < 35 &&
                     ((InMeleeRange() && IsOnCooldown(RDM.Fleche) && IsOnCooldown(RDM.ContreSixte)) ||
                      (IsEnabled(CustomComboPreset.RedMageCorpsACorpsPullFeature) &&
-                     gauge.BlackMana >= 60 && gauge.WhiteMana >= 60)) && level >= RDM.Levels.CorpsACorps && !HasEffect(RDM.Buffs.Dualcast))
+                     gauge.BlackMana >= 60 && gauge.WhiteMana >= 60)) && level >= RDM.Levels.Corpsacorps && !HasEffect(RDM.Buffs.Dualcast))
                     return RDM.Corpsacorps;
 
                 if (IsEnabled(CustomComboPreset.RedMageOgcdComboOnCombos) && canWeave && !HasEffect(RDM.Buffs.Dualcast))


### PR DESCRIPTION
RDM
 - Adjusting case of Corps-a-corps to match the action (CorpsACorps to Corpsacorps)

Note: Just to try and prevent confusion as why only one works with RDM and the other only works with RDM.Levels.  OCD kicking in!