### PR TITLE
SAMPvP: Minor Adjustments

### DIFF
--- a/XIVSlothCombo/CombosPVP/SAMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/SAMPVP.cs
@@ -31,6 +31,9 @@
         {
             public const string
                 SamSotenCharges = "SamSotenCharges";
+            public const string
+                SamSotenHP = "SamSotenHP";
+
         }
 
         internal class SAMBurstMode : CustomCombo
@@ -43,9 +46,11 @@
                 
                 if ((IsNotEnabled(CustomComboPreset.SamPVPMainComboFeature) && actionID == SAMPvP.MeikyoShisui) ||
                     (IsEnabled(CustomComboPreset.SamPVPMainComboFeature) && actionID is SAMPvP.Yukikaze or SAMPvP.Gekko or SAMPvP.Kasha or SAMPvP.Hyosetsu or SAMPvP.Oka or SAMPvP.Mangetsu))
-                { 
-                        //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+                {
+                    //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
+                    if (!TargetHasEffectAny(PVPCommon.Buffs.Guard))
+                    {
                         if (IsOffCooldown(SAMPvP.MeikyoShisui))
                             return OriginalHook(SAMPvP.MeikyoShisui);
                         if (IsEnabled(CustomComboPreset.SAMBurstChitenFeature) && IsOffCooldown(SAMPvP.Chiten) && InCombat() && PlayerHealthPercentageHp() <= 95)
@@ -62,6 +67,7 @@
                             return OriginalHook(SAMPvP.Soten);
                         if (OriginalHook(SAMPvP.OgiNamikiri) == SAMPvP.Kaeshi)
                             return OriginalHook(SAMPvP.OgiNamikiri);
+                    }
                 }
 
                 return actionID;
@@ -74,11 +80,13 @@
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
+                var SamSotenHP = Service.Configuration.GetCustomIntValue(SAMPvP.Config.SamSotenHP);
+
                 if (actionID is SAMPvP.Yukikaze or SAMPvP.Gekko or SAMPvP.Kasha or SAMPvP.Hyosetsu or SAMPvP.Mangetsu or SAMPvP.Oka)
                 {
                     if (!InMeleeRange())
                     {
-                        if (IsEnabled(CustomComboPreset.SamGapCloserFeature) && GetRemainingCharges(SAMPvP.Soten) > 0)
+                        if (IsEnabled(CustomComboPreset.SamGapCloserFeature) && GetRemainingCharges(SAMPvP.Soten) > 0 && EnemyHealthPercentage() <= SamSotenHP)
                             return OriginalHook(SAMPvP.Soten);
                         if (IsEnabled(CustomComboPreset.SamAOEMeleeFeature) && !IsOriginal(SAMPvP.Yukikaze) && !HasEffect(SAMPvP.Buffs.Midare) && IsOnCooldown(SAMPvP.MeikyoShisui) && IsOnCooldown(SAMPvP.OgiNamikiri) && OriginalHook(SAMPvP.OgiNamikiri) != SAMPvP.Kaeshi)
                             return SAM.Yukikaze;

--- a/XIVSlothCombo/CombosPVP/SAMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/SAMPVP.cs
@@ -23,7 +23,8 @@
         public static class Buffs
         {
             public const ushort
-                Kaiten = 3201;
+                Kaiten = 3201,
+                Midare = 3203;
         }
 
         public static class Config
@@ -79,7 +80,7 @@
                     {
                         if (IsEnabled(CustomComboPreset.SamGapCloserFeature) && GetRemainingCharges(SAMPvP.Soten) > 0)
                             return OriginalHook(SAMPvP.Soten);
-                        if (IsEnabled(CustomComboPreset.SamAOEMeleeFeature) && HasEffect(SAMPvP.Buffs.Kaiten))
+                        if (IsEnabled(CustomComboPreset.SamAOEMeleeFeature) && !IsOriginal(SAMPvP.Yukikaze) && !HasEffect(SAMPvP.Buffs.Midare) && IsOnCooldown(SAMPvP.MeikyoShisui) && IsOnCooldown(SAMPvP.OgiNamikiri) && OriginalHook(SAMPvP.OgiNamikiri) != SAMPvP.Kaeshi)
                             return SAM.Yukikaze;
                     }
                 }

--- a/XIVSlothCombo/CombosPVP/SAMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/SAMPVP.cs
@@ -52,11 +52,11 @@
                             return OriginalHook(SAMPvP.Chiten);
                         if (GetCooldownRemainingTime(SAMPvP.Soten) < 1 && CanWeave(SAMPvP.Yukikaze))
                             return OriginalHook(SAMPvP.Soten);
-                        if (OriginalHook(SAMPvP.MeikyoShisui) == SAMPvP.Midare)
+                        if (OriginalHook(SAMPvP.MeikyoShisui) == SAMPvP.Midare && !this.IsMoving)
                             return OriginalHook(SAMPvP.MeikyoShisui);
                         if (IsEnabled(CustomComboPreset.SAMBurstStunFeature) && IsOffCooldown(SAMPvP.Mineuchi))
                             return OriginalHook(SAMPvP.Mineuchi);
-                        if (IsOffCooldown(SAMPvP.OgiNamikiri))
+                        if (IsOffCooldown(SAMPvP.OgiNamikiri) && !this.IsMoving)
                             return OriginalHook(SAMPvP.OgiNamikiri);
                         if (GetRemainingCharges(SAMPvP.Soten) > sotenCharges)
                             return OriginalHook(SAMPvP.Soten);

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -819,8 +819,11 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawSliderInt(0, 85, SAM.Config.SamKenkiOvercapAmount, "Set the Kenki overcap amount for ST combos.");
             if (preset == CustomComboPreset.SamuraiOvercapFeatureAoe && enabled)
                 ConfigWindowFunctions.DrawSliderInt(0, 85, SAM.Config.SamAOEKenkiOvercapAmount, "Set the Kenki overcap amount for AOE combos.");
+            //PVP
             if (preset == CustomComboPreset.SAMBurstMode && enabled)
                 ConfigWindowFunctions.DrawSliderInt(0, 2, SAMPvP.Config.SamSotenCharges, "How many charges of Soten to keep ready? (0 = Use All).");
+            if (preset == CustomComboPreset.SamGapCloserFeature && enabled)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SAMPvP.Config.SamSotenHP, "Use Soten on enemies below selected HP.");
             //Fillers
             if (preset == CustomComboPreset.SamuraiFillersonMainCombo)
                 ConfigWindowFunctions.DrawRadioButton(SAM.Config.SamFillerCombo, "2.14+", "2 Filler GCDs", 1);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2540,7 +2540,7 @@ namespace XIVSlothComboPlugin
 
         // SAM
         [SecretCustomCombo]
