### PR TITLE
[SCH] Code Cleanup & New Features

### DIFF
--- a/XIVSlothCombo/Combos/SCH.cs
+++ b/XIVSlothCombo/Combos/SCH.cs
@@ -1,4 +1,6 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Game.ClientState.Objects.Enums;
 
 namespace XIVSlothComboPlugin.Combos
 {
@@ -16,13 +18,14 @@ namespace XIVSlothComboPlugin.Combos
             Lustrate = 189,
             SacredSoil = 188,
             Indomitability = 3583,
+            Excogitation = 7434,
             Consolation = 16546,
 
             // Offense
             Bio1 = 17864,
             Bio2 = 17865,
             Biolysis = 16540,
-            Ruin1 = 163,
+            Ruin1 = 17869,
             Ruin2 = 17870,
             Broil1 = 3584,
             Broil2 = 7435,
@@ -43,17 +46,17 @@ namespace XIVSlothComboPlugin.Combos
 
             // Other
             Aetherflow = 166,
+            Recitation = 16542,
             ChainStratagem = 7436,
 
             // Role
-            Resurrection = 173,
-            Esuna = 5768,
-            LucidDreaming = 7562;
+            Resurrection = 173;
+            //Esuna = 5768,
 
         public static class Buffs
         {
             public const ushort
-            Placeholder = 1;
+            Recitation = 1896;
         }
 
         public static class Debuffs
@@ -105,164 +108,184 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
-                ScholarLucidDreaming = "LucidScholar",
-                ScholarFairy = "ScholarFairy";
+                SCH_ST_Broil_Lucid = "SCH_ST_Broil_Lucid",
+                SCH_ST_Broil_BioHPPer = "SCH_ST_Broil_BioHPPer",
+                SCH_ST_Broil_ChainStratagem = "SCH_ST_Broil_ChainStratagem",
+                SCH_Aetherflow_Recite_Excog = "SCH_Aetherflow_Recite_Excog",
+                SCH_Aetherflow_Recite_Indom = "SCH_Aetherflow_Recite_Indom",
+                SCH_FairyFeature = "SCH_FairyFeature";
         }
     }
 
+    //Even though Summon Seraph becomes Consolation, this Feature puts the temporary fairy aoe heal+barrier ontop of the existing fairy AoE skill Fey Blessing
     internal class ScholarSeraphConsolationFeature : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ScholarSeraphConsolationFeature;
-
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ConsolationFeature;
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SCH.FeyBlessing)
-            {
-                var gauge = GetJobGauge<SCHGauge>();
-                if (gauge.SeraphTimer > 0)
-                    return SCH.Consolation;
-            }
-
-            return actionID;
+            if (actionID is SCH.FeyBlessing &&
+                level >= SCH.Levels.SummonSeraph &&
+                GetJobGauge<SCHGauge>().SeraphTimer > 0
+               ) return SCH.Consolation; else return actionID;
         }
     }
 
