### PR TITLE
Fixes

### DIFF
--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -210,8 +210,21 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     if (IsEnabled(CustomComboPreset.DarkManaOvercapAoEFeature) && level >= DRK.Levels.FloodOfDarkness && (gauge.HasDarkArts || LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10))
                             return OriginalHook(DRK.FloodOfDarkness);
-                    if (gauge.DarksideTimeRemaining > 0)
+                    if (gauge.DarksideTimeRemaining > 1)
                     {
+                        if (IsEnabled(CustomComboPreset.DarkBloodWeaponAOEOption) && IsOffCooldown(DRK.BloodWeapon) && level >= DRK.Levels.BloodWeapon)
+                            return DRK.BloodWeapon;
+                        if (IsEnabled(CustomComboPreset.DarkDeliriumAOEOption) && IsOffCooldown(DRK.Delirium) && level >= DRK.Levels.Delirium)
+                            return DRK.Delirium;
+                        if (IsEnabled(CustomComboPreset.DarkLivingShadowAOEOption) && gauge.Blood >= 50 && IsOffCooldown(DRK.LivingShadow) && level >= DRK.Levels.LivingShadow)
+                            return DRK.LivingShadow;
+                        if (IsEnabled(CustomComboPreset.DarkSaltedEarthAOEOption) && level >= DRK.Levels.SaltedEarth)
+                        {
+                            if ((IsOffCooldown(DRK.SaltedEarth) && !HasEffect(DRK.Buffs.SaltedEarth)) || //Salted Earth
+                                (HasEffect(DRK.Buffs.SaltedEarth) && IsOffCooldown(DRK.SaltAndDarkness) && IsOnCooldown(DRK.SaltedEarth) && level >= DRK.Levels.SaltAndDarkness)) //Salt and Darkness
+                                return OriginalHook(DRK.SaltedEarth);
+                        }
+
                         if (IsEnabled(CustomComboPreset.DRKStalwartabyssalDrainFeature) && level >= DRK.Levels.AbyssalDrain && IsOffCooldown(DRK.AbyssalDrain) && PlayerHealthPercentageHp() <= 60)
                             return DRK.AbyssalDrain;
                         if (IsEnabled(CustomComboPreset.DRKStalwartShadowbringerFeature) && level >= DRK.Levels.Shadowbringer && GetRemainingCharges(DRK.Shadowbringer) > 0)

--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -73,8 +73,7 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
-                DrkKeepPlungeCharges = "DrkKeepPlungeCharges";
-            public const string
+                DrkKeepPlungeCharges = "DrkKeepPlungeCharges",
                 DrkMPManagement = "DrkMPManagement";
         }
     }
@@ -147,10 +146,10 @@ namespace XIVSlothComboPlugin.Combos
 
                                 if (IsEnabled(CustomComboPreset.DarkCnSFeature) && IsOffCooldown(DRK.CarveAndSpit) && level >= DRK.Levels.CarveAndSpit)
                                     return DRK.CarveAndSpit;
-                                if (level >= DRK.Levels.Plunge && IsEnabled(CustomComboPreset.DarkPlungeFeature))
+                                if (level >= DRK.Levels.Plunge && IsEnabled(CustomComboPreset.DarkPlungeFeature) && GetRemainingCharges(DRK.Plunge) > plungeChargesRemaining)
                                 {
-                                    if ((GetRemainingCharges(DRK.Plunge) > plungeChargesRemaining && IsNotEnabled(CustomComboPreset.DarkPlungeBurstOption)) ||
-                                        (IsEnabled(CustomComboPreset.DarkPlungeBurstOption) && GetRemainingCharges(DRK.Plunge) > 0 && gauge.ShadowTimeRemaining > 1 && IsOnCooldown(DRK.Delirium))) //burst feature
+                                    if (IsNotEnabled(CustomComboPreset.DarkMeleePlungeOption) ||
+                                        (IsEnabled(CustomComboPreset.DarkMeleePlungeOption) && GetCooldownRemainingTime(DRK.Delirium) >= 45 && GetTargetDistance() <= 1))
                                         return DRK.Plunge;
                                 }
                             }

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -125,10 +125,6 @@ namespace XIVSlothComboPlugin.Combos
                                     return GNB.Bloodfest;
                         }
 