-        [CustomComboInfo("Burst Mode", "Adds Meikyo Shisui, Midare:Setsugekka, Ogi Namikiri, Kaeshi: Namikiri and Soten to Meikyo Shisui.", SAM.JobID)]
+        [CustomComboInfo("Burst Mode", "Adds Meikyo Shisui, Midare:Setsugekka, Ogi Namikiri, Kaeshi: Namikiri and Soten to Meikyo Shisui.\nWill only cast Midare and Ogi Namikiri when you're not moving.", SAM.JobID)]
         SAMBurstMode = 80080,
 
             [SecretCustomCombo]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2540,7 +2540,7 @@ namespace XIVSlothComboPlugin
 
         // SAM
         [SecretCustomCombo]
-        [CustomComboInfo("Burst Mode", "Adds Meikyo Shisui, Midare:Setsugekka, Ogi Namikiri, Kaeshi: Namikiri and Soten to Meikyo Shisui.\nWill only cast Midare and Ogi Namikiri when you're not moving.", SAM.JobID)]
+        [CustomComboInfo("Burst Mode", "Adds Meikyo Shisui, Midare:Setsugekka, Ogi Namikiri, Kaeshi: Namikiri and Soten to Meikyo Shisui.\nWill only cast Midare and Ogi Namikiri when you're not moving.\nWill not use if target is guarding.", SAM.JobID)]
         SAMBurstMode = 80080,
 
             [SecretCustomCombo]


### PR DESCRIPTION
SAMPvP: Fixed issue where AOE melee protection extended to non Kasha Combo skills.
SAMPvP: Added a Movement Check for Midare and Ogi Namikiri
SAMPvP: Added Enemy HP Slider for Gap Closer Feature
SAMPvP: Stops Burst from happening if Enemy is guarding.