-    internal class ScholarEnergyDrainFeature : CustomCombo
+    //Replaces all EnergyDrain actions with Aetherflow when depleted
+    //Revised to a similar flow as Sage Rhizomata, but with Dissipation / Recitation as a backup
+    internal class ScholarAetherflowFeature : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ScholarEnergyDrainFeature;
-
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AetherflowFeature;
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SCH.EnergyDrain)
+            if (actionID is SCH.EnergyDrain or SCH.Lustrate or SCH.SacredSoil or SCH.Indomitability or SCH.Excogitation &&
+                level >= SCH.Levels.Aetherflow)
             {
-                var gauge = GetJobGauge<SCHGauge>();
-                if (gauge.Aetherflow == 0)
-                    return SCH.Aetherflow;
-            }
-
-            return actionID;
-        }
-
-        internal class SchRaiseFeature : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SchRaiseFeature;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID == All.Swiftcast)
+                var gauge = GetJobGauge<SCHGauge>().Aetherflow;
+                if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite) && 
+                    level >= SCH.Levels.Recitation && 
+                    (IsOffCooldown(SCH.Recitation) || HasEffect(SCH.Buffs.Recitation)) )
                 {
-                    if (IsEnabled(CustomComboPreset.SchRaiseFeature))
-                    {
-                        if (HasEffect(All.Buffs.Swiftcast))
-                            return SCH.Resurrection;
+                    //Request here. Recitation Indominability and Excogitation, with optional check against AF zero stack count
+                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite_Excog) &&
+                        (GetOptionValue(SCH.Config.SCH_Aetherflow_Recite_Excog) == 1 || (GetOptionValue(SCH.Config.SCH_Aetherflow_Recite_Excog) == 2 && gauge == 0)) &&
+                        actionID is SCH.Excogitation )
+                    {   //Do not merge this nested if with above. Won't procede with next set
+                        if (HasEffect(SCH.Buffs.Recitation) && IsOffCooldown(SCH.Excogitation)) return SCH.Excogitation; else return SCH.Recitation;
                     }
 
-                    return OriginalHook(All.Swiftcast);
+                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite_Indom) &&
+                        (GetOptionValue(SCH.Config.SCH_Aetherflow_Recite_Indom) == 1 || (GetOptionValue(SCH.Config.SCH_Aetherflow_Recite_Indom) == 2 && gauge == 0)) &&
+                        actionID is SCH.Indomitability )
+                    {
+                        if (HasEffect(SCH.Buffs.Recitation) && IsOffCooldown(SCH.Excogitation)) return SCH.Indomitability; else return SCH.Recitation;
+                    }
                 }
-
-                return actionID;
-            }
-        }
-    }
-
-    internal class SCHDPSAlternateFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCHDPSAlternateFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == SCH.Ruin2)
-            {
-                var gauge = GetJobGauge<SCHGauge>();
-                var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var biolysisDebuff = FindTargetEffect(SCH.Debuffs.Biolysis);
-                var bio2Debuff = FindTargetEffect(SCH.Debuffs.Bio2);
-                var bio1Debuff = FindTargetEffect(SCH.Debuffs.Bio1);
-
-                if (IsEnabled(CustomComboPreset.SCHDPSAlternateFeature) && level >= SCH.Levels.Biolysis)
+                if (gauge == 0)
                 {
-                    if ((!TargetHasEffect(SCH.Debuffs.Biolysis) && incombat && level >= SCH.Levels.Biolysis) || (biolysisDebuff.RemainingTime < 5 && incombat && level >= SCH.Levels.Biolysis))
-                        return SCH.Biolysis;
-                }
+                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Dissipation) &&
+                        level >= SCH.Levels.Dissipation &&
+                        IsOffCooldown(SCH.Dissipation) &&
+                        IsOnCooldown(SCH.Aetherflow) &&
+                        HasPetPresent() //Dissipation requires fairy, can't seem to make it replace dissipation with fairy summon feature *shrug*
+                       ) return SCH.Dissipation;
+                    else return SCH.Aetherflow;
 
-                if (IsEnabled(CustomComboPreset.SCHDPSAlternateFeature) && level >= SCH.Levels.Bio2 && level < SCH.Levels.Biolysis)
-                {
-                    if ((!TargetHasEffect(SCH.Debuffs.Bio2) && level < SCH.Levels.Biolysis && level >= SCH.Levels.Bio2) || (bio2Debuff.RemainingTime < 5 && incombat && level >= SCH.Levels.Bio2 && level < SCH.Levels.Biolysis))
-                        return SCH.Bio2;
-                }
-
-                if (IsEnabled(CustomComboPreset.SCHDPSAlternateFeature) && level < SCH.Levels.Bio2)
-                {
-                    if ((!TargetHasEffect(SCH.Debuffs.Bio1) && level < SCH.Levels.Bio2) || (bio1Debuff.RemainingTime < 5 && incombat && level < SCH.Levels.Bio2))
-                        return SCH.Bio1;
                 }
             }
             return actionID;
         }
     }
