### PR TITLE
[BRD] Timing tweaks for the burst phase

### DIFF
--- a/XIVSlothCombo/Combos/ALL.cs
+++ b/XIVSlothCombo/Combos/ALL.cs
@@ -97,10 +97,10 @@ namespace XIVSlothComboPlugin.Combos
         {
             if (actionID is All.LowBlow or PLD.ShieldBash)
             {
-                if (IsOffCooldown(All.LowBlow) && level >= All.Levels.LowBlow)
-                    return All.LowBlow;
                 if (CanInterruptEnemy() && IsOffCooldown(All.Interject) && level >= All.Levels.Interject)
                     return All.Interject;
+                if (IsOffCooldown(All.LowBlow) && level >= All.Levels.LowBlow)
+                    return All.LowBlow;
                 if (actionID == PLD.ShieldBash && IsOnCooldown(All.LowBlow))
                     return actionID;
             }

--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -615,10 +615,10 @@ namespace XIVSlothComboPlugin.Combos
                     }
                 }
 
-                if (IsEnabled(CustomComboPreset.BardSimpleBuffsFeature)  && gauge.Song != Song.NONE && isEnemyHealthHigh)
+                if (IsEnabled(CustomComboPreset.BardSimpleBuffsFeature)  && ( gauge.Song != Song.NONE || level < BRD.Levels.MagesBallad ) && isEnemyHealthHigh)
                 {
                     if (((canWeaveBuffs && CombatEngageDuration().Minutes == 0 ) || (canWeaveDelayed && CombatEngageDuration().Minutes > 0)) && level >= BRD.Levels.RagingStrikes && IsOffCooldown(BRD.RagingStrikes) &&
-                        (GetCooldown(BRD.BattleVoice).CooldownRemaining <= 5.38 || IsOffCooldown(BRD.BattleVoice)))
+                        (GetCooldown(BRD.BattleVoice).CooldownRemaining <= 5.38 || IsOffCooldown(BRD.BattleVoice) || level < BRD.Levels.BattleVoice))
                     {
                         return BRD.RagingStrikes;
                     }

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -531,9 +531,11 @@ namespace XIVSlothComboPlugin.Combos
         /// at the later half of the gcd without causing clipping (aka Delayed Weaving)
         /// </summary>
         /// <param name="actionID">Action ID to check.</param>
+        /// <param name="start">Time (in seconds) to start to check for the weave window.</param>
+        /// <param name="end">Time (in seconds) to end the check for the weave window.</param>
         /// <returns>True or false.</returns>
-        protected static bool CanDelayedWeave(uint actionID)
-           => GetCooldown(actionID).CooldownRemaining < 1.250 && GetCooldown(actionID).CooldownRemaining > 0.6;
+        protected static bool CanDelayedWeave(uint actionID, double start = 1.25, double end = 0.6)
+           => GetCooldown(actionID).CooldownRemaining < start && GetCooldown(actionID).CooldownRemaining > end;
 
         /// <summary>
         /// Get a job gauge.


### PR DESCRIPTION
### BRD
- PVE
   - Burst Phase
      - Some logic refactor to better accommodate `Battle Voice` and `Radiant Finale`.
         - Have been tested with GCDs of 2.45 up to 2.50.
      - Added delayed weaving for `Wanderer's Minuet` and `Raging Strikes` after the opener for better alignment.
   - Song Protection
      -  Added a tentative desync prevention for `Army Paeon` , the situation when `Wanderer's Minuet` come back from CD too soon because of a death or downtime, and the `Army Paeon` still had considerable duration.
         - Will now wait for at least 4 repertoires of `Army Paeon` to change to `Wanderer's Minuet` to get the full buff of `Army's Muse`
   - Fixes
      - Very low level check for `Raging Strikes` uses, mainly before songs are acquired.

### ALL
- Tanks
   - Interrupt
      - Changed priority of interject , elevated it to top priority. 
         - Was having to use a stun 1st and then the interject would come up when it should be the contrary. 

### Framework
- Helper
   - `CanDelayedWeave`
      - Can now have custom timings for when to start and end the weave window.
         - Defaults are preserved.