-                        //Rough Divide Feature
-                        if (level >= GNB.Levels.RoughDivide && IsEnabled(CustomComboPreset.GunbreakerRoughDivideFeature) && GetRemainingCharges(GNB.RoughDivide) > roughDivideChargesRemaining)
-                                return GNB.RoughDivide;
-
                         //Blasting Zone outside of NM
                         if (IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup) && level >= GNB.Levels.DangerZone && IsOffCooldown(GNB.DangerZone))
                         {
@@ -160,6 +156,14 @@ namespace XIVSlothComboPlugin.Combos
                         if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.Continuation &&
                             (HasEffect(GNB.Buffs.ReadyToRip) || HasEffect(GNB.Buffs.ReadyToTear) || HasEffect(GNB.Buffs.ReadyToGouge)) && level >= GNB.Levels.Continuation)
                                 return OriginalHook(GNB.Continuation);
+
+                        //Rough Divide Feature
+                        if (level >= GNB.Levels.RoughDivide && IsEnabled(CustomComboPreset.GunbreakerRoughDivideFeature) && GetRemainingCharges(GNB.RoughDivide) > roughDivideChargesRemaining)
+                        {
+                            if (IsNotEnabled(CustomComboPreset.GunbreakerMeleeRoughDivideOption) ||
+                                (IsEnabled(CustomComboPreset.GunbreakerMeleeRoughDivideOption) && GetTargetDistance() <= 1 && HasEffect(GNB.Buffs.NoMercy) && IsOnCooldown(OriginalHook(GNB.DangerZone)) && IsOnCooldown(GNB.BowShock) && IsOnCooldown(GNB.Bloodfest)))
+                                return GNB.RoughDivide;
+                        }
                     }
 
                     // 60s window features

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -185,7 +185,6 @@ namespace XIVSlothComboPlugin.Combos
                     }
 
                     //Pre Gnashing Fang stuff
-
                     if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.GnashingFang)
                     {
                         if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 &&
@@ -332,26 +331,28 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
+            var gauge = GetJobGauge<GNBGauge>();
             if (actionID == GNB.DemonSlaughter)
             {
+                if (CanWeave(actionID))
+                {
+                    if (IsEnabled(CustomComboPreset.GunbreakerNoMercyAOEOption) && IsOffCooldown(GNB.NoMercy) && level >= GNB.Levels.NoMercy)
+                        return GNB.NoMercy;
+                    if (IsEnabled(CustomComboPreset.GunbreakerBloodfestAOEOption) && gauge.Ammo == 0 && IsOffCooldown(GNB.Bloodfest) && level >= GNB.Levels.Bloodfest)
+                        return GNB.Bloodfest;
+                }
+
+                if (IsEnabled(CustomComboPreset.GunbreakerDoubleDownAOEOption) && gauge.Ammo >= 2 && IsOffCooldown(GNB.DoubleDown) && level >= GNB.Levels.DoubleDown)
+                    return GNB.DoubleDown;
+                if (IsEnabled(CustomComboPreset.GunbreakerBloodfestAOEOption) && gauge.Ammo != 0 && GetCooldownRemainingTime(GNB.Bloodfest) < 6 &&  level >= GNB.Levels.FatedCircle)
+                    return GNB.FatedCircle;
+
                 if (comboTime > 0 && lastComboMove == GNB.DemonSlice && level >= GNB.Levels.DemonSlaughter)
                 {
-                    if (IsEnabled(CustomComboPreset.GunbreakerAmmoOvercapFeature) && level >= GNB.Levels.FatedCircle)
-                    {
-                        var gauge = GetJobGauge<GNBGauge>();
-
-                        if (gauge.Ammo == GNB.MaxCartridges(level))
-                        {
+                    if (IsEnabled(CustomComboPreset.GunbreakerAmmoOvercapFeature) && level >= GNB.Levels.FatedCircle && gauge.Ammo == GNB.MaxCartridges(level))
                             return GNB.FatedCircle;
-                        }
-                    }
-
-                    if(IsEnabled(CustomComboPreset.GunbreakerBowShockFeature) && level >= GNB.Levels.BowShock)
-                    {
-                        if (IsOffCooldown(GNB.BowShock))
+                    if (IsEnabled(CustomComboPreset.GunbreakerBowShockFeature) && level >= GNB.Levels.BowShock && IsOffCooldown(GNB.BowShock))
                             return GNB.BowShock;
-                    }
-
                     return GNB.DemonSlaughter;
                 }
 
@@ -368,9 +369,9 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
+            var gauge = GetJobGauge<GNBGauge>().Ammo;
             if (actionID == GNB.BurstStrike)
             {
-                var gauge = GetJobGauge<GNBGauge>().Ammo;
                 if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
                     return GNB.Hypervelocity;
                 if (gauge == 0 && level >= GNB.Levels.Bloodfest)
@@ -380,4 +381,22 @@ namespace XIVSlothComboPlugin.Combos
             return actionID;
         }
     }
+
+    internal class GunbreakerDDonBurstStrikeFeature : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerDDonBurstStrikeFeature;
+
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            var gauge = GetJobGauge<GNBGauge>().Ammo;
+            if (actionID == GNB.BurstStrike)
+            {
+                if (HasEffect(GNB.Buffs.NoMercy) && IsOffCooldown(GNB.DoubleDown) && gauge >= 2)
+                    return GNB.DoubleDown;
+            }
+
+            return actionID;
+        }
+    }
+    
 }