+
+    //Swiftcast changes to Raise when activated / on cooldown
+    internal class ScholarRaiseFeature : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_RaiseFeature;
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            if (actionID is All.Swiftcast && IsOnCooldown(All.Swiftcast)) return SCH.Resurrection;
+            else return actionID;
+        }
+    }
+
+    //Replaces Fairy abilitys with fairy summoning with Eos (default) or Selene
     internal class ScholarFairyFeature : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ScholarFairyFeature;
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_FairyFeature;
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SCH.WhisperingDawn || actionID == SCH.FeyBlessing || actionID == SCH.FeyBlessing || actionID == SCH.FeyIllumination || actionID == SCH.Dissipation || actionID == SCH.Aetherpact)
+            if (actionID is SCH.WhisperingDawn or SCH.FeyBlessing or SCH.FeyBlessing or SCH.FeyIllumination or SCH.Dissipation or SCH.Aetherpact or SCH.Dissipation &&
+                !HasPetPresent() && 
+                GetJobGauge<SCHGauge>().SeraphTimer == 0)
             {
-                var gauge = GetJobGauge<SCHGauge>();
-                if (!Service.BuddyList.PetBuddyPresent && gauge.SeraphTimer == 0)
-                {
-                    if ((Service.Configuration.GetCustomIntValue(SCH.Config.ScholarFairy)) == 2) return SCH.SummonSelene;
-                    else return SCH.SummonEos;
-                }
+                if ((GetOptionValue(SCH.Config.SCH_FairyFeature)) == 2) return SCH.SummonSelene; //it's a 1 or 2 option atm.
+                else return SCH.SummonEos;
             }
             return actionID;
         }
     }
 
-    internal class ScholarDPSFeature : CustomCombo
+    //Overwrides main DPS ability family, The Broils (and ruin 1)
+    //Implements new Sage features as ToT, and Ruin 2 as the movement option
+    //ChainStratagem has overlap protection
+    internal class ScholarBroilFeature : CustomCombo
     {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ScholarDPSFeature;
-
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_BroilFeature;
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is SCH.Broil4 or SCH.Broil3 or SCH.Broil2 or SCH.Broil1 or SCH.Ruin1)
+            if (actionID is SCH.Ruin1 or SCH.Broil1 or SCH.Broil2 or SCH.Broil3 or SCH.Broil4 && InCombat())
             {
-                var actionIDCD = GetCooldown(actionID);
-                var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var biolysis = FindTargetEffect(SCH.Debuffs.Biolysis);
-                var bio1 = FindTargetEffect(SCH.Debuffs.Bio1);
-                var bio2 = FindTargetEffect(SCH.Debuffs.Bio2);
-                var chainBuff = GetCooldown(SCH.ChainStratagem);
-                var chainTarget = TargetHasEffect(SCH.Debuffs.ChainStratagem);
+                //Lucid Dreaming
+                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Lucid) &&
+                    level >= All.Levels.LucidDreaming &&
+                    IsOffCooldown(All.LucidDreaming) &&
+                    LocalPlayer.CurrentMp <= GetOptionValue(SCH.Config.SCH_ST_Broil_Lucid) &&
+                    CanSpellWeave(actionID)
+                   ) return All.LucidDreaming;
 
