### PR TITLE
[WarPVP] Adjust blota's primal rend cooldown check to be optional

### DIFF
--- a/XIVSlothCombo/CombosPVP/WARPVP.cs
+++ b/XIVSlothCombo/CombosPVP/WARPVP.cs
@@ -40,7 +40,8 @@ namespace XIVSlothComboPlugin
                 if (!GetCooldown(WARPVP.PrimalRend).IsCooldown)
                     return OriginalHook(WARPVP.PrimalRend);
                 
-                if (!InMeleeRange() && !GetCooldown(WARPVP.Blota).IsCooldown && !TargetHasEffectAny(PVPCommon.Debuffs.Stun) && GetCooldown(WARPVP.PrimalRend).CooldownRemaining >= 5)
+                if (!InMeleeRange() && !GetCooldown(WARPVP.Blota).IsCooldown && !TargetHasEffectAny(PVPCommon.Debuffs.Stun) && 
+                    (IsNotEnabled(CustomComboPreset.WARBurstBlotaOption) || GetCooldown(WARPVP.PrimalRend).CooldownRemaining >= 5))
                     return OriginalHook(WARPVP.Blota);
 
                 if (!GetCooldown(WARPVP.Onslaught).IsCooldown && canWeave)

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2507,6 +2507,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Bloodwhetting Option", "Allows usage of bloodwhetting anytime, not just inbetween GCDs.", WARPVP.JobID)]
         WARBurstOption = 80041,
 
+        [SecretCustomCombo]
+        [ParentCombo(WARBurstMode)]
+        [CustomComboInfo("Blota Option", "Removes blota from main combo if Primal Rend has 5 seconds or less on its cooldown.", WARPVP.JobID)]
+        WARBurstBlotaOption = 80042,
+        
         // NIN
         [ConflictingCombos(NINAoEBurstMode)]
         [SecretCustomCombo]


### PR DESCRIPTION
Adds option for blota's primal rend cooldown check to be optional.