### PR TITLE
SMN Logic Update

### DIFF
--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -883,11 +883,18 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawRadioButton(SMN.Config.SMNSearingLightChoice, "Option 5", "Use Searing Light only in Garuda phase.", 4);
                 ConfigWindowFunctions.DrawRadioButton(SMN.Config.SMNSearingLightChoice, "Option 6", "Use Searing Light only in Titan phase.", 5);
             }
-            if (preset == CustomComboPreset.SummonerEgiSummonsonMainFeature)
-                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SummonerPrimalChoice, "Titan", "Summons Titan first, Garuda second, Ifrit third", 1);
 
             if (preset == CustomComboPreset.SummonerEgiSummonsonMainFeature)
+            {
+                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SummonerPrimalChoice, "Titan", "Summons Titan first, Garuda second, Ifrit third", 1);
                 ConfigWindowFunctions.DrawRadioButton(SMN.Config.SummonerPrimalChoice, "Garuda", "Summons Garuda first, Titan second, Ifrit third", 2);
+            }
+
+            if (preset == CustomComboPreset.SummonerPrimalBurstChoice)
+            {
+                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SummonerBurstPhase, "Bahamut", "Burst during Bahamut Phase", 1);
+                ConfigWindowFunctions.DrawRadioButton(SMN.Config.SummonerBurstPhase, "Phoenix", "Burst during Phoenix Phase", 2);
+            }
 
             if (preset == CustomComboPreset.SMNLucidDreamingFeature)
                 ConfigWindowFunctions.DrawSliderInt(4000, 9500, SMN.Config.SMNLucidDreamingFeature, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2273,8 +2273,12 @@ namespace XIVSlothComboPlugin
         SummonerESAOEFeature = 17017,
 
         [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Searing Light on Ruin", "Adds Searing Light to the Main Combo.", SMN.JobID, 0, "My eyes!", "I can't see!")]
+        [CustomComboInfo("Searing Light on Ruin", "Adds Searing Light to the Main Combo and will be used on cooldown.", SMN.JobID, 0, "My eyes!", "I can't see!")]
         SearingLightonRuinFeature = 17018,
+
+        [ParentCombo(SearingLightonRuinFeature)]
+        [CustomComboInfo("Searing Light Burst Option", "Casts Searing Light only during Bahamut/Phoenix Phase.\nChoose which phase to burst in under 'Burst Phase Choice' option.", SMN.JobID, 0, "My eyes!", "I can't see!")]
+        SummonerSearingLightBurstOption = 170181,
 
         [ParentCombo(SummonerAOEComboFeature)]
         [CustomComboInfo("Searing Light AoE Option", "Adds Searing Light to the AOE Combo.", SMN.JobID, 2, "Our Eyes!", "Yay, we're all legally blind!")]
@@ -2299,11 +2303,11 @@ namespace XIVSlothComboPlugin
 
         [ParentCombo(EgisOnRuinFeature)]
         [ConflictingCombos(SummonerSwiftcastFeatureGaruda)]
-        [CustomComboInfo("Swiftcast Ifrit Option", "Always swiftcasts 2nd Ruby Rite if available.", SMN.JobID, 1, "No Raising for you!", "Always cancels the Ifrit phase entirely, doing nothing instead.")]
+        [CustomComboInfo("Swiftcast Ifrit Option", "Always swiftcasts Ruby Rite if available.", SMN.JobID, 1, "No Raising for you!", "Always cancels the Ifrit phase entirely, doing nothing instead.")]
         SummonerSwiftcastFeatureIfrit = 17024,
 
         [ParentCombo(SummonerEDMainComboFeature)]
-        [CustomComboInfo("Pooled Festers Feature", "Pools Festers/Energy Drain for Searing Light/2 min windows.", SMN.JobID, 0)]
+        [CustomComboInfo("Pooled Festers Feature", "Pools Festers/Energy Drain to use under Searing Light and in Bahamut/Phoenix Phase.\nChoose which phase to burst in under 'Burst Phase Choice' option.", SMN.JobID, 0)]
         SummonerEDPoolonMainFeature = 17025,
 
         [ParentCombo(SummonerAOEComboFeature)]
@@ -2327,6 +2331,14 @@ namespace XIVSlothComboPlugin
 
         [CustomComboInfo("Lucid Dreaming Feature", "Adds Lucid dreaming to the Main Combo when below set MP value.", SMN.JobID, 0, "", "")]
         SMNLucidDreamingFeature = 17031,
+
+        [ParentCombo(SummonerMainComboFeature)]
+        [CustomComboInfo("Burse Phase Choice", "Chooses which phase to burst in for all relevant burst features. Festers and Searing Lights will only be used during Bahamut/Phoenix windows.", SMN.JobID, 0, "", "")]
+        SummonerPrimalBurstChoice = 17032,
+
+        [CustomComboInfo("Egi Abilities on Egi Summons", "Adds Egi Abilities (Astral Flow) to Egi Summons when ready.", SMN.JobID, 0, "", "")]
+        SummonerAstralFlowonSummonsFeature = 17034,
+        
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
- Swiftcast Garuda Option: Slipstream gets used when Swiftcast's buff is up to help accommodate SpS builds.
- Swiftcast Ifrit Option: Swiftcast is used earlier to accommodate SpS builds reverse drifting on the final Ruin.
- Searing Light Option: Broken into two, base used on cooldown. Burst Option is used during Bahamut/Phoenix Phase and now works for SpS builds.
- ClassID fixed
- Burst Choice Option added to let users to decide to burst in Bahamut Phase or Phoenix Phase.
- Pooled Festers logic updated to fix conflicts pre Searing Light unlock, Pooled Festers now used strictly during Searing Light and in Bahamut/Phoenix Phase.
- Egi Abilities on Egi Summons Feature added: Allows use of Egi Abilities (Astral Flow) on Egi Summons when Primals are summoned.