-                if (IsEnabled(CustomComboPreset.ScholarLucidDPSFeature) && level >= All.Levels.LucidDreaming)
+                //Chain Stratagem
+                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_ChainStratagem) &&
+                    level >= SCH.Levels.ChainStratagem &&
+                    IsOffCooldown(SCH.ChainStratagem) &&
+                    !TargetHasEffectAny(SCH.Debuffs.ChainStratagem) && //Overwrite protection
+                    EnemyHealthPercentage() > GetOptionValue(SCH.Config.SCH_ST_Broil_ChainStratagem) &&
+                    CanSpellWeave(actionID)
+                   ) return SCH.ChainStratagem;
+
+                //Bio/Biolysis
+                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Bio) && level >= SCH.Levels.Bio1 && CurrentTarget is not null)
                 {
-                    var lucidMPThreshold = Service.Configuration.GetCustomIntValue(SCH.Config.ScholarLucidDreaming);
-                    if ( IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidMPThreshold && CanSpellWeave(actionID) )
-                        return All.LucidDreaming;
+                    var OurTarget = CurrentTarget;
+                    //Check if our Target is there and not an enemy
+                    if ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy)
+                    {
+                        //If ToT is enabled, Check if ToT is not null
+                        if ((IsEnabled(CustomComboPreset.SCH_ST_Broil_BioToT)) &&
+                            (CurrentTarget.TargetObject is not null) &&
+                            ((CurrentTarget.TargetObject as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy))
+                            //Set Ourtarget as the Target of Target
+                            OurTarget = CurrentTarget.TargetObject;
+                        //Our Target of Target wasn't hostile, our target isn't hostile, time to exit, nothing to check debuff on, fuck this shit we're out
+                        else return actionID;
+                    }
+
+                    //Determine which Bio debuff to check
+                    var BioDebuffID = level switch
+                    {
+                        //Using FindEffect b/c we have a custom Target variable
+                        >= SCH.Levels.Biolysis => FindEffect(SCH.Debuffs.Biolysis, OurTarget, LocalPlayer?.ObjectId),
+                        >= SCH.Levels.Bio2 => FindEffect(SCH.Debuffs.Bio2, OurTarget, LocalPlayer?.ObjectId),
+                        //Bio 1 checked at the start, fine for default
+                        _ => FindEffect(SCH.Debuffs.Bio1, OurTarget, LocalPlayer?.ObjectId),
+                    };
+                    if ((BioDebuffID is null) || (BioDebuffID.RemainingTime <= 3))
+                    {
+                        //Advanced Options Enabled to procede with auto-bio
+                        //Incompatible with ToT due to Enemy checks that are using CurrentTarget.
+                        if (IsEnabled(CustomComboPreset.SCH_ST_Broil_BioHPPer))
+                        {
+                            if (EnemyHealthPercentage() > GetOptionValue(SCH.Config.SCH_ST_Broil_BioHPPer))
+                                return OriginalHook(SCH.Bio1);
+                        }
+                        else return OriginalHook(SCH.Bio1); ;
+                    }
                 }
 
-                if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= SCH.Levels.Biolysis && incombat)
-                {
-                    if ((biolysis is null) || (biolysis.RemainingTime <= 3))
-                        return SCH.Biolysis;
-                }
-                if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= SCH.Levels.Bio2 && level < SCH.Levels.Biolysis && incombat)
-                {
-                    if ((bio2 is null) || (bio2.RemainingTime <= 3))
-                        return SCH.Bio2;
-                }
-                if (IsEnabled(CustomComboPreset.ScholarDPSFeature) && level >= SCH.Levels.Bio1 && level < SCH.Levels.Bio2 && incombat)
-                {
-                    if ((bio1 is null) || (bio1.RemainingTime <= 3))
-                        return SCH.Bio1;
-                }
-                if (IsEnabled(CustomComboPreset.ScholarDPSFeatureBuffOption) && level >= SCH.Levels.ChainStratagem)
-                {
-                    if (!chainBuff.IsCooldown && !chainTarget && actionIDCD.IsCooldown && incombat)
-                        return SCH.ChainStratagem;
-                }
+                //Aetherflow
+                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Aetherflow) &&
+                    level >= SCH.Levels.Aetherflow &&
+                    GetJobGauge<SCHGauge>().Aetherflow == 0 &&
+                    IsOffCooldown(SCH.Aetherflow)
+                   ) return SCH.Aetherflow;
 