--- a/XIVSlothCombo/Combos/PLD.cs
+++ b/XIVSlothCombo/Combos/PLD.cs
@@ -136,6 +136,15 @@
                         return PLD.HolySpirit;
                 }
 
+                // Buffs
+                if (GetCooldown(actionID).CooldownRemaining < 0.9 && GetCooldown(actionID).CooldownRemaining > 0.2)
+                {
+                    if (IsEnabled(CustomComboPreset.PaladinFightOrFlightFeature) && level >= PLD.Levels.FightOrFlight && lastComboMove is PLD.FastBlade && IsOffCooldown(PLD.FightOrFlight))
+                        return PLD.FightOrFlight;
+                    if (IsEnabled(CustomComboPreset.PaladinReqMainComboFeature) && level >= PLD.Levels.Requiescat && HasEffect(PLD.Buffs.FightOrFlight) && GetBuffRemainingTime(PLD.Buffs.FightOrFlight) < 17 && IsOffCooldown(PLD.Requiescat))
+                        return PLD.Requiescat;
+                }
+
                 // oGCD features
                 if (CanWeave(actionID))
                 {
@@ -149,16 +158,10 @@
                     }
 
                     if (IsEnabled(CustomComboPreset.PaladinInterveneFeature) && level >= PLD.Levels.Intervene && GetRemainingCharges(PLD.Intervene) > interveneChargesRemaining)
-                        return PLD.Intervene;
-
-                    // Buffs
-                    if (GetCooldown(actionID).CooldownRemaining < 0.9 && GetCooldown(actionID).CooldownRemaining > 0.6)
                     {
-                        if (IsEnabled(CustomComboPreset.PaladinFightOrFlightFeature) && level >= PLD.Levels.FightOrFlight && lastComboMove is PLD.FastBlade && IsOffCooldown(PLD.FightOrFlight))
-                            return PLD.FightOrFlight;
-
-                        if (IsEnabled(CustomComboPreset.PaladinReqMainComboFeature) && level >= PLD.Levels.Requiescat && HasEffect(PLD.Buffs.FightOrFlight) && GetBuffRemainingTime(PLD.Buffs.FightOrFlight) < 17 && IsOffCooldown(PLD.Requiescat))
-                            return PLD.Requiescat;
+                        if (IsNotEnabled(CustomComboPreset.PaladinMeleeInterveneOption) ||
+                            (IsEnabled(CustomComboPreset.PaladinMeleeInterveneOption) && HasEffect(PLD.Buffs.FightOrFlight) && GetTargetDistance() <= 1))
+                            return PLD.Intervene;
                     }
                 }
 