+                //Ruin 2 Movement 
+                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Ruin2Movement) &&
+                    level >= SCH.Levels.Ruin2 &&
+                    HasBattleTarget() &&
+                    this.IsMoving
+                   ) return OriginalHook(SCH.Ruin2); //Who knows in the future
+
+                //End
             }
             return actionID;
         }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -448,6 +448,8 @@ namespace XIVSlothComboPlugin
             ImGui.PopStyleColor();
             ImGui.Spacing();
 
+            DrawUserConfigs(preset, enabled);
+
             if (conflicts.Length > 0)
             {
                 var conflictText = conflicts.Select(conflict =>
@@ -475,8 +477,6 @@ namespace XIVSlothComboPlugin
                     ImGui.Spacing();
                 }
             }
-
-            DrawUserConfigs(preset, enabled);
 
             i++;
 
@@ -772,17 +772,17 @@ namespace XIVSlothComboPlugin
             #region RED MAGE
 
             if (preset == CustomComboPreset.RedMageLucidOnJolt && enabled)
-                ConfigWindowFunctions.DrawSliderInt(0, 10000, RDM.Config.RdmLucidMpThreshold, "Add Lucid Dreaming when below this MP.", 300, 100);
+                ConfigWindowFunctions.DrawSliderInt(0, 10000, RDM.Config.RdmLucidMpThreshold, "Add Lucid Dreaming when below this MP.", 150, SliderIncrements.Hundreds);
 
             #endregion
             // ====================================================================================
             #region SAGE
 
             if (preset == CustomComboPreset.SGE_ST_Dosis_EDosisHPPer)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Dosis_EDosisHPPer, "");
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Dosis_EDosisHPPer, "Enemy HP %% Threshold");
 
             if (preset == CustomComboPreset.SGE_ST_Dosis_Lucid)
-                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_Dosis_Lucid, "", 150, SliderIncrements.Hundreds);
+                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_Dosis_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
 
             if (preset == CustomComboPreset.SGE_ST_Dosis_Toxikon)
                 ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show when moving only", "", 1);
@@ -813,8 +813,6 @@ namespace XIVSlothComboPlugin
 
             if (preset == CustomComboPreset.SGE_ST_Heal_Diagnosis)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Diagnosis, "Set HP percentage value for Eukrasian Diagnosis to trigger");
-
-
             #endregion
             // ====================================================================================
             #region SAMURAI
@@ -842,18 +840,30 @@ namespace XIVSlothComboPlugin
 
             if (preset == CustomComboPreset.MnkBootshineCombo)
                 ConfigWindowFunctions.DrawSliderInt(5, 10, MNK.Config.MnkDisciplinedFistApply, "Seconds remaining before refreshing Disciplined Fist.");
-
             #endregion
             // ====================================================================================
             #region SCHOLAR
-            if (preset == CustomComboPreset.ScholarLucidDPSFeature)
-                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SCH.Config.ScholarLucidDreaming, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);
-            if (preset == CustomComboPreset.ScholarFairyFeature)
-                ConfigWindowFunctions.DrawRadioButton(SCH.Config.ScholarFairy, "Eos", "Summon Eos", 1);
-            if (preset == CustomComboPreset.ScholarFairyFeature)
-                ConfigWindowFunctions.DrawRadioButton(SCH.Config.ScholarFairy, "Selene", "Summon Selene", 2);
-
-
+            if (preset == CustomComboPreset.SCH_ST_Broil_Lucid)
+                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SCH.Config.SCH_ST_Broil_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
+            if (preset == CustomComboPreset.SCH_ST_Broil_BioHPPer)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SCH.Config.SCH_ST_Broil_BioHPPer, "Enemy HP %% Threshold");
+            if (preset == CustomComboPreset.SCH_ST_Broil_ChainStratagem)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SCH.Config.SCH_ST_Broil_ChainStratagem, "Enemy HP%% Threshold");
+            if (preset == CustomComboPreset.SCH_FairyFeature)
+            {
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Eos", "", 1);
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Selene", "", 2);
+            }
+            if (preset == CustomComboPreset.SCH_Aetherflow_Recite_Excog)
+            {
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Excog, "Always when available", "", 1);
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Excog, "Only when out of Aetherflow Stacks", "", 2);
+            }
+            if (preset == CustomComboPreset.SCH_Aetherflow_Recite_Indom)
+            {
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Indom, "Always when available", "", 1);
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Indom, "Only when out of Aetherflow Stacks", "", 2);
+            }
             #endregion
             // ====================================================================================
             #region SUMMONER

--- a/XIVSlothCombo/ConfigWindowFunctions.cs
+++ b/XIVSlothCombo/ConfigWindowFunctions.cs
@@ -95,9 +95,12 @@ namespace XIVSlothComboPlugin.ConfigFunctions
                 Service.Configuration.Save();
             }
 
-            ImGui.PushStyleColor(ImGuiCol.Text, descriptionColor);
-            ImGui.TextWrapped(checkboxDescription);
-            ImGui.PopStyleColor();
+            if (!checkboxDescription.IsNullOrEmpty())
+            { 
+                ImGui.PushStyleColor(ImGuiCol.Text, descriptionColor);
+                ImGui.TextWrapped(checkboxDescription);
+                ImGui.PopStyleColor();
+            }
             ImGui.Unindent();
             ImGui.Spacing();
         }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -106,7 +106,7 @@ namespace XIVSlothComboPlugin
         AllHealerFeatures = 100098,
 
             #region Global Healer Features
-            [ConflictingCombos(AstrologianAscendFeature, SchRaiseFeature, SGE_RaiseFeature, WHMRaiseFeature)]
+            [ConflictingCombos(AstrologianAscendFeature, SCH_RaiseFeature, SGE_RaiseFeature, WHMRaiseFeature)]
             [ParentCombo(AllHealerFeatures)]
             [CustomComboInfo("Healer: Raise Feature", "Changes the class' Raise Ability into Swiftcast.", ADV.JobID)]
             AllHealerRaiseFeature = 100010,
@@ -1935,7 +1935,6 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Soteria to Kardia Feature", "Soteria turns into Kardia when not active or Soteria is on-cooldown.", SGE.JobID, 320)]
         SGE_KardiaFeature = 14320,
 
-
         #endregion
         // ====================================================================================
         #region SAMURAI
@@ -2122,33 +2121,80 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region SCHOLAR
 
-        [CustomComboInfo("Seraph Fey Blessing/Consolation", "Change Fey Blessing into Consolation when Seraph is out.", SCH.JobID, 0, "", "Stupid little fairy thing")]
-        ScholarSeraphConsolationFeature = 16000,
+        //SCHOLAR_FEATURE_NUMBERING
+        //Numbering Scheme: 16[Section][Feature Number][Sub-Feature]
+        //Example: 16110 (Section 1: DPS, Feature Number 1, Sub-feature 0)
+        //New features should be added to the appropriate sections.
 