--- a/XIVSlothCombo/Combos/SAM.cs
+++ b/XIVSlothCombo/Combos/SAM.cs
@@ -451,8 +451,13 @@ namespace XIVSlothComboPlugin.Combos
                             {
                                 if (gauge.Kaeshi == Kaeshi.SETSUGEKKA && level >= SAM.Levels.TsubameGaeshi && GetRemainingCharges(SAM.TsubameGaeshi) > 0)
                                     return OriginalHook(SAM.TsubameGaeshi);
-                                if (!this.IsMoving && (((oneSeal || oneSeal && meikyostacks == 2) && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) <= 10) || (threeSeal && level >= SAM.Levels.Setsugekka)))
-                                    return OriginalHook(SAM.Iaijutsu);
+                                if (!this.IsMoving)
+                                {
+                                    if (((oneSeal || (oneSeal && meikyostacks == 2)) && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) <= 10) ||
+                                        (twoSeal && level < SAM.Levels.Setsugekka) ||
+                                        (threeSeal && level >= SAM.Levels.Setsugekka))
+                                        return OriginalHook(SAM.Iaijutsu);
+                                }
                             }
 
                             //Ogi Namikiri Features
@@ -591,14 +596,27 @@ namespace XIVSlothComboPlugin.Combos
                         return SAM.Oka;
                 }
 
-                if (comboTime > 0 && level >= SAM.Levels.Mangetsu && (lastComboMove == SAM.Fuko || lastComboMove == SAM.Fuga))
+                if (comboTime > 0)
                 {
-                    if (IsNotEnabled(CustomComboPreset.SamuraiOkaFeature) || 
-                        gauge.Sen.HasFlag(Sen.GETSU) == false || GetBuffRemainingTime(SAM.Buffs.Fugetsu) < GetBuffRemainingTime(SAM.Buffs.Fuka) || !HasEffect(SAM.Buffs.Fugetsu))
-                        return SAM.Mangetsu;
-                    if (IsEnabled(CustomComboPreset.SamuraiOkaFeature) && level >= SAM.Levels.Oka &&
-                        (gauge.Sen.HasFlag(Sen.KA) == false || GetBuffRemainingTime(SAM.Buffs.Fuka) < GetBuffRemainingTime(SAM.Buffs.Fugetsu) || !HasEffect(SAM.Buffs.Fuka)))
-                        return SAM.Oka;
+                    if (level >= SAM.Levels.Mangetsu && (lastComboMove == SAM.Fuko || lastComboMove == SAM.Fuga))
+                    {
+                        if (IsNotEnabled(CustomComboPreset.SamuraiOkaFeature) ||
+                            gauge.Sen.HasFlag(Sen.GETSU) == false || GetBuffRemainingTime(SAM.Buffs.Fugetsu) < GetBuffRemainingTime(SAM.Buffs.Fuka) || !HasEffect(SAM.Buffs.Fugetsu))
+                            return SAM.Mangetsu;
+                        if (IsEnabled(CustomComboPreset.SamuraiOkaFeature) && level >= SAM.Levels.Oka &&
+                            (gauge.Sen.HasFlag(Sen.KA) == false || GetBuffRemainingTime(SAM.Buffs.Fuka) < GetBuffRemainingTime(SAM.Buffs.Fugetsu) || !HasEffect(SAM.Buffs.Fuka)))
+                            return SAM.Oka;
+                    }
+                }
+
+                if (level < SAM.Levels.Oka && level >= SAM.Levels.Kasha)
+                {
+                    if (lastComboMove == SAM.Shifu)
+                        return SAM.Kasha;
+                    if (lastComboMove == SAM.Hakaze)
+                        return SAM.Shifu;
+                    if (gauge.Sen.HasFlag(Sen.KA) == false || GetBuffRemainingTime(SAM.Buffs.Fuka) < GetBuffRemainingTime(SAM.Buffs.Fugetsu) || !HasEffect(SAM.Buffs.Fuka))
+                        return SAM.Hakaze;
                 }
 
                 return OriginalHook(SAM.Fuko);

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -73,10 +73,8 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
-                WarInfuriateRange = "WarInfuriateRange";
-            public const string
-                WarSurgingRefreshRange = "WarSurgingRefreshRange";
-            public const string
+                WarInfuriateRange = "WarInfuriateRange",
+                WarSurgingRefreshRange = "WarSurgingRefreshRange",
                 WarKeepOnslaughtCharges = "WarKeepOnslaughtCharges";
         }
     }
@@ -116,7 +114,11 @@ namespace XIVSlothComboPlugin.Combos
                         if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(WAR.Upheaval) && level >= WAR.Levels.Upheaval)
                             return WAR.Upheaval;
                         if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && level >= WAR.Levels.Onslaught && GetRemainingCharges(WAR.Onslaught) > onslaughtChargesRemaining)