-        [CustomComboInfo("ED Aetherflow", "Change Energy Drain into Aetherflow when you have no more Aetherflow stacks.", SCH.JobID, 0, "", "Stop trying to pretend you're a SMN. You're not fooling anyone")]
-        ScholarEnergyDrainFeature = 16001,
+        //Section_1_DPS
+        [CustomComboInfo("Single Target DPS Feature", "Replace Ruin 1 / Broils with options below", SCH.JobID, 110)]
+        SCH_ST_BroilFeature = 16110,
+
+            [ParentCombo(SCH_ST_BroilFeature)]
+            [CustomComboInfo("Lucid Dreaming Option###SCHST", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID, 111)]
+            SCH_ST_Broil_Lucid = 16111,
+
+            [ParentCombo(SCH_ST_BroilFeature)]
+            [ConflictingCombos(SCH_ST_Broil_BioToT)]
+            [CustomComboInfo("Chain Stratagem Option", "Adds Chain Stratagem on Cooldown with overlap protection", SCH.JobID, 112)]
+            SCH_ST_Broil_ChainStratagem = 16112,
+
+            [ParentCombo(SCH_ST_BroilFeature)]
+            [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT Uptime", SCH.JobID, 113)]
+            SCH_ST_Broil_Bio = 16113,
+
+                [ParentCombo(SCH_ST_Broil_Bio)]
+                [ConflictingCombos(SCH_ST_Broil_BioToT)]
+                [CustomComboInfo("Enemy HP%% Limiter Option", "Stop using Bio when Enemy HP%% is below this value:", SCH.JobID, 1131)]
+                SCH_ST_Broil_BioHPPer = 161131,
+
+                [ParentCombo(SCH_ST_Broil_Bio)]
+                [ConflictingCombos(SCH_ST_Broil_BioHPPer)]
+                [CustomComboInfo("Target of Target Bio Option", "Target of Target checking for Bio", SCH.JobID, 1132)]
+                SCH_ST_Broil_BioToT = 161132,
+
+            [ParentCombo(SCH_ST_BroilFeature)]
+            [CustomComboInfo("Refresh Aetherflow Feature", "Use Aetherflow when out of aetherflow stacks", SCH.JobID, 114)]
+            SCH_ST_Broil_Aetherflow = 16114,
+
+            [ParentCombo(SCH_ST_BroilFeature)]
+            [CustomComboInfo("Ruin 2 Moving Feature", "Use Ruin 2 when you have to move", SCH.JobID, 115)]
+            SCH_ST_Broil_Ruin2Movement = 16115,
+
+
+        //Section_2_Healing
+        [CustomComboInfo("Fey Blessing to Seraph's Consolation Feature", "Change Fey Blessing into Consolation when Seraph is out.", SCH.JobID, 210, "", "Stupid little fairy thing")]
+        SCH_ConsolationFeature = 16210,
+
+
+        //Section_3_Utilities
+        [CustomComboInfo("Aetherflow Helper Feature", "Change Aetherflow using skills to Aetherflow, Recitation, or Dissipation as selected", SCH.JobID, 310, "", "Stop trying to pretend you're a SMN. You're not fooling anyone")]
+        SCH_AetherflowFeature = 16310,
+
+            [ParentCombo(SCH_AetherflowFeature)]
+            [CustomComboInfo("Recitation Option", "Prioritizes Recitation usage on Excogitation or Indominability", SCH.JobID, 311)]
+            SCH_Aetherflow_Recite = 16311,
+
+                [ParentCombo(SCH_Aetherflow_Recite)]
+                [CustomComboInfo("On Excogitation Option", "", SCH.JobID, 3111)]
+                SCH_Aetherflow_Recite_Excog = 163111,
+
+                [ParentCombo(SCH_Aetherflow_Recite)]
+                [CustomComboInfo("On Indominability Option", "", SCH.JobID, 3112)]
+                SCH_Aetherflow_Recite_Indom = 163112,
+
+            [ParentCombo(SCH_AetherflowFeature)]
+            [CustomComboInfo("Dissipation Option", "Show Dissipation if Aetherflow is on cooldown and you have no Aetherflow stacks", SCH.JobID, 312, "", "Oh wow look at that that one...it looks so delicious")]
+            SCH_Aetherflow_Dissipation = 16312,
 
         [ConflictingCombos(AllHealerRaiseFeature)]
-        [CustomComboInfo("SCH Alternative Raise Feature", "Changes Swiftcast to Resurrection.", SCH.JobID, 0, "", "Well, at least PF wants you for something")]
-        SchRaiseFeature = 16002,
+        [CustomComboInfo("Swiftcast Raise Combo Feature###SCH", "Changes Swiftcast to Resurrection while Swiftcast is on cooldown", SCH.JobID, 410, "", "BRING OUT YOUR DEAD")]
+        SCH_RaiseFeature = 16410,
 
-        [CustomComboInfo("Fairy Feature", "Change all fairy actions into Fairy Summons if you do not have a fairy summoned.", SCH.JobID, 0, "", "You're really gonna forget? Really?")]
-        ScholarFairyFeature = 16004,
+        [CustomComboInfo("Fairy Feature", "Change all fairy actions into Fairy Summons if you do not have a fairy summoned.", SCH.JobID, 510, "", "You're really gonna forget? Really?")]
+        SCH_FairyFeature = 16510,
 
-        [CustomComboInfo("DPS Feature", "Adds Bio1/Bio2/Biosys to Broil/Ruin whenever the debuff is not present or about to expire.", SCH.JobID, 0, "", "Pretend something interesting is going on. DPS Routine!")]
-        ScholarDPSFeature = 16005,
-
-        [ParentCombo(ScholarDPSFeature)]
-        [CustomComboInfo("DPS Feature Buff Option", "Adds Chain Stratagem to the DPS Feature.", SCH.JobID, 0, "", "Raid buffs for everyone!")]
-        ScholarDPSFeatureBuffOption = 16006,
-
-        [ParentCombo(ScholarDPSFeature)]
-        [CustomComboInfo("DPS Feature Lucid Dreaming Option", "Adds Lucid dreaming to the DPS feature when below set MP value.", SCH.JobID, 0, "", "Nobody's perfect. Maybe this'll help")]
-        ScholarLucidDPSFeature = 16007,
-
-        [CustomComboInfo("SCH Extra DPS Feature", "Adds Bio DoT on Ruin II. Won't work below level 38", SCH.JobID, 0, "", "People still use Ruin 2? Shouldn't you be healing or something?")]
-        SCHDPSAlternateFeature = 16003,
-
+ 
         #endregion
         // ====================================================================================
         #region SUMMONER


### PR DESCRIPTION
SCH Refactor / Cleanup
SCH.cs

- SCH Ruin1: Corrected ID
- SCH Recitation Buff ID added
- ScholarSeraphConsolationFeature: Nested if cleanup
- ScholarEnergyDrainFeature -> ScholarAetherflowFeature. Similar now to Sage's Rhizomata Feature, it replaces all Aether stack using abilities with Aetherflow OR some finer details such as Recitation & Disspiation. Fully tested, resolves Nik-Potokar#605
- ScholarRaiseFeature: Fixed logic. Will replace Swiftcast with Resurrection when off cooldown (allowing for hard cast raise)
- ScholarFairyFeature: Mild code cleanup
- ScholarDPSFeature -> ScholarBroilFeature. Similar to SageSTDosisFeature now, with HP% check, ToT. Lucid Dreaming and Chain Stratagem (now with HP% check, and overlap protection) now using CanSpellWeave for better reliability (fixes Nik-Potokar#626). Ruin 2 added as an optional, movement only skill (Bio has priority).
- SCHDPSAlternateFeature: Removed since Ruin 2 Movement option was added to ScholarBroilFeature
- CustomComboPreset: Rearranged, renumbered, etc based upon changes to Scholar.

ConfigWindowFunctions

- DrawRadioButton: Don't make a space under a radio button option if there is no description (Used on the SCH Fairy Feature. "Eos" as an option doesn't really need a description. Removes the awkward spacing.

ConfigWindow

- DrawPreset: Moved sliders above the "Conflicts with" area. Felt quite odd having "Description", "Conflicts with LIST", then a slider.
- RDM/SGE/SCH Lucid Sliders: Changed Descriptions for consistency
- SGE/SCH Changed Description of Enemy HP% sliders for consistency