-                            return WAR.Onslaught;
+                        {
+                            if (IsNotEnabled(CustomComboPreset.WarriorMeleeOnslaughtOption) ||
+                                (IsEnabled(CustomComboPreset.WarriorMeleeOnslaughtOption) && GetTargetDistance() <= 1))
+                                return WAR.Onslaught;
+                        }
                     }
 
                     if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady) && level >= WAR.Levels.PrimalRend)

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -840,6 +840,23 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Blood Weapon on CD", "Adds Blood Weapon to Main Combo on CD and when Darkside is up.", DRK.JobID, 0)]
         DarkBloodWeaponOption = 5026,
 
+        [ParentCombo(DarkStalwartSoulCombo)]
+        [CustomComboInfo("Blood Weapon Option", "Adds Blood Weapon to AOE Combo on CD and when Darkside is up.", DRK.JobID, 0)]
+        DarkBloodWeaponAOEOption = 5027,
+
+        [ParentCombo(DarkStalwartSoulCombo)]
+        [CustomComboInfo("Delirium Option", "Adds Deliriun to AOE Combo on CD and when Darkside is up.", DRK.JobID, 0)]
+        DarkDeliriumAOEOption = 5028,
+
+        [ParentCombo(DarkStalwartSoulCombo)]
+        [CustomComboInfo("Salted Earth Option", "Adds Salted Earth and Salt and Darkness to AOE on CD and when Darkside is up.", DRK.JobID, 0)]
+        DarkSaltedEarthAOEOption = 5029,
+
+        [ParentCombo(DarkStalwartSoulCombo)]
+        [CustomComboInfo("Living Shadow Option", "Adds Living Shadow to AOE on CD and when Darkside is up.", DRK.JobID, 0)]
+        DarkLivingShadowAOEOption = 5030,
+        
+
         #endregion
         // ====================================================================================
         #region DRAGOON

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1057,10 +1057,6 @@ namespace XIVSlothComboPlugin
         GunbreakerMainComboCDsGroup = 7002,
 
         [ParentCombo(GunbreakerMainComboCDsGroup)]
-        [CustomComboInfo("Danger Zone/Blasting Zone on Main Combo", "Adds Danger Zone/Blasting Zone to the Main Combo", GNB.JobID, 0)]
-        GunbreakerDZOnMainComboFeature = 7005,
-
-        [ParentCombo(GunbreakerMainComboCDsGroup)]
         [CustomComboInfo("Double Down on Main Combo", "Adds Double Down on main combo when under No Mercy buff", GNB.JobID, 0, "ALL the deeps", "For when you're both feeling merciless and are stuffed full of powder. BANG!")]
         GunbreakerDDonMain = 7003,
 
@@ -1068,9 +1064,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Rough Divide Option", "Adds Rough Divide onto main combo whenever it's available.", GNB.JobID, 0, "Divide... Roughly", "Ayo pour one out for the homie Squall")]
         GunbreakerRoughDivideFeature = 7004,
 
-        [ParentCombo(GunbreakerDemonSlaughterCombo)]
-        [CustomComboInfo("Bow Shock on AoE Feature", "Adds Bow Shock onto the aoe combo when it's off cooldown. Recommended to use with Gnashing Fang features.", GNB.JobID, 0, "AoE cattleprod enabler")]
-        GunbreakerBowShockFeature = 7017,
+        [ParentCombo(GunbreakerMainComboCDsGroup)]
+        [CustomComboInfo("Danger Zone/Blasting Zone on Main Combo", "Adds Danger Zone/Blasting Zone to the Main Combo", GNB.JobID, 0)]
+        GunbreakerDZOnMainComboFeature = 7005,
 
         [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain.", GNB.JobID, 0, "dEmOn SlAuGhTeR", "Demon Slaughter? Really? What is this, RPR?")]
         GunbreakerDemonSlaughterCombo = 7006,
@@ -1099,13 +1095,21 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Burst Strike to Bloodfest Feature", "Replace Burst Strike with Bloodfest if you have no powder gauge.", GNB.JobID, 0, "P4S Vampire man Bloodfest Feature", "Again with the edgelord names?\nTut, tut, Yoshi-P. Do better.")]
         GunbreakerBloodfestOvercapFeature = 7013,
 
+        [ParentCombo(GunbreakerMainComboCDsGroup)]
+        [CustomComboInfo("Bloodfest on Main Combo", "Adds Bloodfest to main combo when ammo is 0.", GNB.JobID, 0)]
+        GunbreakerBloodfestonST = 7014,
+
         [ParentCombo(GunbreakerSolidBarrelCombo)]
         [CustomComboInfo("Lightning Shot Uptime", "Replace Solid Barrel Combo Feature with Lightning Shot when you are out of range.", GNB.JobID, 0, "Stubby-armed GNB", "Can't reach?")]
         GunbreakerRangedUptimeFeature = 7015,
 
-        [ParentCombo(GunbreakerMainComboCDsGroup)]
-        [CustomComboInfo("Bloodfest on Main Combo", "Adds Bloodfest to main combo when ammo is 0.", GNB.JobID, 0)]
-        GunbreakerBloodfestonST = 7014,
+        [ParentCombo(GunbreakerDemonSlaughterCombo)]
+        [CustomComboInfo("No Mercy AOE Option", "Adds No Mercy to AOE Combo when it's available.", GNB.JobID, 0, "")]
+        GunbreakerNoMercyAOEOption = 7016,
+
+        [ParentCombo(GunbreakerDemonSlaughterCombo)]
+        [CustomComboInfo("Bow Shock on AoE Feature", "Adds Bow Shock onto the aoe combo when it's off cooldown. Recommended to use with Gnashing Fang features.", GNB.JobID, 0, "AoE cattleprod enabler")]
+        GunbreakerBowShockFeature = 7017,
 
         [ParentCombo(GunbreakerMainComboCDsGroup)]
         [CustomComboInfo("No Mercy on Main Combo", "Adds No Mercy to main combo when at full ammo.", GNB.JobID, 0)]
@@ -1129,6 +1133,18 @@ namespace XIVSlothComboPlugin
         [ParentCombo(GunbreakerMainComboCDsGroup)]
         [CustomComboInfo("Burst Strike on Main Combo", "Adds Burst Strike to Main Combo when under No Mercy and Gnashing Fang is over.", GNB.JobID, 0)]
         GunbreakerBSinNMFeature = 7023,
+
+        [ParentCombo(GunbreakerDemonSlaughterCombo)]
+        [CustomComboInfo("Bloodfest AOE Option", "Adds Bloodfest to AOE Combo when it's available. Will dump Ammo through Fated Circle to prepare for Bloodfest.", GNB.JobID, 0, "")]
+        GunbreakerBloodfestAOEOption = 7024,
+
+        [ParentCombo(GunbreakerDemonSlaughterCombo)]
+        [CustomComboInfo("Double Down AOE Option", "Adds Double Down to AOE Combo when it's available and there is 2 or more ammo.", GNB.JobID, 0, "")]
+        GunbreakerDoubleDownAOEOption = 7025,
+
+        [CustomComboInfo("Double Down on Burst Strike Feature", "Adds Double Down to Burst Strike when under No Mercy and ammo is above 2.", GNB.JobID, 0, "")]
+        GunbreakerDDonBurstStrikeFeature = 7026,
+        
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -825,8 +825,8 @@ namespace XIVSlothComboPlugin
         DarkCnSFeature = 5022,
 
         [ParentCombo(DarkPlungeFeature)]
-        [CustomComboInfo("Plunge Burst Option", "Pools Plunge to use during minute window bursts.", DRK.JobID, 0)]
-        DarkPlungeBurstOption = 5023,
+        [CustomComboInfo("Melee Plunge Option", "Uses Plunge when under Darkside and in the target ring (1 yalm).\nWill use as many stacks as selected in the above slider.", DRK.JobID, 0)]
+        DarkMeleePlungeOption = 5023,
 
         [ParentCombo(DarkMainComboCDsGroup)]
         [CustomComboInfo("Salted Earth Feature", "Adds Salted Earth on Main Combo while Darkside is up, will use Salt and Darkness if unlocked.", DRK.JobID, 0)]
@@ -1144,7 +1144,11 @@ namespace XIVSlothComboPlugin
 
         [CustomComboInfo("Double Down on Burst Strike Feature", "Adds Double Down to Burst Strike when under No Mercy and ammo is above 2.", GNB.JobID, 0, "")]
         GunbreakerDDonBurstStrikeFeature = 7026,
-        
+
+        [ParentCombo(GunbreakerRoughDivideFeature)]
+        [CustomComboInfo("Melee Rough Divide Option", "Uses Rough Divide when under No Mercy, burst CDs on CD, and in the target ring (1 yalm).\nWill use as many stacks as selected in the above slider.", GNB.JobID, 0, "", "")]
+        GunbreakerMeleeRoughDivideOption = 7027,
+
 
         #endregion
         // ====================================================================================
@@ -1596,6 +1600,10 @@ namespace XIVSlothComboPlugin
         [ParentCombo(PaladinRoyalAuthorityCombo)]
         [CustomComboInfo("Atonement Feature", "Replace Royal Authority with Atonement when under the effect of Sword Oath.", PLD.JobID, 1, "", "Atonement for what? Picking the weakest Tank?")]
         PaladinAtonementFeature = 11025,
+
+        [ParentCombo(PaladinInterveneFeature)]
+        [CustomComboInfo("Melee Intervene Option", "Uses Intervene when under Fight or Flight and in the target ring (1 yalm).\nWill use as many stacks as selected in the above slider.", PLD.JobID, 4, "", "")]
+        PaladinMeleeInterveneOption = 11026,
 
         #endregion
         // ====================================================================================
@@ -2454,6 +2462,11 @@ namespace XIVSlothComboPlugin
         [ParentCombo(WarriorPrimalRendFeature)]
         [CustomComboInfo("Primal Rend Melee Feature", "Uses Primal Rend when in the target's target ring (1 yalm) and closer otherwise will use it when buff is less than 10 seconds.", WAR.JobID, 0, "Don't blow it all in one place.", "Save some for later.")]
         WarriorPrimalRendCloseRangeFeature = 18023,
+
+        [ParentCombo(WarriorOnslaughtFeature)]
+        [CustomComboInfo("Melee Onslaught Option", "Uses Onslaught when under Surging Tempest and in the target ring (1 yalm).\nWill use as many stacks as selected in the above slider.", WAR.JobID, 0, "", "")]
+        WarriorMeleeOnslaughtOption = 18024,
+        
 
 
         #endregion

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2057,6 +2057,7 @@ namespace XIVSlothComboPlugin
 
             #region Mangetsu Combo
             [ParentCombo(SamuraiMangetsuCombo)]
+            [ConflictingCombos(SamTwoTargetFeature)]
             [CustomComboInfo("Oka to Mangetsu Combo", "Adds Oka combo after Mangetsu combo loop. \n Will add Oka if needed during Meikyo Shisui.", SAM.JobID, 0)]
             SamuraiOkaFeature = 15021,
 
@@ -2078,12 +2079,14 @@ namespace XIVSlothComboPlugin
             SamuraiGurenAOEFeature = 15025,
             #endregion
 
+        
         [CustomComboInfo("Oka Combo", "Replace Oka with its combo chain.", SAM.JobID, 0, "Okeh Combo", "Okeh")]
         SamuraiOkaCombo = 15026,
 
             #region Oka Combo
             [ParentCombo(SamuraiOkaCombo)]
-            [CustomComboInfo("Oka Two Target Rotation Feature", "Adds the Yukikaze Combo, Mangetsu Combo, Senei, Shinten, and Shoha to Oka Combo.\nOptimal for two targets and when 86 and above.", SAM.JobID, 0)]
+            [ConflictingCombos(SamuraiOkaFeature)]
+            [CustomComboInfo("Oka Two Target Rotation Feature", "Adds the Yukikaze Combo, Mangetsu Combo, Senei, Shinten, and Shoha to Oka Combo.\nUsed for two targets only and when 86 and above.", SAM.JobID, 0)]
             SamTwoTargetFeature = 150261,
             #endregion
 


### PR DESCRIPTION
SAM: Adds Tenka Goken to Main Combo sub 50
SAM:  Adds Kasha Combo from 40 to 45 on AOE Combo in order to Tenka Goken
SAM: Made Two Target Feature on Oka incompatible with Oka Feature on Mangetsu.
DRK: Added Blood Weapon, Delirium, Salted Earth and Salt and Darkness, and Living Shadow to AOE Combo
GNB: Added DD, No Mercy, and Bloodfest Options to AOE Combo
GNB: Added DD to Burst Strike as requested in #585
All Tanks; Melee Gap Close Feature added.