### PR TITLE
Restructure plus gigachad shit.

### DIFF
--- a/XIVSlothCombo/ActionWatching.cs
+++ b/XIVSlothCombo/ActionWatching.cs
@@ -1,0 +1,110 @@
+﻿using Dalamud.Game.ClientState.Conditions;
+using Dalamud.Hooking;
+using FFXIVClientStructs.FFXIV.Client.Game;
+using System;
+using System.Runtime.InteropServices;
+
+namespace XIVSlothComboPlugin
+{
+    public static class ActionWatching
+    {
+        private delegate void ReceiveActionEffectDelegate(int sourceObjectId, IntPtr sourceActor, IntPtr position, IntPtr effectHeader, IntPtr effectArray, IntPtr effectTrail);
+        private readonly static Hook<ReceiveActionEffectDelegate>? ReceiveActionEffectHook;
+        private static void ReceiveActionEffectDetour(int sourceObjectId, IntPtr sourceActor, IntPtr position, IntPtr effectHeader, IntPtr effectArray, IntPtr effectTrail)
+        {
+            ReceiveActionEffectHook!.Original(sourceObjectId, sourceActor, position, effectHeader, effectArray, effectTrail);
+            var header = Marshal.PtrToStructure<ActionEffectHeader>(effectHeader);
+
+            if (ActionType is (13 or 2)) return;
+            Dalamud.Logging.PluginLog.Debug(ActionType.ToString());
+            if (header.ActionId != 7 &&
+                header.ActionId != 8 &&
+                sourceObjectId == Service.ClientState.LocalPlayer.ObjectId)
+            {
+                LastAbilityUseCount++;
+                if (header.ActionId != LastAbility)
+                {
+                    LastAbilityUseCount = 1;
+                }
+                LastAbility = header.ActionId;
+
+            }
+        }
+
+        private delegate void SendActionDelegate(long targetObjectId, byte actionType, uint actionId, ushort sequence, long a5, long a6, long a7, long a8, long a9);
+        private static readonly Hook<SendActionDelegate>? SendActionHook;
+        private static void SendActionDetour(long targetObjectId, byte actionType, uint actionId, ushort sequence, long a5, long a6, long a7, long a8, long a9)
+        {
+            SendActionHook!.Original(targetObjectId, actionType, actionId, sequence, a5, a6, a7, a8, a9);
+            ActionType = actionType;
+        }
+
+        public static uint LastAbility { get; set; } = 0;
+
+        public static int LastAbilityUseCount { get; set; } = 0;
+
+        public static uint ActionType { get; set; } = 0;
+
+        public static void Dispose()
+        {
+            ReceiveActionEffectHook?.Dispose();
+            SendActionHook?.Dispose();
+        }
+
+        static ActionWatching()
+        {
+            ReceiveActionEffectHook ??= new Hook<ReceiveActionEffectDelegate>(Service.SigScanner.ScanText("E8 ?? ?? ?? ?? 48 8B 8D F0 03 00 00"), ReceiveActionEffectDetour);
+            SendActionHook ??= new Hook<SendActionDelegate>(Service.SigScanner.ScanText("E8 ?? ?? ?? ?? E9 ?? ?? ?? ?? F3 0F 10 3D ?? ?? ?? ?? 48 8D 4D BF"), SendActionDetour);
+        }
+
+        public static void Enable()
+        {
+            ReceiveActionEffectHook?.Enable();
+            SendActionHook?.Enable();
+        }
+
+        public static void Disable()
+        {
+            ReceiveActionEffectHook.Disable();
+            SendActionHook?.Disable();
+        }
+
+    }
+
+    internal unsafe static class ActionManagerHelper
+    {
+        private static readonly IntPtr actionMgrPtr;
+
+        internal static IntPtr FpUseAction =>
+            (IntPtr)ActionManager.fpUseAction;
+        internal static IntPtr FpUseActionLocation =>
+            (IntPtr)ActionManager.fpUseActionLocation;
+
+        public static ushort CurrentSeq => actionMgrPtr != IntPtr.Zero
+            ? (ushort)Marshal.ReadInt16(actionMgrPtr + 0x110) : (ushort)0;
+        public static ushort LastRecievedSeq => actionMgrPtr != IntPtr.Zero
+            ? (ushort)Marshal.ReadInt16(actionMgrPtr + 0x112) : (ushort)0;
+
+        public static bool IsCasting => actionMgrPtr != IntPtr.Zero
+            && Marshal.ReadByte(actionMgrPtr + 0x28) != 0;
+        public static uint CastingActionId => actionMgrPtr != IntPtr.Zero
+            ? (uint)Marshal.ReadInt32(actionMgrPtr + 0x24) : 0u;
+        public static uint CastTargetObjectId => actionMgrPtr != IntPtr.Zero
+            ? (uint)Marshal.ReadInt32(actionMgrPtr + 0x38) : 0u;
+
+        static ActionManagerHelper()
+        {
+            actionMgrPtr = (IntPtr)ActionManager.Instance();
+        }
+    }
+
+    [StructLayout(LayoutKind.Explicit)]
+    public struct ActionEffectHeader
+    {
+        [FieldOffset(0x0)] public long TargetObjectId;
+        [FieldOffset(0x8)] public uint ActionId;
+        [FieldOffset(0x14)] public uint UnkObjectId;
+        [FieldOffset(0x18)] public ushort Sequence;
+        [FieldOffset(0x1A)] public ushort Unk_1A;
+    }
+}

--- a/XIVSlothCombo/ActionWatching.cs
+++ b/XIVSlothCombo/ActionWatching.cs
@@ -16,7 +16,6 @@ namespace XIVSlothComboPlugin
             var header = Marshal.PtrToStructure<ActionEffectHeader>(effectHeader);
 
             if (ActionType is (13 or 2)) return;
-            Dalamud.Logging.PluginLog.Debug(ActionType.ToString());
             if (header.ActionId != 7 &&
                 header.ActionId != 8 &&
                 sourceObjectId == Service.ClientState.LocalPlayer.ObjectId)

--- a/XIVSlothCombo/Attributes/HoverInfoAttribute.cs
+++ b/XIVSlothCombo/Attributes/HoverInfoAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace XIVSlothComboPlugin.Attributes
+{
+    [AttributeUsage(AttributeTargets.Field)]
+    public class HoverInfoAttribute :  Attribute
+    {
+        internal HoverInfoAttribute(string hoverText)
+        {
+            this.HoverText = hoverText;
+        }
+
+        public string HoverText { get; set; }
+    }
+}

--- a/XIVSlothCombo/Attributes/ReplaceSkillAttribute.cs
+++ b/XIVSlothCombo/Attributes/ReplaceSkillAttribute.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XIVSlothComboPlugin;
+
+namespace XIVSlothComboPlugin
+{
+    /// <summary>
+    /// Attribute documenting which skill each preset replace.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class ReplaceSkillAttribute : Attribute
+    {
+        private static Dictionary<uint, Lumina.Excel.GeneratedSheets.Action>? ActionSheet = Service.DataManager?.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>()?
+                    .Where(i => i.ClassJobCategory.Row > 0 && i.ActionCategory.Row <= 4 && i.RowId is not 7)
+                    .ToDictionary(i => i.RowId, i => i);
+
+        /// <summary>
+        /// List of each action the feature replaces. Initializes a new instance of the <see cref="ReplaceSkillAttribute"/> class.
+        /// </summary>
+        /// <param name="actionIDs">List of actions the preset replaces</param>
+        internal ReplaceSkillAttribute(params uint[] actionIDs)
+        {
+            foreach(uint id in actionIDs)
+            {
+                if (ActionSheet.TryGetValue(id, out var action))
+                {
+                    if (action != null)
+                    {
+                        ActionNames.Add($"{action.Name}");
+                    }
+                }
+            }
+
+        }
+
+        internal List<string> ActionNames { get; set; } = new();
+
+    }
+}

--- a/XIVSlothCombo/Combos/ADV.cs
+++ b/XIVSlothCombo/Combos/ADV.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
+using System;
 
 namespace XIVSlothComboPlugin.Combos
 {
@@ -34,18 +35,18 @@ namespace XIVSlothComboPlugin.Combos
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (InCombat())
+                if (true)
                 {
                     if (LocalPlayer.TargetObject is BattleChara chara)
                     {
                         foreach (var status in chara.StatusList)
                         {
-                            Dalamud.Logging.PluginLog.Debug($"TARGET STATUS CHECK: {chara.Name} -> {status.StatusId}");
+                            Dalamud.Logging.PluginLog.Debug($"TARGET STATUS CHECK: {chara.Name} -> {GetStatusName(status.StatusId)}: {status.StatusId}");
                         }
                     }
                     foreach (var status in (LocalPlayer as BattleChara).StatusList)
                     {
-                        Dalamud.Logging.PluginLog.Debug($"SELF STATUS CHECK: {LocalPlayer.Name} -> {status.StatusId}");
+                        Dalamud.Logging.PluginLog.Debug($"SELF STATUS CHECK: {LocalPlayer.Name} -> {GetStatusName(status.StatusId)}: {status.StatusId}");
                     }
 
                     Dalamud.Logging.PluginLog.Debug($"TARGET OBJECT KIND: {LocalPlayer.TargetObject?.ObjectKind}");
@@ -58,8 +59,10 @@ namespace XIVSlothComboPlugin.Combos
                     Dalamud.Logging.PluginLog.Debug($"ZONE: {Service.ClientState.TerritoryType}");
 
                 }
+
                 return actionID;
             }
+
         }
 #endif
 

--- a/XIVSlothCombo/Combos/ADV.cs
+++ b/XIVSlothCombo/Combos/ADV.cs
@@ -54,9 +54,13 @@ namespace XIVSlothComboPlugin.Combos
                     Dalamud.Logging.PluginLog.Debug($"TARGET IS BATTLE CHARA: {LocalPlayer.TargetObject is BattleChara}");
                     Dalamud.Logging.PluginLog.Debug($"PLAYER IS BATTLE CHARA: {LocalPlayer is BattleChara}");
                     Dalamud.Logging.PluginLog.Debug($"IN MELEE RANGE: {InMeleeRange()}");
-                    Dalamud.Logging.PluginLog.Debug($"LAST COMBO MOVE: {lastComboActionID}");
+                    Dalamud.Logging.PluginLog.Debug($"LAST ACTION: {GetActionName(ActionWatching.LastAction)}");
+                    Dalamud.Logging.PluginLog.Debug($"LAST WEAPONSKILL: {GetActionName(ActionWatching.LastWeaponskill)}");
+                    Dalamud.Logging.PluginLog.Debug($"LAST SPELL: {GetActionName(ActionWatching.LastSpell)}");
+                    Dalamud.Logging.PluginLog.Debug($"LAST ABILITY: {GetActionName(ActionWatching.LastAbility)}");
                     Dalamud.Logging.PluginLog.Debug($"IN PVP ZONE: {InPvP()}");
                     Dalamud.Logging.PluginLog.Debug($"ZONE: {Service.ClientState.TerritoryType}");
+                    Dalamud.Logging.PluginLog.Debug($"LAST ACTION TYPE: {ActionWatching.ActionType}");
 
                 }
 

--- a/XIVSlothCombo/Combos/ALL.cs
+++ b/XIVSlothCombo/Combos/ALL.cs
@@ -95,12 +95,12 @@
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (ActionWatching.LastAbility != LastAction || ActionWatching.LastAbilityUseCount != LastActionCount)
+                if (ActionWatching.LastAction != LastAction || ActionWatching.LastActionUseCount != LastActionCount)
                 {
-                    LastAction = ActionWatching.LastAbility;
-                    LastActionCount = ActionWatching.LastAbilityUseCount;
+                    LastAction = ActionWatching.LastAction;
+                    LastActionCount = ActionWatching.LastActionUseCount;
 
-                    Service.ChatGui.Print($"You just used: {GetActionName(ActionWatching.LastAbility)} x{LastActionCount}");
+                    Service.ChatGui.Print($"You just used: {GetActionName(ActionWatching.LastAction)} x{LastActionCount}");
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/ALL.cs
+++ b/XIVSlothCombo/Combos/ALL.cs
@@ -1,6 +1,4 @@
-﻿using Dalamud.Game.ClientState.JobGauge.Types;
-
-namespace XIVSlothComboPlugin.Combos
+﻿namespace XIVSlothComboPlugin.Combos
 {
     internal static class All
     {
@@ -86,161 +84,184 @@ namespace XIVSlothComboPlugin.Combos
                 Shirk = 48,
                 TrueNorth = 50;
         }
-    }
 
-    //Tank Features
-    internal class AllTankInterruptFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllTankInterruptFeature;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        //Non-gameplay features
+        internal class OutputCombatLog : CustomCombo
         {
-            if (actionID is All.LowBlow or PLD.ShieldBash)
+            private uint LastAction = 0;
+            private int LastActionCount = 0;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllOutputCombatLog;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (CanInterruptEnemy() && IsOffCooldown(All.Interject) && level >= All.Levels.Interject)
-                    return All.Interject;
-                if (IsOffCooldown(All.LowBlow) && level >= All.Levels.LowBlow)
-                    return All.LowBlow;
-                if (actionID == PLD.ShieldBash && IsOnCooldown(All.LowBlow))
-                    return actionID;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class AllTankReprisalFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllTankReprisalFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is All.Reprisal)
-            {
-                if (TargetHasEffectAny(All.Debuffs.Reprisal) && IsOffCooldown(All.Reprisal))
-                    return WHM.Stone1;
-            }
-
-            return actionID;
-        }
-    }
-
-    //Healer Features
-    internal class AllHealerRaiseFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllHealerRaiseFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is WHM.Raise or SCH.Resurrection or AST.Ascend or SGE.Egeiro)
-            {
-                if (IsOffCooldown(All.Swiftcast))
-                    return All.Swiftcast;
-                if (HasEffect(All.Buffs.Swiftcast))
+                if (ActionWatching.LastAbility != LastAction || ActionWatching.LastAbilityUseCount != LastActionCount)
                 {
-                    if (actionID == WHM.Raise && IsEnabled(CustomComboPreset.WHMThinAirFeature) && GetRemainingCharges(WHM.ThinAir) > 0 && !HasEffect(WHM.Buffs.ThinAir) && level >= WHM.Levels.ThinAir)
-                        return WHM.ThinAir;
-                    return actionID;
+                    LastAction = ActionWatching.LastAbility;
+                    LastActionCount = ActionWatching.LastAbilityUseCount;
+
+                    Service.ChatGui.Print($"You just used: {GetActionName(ActionWatching.LastAbility)} x{LastActionCount}");
                 }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    //Caster Features
-    internal class AllCasterAddleFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllCasterAddleFeature;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        //Tank Features
+        internal class AllTankInterruptFeature : CustomCombo
         {
-            if (actionID is All.Addle)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllTankInterruptFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (TargetHasEffectAny(All.Debuffs.Addle) && IsOffCooldown(All.Addle))
-                    return WAR.FellCleave;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class AllCasterRaiseFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllCasterRaiseFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is BLU.AngelWhisper or RDM.Verraise or SMN.Resurrection)
-            {
-                if (HasEffect(All.Buffs.Swiftcast) || HasEffect(RDM.Buffs.Dualcast))
-                    return actionID;
-                if (IsOffCooldown(All.Swiftcast))
-                    return All.Swiftcast;
-            }
-
-            return actionID;
-        }
-    }
-
-    //Melee DPS Features
-    internal class AllMeleeFeintFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllMeleeFeintFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is All.Feint)
-            {
-                if (TargetHasEffectAny(All.Debuffs.Feint) && IsOffCooldown(All.Feint))
-                    return BLM.Fire;
-            }
-
-            return actionID;
-        }
-    }
-
-    //Ranged Physical Features
-    internal class AllRangedPhysicalMitigationFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllRangedPhysicalMitigationFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is BRD.Troubadour or MCH.Tactician or DNC.ShieldSamba)
-            {
-                if ((HasEffectAny(BRD.Buffs.Troubadour) || HasEffectAny(MCH.Buffs.Tactician) || HasEffectAny(DNC.Buffs.ShieldSamba)) && IsOffCooldown(actionID))
-                    return DRG.Stardiver;
-            }
-
-            return actionID;
-        }
-    }
-
-
-    /*
-    internal class DoMSwiftcastFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DoMSwiftcastFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (IsEnabled(CustomComboPreset.DoMSwiftcastFeature))
-            {
-                if (actionID == WHM.Raise || actionID == SMN.Resurrection || actionID == SGE.Egeiro || actionID == AST.Ascend || actionID == RDM.Verraise)
+                if (actionID is LowBlow or PLD.ShieldBash)
                 {
-                    var swiftCD = GetCooldown(All.Swiftcast);
-                    if ((swiftCD.CooldownRemaining == 0 && !HasEffect(RDM.Buffs.Dualcast))
-                        || level <= All.Levels.Raise
-                        || (level <= RDM.Levels.Verraise && actionID == RDM.Verraise))
-                        return All.Swiftcast;
+                    if (CanInterruptEnemy() && IsOffCooldown(Interject) && level >= Levels.Interject)
+                        return Interject;
+                    if (IsOffCooldown(LowBlow) && level >= Levels.LowBlow)
+                        return LowBlow;
+                    if (actionID == PLD.ShieldBash && IsOnCooldown(LowBlow))
+                        return actionID;
                 }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    */
+        internal class AllTankReprisalFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllTankReprisalFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is All.Reprisal)
+                {
+                    if (TargetHasEffectAny(Debuffs.Reprisal) && IsOffCooldown(Reprisal))
+                        return WHM.Stone1;
+                }
+
+                return actionID;
+            }
+        }
+
+        //Healer Features
+        internal class AllHealerRaiseFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllHealerRaiseFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is WHM.Raise or SCH.Resurrection or AST.Ascend or SGE.Egeiro)
+                {
+                    if (IsOffCooldown(Swiftcast))
+                        return Swiftcast;
+                    if (HasEffect(Buffs.Swiftcast))
+                    {
+                        if (actionID == WHM.Raise && IsEnabled(CustomComboPreset.WHMThinAirFeature) && GetRemainingCharges(WHM.ThinAir) > 0 && !HasEffect(WHM.Buffs.ThinAir) && level >= WHM.Levels.ThinAir)
+                            return WHM.ThinAir;
+                        return actionID;
+                    }
+                }
+
+                return actionID;
+            }
+        }
+
+        //Caster Features
+        internal class AllCasterAddleFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllCasterAddleFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is All.Addle)
+                {
+                    if (TargetHasEffectAny(Debuffs.Addle) && IsOffCooldown(Addle))
+                        return WAR.FellCleave;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class AllCasterRaiseFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllCasterRaiseFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is BLU.AngelWhisper or RDM.Verraise or SMN.Resurrection)
+                {
+                    if (HasEffect(Buffs.Swiftcast) || HasEffect(RDM.Buffs.Dualcast))
+                        return actionID;
+                    if (IsOffCooldown(Swiftcast))
+                        return Swiftcast;
+                }
+
+                return actionID;
+            }
+        }
+
+        //Melee DPS Features
+        internal class AllMeleeFeintFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllMeleeFeintFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is All.Feint)
+                {
+                    if (TargetHasEffectAny(Debuffs.Feint) && IsOffCooldown(Feint))
+                        return BLM.Fire;
+                }
+
+                return actionID;
+            }
+        }
+
+        //Ranged Physical Features
+        internal class AllRangedPhysicalMitigationFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AllRangedPhysicalMitigationFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is BRD.Troubadour or MCH.Tactician or DNC.ShieldSamba)
+                {
+                    if ((HasEffectAny(BRD.Buffs.Troubadour) || HasEffectAny(MCH.Buffs.Tactician) || HasEffectAny(DNC.Buffs.ShieldSamba)) && IsOffCooldown(actionID))
+                        return DRG.Stardiver;
+                }
+
+                return actionID;
+            }
+        }
+
+
+        /*
+        internal class DoMSwiftcastFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DoMSwiftcastFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (IsEnabled(CustomComboPreset.DoMSwiftcastFeature))
+                {
+                    if (actionID == WHM.Raise || actionID == SMN.Resurrection || actionID == SGE.Egeiro || actionID == AST.Ascend || actionID == RDM.Verraise)
+                    {
+                        var swiftCD = GetCooldown(All.Swiftcast);
+                        if ((swiftCD.CooldownRemaining == 0 && !HasEffect(RDM.Buffs.Dualcast))
+                            || level <= All.Levels.Raise
+                            || (level <= RDM.Levels.Verraise && actionID == RDM.Verraise))
+                            return All.Swiftcast;
+                    }
+                }
+
+                return actionID;
+            }
+        }
+
+        */
+    }
 }
 

--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -266,138 +266,100 @@ namespace XIVSlothComboPlugin.Combos
                 Sage = "賢者",
                 Conjurer = "幻術士";
         }
-    }
 
-    internal class AstrologianCardsOnDrawFeaturelikewhat : CustomCombo
-    {
-        private new bool GetTarget = true;
 
-        private GameObject? CurrentTarget;
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianCardsOnDrawFeaturelikewhat;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianCardsOnDrawFeaturelikewhat : CustomCombo
         {
-            if (actionID == AST.Play)
+            private new bool GetTarget = true;
+
+            private GameObject? CurrentTarget;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianCardsOnDrawFeaturelikewhat;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Play)
+                {
+                    var gauge = GetJobGauge<ASTGauge>();
+                    var haveCard = HasEffect(Buffs.Balance) || HasEffect(Buffs.Bole) || HasEffect(Buffs.Arrow) || HasEffect(Buffs.Spear) || HasEffect(Buffs.Ewer) || HasEffect(Buffs.Spire);
+                    var cardDrawn = gauge.DrawnCard;
+
+                    if (!gauge.ContainsSeal(SealType.NONE) && IsEnabled(CustomComboPreset.AstrologianAstrodyneOnPlayFeature) && (gauge.DrawnCard != CardType.NONE || GetCooldown(Draw).CooldownRemaining > 30))
+                        return Astrodyne;
+
+                    if (haveCard)
+                    {
+                        if (HasEffect(Buffs.ClarifyingDraw) && IsEnabled(CustomComboPreset.AstRedrawFeature))
+                        {
+                            if ((cardDrawn == CardType.BALANCE && gauge.Seals.Contains(SealType.SUN)) ||
+                                (cardDrawn == CardType.ARROW && gauge.Seals.Contains(SealType.MOON)) ||
+                                (cardDrawn == CardType.SPEAR && gauge.Seals.Contains(SealType.CELESTIAL)) ||
+                                (cardDrawn == CardType.BOLE && gauge.Seals.Contains(SealType.SUN)) ||
+                                (cardDrawn == CardType.EWER && gauge.Seals.Contains(SealType.MOON)) ||
+                                (cardDrawn == CardType.SPIRE && gauge.Seals.Contains(SealType.CELESTIAL)))
+
+                                return Redraw;
+                        }
+                        if (IsEnabled(CustomComboPreset.AstAutoCardTarget))
+                        {
+                            if (GetTarget || (IsEnabled(CustomComboPreset.AstrologianTargetLock)))
+                                SetTarget();
+
+
+                        }
+
+                        return OriginalHook(Play);
+                    }
+
+                    if (!GetTarget && (IsEnabled(CustomComboPreset.AstReFocusFeature) || IsEnabled(CustomComboPreset.AstReTargetFeature)))
+                    {
+                        if (IsEnabled(CustomComboPreset.AstReTargetFeature))
+                        {
+                            Dalamud.Logging.PluginLog.Debug("Previous?");
+                            TargetObject(CurrentTarget);
+                        }
+
+
+                        if (IsEnabled(CustomComboPreset.AstReFocusFeature))
+                            TargetObject(TargetType.FocusTarget);
+                    }
+
+                    GetTarget = true;
+                    return OriginalHook(Draw);
+                }
+
+                return actionID;
+            }
+
+            private bool SetTarget()
             {
                 var gauge = GetJobGauge<ASTGauge>();
-                var haveCard = HasEffect(AST.Buffs.Balance) || HasEffect(AST.Buffs.Bole) || HasEffect(AST.Buffs.Arrow) || HasEffect(AST.Buffs.Spear) || HasEffect(AST.Buffs.Ewer) || HasEffect(AST.Buffs.Spire);
+                if (gauge.DrawnCard.Equals(CardType.NONE)) return false;
                 var cardDrawn = gauge.DrawnCard;
+                if (GetTarget) CurrentTarget = LocalPlayer.TargetObject;
+                //Checks for trusts then normal parties
+                int maxPartySize = GetPartySlot(5) == null ? 4 : 8;
+                if (GetPartyMembers().Length > 0) maxPartySize = GetPartyMembers().Length;
+                if (GetPartyMembers().Length == 0 && Service.BuddyList.Length == 0) maxPartySize = 0;
 
-                if (!gauge.ContainsSeal(SealType.NONE) && IsEnabled(CustomComboPreset.AstrologianAstrodyneOnPlayFeature) && (gauge.DrawnCard != CardType.NONE || GetCooldown(AST.Draw).CooldownRemaining > 30))
-                    return AST.Astrodyne;
-
-                if (haveCard)
-                {
-                    if (HasEffect(AST.Buffs.ClarifyingDraw) && IsEnabled(CustomComboPreset.AstRedrawFeature))
-                    {
-                        if ((cardDrawn == CardType.BALANCE && gauge.Seals.Contains(SealType.SUN)) ||
-                            (cardDrawn == CardType.ARROW && gauge.Seals.Contains(SealType.MOON)) ||
-                            (cardDrawn == CardType.SPEAR && gauge.Seals.Contains(SealType.CELESTIAL)) ||
-                            (cardDrawn == CardType.BOLE && gauge.Seals.Contains(SealType.SUN)) ||
-                            (cardDrawn == CardType.EWER && gauge.Seals.Contains(SealType.MOON)) ||
-                            (cardDrawn == CardType.SPIRE && gauge.Seals.Contains(SealType.CELESTIAL)))
-
-                            return AST.Redraw;
-                    }
-                    if (IsEnabled(CustomComboPreset.AstAutoCardTarget))
-                    {
-                        if (GetTarget || (IsEnabled(CustomComboPreset.AstrologianTargetLock)))
-                            SetTarget();
-                        
-                            
-                    }
-
-                    return OriginalHook(AST.Play);
-                }
-
-                if (!GetTarget && (IsEnabled(CustomComboPreset.AstReFocusFeature) || IsEnabled(CustomComboPreset.AstReTargetFeature)))
-                {
-                    if (IsEnabled(CustomComboPreset.AstReTargetFeature))
-                    {
-                        Dalamud.Logging.PluginLog.Debug("Previous?");
-                        TargetObject(CurrentTarget);
-                    }
-                    
-
-                    if (IsEnabled(CustomComboPreset.AstReFocusFeature))
-                        TargetObject(TargetType.FocusTarget);
-                }
-
-                GetTarget = true;
-                return OriginalHook(AST.Draw);
-            }
-
-            return actionID;
-        }
-
-        private bool SetTarget()
-        {
-            var gauge = GetJobGauge<ASTGauge>();
-            if (gauge.DrawnCard.Equals(CardType.NONE)) return false;
-            var cardDrawn = gauge.DrawnCard;
-            if (GetTarget) CurrentTarget = LocalPlayer.TargetObject;
-            //Checks for trusts then normal parties
-            int maxPartySize = GetPartySlot(5) == null ? 4 : 8;
-            if (GetPartyMembers().Length > 0) maxPartySize = GetPartyMembers().Length;
-            if (GetPartyMembers().Length == 0 && Service.BuddyList.Length == 0) maxPartySize = 0;
-
-            for (int i = 2; i <= maxPartySize; i++)
-            {
-                GameObject? member = GetPartySlot(i);
-
-                if (member == null) break;
-                string job = "";
-                if (member is BattleNpc) job = (member as BattleNpc).ClassJob.GameData.Name.ToString();
-                if (member is BattleChara) job = (member as BattleChara).ClassJob.GameData.Name.ToString();
-
-                if (FindEffectOnMember(AST.Buffs.BalanceDamage, member) is not null) continue;
-                if (FindEffectOnMember(AST.Buffs.ArrowDamage, member) is not null) continue;
-                if (FindEffectOnMember(AST.Buffs.BoleDamage, member) is not null) continue;
-                if (FindEffectOnMember(AST.Buffs.EwerDamage, member) is not null) continue;
-                if (FindEffectOnMember(AST.Buffs.SpireDamage, member) is not null) continue;
-                if (FindEffectOnMember(AST.Buffs.SpearDamage, member) is not null) continue;
-
-                if (cardDrawn is CardType.BALANCE or CardType.ARROW or CardType.SPEAR)
-                {
-                    if (typeof(AST.MeleeCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.MeleeCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.MeleeCardTargetsJP).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
-                    {
-                        TargetObject(member);
-                        GetTarget = false;
-                        return true;
-                    }
-
-                }
-                if (cardDrawn is CardType.BOLE or CardType.EWER or CardType.SPIRE)
-                {
-                    if (typeof(AST.RangedCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.RangedCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.RangedCardTargetsJP).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
-                    {
-                        TargetObject(member);
-                        GetTarget = false;
-                        return true;
-                    }
-                }
-            }
-
-            if (IsEnabled(CustomComboPreset.AstrologianTargetExtraFeature))
-            {
-                for (int i = 1; i <= maxPartySize; i++)
+                for (int i = 2; i <= maxPartySize; i++)
                 {
                     GameObject? member = GetPartySlot(i);
+
                     if (member == null) break;
                     string job = "";
                     if (member is BattleNpc) job = (member as BattleNpc).ClassJob.GameData.Name.ToString();
                     if (member is BattleChara) job = (member as BattleChara).ClassJob.GameData.Name.ToString();
 
-                    if (FindEffectOnMember(AST.Buffs.BalanceDamage, member) is not null) continue;
-                    if (FindEffectOnMember(AST.Buffs.ArrowDamage, member) is not null) continue;
-                    if (FindEffectOnMember(AST.Buffs.BoleDamage, member) is not null) continue;
-                    if (FindEffectOnMember(AST.Buffs.EwerDamage, member) is not null) continue;
-                    if (FindEffectOnMember(AST.Buffs.SpireDamage, member) is not null) continue;
-                    if (FindEffectOnMember(AST.Buffs.SpearDamage, member) is not null) continue;
+                    if (FindEffectOnMember(Buffs.BalanceDamage, member) is not null) continue;
+                    if (FindEffectOnMember(Buffs.ArrowDamage, member) is not null) continue;
+                    if (FindEffectOnMember(Buffs.BoleDamage, member) is not null) continue;
+                    if (FindEffectOnMember(Buffs.EwerDamage, member) is not null) continue;
+                    if (FindEffectOnMember(Buffs.SpireDamage, member) is not null) continue;
+                    if (FindEffectOnMember(Buffs.SpearDamage, member) is not null) continue;
 
                     if (cardDrawn is CardType.BALANCE or CardType.ARROW or CardType.SPEAR)
                     {
-                        if (typeof(AST.TankCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.TankCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.TankCardTargetsJP).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
+                        if (typeof(AST.MeleeCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.MeleeCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.MeleeCardTargetsJP).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
                         {
                             TargetObject(member);
                             GetTarget = false;
@@ -407,463 +369,502 @@ namespace XIVSlothComboPlugin.Combos
                     }
                     if (cardDrawn is CardType.BOLE or CardType.EWER or CardType.SPIRE)
                     {
-                        if (typeof(AST.HealerCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.HealerCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.HealerCardTargetsJP).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
+                        if (typeof(AST.RangedCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.RangedCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.RangedCardTargetsJP).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
                         {
                             TargetObject(member);
                             GetTarget = false;
                             return true;
                         }
-                        
                     }
                 }
 
+                if (IsEnabled(CustomComboPreset.AstrologianTargetExtraFeature))
+                {
+                    for (int i = 1; i <= maxPartySize; i++)
+                    {
+                        GameObject? member = GetPartySlot(i);
+                        if (member == null) break;
+                        string job = "";
+                        if (member is BattleNpc) job = (member as BattleNpc).ClassJob.GameData.Name.ToString();
+                        if (member is BattleChara) job = (member as BattleChara).ClassJob.GameData.Name.ToString();
+
+                        if (FindEffectOnMember(Buffs.BalanceDamage, member) is not null) continue;
+                        if (FindEffectOnMember(Buffs.ArrowDamage, member) is not null) continue;
+                        if (FindEffectOnMember(Buffs.BoleDamage, member) is not null) continue;
+                        if (FindEffectOnMember(Buffs.EwerDamage, member) is not null) continue;
+                        if (FindEffectOnMember(Buffs.SpireDamage, member) is not null) continue;
+                        if (FindEffectOnMember(Buffs.SpearDamage, member) is not null) continue;
+
+                        if (cardDrawn is CardType.BALANCE or CardType.ARROW or CardType.SPEAR)
+                        {
+                            if (typeof(AST.TankCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.TankCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.TankCardTargetsJP).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
+                            {
+                                TargetObject(member);
+                                GetTarget = false;
+                                return true;
+                            }
+
+                        }
+                        if (cardDrawn is CardType.BOLE or CardType.EWER or CardType.SPIRE)
+                        {
+                            if (typeof(AST.HealerCardTargets).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.HealerCardTargetsCN).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job) || typeof(AST.HealerCardTargetsJP).GetFields().Select(x => x.GetRawConstantValue().ToString()).Contains(job))
+                            {
+                                TargetObject(member);
+                                GetTarget = false;
+                                return true;
+                            }
+
+                        }
+                    }
+
+                }
+
+                return false;
+
             }
-
-            return false;
-
         }
-    }
 
 
-    internal class AstrologianCrownPlayFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianCrownPlayFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianCrownPlayFeature : CustomCombo
         {
-            if (actionID == AST.CrownPlay)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianCrownPlayFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<ASTGauge>();
-                /*var ladyofCrown = HasEffect(AST.Buffs.LadyOfCrownsDrawn);
-                var lordofCrown = HasEffect(AST.Buffs.LordOfCrownsDrawn);
-                var minorArcanaCD = GetCooldown(AST.MinorArcana);*/
-                if (level >= AST.Levels.MinorArcana && gauge.DrawnCrownCard == CardType.NONE)
-                    return AST.MinorArcana;
+                if (actionID == CrownPlay)
+                {
+                    var gauge = GetJobGauge<ASTGauge>();
+                    /*var ladyofCrown = HasEffect(AST.Buffs.LadyOfCrownsDrawn);
+                    var lordofCrown = HasEffect(AST.Buffs.LordOfCrownsDrawn);
+                    var minorArcanaCD = GetCooldown(AST.MinorArcana);*/
+                    if (level >= Levels.MinorArcana && gauge.DrawnCrownCard == CardType.NONE)
+                        return MinorArcana;
+                }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class AstrologianBeneficFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianBeneficFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianBeneficFeature : CustomCombo
         {
-            if (actionID == AST.Benefic2)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianBeneficFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (level < AST.Levels.Benefic2)
-                    return AST.Benefic;
+                if (actionID == Benefic2)
+                {
+                    if (level < Levels.Benefic2)
+                        return Benefic;
+                }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class AstrologianAscendFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianAscendFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianAscendFeature : CustomCombo
         {
-            if (actionID == All.Swiftcast)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianAscendFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (IsEnabled(CustomComboPreset.AstrologianAscendFeature))
+                if (actionID == All.Swiftcast)
                 {
-                    if (HasEffect(All.Buffs.Swiftcast))
-                        return AST.Ascend;
+                    if (IsEnabled(CustomComboPreset.AstrologianAscendFeature))
+                    {
+                        if (HasEffect(All.Buffs.Swiftcast))
+                            return Ascend;
+                    }
+
+                    return OriginalHook(All.Swiftcast);
                 }
 
-                return OriginalHook(All.Swiftcast);
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class AstrologianDpsFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianDpsFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianDpsFeature : CustomCombo
         {
-            if (actionID == AST.FallMalefic || actionID == AST.Malefic4 || actionID == AST.Malefic3 || actionID == AST.Malefic2 || actionID == AST.Malefic1)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianDpsFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
+                if (actionID == FallMalefic || actionID == Malefic4 || actionID == Malefic3 || actionID == Malefic2 || actionID == Malefic1)
+                {
 
-                var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var combust3Debuff = FindTargetEffect(AST.Debuffs.Combust3);
-                var combust2Debuff = FindTargetEffect(AST.Debuffs.Combust2);
-                var combust1Debuff = FindTargetEffect(AST.Debuffs.Combust1);
-                var gauge = GetJobGauge<ASTGauge>();
-                var lucidDreaming = GetCooldown(All.LucidDreaming);
-                var fallmalefic = GetCooldown(AST.FallMalefic);
-                var minorarcanaCD = GetCooldown(AST.MinorArcana);
-                var drawCD = GetCooldown(AST.Draw);
-                var actionIDCD = GetCooldown(actionID);
-                var lucidMPThreshold = Service.Configuration.GetCustomIntValue(AST.Config.ASTLucidDreamingFeature);
+                    var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var combust3Debuff = FindTargetEffect(Debuffs.Combust3);
+                    var combust2Debuff = FindTargetEffect(Debuffs.Combust2);
+                    var combust1Debuff = FindTargetEffect(Debuffs.Combust1);
+                    var gauge = GetJobGauge<ASTGauge>();
+                    var lucidDreaming = GetCooldown(All.LucidDreaming);
+                    var fallmalefic = GetCooldown(FallMalefic);
+                    var minorarcanaCD = GetCooldown(MinorArcana);
+                    var drawCD = GetCooldown(Draw);
+                    var actionIDCD = GetCooldown(actionID);
+                    var lucidMPThreshold = Service.Configuration.GetCustomIntValue(Config.ASTLucidDreamingFeature);
 
-                if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
-                {
-                    var lightspeed = GetCooldown(AST.Lightspeed);
-                    if (!lightspeed.IsCooldown && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.6)
-                        return AST.Lightspeed;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAstrodyneFeature) && level >= 50)
-                {
-                    if (!gauge.ContainsSeal(SealType.NONE) && incombat && fallmalefic.CooldownRemaining >= 0.6 && level >= 50)
-                        return AST.Astrodyne;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAutoDrawFeature) && level >= 30)
-                {
-                    if (gauge.DrawnCard.Equals(CardType.NONE) && incombat && actionIDCD.CooldownRemaining >= 0.6 && drawCD.CooldownRemaining < 30 && level >= 30)
-                        return AST.Draw;
+                    if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
+                    {
+                        var lightspeed = GetCooldown(Lightspeed);
+                        if (!lightspeed.IsCooldown && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.6)
+                            return Lightspeed;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAstrodyneFeature) && level >= 50)
+                    {
+                        if (!gauge.ContainsSeal(SealType.NONE) && incombat && fallmalefic.CooldownRemaining >= 0.6 && level >= 50)
+                            return Astrodyne;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAutoDrawFeature) && level >= 30)
+                    {
+                        if (gauge.DrawnCard.Equals(CardType.NONE) && incombat && actionIDCD.CooldownRemaining >= 0.6 && drawCD.CooldownRemaining < 30 && level >= 30)
+                            return Draw;
 
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAutoCrownDrawFeature) && level >= 70)
-                {
-                    if (gauge.DrawnCrownCard == CardType.NONE && incombat && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
-                        return AST.MinorArcana;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
-                {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2)
-                        return All.LucidDreaming;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
-                {
-                    if (gauge.DrawnCrownCard == CardType.LORD && incombat && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
-                        return AST.LordOfCrowns;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianDpsFeature) && !IsEnabled(CustomComboPreset.DisableCombustOnDpsFeature) && level >= 72 && incombat)
-                {
-                    if ((combust3Debuff is null) || (combust3Debuff.RemainingTime <= 3))
-                        return AST.Combust3;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAutoCrownDrawFeature) && level >= 70)
+                    {
+                        if (gauge.DrawnCrownCard == CardType.NONE && incombat && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
+                            return MinorArcana;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
+                    {
+                        if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2)
+                            return All.LucidDreaming;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
+                    {
+                        if (gauge.DrawnCrownCard == CardType.LORD && incombat && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
+                            return LordOfCrowns;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianDpsFeature) && !IsEnabled(CustomComboPreset.DisableCombustOnDpsFeature) && level >= 72 && incombat)
+                    {
+                        if ((combust3Debuff is null) || (combust3Debuff.RemainingTime <= 3))
+                            return Combust3;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.AstrologianDpsFeature) && !IsEnabled(CustomComboPreset.DisableCombustOnDpsFeature) && level >= 46 && level <= 71 && incombat)
+                    {
+                        if ((combust2Debuff is null) || (combust2Debuff.RemainingTime <= 3))
+                            return Combust2;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.AstrologianDpsFeature) && !IsEnabled(CustomComboPreset.DisableCombustOnDpsFeature) && level >= 4 && level <= 45 && incombat)
+                    {
+                        if ((combust1Debuff is null) || (combust1Debuff.RemainingTime <= 3))
+                            return Combust1;
+                    }
                 }
 
-                if (IsEnabled(CustomComboPreset.AstrologianDpsFeature) && !IsEnabled(CustomComboPreset.DisableCombustOnDpsFeature) && level >= 46 && level <= 71 && incombat)
-                {
-                    if ((combust2Debuff is null) || (combust2Debuff.RemainingTime <= 3))
-                        return AST.Combust2;
-                }
-
-                if (IsEnabled(CustomComboPreset.AstrologianDpsFeature) && !IsEnabled(CustomComboPreset.DisableCombustOnDpsFeature) && level >= 4 && level <= 45 && incombat)
-                {
-                    if ((combust1Debuff is null) || (combust1Debuff.RemainingTime <= 3))
-                        return AST.Combust1;
-                }
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class AstrologianHeliosFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianHeliosFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianHeliosFeature : CustomCombo
         {
-            if (actionID == AST.AspectedHelios)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianHeliosFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var heliosBuff = FindEffect(AST.Buffs.AspectedHelios);
-                var horoscopeCD = GetCooldown(AST.Horoscope);
-                var celestialOppositionCD = GetCooldown(AST.CelestialOpposition);
-                var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var gauge = GetJobGauge<ASTGauge>();
-
-                if (level < AST.Levels.AspectedHelios)
-                    return AST.Helios;
-
-                if (IsEnabled(CustomComboPreset.AstrologianLazyLadyFeature))
+                if (actionID == AspectedHelios)
                 {
-                    if (gauge.DrawnCrownCard == CardType.LADY && incombat && level >= AST.Levels.CrownPlay)
-                        return AST.LadyOfCrown;
+                    var heliosBuff = FindEffect(Buffs.AspectedHelios);
+                    var horoscopeCD = GetCooldown(Horoscope);
+                    var celestialOppositionCD = GetCooldown(CelestialOpposition);
+                    var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var gauge = GetJobGauge<ASTGauge>();
+
+                    if (level < Levels.AspectedHelios)
+                        return Helios;
+
+                    if (IsEnabled(CustomComboPreset.AstrologianLazyLadyFeature))
+                    {
+                        if (gauge.DrawnCrownCard == CardType.LADY && incombat && level >= Levels.CrownPlay)
+                            return LadyOfCrown;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.AstrologianCelestialOppositionFeature) && celestialOppositionCD.CooldownRemaining == 0 && level >= Levels.CelestialOpposition)
+                        return CelestialOpposition;
+
+                    if (IsEnabled(CustomComboPreset.AstrologianHoroscopeFeature))
+                    {
+                        if (horoscopeCD.CooldownRemaining == 0 && level >= Levels.Horoscope)
+                            return Horoscope;
+
+                        if ((!HasEffect(Buffs.AspectedHelios) && level >= Levels.AspectedHelios)
+                             || HasEffect(Buffs.Horoscope)
+                             || (HasEffect(Buffs.NeutralSect) && !HasEffect(Buffs.NeutralSectShield)))
+                            return AspectedHelios;
+
+                        if (HasEffect(Buffs.HoroscopeHelios))
+                            return OriginalHook(Horoscope);
+                    }
+
+                    if (HasEffect(Buffs.AspectedHelios) && heliosBuff.RemainingTime > 2)
+                        return Helios;
                 }
 
-                if (IsEnabled(CustomComboPreset.AstrologianCelestialOppositionFeature) && celestialOppositionCD.CooldownRemaining == 0 && level >= AST.Levels.CelestialOpposition)
-                    return AST.CelestialOpposition;
-
-                if (IsEnabled(CustomComboPreset.AstrologianHoroscopeFeature))
-                {
-                    if (horoscopeCD.CooldownRemaining == 0 && level >= AST.Levels.Horoscope)
-                        return AST.Horoscope;
-
-                    if ((!HasEffect(AST.Buffs.AspectedHelios) && level >= AST.Levels.AspectedHelios)
-                         || HasEffect(AST.Buffs.Horoscope)
-                         || (HasEffect(AST.Buffs.NeutralSect) && !HasEffect(AST.Buffs.NeutralSectShield)))
-                        return AST.AspectedHelios;
-
-                    if (HasEffect(AST.Buffs.HoroscopeHelios))
-                        return OriginalHook(AST.Horoscope);
-                }
-
-                if (HasEffect(AST.Buffs.AspectedHelios) && heliosBuff.RemainingTime > 2)
-                    return AST.Helios;
+                return actionID;
             }
-
-            return actionID;
         }
-    }
-    internal class AstrologianDpsAoEFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianDpsAoEFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianDpsAoEFeature : CustomCombo
         {
-            if (actionID == AST.Gravity || actionID == AST.Gravity2)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianDpsAoEFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
+                if (actionID == Gravity || actionID == Gravity2)
+                {
 
-                var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var gauge = GetJobGauge<ASTGauge>();
-                var lucidDreaming = GetCooldown(All.LucidDreaming);
-                var minorarcanaCD = GetCooldown(AST.MinorArcana);
-                var drawCD = GetCooldown(AST.Draw);
-                var actionIDCD = GetCooldown(actionID);
-                var lucidMPThreshold = Service.Configuration.GetCustomIntValue(AST.Config.ASTLucidDreamingFeature);
+                    var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var gauge = GetJobGauge<ASTGauge>();
+                    var lucidDreaming = GetCooldown(All.LucidDreaming);
+                    var minorarcanaCD = GetCooldown(MinorArcana);
+                    var drawCD = GetCooldown(Draw);
+                    var actionIDCD = GetCooldown(actionID);
+                    var lucidMPThreshold = Service.Configuration.GetCustomIntValue(Config.ASTLucidDreamingFeature);
 
-                if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
-                {
-                    var lightspeed = GetCooldown(AST.Lightspeed);
-                    if (!lightspeed.IsCooldown && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.6)
-                        return AST.Lightspeed;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAstrodyneFeature) && level >= 50)
-                {
-                    if (!gauge.ContainsSeal(SealType.NONE) && incombat && actionIDCD.CooldownRemaining >= 0.6 && level >= 50)
-                        return AST.Astrodyne;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAutoDrawFeature) && level >= 30)
-                {
-                    if (gauge.DrawnCard.Equals(CardType.NONE) && incombat && actionIDCD.CooldownRemaining >= 0.6 && drawCD.CooldownRemaining < 30 && level >= 30)
-                        return AST.Draw;
+                    if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
+                    {
+                        var lightspeed = GetCooldown(Lightspeed);
+                        if (!lightspeed.IsCooldown && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.6)
+                            return Lightspeed;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAstrodyneFeature) && level >= 50)
+                    {
+                        if (!gauge.ContainsSeal(SealType.NONE) && incombat && actionIDCD.CooldownRemaining >= 0.6 && level >= 50)
+                            return Astrodyne;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAutoDrawFeature) && level >= 30)
+                    {
+                        if (gauge.DrawnCard.Equals(CardType.NONE) && incombat && actionIDCD.CooldownRemaining >= 0.6 && drawCD.CooldownRemaining < 30 && level >= 30)
+                            return Draw;
 
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
+                    {
+                        if (gauge.DrawnCrownCard == CardType.LORD && incombat && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
+                            return LordOfCrowns;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAutoCrownDrawFeature) && level >= 70)
+                    {
+                        if (gauge.DrawnCrownCard == CardType.NONE && incombat && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
+                            return MinorArcana;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
+                    {
+                        if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && actionIDCD.CooldownRemaining > 0.2)
+                            return All.LucidDreaming;
+                    }
                 }
-                if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
-                {
-                    if (gauge.DrawnCrownCard == CardType.LORD && incombat && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
-                        return AST.LordOfCrowns;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAutoCrownDrawFeature) && level >= 70)
-                {
-                    if (gauge.DrawnCrownCard == CardType.NONE && incombat && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
-                        return AST.MinorArcana;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
-                {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && actionIDCD.CooldownRemaining > 0.2 )
-                        return All.LucidDreaming;
-                }
+                return actionID;
             }
-            return actionID;
         }
-    }
-    internal class AstrologianAstrodyneOnPlayFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianAstrodyneOnPlayFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianAstrodyneOnPlayFeature : CustomCombo
         {
-            if (actionID == AST.Play && !IsEnabled(CustomComboPreset.AstrologianCardsOnDrawFeaturelikewhat))
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianAstrodyneOnPlayFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<ASTGauge>();
-                if (!gauge.ContainsSeal(SealType.NONE))
-                    return AST.Astrodyne;
+                if (actionID == Play && !IsEnabled(CustomComboPreset.AstrologianCardsOnDrawFeaturelikewhat))
+                {
+                    var gauge = GetJobGauge<ASTGauge>();
+                    if (!gauge.ContainsSeal(SealType.NONE))
+                        return Astrodyne;
+                }
+                return actionID;
+
             }
-            return actionID;
-
         }
-    }
-    internal class AstrologianAlternateDpsFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianAlternateDpsFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianAlternateDpsFeature : CustomCombo
         {
-            if (actionID == AST.Combust1 || actionID == AST.Combust2 || actionID == AST.Combust3)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianAlternateDpsFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
+                if (actionID == Combust1 || actionID == Combust2 || actionID == Combust3)
+                {
 
-                var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var combust3Debuff = FindTargetEffect(AST.Debuffs.Combust3);
-                var combust2Debuff = FindTargetEffect(AST.Debuffs.Combust2);
-                var combust1Debuff = FindTargetEffect(AST.Debuffs.Combust1);
-                var gauge = GetJobGauge<ASTGauge>();
-                var lucidDreaming = GetCooldown(All.LucidDreaming);
-                var fallmalefic = GetCooldown(AST.FallMalefic);
-                var minorarcanaCD = GetCooldown(AST.MinorArcana);
-                var drawCD = GetCooldown(AST.Draw);
-                var actionIDCD = GetCooldown(actionID);
-                var lucidMPThreshold = Service.Configuration.GetCustomIntValue(AST.Config.ASTLucidDreamingFeature);
+                    var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var combust3Debuff = FindTargetEffect(Debuffs.Combust3);
+                    var combust2Debuff = FindTargetEffect(Debuffs.Combust2);
+                    var combust1Debuff = FindTargetEffect(Debuffs.Combust1);
+                    var gauge = GetJobGauge<ASTGauge>();
+                    var lucidDreaming = GetCooldown(All.LucidDreaming);
+                    var fallmalefic = GetCooldown(FallMalefic);
+                    var minorarcanaCD = GetCooldown(MinorArcana);
+                    var drawCD = GetCooldown(Draw);
+                    var actionIDCD = GetCooldown(actionID);
+                    var lucidMPThreshold = Service.Configuration.GetCustomIntValue(Config.ASTLucidDreamingFeature);
 
 
-                if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
-                {
-                    var lightspeed = GetCooldown(AST.Lightspeed);
-                    if (!lightspeed.IsCooldown && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.6)
-                        return AST.Lightspeed;
-                }
-                if (!HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
-                {
-                    return OriginalHook(AST.Malefic1);
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAstrodyneFeature) && level >= 50)
-                {
-                    if (!gauge.ContainsSeal(SealType.NONE) && incombat && fallmalefic.CooldownRemaining >= 0.6 && level >= 50)
-                        return AST.Astrodyne;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAutoDrawFeature) && level >= 30)
-                {
-                    if (gauge.DrawnCard.Equals(CardType.NONE) && incombat && actionIDCD.CooldownRemaining >= 0.6 && drawCD.CooldownRemaining < 30 && level >= 30)
-                        return AST.Draw;
+                    if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
+                    {
+                        var lightspeed = GetCooldown(Lightspeed);
+                        if (!lightspeed.IsCooldown && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.6)
+                            return Lightspeed;
+                    }
+                    if (!HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
+                    {
+                        return OriginalHook(Malefic1);
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAstrodyneFeature) && level >= 50)
+                    {
+                        if (!gauge.ContainsSeal(SealType.NONE) && incombat && fallmalefic.CooldownRemaining >= 0.6 && level >= 50)
+                            return Astrodyne;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAutoDrawFeature) && level >= 30)
+                    {
+                        if (gauge.DrawnCard.Equals(CardType.NONE) && incombat && actionIDCD.CooldownRemaining >= 0.6 && drawCD.CooldownRemaining < 30 && level >= 30)
+                            return Draw;
 
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAutoCrownDrawFeature) && level >= 70)
-                {
-                    if (gauge.DrawnCrownCard == CardType.NONE && incombat && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
-                        return AST.MinorArcana;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
-                {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2)
-                        return All.LucidDreaming;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
-                {
-                    if (gauge.DrawnCrownCard == CardType.LORD && incombat && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
-                        return AST.LordOfCrowns;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAlternateDpsFeature) && level >= 72 && incombat)
-                {
-                    if ((combust3Debuff is null) || (combust3Debuff.RemainingTime <= 3))
-                        return AST.Combust3;
-                }
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAutoCrownDrawFeature) && level >= 70)
+                    {
+                        if (gauge.DrawnCrownCard == CardType.NONE && incombat && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
+                            return MinorArcana;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
+                    {
+                        if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.2)
+                            return All.LucidDreaming;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
+                    {
+                        if (gauge.DrawnCrownCard == CardType.LORD && incombat && actionIDCD.CooldownRemaining >= 0.6 && level >= 70)
+                            return LordOfCrowns;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAlternateDpsFeature) && level >= 72 && incombat)
+                    {
+                        if ((combust3Debuff is null) || (combust3Debuff.RemainingTime <= 3))
+                            return Combust3;
+                    }
 
-                if (IsEnabled(CustomComboPreset.AstrologianAlternateDpsFeature) && level >= 46 && level <= 71 && incombat)
-                {
-                    if ((combust2Debuff is null) || (combust2Debuff.RemainingTime <= 3))
-                        return AST.Combust2;
-                }
+                    if (IsEnabled(CustomComboPreset.AstrologianAlternateDpsFeature) && level >= 46 && level <= 71 && incombat)
+                    {
+                        if ((combust2Debuff is null) || (combust2Debuff.RemainingTime <= 3))
+                            return Combust2;
+                    }
 
-                if (IsEnabled(CustomComboPreset.AstrologianAlternateDpsFeature) && level >= 4 && level <= 45 && incombat)
-                {
-                    if ((combust1Debuff is null) || (combust1Debuff.RemainingTime <= 3))
-                        return AST.Combust1;
+                    if (IsEnabled(CustomComboPreset.AstrologianAlternateDpsFeature) && level >= 4 && level <= 45 && incombat)
+                    {
+                        if ((combust1Debuff is null) || (combust1Debuff.RemainingTime <= 3))
+                            return Combust1;
+                    }
+                    return OriginalHook(Malefic1);
                 }
-                return OriginalHook(AST.Malefic1);
+                return actionID;
             }
-            return actionID;
         }
-    }
-    internal class CustomValuesTest : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.CustomValuesTest;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class CustomValuesTest : CustomCombo
         {
-            if (actionID == AST.FallMalefic || actionID == AST.Malefic4 || actionID == AST.Malefic3 || actionID == AST.Malefic2 || actionID == AST.Malefic1)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.CustomValuesTest;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
+                if (actionID == FallMalefic || actionID == Malefic4 || actionID == Malefic3 || actionID == Malefic2 || actionID == Malefic1)
+                {
 
-                var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var combust3Debuff = FindTargetEffect(AST.Debuffs.Combust3);
-                var combust2Debuff = FindTargetEffect(AST.Debuffs.Combust2);
-                var combust1Debuff = FindTargetEffect(AST.Debuffs.Combust1);
-                var gauge = GetJobGauge<ASTGauge>();
-                var lucidDreaming = GetCooldown(All.LucidDreaming);
-                var fallmalefic = GetCooldown(AST.FallMalefic);
-                var minorarcanaCD = GetCooldown(AST.MinorArcana);
-                var drawCD = GetCooldown(AST.Draw);
-                var actionIDCD = GetCooldown(actionID);
-                var MaxHpValue = Service.Configuration.EnemyHealthMaxHp;
-                var PercentageHpValue = Service.Configuration.EnemyHealthPercentage;
-                var CurrentHpValue = Service.Configuration.EnemyCurrentHp;
-                var lucidMPThreshold = Service.Configuration.GetCustomIntValue(AST.Config.ASTLucidDreamingFeature);
+                    var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var combust3Debuff = FindTargetEffect(Debuffs.Combust3);
+                    var combust2Debuff = FindTargetEffect(Debuffs.Combust2);
+                    var combust1Debuff = FindTargetEffect(Debuffs.Combust1);
+                    var gauge = GetJobGauge<ASTGauge>();
+                    var lucidDreaming = GetCooldown(All.LucidDreaming);
+                    var fallmalefic = GetCooldown(FallMalefic);
+                    var minorarcanaCD = GetCooldown(MinorArcana);
+                    var drawCD = GetCooldown(Draw);
+                    var actionIDCD = GetCooldown(actionID);
+                    var MaxHpValue = Service.Configuration.EnemyHealthMaxHp;
+                    var PercentageHpValue = Service.Configuration.EnemyHealthPercentage;
+                    var CurrentHpValue = Service.Configuration.EnemyCurrentHp;
+                    var lucidMPThreshold = Service.Configuration.GetCustomIntValue(Config.ASTLucidDreamingFeature);
 
-                if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
-                {
-                    var lightspeed = GetCooldown(AST.Lightspeed);
-                    if (!lightspeed.IsCooldown && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.4)
-                        return AST.Lightspeed;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAstrodyneFeature) && level >= 50)
-                {
-                    if (!gauge.ContainsSeal(SealType.NONE) && lastComboMove == OriginalHook(actionID) && fallmalefic.CooldownRemaining >= 0.4 && level >= 50)
-                        return AST.Astrodyne;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAutoDrawFeature) && level >= 30)
-                {
-                    if (gauge.DrawnCard.Equals(CardType.NONE) && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.4 && drawCD.CooldownRemaining < 30 && level >= 30)
-                        return AST.Draw;
+                    if (IsEnabled(CustomComboPreset.AstrologianLightSpeedFeature) && level >= 6)
+                    {
+                        var lightspeed = GetCooldown(Lightspeed);
+                        if (!lightspeed.IsCooldown && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.4)
+                            return Lightspeed;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAstrodyneFeature) && level >= 50)
+                    {
+                        if (!gauge.ContainsSeal(SealType.NONE) && lastComboMove == OriginalHook(actionID) && fallmalefic.CooldownRemaining >= 0.4 && level >= 50)
+                            return Astrodyne;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAutoDrawFeature) && level >= 30)
+                    {
+                        if (gauge.DrawnCard.Equals(CardType.NONE) && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.4 && drawCD.CooldownRemaining < 30 && level >= 30)
+                            return Draw;
 
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianAutoCrownDrawFeature) && level >= 70)
-                {
-                    if (gauge.DrawnCrownCard == CardType.NONE && lastComboMove == OriginalHook(actionID) && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.4 && level >= 70)
-                        return AST.MinorArcana;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
-                {
-                    if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.4)
-                        return All.LucidDreaming;
-                }
-                if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
-                {
-                    var buff = HasEffect(AST.Buffs.Divination);
-                    var buffcd = GetCooldown(AST.Divination);
-                    if (gauge.DrawnCrownCard == CardType.LORD && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.4 && level >= 70 && buff || gauge.DrawnCrownCard == CardType.LORD && incombat && actionIDCD.CooldownRemaining >= 0.4 && level >= 70 && buffcd.IsCooldown)
-                        return AST.LordOfCrowns;
-                }
-                if (IsEnabled(CustomComboPreset.CustomValuesTest) && level >= 72 && incombat)
-                {
-                    if ((combust3Debuff is null) && EnemyHealthMaxHp() > MaxHpValue && EnemyHealthPercentage() > PercentageHpValue && EnemyHealthCurrentHp() > CurrentHpValue || (combust3Debuff.RemainingTime <= 3) && EnemyHealthPercentage() > PercentageHpValue && EnemyHealthCurrentHp() > CurrentHpValue)
-                        return AST.Combust3;
-                }
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianAutoCrownDrawFeature) && level >= 70)
+                    {
+                        if (gauge.DrawnCrownCard == CardType.NONE && lastComboMove == OriginalHook(actionID) && minorarcanaCD.CooldownRemaining == 0 && actionIDCD.CooldownRemaining >= 0.4 && level >= 70)
+                            return MinorArcana;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianLucidFeature) && level >= All.Levels.LucidDreaming)
+                    {
+                        if (!lucidDreaming.IsCooldown && LocalPlayer.CurrentMp <= lucidMPThreshold && fallmalefic.CooldownRemaining > 0.4)
+                            return All.LucidDreaming;
+                    }
+                    if (IsEnabled(CustomComboPreset.AstrologianLazyLordFeature) && level >= 70)
+                    {
+                        var buff = HasEffect(Buffs.Divination);
+                        var buffcd = GetCooldown(Divination);
+                        if (gauge.DrawnCrownCard == CardType.LORD && lastComboMove == OriginalHook(actionID) && actionIDCD.CooldownRemaining >= 0.4 && level >= 70 && buff || gauge.DrawnCrownCard == CardType.LORD && incombat && actionIDCD.CooldownRemaining >= 0.4 && level >= 70 && buffcd.IsCooldown)
+                            return LordOfCrowns;
+                    }
+                    if (IsEnabled(CustomComboPreset.CustomValuesTest) && level >= 72 && incombat)
+                    {
+                        if ((combust3Debuff is null) && EnemyHealthMaxHp() > MaxHpValue && EnemyHealthPercentage() > PercentageHpValue && EnemyHealthCurrentHp() > CurrentHpValue || (combust3Debuff.RemainingTime <= 3) && EnemyHealthPercentage() > PercentageHpValue && EnemyHealthCurrentHp() > CurrentHpValue)
+                            return Combust3;
+                    }
 
-                if (IsEnabled(CustomComboPreset.CustomValuesTest) && level >= 46 && level <= 71 && incombat)
-                {
-                    if ((combust2Debuff is null) || (combust2Debuff.RemainingTime <= 3))
-                        return AST.Combust2;
-                }
+                    if (IsEnabled(CustomComboPreset.CustomValuesTest) && level >= 46 && level <= 71 && incombat)
+                    {
+                        if ((combust2Debuff is null) || (combust2Debuff.RemainingTime <= 3))
+                            return Combust2;
+                    }
 
-                if (IsEnabled(CustomComboPreset.CustomValuesTest) && level >= 4 && level <= 45 && incombat)
-                {
-                    if ((combust1Debuff is null) || (combust1Debuff.RemainingTime <= 3))
-                        return AST.Combust1;
+                    if (IsEnabled(CustomComboPreset.CustomValuesTest) && level >= 4 && level <= 45 && incombat)
+                    {
+                        if ((combust1Debuff is null) || (combust1Debuff.RemainingTime <= 3))
+                            return Combust1;
+                    }
                 }
+                return actionID;
             }
-            return actionID;
+
         }
 
-    }
-
-    internal class AstrologianSimpleSingleTargetHeal : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianSimpleSingleTargetHeal;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class AstrologianSimpleSingleTargetHeal : CustomCombo
         {
-            if (actionID == AST.Benefic2)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AstrologianSimpleSingleTargetHeal;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var aspectedBeneficHoT = FindTargetEffect(AST.Buffs.AspectedBenefic);
-                var NeutralSectBuff = FindTargetEffect(AST.Buffs.NeutralSect);
-                var NeutralSectShield = FindTargetEffect(AST.Buffs.NeutralSectShield);
-                var customEssentialDignity = Service.Configuration.GetCustomIntValue(AST.Config.AstroEssentialDignity);
-                var exaltationCD = GetCooldown(AST.Exaltation);
+                if (actionID == Benefic2)
+                {
+                    var aspectedBeneficHoT = FindTargetEffect(Buffs.AspectedBenefic);
+                    var NeutralSectBuff = FindTargetEffect(Buffs.NeutralSect);
+                    var NeutralSectShield = FindTargetEffect(Buffs.NeutralSectShield);
+                    var customEssentialDignity = Service.Configuration.GetCustomIntValue(Config.AstroEssentialDignity);
+                    var exaltationCD = GetCooldown(Exaltation);
 
-                if (IsEnabled(CustomComboPreset.AspectedBeneficFeature) && ((aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3)) || ((NeutralSectShield is null) && (NeutralSectBuff is not null)))
-                    return AST.AspectedBenefic;
+                    if (IsEnabled(CustomComboPreset.AspectedBeneficFeature) && ((aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3)) || ((NeutralSectShield is null) && (NeutralSectBuff is not null)))
+                        return AspectedBenefic;
 
-                if (IsEnabled(CustomComboPreset.AstroEssentialDignity) && GetCooldown(AST.EssentialDignity).RemainingCharges > 0 && level >= AST.Levels.EssentialDignity && EnemyHealthPercentage() <= customEssentialDignity)
-                    return AST.EssentialDignity;
+                    if (IsEnabled(CustomComboPreset.AstroEssentialDignity) && GetCooldown(EssentialDignity).RemainingCharges > 0 && level >= Levels.EssentialDignity && EnemyHealthPercentage() <= customEssentialDignity)
+                        return EssentialDignity;
 
-                if (IsEnabled(CustomComboPreset.ExaltationFeature) && exaltationCD.CooldownRemaining == 0 && level >= AST.Levels.Exaltation)
-                    return AST.Exaltation;
+                    if (IsEnabled(CustomComboPreset.ExaltationFeature) && exaltationCD.CooldownRemaining == 0 && level >= Levels.Exaltation)
+                        return Exaltation;
 
-                if (IsEnabled(CustomComboPreset.CelestialIntersectionFeature) && GetCooldown(AST.CelestialIntersection).RemainingCharges > 0 && level >= AST.Levels.CelestialIntersection)
-                    return AST.CelestialIntersection;
+                    if (IsEnabled(CustomComboPreset.CelestialIntersectionFeature) && GetCooldown(CelestialIntersection).RemainingCharges > 0 && level >= Levels.CelestialIntersection)
+                        return CelestialIntersection;
+                }
+
+
+                return actionID;
             }
 
-
-            return actionID;
         }
-
     }
 }

--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -314,7 +314,6 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (IsEnabled(CustomComboPreset.AstReTargetFeature))
                         {
-                            Dalamud.Logging.PluginLog.Debug("Previous?");
                             TargetObject(CurrentTarget);
                         }
 

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -101,373 +101,777 @@ namespace XIVSlothComboPlugin.Combos
             public const string BlmPolyglotsStored = "BlmPolyglotsStored";
             public const string BlmAstralFireRefresh = "BlmAstralFireRefresh";
         }
-    }
 
-    internal class BlackBlizzardFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackBlizzardFeature;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BlackBlizzardFeature : CustomCombo
         {
-            if (actionID == BLM.Blizzard)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackBlizzardFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<BLMGauge>().InUmbralIce;
-                if (level >= BLM.Levels.Freeze && !gauge)
+                if (actionID == Blizzard)
                 {
-                    return BLM.Blizzard3;
+                    var gauge = GetJobGauge<BLMGauge>().InUmbralIce;
+                    if (level >= Levels.Freeze && !gauge)
+                    {
+                        return Blizzard3;
+                    }
                 }
-            }
 
-            if (actionID == BLM.Freeze && level < BLM.Levels.Freeze)
-            {
-                return BLM.Blizzard2;
-            }
+                if (actionID == Freeze && level < Levels.Freeze)
+                {
+                    return Blizzard2;
+                }
 
-            return actionID;
+                return actionID;
+            }
         }
-    }
 
-    internal class BlackFire13Feature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackFire13Feature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BlackFire13Feature : CustomCombo
         {
-            if (actionID == BLM.Fire)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackFire13Feature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<BLMGauge>();
-                if ((level >= BLM.Levels.Fire3 && !gauge.InAstralFire) || HasEffect(BLM.Buffs.Firestarter))
+                if (actionID == Fire)
                 {
-                    return BLM.Fire3;
+                    var gauge = GetJobGauge<BLMGauge>();
+                    if ((level >= Levels.Fire3 && !gauge.InAstralFire) || HasEffect(Buffs.Firestarter))
+                    {
+                        return Fire3;
+                    }
                 }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class BlackLeyLinesFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackLeyLinesFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BlackLeyLinesFeature : CustomCombo
         {
-            if (actionID == BLM.LeyLines && HasEffect(BLM.Buffs.LeyLines) && level >= BLM.Levels.BetweenTheLines)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackLeyLinesFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                return BLM.BetweenTheLines;
+                if (actionID == LeyLines && HasEffect(Buffs.LeyLines) && level >= Levels.BetweenTheLines)
+                {
+                    return BetweenTheLines;
+                }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class BlackManaFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackManaFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BlackManaFeature : CustomCombo
         {
-            if (actionID == BLM.Transpose)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackManaFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<BLMGauge>();
-                if (gauge.InUmbralIce && level >= BLM.Levels.UmbralSoul)
+                if (actionID == Transpose)
                 {
-                    return BLM.UmbralSoul;
+                    var gauge = GetJobGauge<BLMGauge>();
+                    if (gauge.InUmbralIce && level >= Levels.UmbralSoul)
+                    {
+                        return UmbralSoul;
+                    }
                 }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class BlackEnochianFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackEnochianFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BlackEnochianFeature : CustomCombo
         {
-            if (actionID == BLM.Scathe)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackEnochianFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<BLMGauge>();
-                var GCD = GetCooldown(actionID);
-                var thundercloudduration = FindEffectAny(BLM.Buffs.Thundercloud);
-                var thunderdebuffontarget = FindTargetEffect(BLM.Debuffs.Thunder3);
-                var thunderOneDebuff = FindTargetEffect(BLM.Debuffs.Thunder);
-                var thunder3DebuffOnTarget = TargetHasEffect(BLM.Debuffs.Thunder3);
-
-                if (gauge.InUmbralIce && level >= BLM.Levels.Blizzard4)
+                if (actionID == Scathe)
                 {
-                    if (gauge.ElementTimeRemaining >= 0 && IsEnabled(CustomComboPreset.BlackThunderFeature))
+                    var gauge = GetJobGauge<BLMGauge>();
+                    var GCD = GetCooldown(actionID);
+                    var thundercloudduration = FindEffectAny(Buffs.Thundercloud);
+                    var thunderdebuffontarget = FindTargetEffect(Debuffs.Thunder3);
+                    var thunderOneDebuff = FindTargetEffect(Debuffs.Thunder);
+                    var thunder3DebuffOnTarget = TargetHasEffect(Debuffs.Thunder3);
+
+                    if (gauge.InUmbralIce && level >= Levels.Blizzard4)
                     {
-                        if (HasEffect(BLM.Buffs.Thundercloud))
+                        if (gauge.ElementTimeRemaining >= 0 && IsEnabled(CustomComboPreset.BlackThunderFeature))
                         {
-                            if ((TargetHasEffect(BLM.Debuffs.Thunder3) && thunderdebuffontarget.RemainingTime < 4) || (!thunder3DebuffOnTarget && HasEffect(BLM.Buffs.Thundercloud) && thundercloudduration.RemainingTime > 0 && thundercloudduration.RemainingTime < 35))
-                                return BLM.Thunder3;
+                            if (HasEffect(Buffs.Thundercloud))
+                            {
+                                if ((TargetHasEffect(Debuffs.Thunder3) && thunderdebuffontarget.RemainingTime < 4) || (!thunder3DebuffOnTarget && HasEffect(Buffs.Thundercloud) && thundercloudduration.RemainingTime > 0 && thundercloudduration.RemainingTime < 35))
+                                    return Thunder3;
+                            }
+
+                            if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !thunder3DebuffOnTarget && lastComboMove != Thunder3 && LocalPlayer.CurrentMp >= 400)
+                                return Thunder3;
+
+                            if (gauge.IsParadoxActive && level >= 90)
+                                return Paradox;
+
+                            if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && gauge.UmbralHearts == 3 && LocalPlayer.CurrentMp >= 10000)
+                                return Fire3;
+
                         }
 
-                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !thunder3DebuffOnTarget && lastComboMove != BLM.Thunder3 && LocalPlayer.CurrentMp >= 400)
-                            return BLM.Thunder3;
-
-                        if (gauge.IsParadoxActive && level >= 90)
-                            return BLM.Paradox;
-
-                        if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && gauge.UmbralHearts == 3 && LocalPlayer.CurrentMp >= 10000)
-                            return BLM.Fire3;
-
+                        return Blizzard4;
                     }
 
-                    return BLM.Blizzard4;
-                }
-
-                if (level >= BLM.Levels.Fire4)
-                {
-                    if (gauge.ElementTimeRemaining >= 6000 && IsEnabled(CustomComboPreset.BlackThunderFeature))
+                    if (level >= Levels.Fire4)
                     {
-                        if (HasEffect(BLM.Buffs.Thundercloud))
+                        if (gauge.ElementTimeRemaining >= 6000 && IsEnabled(CustomComboPreset.BlackThunderFeature))
                         {
-                            if ((TargetHasEffect(BLM.Debuffs.Thunder3) && thunderdebuffontarget.RemainingTime < 4) || (!thunder3DebuffOnTarget && HasEffect(BLM.Buffs.Thundercloud) && thundercloudduration.RemainingTime > 0 && thundercloudduration.RemainingTime < 35))
-                                return BLM.Thunder3;
+                            if (HasEffect(Buffs.Thundercloud))
+                            {
+                                if ((TargetHasEffect(Debuffs.Thunder3) && thunderdebuffontarget.RemainingTime < 4) || (!thunder3DebuffOnTarget && HasEffect(Buffs.Thundercloud) && thundercloudduration.RemainingTime > 0 && thundercloudduration.RemainingTime < 35))
+                                    return Thunder3;
+                            }
+
+                            if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !thunder3DebuffOnTarget && lastComboMove != Thunder3 && LocalPlayer.CurrentMp >= 400)
+                                return Thunder3;
                         }
 
-                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !thunder3DebuffOnTarget && lastComboMove != BLM.Thunder3 && LocalPlayer.CurrentMp >= 400)
-                            return BLM.Thunder3;
-                    }
-
-                    if (gauge.ElementTimeRemaining < 3000 && HasEffect(BLM.Buffs.Firestarter) && IsEnabled(CustomComboPreset.BlackFire13Feature))
-                    {
-                        return BLM.Fire3;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && level >= BLM.Levels.Blizzard3)
-                    {
-                        if ((LocalPlayer.CurrentMp < 800) || (LocalPlayer.CurrentMp < 1600 && level < BLM.Levels.Despair))
-                            return BLM.Blizzard3;
-                    }
-
-                    if (gauge.ElementTimeRemaining > 0 && LocalPlayer.CurrentMp < 2400 && level >= BLM.Levels.Despair && IsEnabled(CustomComboPreset.BlackDespairFeature))
-                    {
-                        return BLM.Despair;
-                    }
-
-                    if (gauge.IsEnochianActive)
-                    {
-                        if (gauge.ElementTimeRemaining < 6000 && !HasEffect(BLM.Buffs.Firestarter) && IsEnabled(CustomComboPreset.BlackFire13Feature) && level == 90 && gauge.IsParadoxActive)
-                            return BLM.Paradox;
-                        if (gauge.ElementTimeRemaining < 6000 && !HasEffect(BLM.Buffs.Firestarter) && IsEnabled(CustomComboPreset.BlackFire13Feature) && !gauge.IsParadoxActive)
-                            return BLM.Fire;
-                    }
-
-                    return BLM.Fire4;
-                }
-
-                if (gauge.ElementTimeRemaining >= 5000 && IsEnabled(CustomComboPreset.BlackThunderFeature))
-                {
-                    if (level < BLM.Levels.Thunder3)
-                    {
-                        if (HasEffect(BLM.Buffs.Thundercloud))
+                        if (gauge.ElementTimeRemaining < 3000 && HasEffect(Buffs.Firestarter) && IsEnabled(CustomComboPreset.BlackFire13Feature))
                         {
-                            if (TargetHasEffect(BLM.Debuffs.Thunder) && thunderOneDebuff.RemainingTime < 4)
-                                return BLM.Thunder;
+                            return Fire3;
+                        }
+
+                        if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && level >= Levels.Blizzard3)
+                        {
+                            if ((LocalPlayer.CurrentMp < 800) || (LocalPlayer.CurrentMp < 1600 && level < Levels.Despair))
+                                return Blizzard3;
+                        }
+
+                        if (gauge.ElementTimeRemaining > 0 && LocalPlayer.CurrentMp < 2400 && level >= Levels.Despair && IsEnabled(CustomComboPreset.BlackDespairFeature))
+                        {
+                            return Despair;
+                        }
+
+                        if (gauge.IsEnochianActive)
+                        {
+                            if (gauge.ElementTimeRemaining < 6000 && !HasEffect(Buffs.Firestarter) && IsEnabled(CustomComboPreset.BlackFire13Feature) && level == 90 && gauge.IsParadoxActive)
+                                return Paradox;
+                            if (gauge.ElementTimeRemaining < 6000 && !HasEffect(Buffs.Firestarter) && IsEnabled(CustomComboPreset.BlackFire13Feature) && !gauge.IsParadoxActive)
+                                return Fire;
+                        }
+
+                        return Fire4;
+                    }
+
+                    if (gauge.ElementTimeRemaining >= 5000 && IsEnabled(CustomComboPreset.BlackThunderFeature))
+                    {
+                        if (level < Levels.Thunder3)
+                        {
+                            if (HasEffect(Buffs.Thundercloud))
+                            {
+                                if (TargetHasEffect(Debuffs.Thunder) && thunderOneDebuff.RemainingTime < 4)
+                                    return Thunder;
+                            }
+                        }
+                        else
+                        {
+                            if (HasEffect(Buffs.Thundercloud))
+                            {
+                                if (TargetHasEffect(Debuffs.Thunder3) && thunderdebuffontarget.RemainingTime < 4)
+                                    return Thunder3;
+                            }
+                        }
+
+                        if (level < Levels.Thunder3)
+                        {
+                            if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !TargetHasEffect(Debuffs.Thunder) && lastComboMove != Thunder && LocalPlayer.CurrentMp >= 200)
+                                return Thunder;
+                        }
+                        else
+                        {
+                            if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !TargetHasEffect(Debuffs.Thunder3) && lastComboMove != Thunder3 && LocalPlayer.CurrentMp >= 400)
+                                return Thunder3;
                         }
                     }
-                    else
+
+                    if (level < Levels.Fire3)
                     {
-                        if (HasEffect(BLM.Buffs.Thundercloud))
-                        {
-                            if (TargetHasEffect(BLM.Debuffs.Thunder3) && thunderdebuffontarget.RemainingTime < 4)
-                                return BLM.Thunder3;
-                        }
+                        return Fire;
                     }
 
-                    if (level < BLM.Levels.Thunder3)
+                    if (gauge.InAstralFire)
                     {
-                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !TargetHasEffect(BLM.Debuffs.Thunder) && lastComboMove != BLM.Thunder && LocalPlayer.CurrentMp >= 200)
-                            return BLM.Thunder;
+                        if (HasEffect(Buffs.Firestarter) && level == 90)
+                            return Paradox;
+                        if (HasEffect(Buffs.Firestarter))
+                            return Fire3;
+                        if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp < 1600 && level >= Levels.Blizzard3)
+                            return Blizzard3;
+
+                        return Fire;
                     }
-                    else
+
+                    if (gauge.InUmbralIce)
                     {
-                        if (IsEnabled(CustomComboPreset.BlackThunderUptimeFeature) && !TargetHasEffect(BLM.Debuffs.Thunder3) && lastComboMove != BLM.Thunder3 && LocalPlayer.CurrentMp >= 400)
-                            return BLM.Thunder3;
+                        if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp >= 10000 && level >= Levels.Fire3)
+                            return Fire3;
+
+                        return Blizzard;
                     }
                 }
 
-                if (level < BLM.Levels.Fire3)
-                {
-                    return BLM.Fire;
-                }
-
-                if (gauge.InAstralFire)
-                {
-                    if (HasEffect(BLM.Buffs.Firestarter) && level == 90)
-                        return BLM.Paradox;
-                    if (HasEffect(BLM.Buffs.Firestarter))
-                        return BLM.Fire3;
-                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp < 1600 && level >= BLM.Levels.Blizzard3)
-                        return BLM.Blizzard3;
-
-                    return BLM.Fire;
-                }
-
-                if (gauge.InUmbralIce)
-                {
-                    if (IsEnabled(CustomComboPreset.BlackAspectSwapFeature) && LocalPlayer.CurrentMp >= 10000 && level >= BLM.Levels.Fire3)
-                        return BLM.Fire3;
-
-                    return BLM.Blizzard;
-                }
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class BlackAoEComboFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackAoEComboFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BlackAoEComboFeature : CustomCombo
         {
-            if (actionID == BLM.Flare)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackAoEComboFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<BLMGauge>();
-                var thunder4Debuff = TargetHasEffect(BLM.Debuffs.Thunder4);
-                var thunder4Timer = FindTargetEffect(BLM.Debuffs.Thunder4);
-                var thunder2Debuff = TargetHasEffect(BLM.Debuffs.Thunder2);
-                var thunder2Timer = FindTargetEffect(BLM.Debuffs.Thunder2);
-                var currentMP = LocalPlayer.CurrentMp;
-                var polyToStore = Service.Configuration.GetCustomIntValue(BLM.Config.BlmPolyglotsStored);
-
-                // Polyglot usage
-                if (IsEnabled(CustomComboPreset.BlackAoEFoulOption) && level >= BLM.Levels.Manafont && level >= BLM.Levels.Foul)
+                if (actionID == Flare)
                 {
-                    if (gauge.InAstralFire && currentMP <= BLM.MP.AspectFire && IsOffCooldown(BLM.Manafont) && CanSpellWeave(actionID) && lastComboMove == BLM.Foul)
+                    var gauge = GetJobGauge<BLMGauge>();
+                    var thunder4Debuff = TargetHasEffect(Debuffs.Thunder4);
+                    var thunder4Timer = FindTargetEffect(Debuffs.Thunder4);
+                    var thunder2Debuff = TargetHasEffect(Debuffs.Thunder2);
+                    var thunder2Timer = FindTargetEffect(Debuffs.Thunder2);
+                    var currentMP = LocalPlayer.CurrentMp;
+                    var polyToStore = Service.Configuration.GetCustomIntValue(Config.BlmPolyglotsStored);
+
+                    // Polyglot usage
+                    if (IsEnabled(CustomComboPreset.BlackAoEFoulOption) && level >= Levels.Manafont && level >= Levels.Foul)
                     {
-                        return BLM.Manafont;
+                        if (gauge.InAstralFire && currentMP <= MP.AspectFire && IsOffCooldown(Manafont) && CanSpellWeave(actionID) && lastComboMove == Foul)
+                        {
+                            return Manafont;
+                        }
+
+                        if ((gauge.InAstralFire && currentMP <= MP.AspectFire && IsOffCooldown(Manafont) && gauge.PolyglotStacks >= 1) || (IsOnCooldown(Manafont) && (GetCooldownRemainingTime(Manafont) >= 30 && gauge.PolyglotStacks > polyToStore)))
+                        {
+                            return Foul;
+                        }
                     }
 
-                    if ((gauge.InAstralFire && currentMP <= BLM.MP.AspectFire && IsOffCooldown(BLM.Manafont) && gauge.PolyglotStacks >= 1) || (IsOnCooldown(BLM.Manafont) && (GetCooldownRemainingTime(BLM.Manafont) >= 30 && gauge.PolyglotStacks > polyToStore)))
+                    // Thunder uptime
+                    if (currentMP >= MP.AspectThunder && lastComboMove != Manafont)
                     {
-                        return BLM.Foul;
+                        if (level >= Levels.Thunder4)
+                        {
+                            if (lastComboMove != Thunder4 && (!thunder4Debuff || thunder4Timer.RemainingTime <= 4) &&
+                               ((gauge.InUmbralIce && gauge.UmbralHearts == 3) ||
+                                (gauge.InAstralFire && !HasEffect(Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast))))
+                            {
+                                return Thunder4;
+                            }
+                        }
+                        else if (level >= Levels.Thunder2)
+                        {
+                            if (lastComboMove != Thunder2 && (!thunder2Debuff || thunder2Timer.RemainingTime <= 4) &&
+                               ((gauge.InUmbralIce && (gauge.UmbralHearts == 3 || level < Levels.Blizzard4)) ||
+                                (gauge.InAstralFire && !HasEffect(Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast))))
+                            {
+                                return Thunder2;
+                            }
+                        }
                     }
+
+                    // Fire 2 / Flare
+                    if (gauge.InAstralFire)
+                    {
+                        if (currentMP >= 7000)
+                        {
+                            if (gauge.UmbralHearts == 1)
+                            {
+                                return Flare;
+                            }
+                            return level >= Levels.HighFire2 ? HighFire2 : Fire2;
+                        }
+                        else if (currentMP >= MP.Despair)
+                        {
+                            if (level >= Levels.Flare)
+                            {
+                                return Flare;
+                            }
+                            else if (currentMP >= MP.AspectFire)
+                            {
+                                return Fire2;
+                            }
+                        }
+                        else if (level < Levels.Fire3)
+                        {
+                            return Transpose;
+                        }
+                    }
+
+                    // Umbral Hearts
+                    if (gauge.InUmbralIce)
+                    {
+                        if (level >= Levels.Blizzard4 && gauge.UmbralHearts <= 2)
+                        {
+                            return Freeze;
+                        }
+                        else if (level >= Levels.Freeze && currentMP < MP.MaxMP - MP.AspectThunder)
+                        {
+                            return Freeze;
+                        }
+                        if (level < Levels.Fire3)
+                        {
+                            return (currentMP >= MP.MaxMP - MP.AspectThunder) ? Transpose : Blizzard2;
+                        }
+                        return level >= Levels.HighFire2 ? HighFire2 : Fire2;
+                    }
+
+                    return level >= Levels.HighBlizzard2 ? HighBlizzard2 : Blizzard2;
                 }
 
-                // Thunder uptime
-                if (currentMP >= BLM.MP.AspectThunder && lastComboMove != BLM.Manafont)
-                {
-                    if (level >= BLM.Levels.Thunder4)
-                    {
-                        if (lastComboMove != BLM.Thunder4 && (!thunder4Debuff || thunder4Timer.RemainingTime <= 4) && 
-                           ((gauge.InUmbralIce && gauge.UmbralHearts == 3) || 
-                            (gauge.InAstralFire && !HasEffect(BLM.Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast))))
-                        {
-                            return BLM.Thunder4;
-                        }
-                    }
-                    else if (level >= BLM.Levels.Thunder2)
-                    {
-                        if (lastComboMove != BLM.Thunder2 && (!thunder2Debuff || thunder2Timer.RemainingTime <= 4) &&
-                           ((gauge.InUmbralIce && (gauge.UmbralHearts == 3 || level < BLM.Levels.Blizzard4)) || 
-                            (gauge.InAstralFire && !HasEffect(BLM.Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast))))
-                        {
-                            return BLM.Thunder2;
-                        }
-                    }
-                }
-
-                // Fire 2 / Flare
-                if (gauge.InAstralFire)
-                {
-                    if (currentMP >= 7000)
-                    {
-                        if (gauge.UmbralHearts == 1)
-                        {
-                            return BLM.Flare;
-                        }
-                        return level >= BLM.Levels.HighFire2 ? BLM.HighFire2 : BLM.Fire2;
-                    }
-                    else if (currentMP >= BLM.MP.Despair)
-                    {
-                        if (level >= BLM.Levels.Flare)
-                        {
-                            return BLM.Flare;
-                        }
-                        else if (currentMP >= BLM.MP.AspectFire)
-                        {
-                            return BLM.Fire2;
-                        }
-                    }
-                    else if (level < BLM.Levels.Fire3)
-                    {
-                        return BLM.Transpose;
-                    }
-                }
-
-                // Umbral Hearts
-                if (gauge.InUmbralIce)
-                {
-                    if (level >= BLM.Levels.Blizzard4 && gauge.UmbralHearts <= 2)
-                    {
-                        return BLM.Freeze;
-                    }
-                    else if (level >= BLM.Levels.Freeze && currentMP < BLM.MP.MaxMP - BLM.MP.AspectThunder)
-                    {
-                        return BLM.Freeze;
-                    }
-                    if (level < BLM.Levels.Fire3)
-                    {
-                        return (currentMP >= BLM.MP.MaxMP - BLM.MP.AspectThunder) ? BLM.Transpose : BLM.Blizzard2;
-                    }
-                    return level >= BLM.Levels.HighFire2 ? BLM.HighFire2 : BLM.Fire2;
-                }
-
-                return level >= BLM.Levels.HighBlizzard2 ? BLM.HighBlizzard2 : BLM.Blizzard2;
+                return actionID;
             }
-
-            return actionID;
         }
-    }
-    
-    internal class BlackSimpleFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackSimpleFeature;
-        
-        internal static bool inOpener = false;
-        internal static bool openerFinished = false;
 
-        internal delegate bool DotRecast(int value); 
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BlackSimpleFeature : CustomCombo
         {
-            if (actionID == BLM.Scathe)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackSimpleFeature;
+
+            internal static bool inOpener = false;
+            internal static bool openerFinished = false;
+
+            internal delegate bool DotRecast(int value);
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var gauge = GetJobGauge<BLMGauge>();
-                var canWeave = CanSpellWeave(actionID);
-                var currentMP = LocalPlayer.CurrentMp;
-                var astralFireRefresh = Service.Configuration.GetCustomFloatValue(BLM.Config.BlmAstralFireRefresh) * 1000;
-
-                var thunder = TargetHasEffect(BLM.Debuffs.Thunder);
-                var thunder3 = TargetHasEffect(BLM.Debuffs.Thunder3);
-                var thunderDuration = FindTargetEffect(BLM.Debuffs.Thunder);
-                var thunder3Duration = FindTargetEffect(BLM.Debuffs.Thunder3);
-
-                DotRecast thunderRecast = delegate (int duration)
+                if (actionID == Scathe)
                 {
-                    return !thunder || (thunder && thunderDuration.RemainingTime < duration);
-                };
-                DotRecast thunder3Recast = delegate (int duration)
-                {
-                    return !thunder3 || (thunder3 && thunder3Duration.RemainingTime < duration);
-                };
+                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var gauge = GetJobGauge<BLMGauge>();
+                    var canWeave = CanSpellWeave(actionID);
+                    var currentMP = LocalPlayer.CurrentMp;
+                    var astralFireRefresh = Service.Configuration.GetCustomFloatValue(Config.BlmAstralFireRefresh) * 1000;
 
-                // Opener for BLM
-                // Credit to damolitionn for providing code to be used as a base for this opener
-                if (IsEnabled(CustomComboPreset.BlackSimpleOpenerFeature) && level >= BLM.Levels.Foul)
+                    var thunder = TargetHasEffect(Debuffs.Thunder);
+                    var thunder3 = TargetHasEffect(Debuffs.Thunder3);
+                    var thunderDuration = FindTargetEffect(Debuffs.Thunder);
+                    var thunder3Duration = FindTargetEffect(Debuffs.Thunder3);
+
+                    DotRecast thunderRecast = delegate (int duration)
+                    {
+                        return !thunder || (thunder && thunderDuration.RemainingTime < duration);
+                    };
+                    DotRecast thunder3Recast = delegate (int duration)
+                    {
+                        return !thunder3 || (thunder3 && thunder3Duration.RemainingTime < duration);
+                    };
+
+                    // Opener for BLM
+                    // Credit to damolitionn for providing code to be used as a base for this opener
+                    if (IsEnabled(CustomComboPreset.BlackSimpleOpenerFeature) && level >= Levels.Foul)
+                    {
+                        // Only enable sharpcast if it's available
+                        if (!inOpener && !HasEffect(Buffs.Sharpcast) && GetRemainingCharges(Sharpcast) >= 1 && lastComboMove != Thunder3)
+                        {
+                            return Sharpcast;
+                        }
+
+                        if (!inCombat && (inOpener || openerFinished))
+                        {
+                            inOpener = false;
+                            openerFinished = false;
+                        }
+
+                        if (inCombat && !inOpener)
+                        {
+                            inOpener = true;
+                        }
+
+                        if (inCombat && inOpener && !openerFinished)
+                        {
+                            // Exit out of opener if Enochian is lost
+                            if (!gauge.IsEnochianActive)
+                            {
+                                openerFinished = true;
+                                return Blizzard3;
+                            }
+
+                            if (gauge.InAstralFire)
+                            {
+                                // First Triplecast
+                                if (lastComboMove != Triplecast && !HasEffect(Buffs.Triplecast) && GetRemainingCharges(Triplecast) >= 1)
+                                {
+                                    var triplecastMP = 7600;
+                                    if (IsEnabled(CustomComboPreset.BlackSimpleAltOpenerFeature))
+                                    {
+                                        triplecastMP = 6000;
+                                    }
+                                    if (currentMP <= triplecastMP)
+                                    {
+                                        return Triplecast;
+                                    }
+                                }
+
+                                // Weave other oGCDs
+                                if (canWeave)
+                                {
+                                    // Weave Amplifier and Ley Lines
+                                    if (currentMP <= 4400)
+                                    {
+                                        if (level >= Levels.Amplifier && IsOffCooldown(Amplifier))
+                                        {
+                                            return Amplifier;
+                                        }
+                                        if (level >= Levels.LeyLines && IsOffCooldown(LeyLines))
+                                        {
+                                            return LeyLines;
+                                        }
+                                    }
+
+                                    // Swiftcast
+                                    if (IsOffCooldown(All.Swiftcast) && IsOnCooldown(LeyLines))
+                                    {
+                                        return All.Swiftcast;
+                                    }
+
+                                    // Manafont
+                                    if (IsOffCooldown(Manafont) && (lastComboMove == Despair || lastComboMove == Fire))
+                                    {
+                                        if (level >= Levels.Despair)
+                                        {
+                                            if (currentMP < MP.Despair)
+                                            {
+                                                return Manafont;
+                                            }
+                                        }
+                                        else if (currentMP < MP.AspectFire)
+                                        {
+                                            return Manafont;
+                                        }
+                                    }
+
+                                    // Second Triplecast / Sharpcast
+                                    if (!IsEnabled(CustomComboPreset.BlackSimpleAltOpenerFeature))
+                                    {
+                                        if (!HasEffect(Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast) && IsOnCooldown(All.Swiftcast) &&
+                                            lastComboMove != All.Swiftcast && GetRemainingCharges(Triplecast) >= 1 && currentMP < MP.AspectFire)
+                                        {
+                                            return Triplecast;
+                                        }
+
+                                        if (!HasEffect(Buffs.Sharpcast) && GetRemainingCharges(Sharpcast) >= 1 && IsOnCooldown(Manafont) &&
+                                            lastComboMove == Fire4)
+                                        {
+                                            return Sharpcast;
+                                        }
+                                    }
+                                }
+
+                                // Cast Despair
+                                if (level >= Levels.Despair && (currentMP < MP.AspectFire || gauge.ElementTimeRemaining <= 4000) && currentMP >= MP.Despair)
+                                {
+                                    return Despair;
+                                }
+
+                                // Cast Fire
+                                if (level < Levels.Despair && gauge.ElementTimeRemaining <= 6000 && currentMP >= MP.AspectFire)
+                                {
+                                    return Fire;
+                                }
+
+                                // Fire4 / Umbral Ice
+                                return (currentMP >= MP.AspectFire || lastComboMove == Manafont) ? Fire4 : Blizzard3;
+                            }
+
+                            if (gauge.InUmbralIce)
+                            {
+                                // Dump Polyglot Stacks
+                                if (gauge.PolyglotStacks >= 1 && gauge.ElementTimeRemaining >= 6000)
+                                {
+                                    return level >= Levels.Xenoglossy ? Xenoglossy : Foul;
+                                }
+                                if (gauge.IsParadoxActive && level >= Levels.Paradox)
+                                {
+                                    return Paradox;
+                                }
+                                if (gauge.UmbralHearts < 3 && lastComboMove != Blizzard4)
+                                {
+                                    return Blizzard4;
+                                }
+
+                                // Refresh Thunder3
+                                if (HasEffect(Buffs.Thundercloud) && lastComboMove != Thunder3)
+                                {
+                                    return Thunder3;
+                                }
+
+                                openerFinished = true;
+                            }
+                        }
+                    }
+
+                    // Handle thunder uptime and buffs
+                    if (gauge.ElementTimeRemaining > 0)
+                    {
+                        // Thunder uptime
+                        if (gauge.ElementTimeRemaining >= 6000 && (HasEffect(Buffs.Thundercloud) || currentMP >= MP.AspectThunder))
+                        {
+                            if (level < Levels.Thunder3)
+                            {
+                                if (lastComboMove != Thunder && thunderRecast(4) && !TargetHasEffect(Debuffs.Thunder2))
+                                {
+                                    return Thunder;
+                                }
+                            }
+                            else if (lastComboMove != Thunder3 && thunder3Recast(4) && !TargetHasEffect(Debuffs.Thunder2) && !TargetHasEffect(Debuffs.Thunder4))
+                            {
+                                return Thunder3;
+                            }
+                        }
+
+                        // Buffs
+                        if (canWeave)
+                        {
+                            if (IsEnabled(CustomComboPreset.BlackSimpleCastsFeature))
+                            {
+                                // Use Triplecast only with Astral Fire/Umbral Hearts, and we have enough MP to cast Fire IV twice
+                                if (level >= Levels.Triplecast && !HasEffect(Buffs.Triplecast) && GetRemainingCharges(Triplecast) > 0 &&
+                                    (gauge.InAstralFire || gauge.UmbralHearts == 3) && currentMP >= MP.AspectFire * 2)
+                                {
+                                    if (!IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature) || GetRemainingCharges(Triplecast) > 1)
+                                    {
+                                        return Triplecast;
+                                    }
+                                }
+
+                                // Use Swiftcast in Astral Fire
+                                if (!IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) &&
+                                     gauge.InAstralFire && currentMP >= MP.AspectFire * (HasEffect(Buffs.Triplecast) ? 3 : 1))
+                                {
+                                    if (level >= Levels.Despair && currentMP >= MP.Despair)
+                                    {
+                                        return All.Swiftcast;
+                                    }
+                                    else if (currentMP >= MP.AspectFire)
+                                    {
+                                        return All.Swiftcast;
+                                    }
+                                }
+                            }
+
+                            if (IsEnabled(CustomComboPreset.BlackSimpleBuffsFeature))
+                            {
+                                if (level >= Levels.Amplifier && IsOffCooldown(Amplifier) && gauge.PolyglotStacks < 2)
+                                {
+                                    return Amplifier;
+                                }
+                            }
+
+                            if (IsEnabled(CustomComboPreset.BlackSimpleBuffsLeylinesFeature))
+                            {
+                                if (level >= Levels.LeyLines && IsOffCooldown(LeyLines))
+                                {
+                                    return LeyLines;
+                                }
+                            }
+
+                            if (IsEnabled(CustomComboPreset.BlackSimpleBuffsFeature))
+                            {
+                                if (IsOffCooldown(Manafont) && gauge.InAstralFire)
+                                {
+                                    if (level >= Levels.Despair)
+                                    {
+                                        if (currentMP < MP.Despair)
+                                        {
+                                            return Manafont;
+                                        }
+                                    }
+                                    else if (currentMP < MP.AspectFire)
+                                    {
+                                        return Manafont;
+                                    }
+                                }
+                                if (level >= Levels.Sharpcast && lastComboMove != Thunder3 && GetRemainingCharges(Sharpcast) >= 1 && !HasEffect(Buffs.Sharpcast))
+                                {
+                                    // Try to only sharpcast Thunder 3
+                                    if (thunder3Recast(7) ||
+                                       (thunder3Recast(15) && (gauge.InUmbralIce || (gauge.InAstralFire && !gauge.IsParadoxActive))))
+                                    {
+                                        return Sharpcast;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    // Handle initial cast
+                    if ((level >= Levels.Blizzard4 && !gauge.IsEnochianActive) || gauge.ElementTimeRemaining <= 0)
+                    {
+                        if (level >= Levels.Fire3)
+                        {
+                            return (currentMP >= MP.Fire3) ? Fire3 : Blizzard3;
+                        }
+                        return (currentMP >= MP.Fire) ? Fire : Blizzard;
+                    }
+
+                    // Before Blizzard 3; Fire until 0 MP, then Blizzard until max MP.
+                    if (level < Levels.Blizzard3)
+                    {
+                        if (gauge.InAstralFire)
+                        {
+                            return (currentMP < MP.AspectFire) ? Transpose : Fire;
+                        }
+                        if (gauge.InUmbralIce)
+                        {
+                            return (currentMP >= MP.MaxMP - MP.AspectThunder) ? Transpose : Blizzard;
+                        }
+                    }
+
+                    // Before Fire4; Fire until 0 MP (w/ Firestarter), then Blizzard 3 and Blizzard/Blizzard4 until max MP.
+                    if (level < Levels.Fire4)
+                    {
+                        if (gauge.InAstralFire)
+                        {
+                            if (HasEffect(Buffs.Firestarter))
+                            {
+                                return Fire3;
+                            }
+                            return (currentMP < MP.AspectFire) ? Blizzard3 : Fire;
+                        }
+                        if (gauge.InUmbralIce)
+                        {
+                            if (level >= Levels.Blizzard4 && gauge.UmbralHearts < 3)
+                            {
+                                return Blizzard4;
+                            }
+                            return (currentMP >= MP.MaxMP || gauge.UmbralHearts == 3) ? Fire3 : Blizzard;
+                        }
+                    }
+
+                    // Use polyglot stacks if we don't need it for a future weave
+                    if (gauge.PolyglotStacks > 0 && gauge.ElementTimeRemaining >= 5000 && (gauge.InUmbralIce || (gauge.InAstralFire && gauge.UmbralHearts == 0)))
+                    {
+                        if (level >= Levels.Xenoglossy)
+                        {
+                            // Check leylines and triplecast cooldown
+                            if (gauge.PolyglotStacks == 2 && GetCooldown(LeyLines).CooldownRemaining >= 20 && GetCooldown(Triplecast).ChargeCooldownRemaining >= 20 && !thunder3Recast(15))
+                            {
+                                if (!IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature))
+                                {
+                                    return Xenoglossy;
+                                }
+                                if (IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature) && GetRemainingCharges(Triplecast) == 0)
+                                {
+                                    return Xenoglossy;
+                                }
+                            }
+                        }
+                        else if (level >= Levels.Foul)
+                        {
+                            return Foul;
+                        }
+                    }
+
+                    if (gauge.InAstralFire)
+                    {
+                        // Refresh AF
+                        if (gauge.ElementTimeRemaining <= 3000 && HasEffect(Buffs.Firestarter))
+                        {
+                            return Fire3;
+                        }
+                        if (gauge.ElementTimeRemaining <= astralFireRefresh && !HasEffect(Buffs.Firestarter) && currentMP >= MP.AspectFire)
+                        {
+                            return (level >= Levels.Paradox && gauge.IsParadoxActive) ? Paradox : (level >= Levels.Despair ? Despair : Fire);
+                        }
+
+                        // Use Xenoglossy if Amplifier/Triplecast/Leylines/Manafont is available to weave
+                        if (lastComboMove != Xenoglossy && gauge.PolyglotStacks > 0 && level >= Levels.Xenoglossy)
+                        {
+                            var pooledPolyglotStacks = IsEnabled(CustomComboPreset.BlackSimplePoolingFeature) ? 1 : 0;
+                            if (IsEnabled(CustomComboPreset.BlackSimpleBuffsFeature) && level >= Levels.Amplifier && IsOffCooldown(Amplifier))
+                            {
+                                return Xenoglossy;
+                            }
+                            if (gauge.PolyglotStacks > pooledPolyglotStacks)
+                            {
+                                if (IsEnabled(CustomComboPreset.BlackSimpleBuffsLeylinesFeature))
+                                {
+                                    if (level >= Levels.LeyLines && IsOffCooldown(LeyLines))
+                                    {
+                                        return Xenoglossy;
+                                    }
+                                }
+                                if (IsEnabled(CustomComboPreset.BlackSimpleBuffsFeature))
+                                {
+                                    if (level >= Levels.Triplecast && !HasEffect(Buffs.Triplecast) && GetRemainingCharges(Triplecast) > 0 &&
+                                        (!IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature) || GetRemainingCharges(Triplecast) > 1))
+                                    {
+                                        return Xenoglossy;
+                                    }
+                                    if (level >= Levels.Manafont && IsOffCooldown(Manafont) && currentMP < MP.Despair)
+                                    {
+                                        return Xenoglossy;
+                                    }
+                                    if (level >= Levels.Sharpcast && GetRemainingCharges(Sharpcast) >= 1 && !HasEffect(Buffs.Sharpcast) &&
+                                        thunder3Recast(15) && lastComboMove != Thunder3 && gauge.InAstralFire && !gauge.IsParadoxActive)
+                                    {
+                                        return Xenoglossy;
+                                    }
+                                }
+                            }
+                        }
+
+                        // Blizzard3/Despair when below Fire 4 + Despair MP
+                        if (currentMP < (MP.AspectFire + MP.Despair))
+                        {
+                            return (level >= Levels.Despair && currentMP >= MP.Despair) ? Despair : Blizzard3;
+                        }
+
+                        return Fire4;
+                    }
+
+                    if (gauge.InUmbralIce)
+                    {
+                        // Use Paradox when available
+                        if (level >= Levels.Paradox && gauge.IsParadoxActive)
+                        {
+                            return Paradox;
+                        }
+
+                        // Fire3 when at max umbral hearts
+                        return gauge.UmbralHearts == 3 ? Fire3 : Blizzard4;
+                    }
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class BlackSimpleTranposeFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackSimpleTransposeFeature;
+
+            internal static bool inOpener = false;
+            internal static bool openerFinished = false;
+
+            internal delegate bool DotRecast(int value);
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Scathe)
                 {
+                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var gauge = GetJobGauge<BLMGauge>();
+                    var canWeave = CanSpellWeave(actionID);
+                    var canDelayedWeave = CanWeave(actionID, 0.0) && GetCooldown(actionID).CooldownRemaining < 0.7;
+                    var currentMP = LocalPlayer.CurrentMp;
+                    var astralFireRefresh = Service.Configuration.GetCustomFloatValue(Config.BlmAstralFireRefresh) * 1000;
+                    var thunder3 = TargetHasEffect(Debuffs.Thunder3);
+                    var thunder3Duration = FindTargetEffect(Debuffs.Thunder3);
+
+                    DotRecast thunder3Recast = delegate (int duration)
+                    {
+                        return !thunder3 || (thunder3 && thunder3Duration.RemainingTime < duration);
+                    };
+
                     // Only enable sharpcast if it's available
-                    if (!inOpener && !HasEffect(BLM.Buffs.Sharpcast) && GetRemainingCharges(BLM.Sharpcast) >= 1 && lastComboMove != BLM.Thunder3)
+                    if (!inOpener && !HasEffect(Buffs.Sharpcast) && GetRemainingCharges(Sharpcast) >= 1 && lastComboMove != Thunder3)
                     {
-                        return BLM.Sharpcast;
+                        return Sharpcast;
                     }
 
                     if (!inCombat && (inOpener || openerFinished))
@@ -487,22 +891,17 @@ namespace XIVSlothComboPlugin.Combos
                         if (!gauge.IsEnochianActive)
                         {
                             openerFinished = true;
-                            return BLM.Blizzard3;
+                            return Blizzard3;
                         }
 
                         if (gauge.InAstralFire)
                         {
                             // First Triplecast
-                            if (lastComboMove != BLM.Triplecast && !HasEffect(BLM.Buffs.Triplecast) && GetRemainingCharges(BLM.Triplecast) >= 1)
+                            if (lastComboMove != Triplecast && !HasEffect(Buffs.Triplecast) && GetRemainingCharges(Triplecast) >= 1)
                             {
-                                var triplecastMP = 7600;
-                                if (IsEnabled(CustomComboPreset.BlackSimpleAltOpenerFeature))
+                                if (currentMP <= 6000)
                                 {
-                                    triplecastMP = 6000;
-                                }
-                                if (currentMP <= triplecastMP)
-                                {
-                                    return BLM.Triplecast;
+                                    return Triplecast;
                                 }
                             }
 
@@ -510,982 +909,584 @@ namespace XIVSlothComboPlugin.Combos
                             if (canWeave)
                             {
                                 // Weave Amplifier and Ley Lines
-                                if (currentMP <= 4400)
+                                if (currentMP <= 2800)
                                 {
-                                    if (level >= BLM.Levels.Amplifier && IsOffCooldown(BLM.Amplifier))
+                                    if (level >= Levels.Amplifier && IsOffCooldown(Amplifier))
                                     {
-                                        return BLM.Amplifier;
+                                        return Amplifier;
                                     }
-                                    if (level >= BLM.Levels.LeyLines && IsOffCooldown(BLM.LeyLines))
+                                    if (level >= Levels.LeyLines && IsOffCooldown(LeyLines))
                                     {
-                                        return BLM.LeyLines;
+                                        return LeyLines;
                                     }
                                 }
 
-                                // Swiftcast
-                                if (IsOffCooldown(All.Swiftcast) && IsOnCooldown(BLM.LeyLines))
+                                if (IsOnCooldown(LeyLines))
                                 {
-                                    return All.Swiftcast;
+                                    // Swiftcast
+                                    if (IsOffCooldown(All.Swiftcast))
+                                    {
+                                        return All.Swiftcast;
+                                    }
+
+                                    // Sharpcast
+                                    if (!HasEffect(Buffs.Sharpcast) && GetRemainingCharges(Sharpcast) >= 1 && IsOnCooldown(LeyLines))
+                                    {
+                                        return Sharpcast;
+                                    }
                                 }
+
 
                                 // Manafont
-                                if (IsOffCooldown(BLM.Manafont) && (lastComboMove == BLM.Despair || lastComboMove == BLM.Fire))
+                                if (IsOffCooldown(Manafont) && lastComboMove == Despair)
                                 {
-                                    if (level >= BLM.Levels.Despair)
+                                    if (level >= Levels.Despair)
                                     {
-                                        if (currentMP < BLM.MP.Despair)
+                                        if (currentMP < MP.Despair)
                                         {
-                                            return BLM.Manafont;
+                                            return Manafont;
                                         }
                                     }
-                                    else if (currentMP < BLM.MP.AspectFire)
+                                    else if (currentMP < MP.AspectFire)
                                     {
-                                        return BLM.Manafont;
+                                        return Manafont;
                                     }
                                 }
 
-                                // Second Triplecast / Sharpcast
-                                if (!IsEnabled(CustomComboPreset.BlackSimpleAltOpenerFeature))
+                                // Second Triplecast
+                                if (!HasEffect(Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast) && IsOnCooldown(All.Swiftcast) &&
+                                    lastComboMove != All.Swiftcast && GetRemainingCharges(Triplecast) >= 1 && currentMP < 6000)
                                 {
-                                    if (!HasEffect(BLM.Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast) && IsOnCooldown(All.Swiftcast) && 
-                                        lastComboMove != All.Swiftcast && GetRemainingCharges(BLM.Triplecast) >= 1 && currentMP < BLM.MP.AspectFire)
-                                    {
-                                        return BLM.Triplecast;
-                                    }
+                                    return Triplecast;
+                                }
 
-                                    if (!HasEffect(BLM.Buffs.Sharpcast) && GetRemainingCharges(BLM.Sharpcast) >= 1 && IsOnCooldown(BLM.Manafont) && 
-                                        lastComboMove == BLM.Fire4)
-                                    {
-                                        return BLM.Sharpcast;
-                                    }
+                                // Lucid Dreaming
+                                if (GetRemainingCharges(Triplecast) == 0 && IsOffCooldown(All.LucidDreaming))
+                                {
+                                    return All.LucidDreaming;
                                 }
                             }
 
                             // Cast Despair
-                            if (level >= BLM.Levels.Despair && (currentMP < BLM.MP.AspectFire || gauge.ElementTimeRemaining <= 4000) && currentMP >= BLM.MP.Despair)
+                            if (currentMP < MP.AspectFire && currentMP >= MP.Despair)
                             {
-                                return BLM.Despair;
+                                return Despair;
                             }
-
-                            // Cast Fire
-                            if (level < BLM.Levels.Despair && gauge.ElementTimeRemaining <= 6000 && currentMP >= BLM.MP.AspectFire)
+                            if (currentMP >= MP.AspectFire)
                             {
-                                return BLM.Fire;
+                                return Fire4;
                             }
-
-                            // Fire4 / Umbral Ice
-                            return (currentMP >= BLM.MP.AspectFire || lastComboMove == BLM.Manafont) ? BLM.Fire4 : BLM.Blizzard3;
+                            return Transpose;
                         }
-                        
+
                         if (gauge.InUmbralIce)
                         {
-                            // Dump Polyglot Stacks
-                            if (gauge.PolyglotStacks >= 1 && gauge.ElementTimeRemaining >= 6000)
+                            if (gauge.IsParadoxActive)
                             {
-                                return level >= BLM.Levels.Xenoglossy ? BLM.Xenoglossy : BLM.Foul;
+                                return Paradox;
                             }
-                            if (gauge.IsParadoxActive && level >= BLM.Levels.Paradox)
+                            if (gauge.PolyglotStacks >= 1 && lastComboMove != Xenoglossy)
                             {
-                                return BLM.Paradox;
+                                return Xenoglossy;
                             }
-                            if (gauge.UmbralHearts < 3 && lastComboMove != BLM.Blizzard4)
+                            if (HasEffect(Buffs.Thundercloud) && lastComboMove != Thunder3)
                             {
-                                return BLM.Blizzard4;
+                                return Thunder3;
                             }
-
-                            // Refresh Thunder3
-                            if (HasEffect(BLM.Buffs.Thundercloud) && lastComboMove != BLM.Thunder3)
-                            {
-                                return BLM.Thunder3;
-                            }
-
                             openerFinished = true;
                         }
                     }
-                }
 
-                // Handle thunder uptime and buffs
-                if (gauge.ElementTimeRemaining > 0)
-                {
-                    // Thunder uptime
-                    if (gauge.ElementTimeRemaining >= 6000 && (HasEffect(BLM.Buffs.Thundercloud) || currentMP >= BLM.MP.AspectThunder))
+                    if (gauge.ElementTimeRemaining == 0 || !gauge.IsEnochianActive)
                     {
-                        if (level < BLM.Levels.Thunder3)
+                        if (currentMP >= MP.Fire3)
                         {
-                            if (lastComboMove != BLM.Thunder && thunderRecast(4) && !TargetHasEffect(BLM.Debuffs.Thunder2))
-                            {
-                                return BLM.Thunder;
-                            }
+                            return Fire3;
                         }
-                        else if (lastComboMove != BLM.Thunder3 && thunder3Recast(4) && !TargetHasEffect(BLM.Debuffs.Thunder2) && !TargetHasEffect(BLM.Debuffs.Thunder4))
-                        {
-                            return BLM.Thunder3;
-                        }
+                        return Blizzard3;
                     }
 
-                    // Buffs
-                    if (canWeave)
+                    if (gauge.ElementTimeRemaining > 0)
                     {
-                        if (IsEnabled(CustomComboPreset.BlackSimpleCastsFeature))
+                        // Thunder
+                        if (lastComboMove != Thunder3 && currentMP >= MP.AspectThunder &&
+                            thunder3Recast(4) && !TargetHasEffect(Debuffs.Thunder2) && !TargetHasEffect(Debuffs.Thunder4))
                         {
-                            // Use Triplecast only with Astral Fire/Umbral Hearts, and we have enough MP to cast Fire IV twice
-                            if (level >= BLM.Levels.Triplecast && !HasEffect(BLM.Buffs.Triplecast) && GetRemainingCharges(BLM.Triplecast) > 0 && 
-                                (gauge.InAstralFire || gauge.UmbralHearts == 3) && currentMP >= BLM.MP.AspectFire * 2)
-                            {
-                                if (!IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature) || GetRemainingCharges(BLM.Triplecast) > 1)
-                                {
-                                    return BLM.Triplecast;
-                                }
-                            }
-
-                            // Use Swiftcast in Astral Fire
-                            if (!IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && 
-                                 gauge.InAstralFire && currentMP >= BLM.MP.AspectFire * (HasEffect(BLM.Buffs.Triplecast) ? 3 : 1))
-                            {
-                                if (level >= BLM.Levels.Despair && currentMP >= BLM.MP.Despair)
-                                {
-                                    return All.Swiftcast;
-                                }
-                                else if (currentMP >= BLM.MP.AspectFire)
-                                {
-                                    return All.Swiftcast;
-                                }
-                            }
+                            return Thunder3;
                         }
 
-                        if (IsEnabled(CustomComboPreset.BlackSimpleBuffsFeature))
-                        {
-                            if (level >= BLM.Levels.Amplifier && IsOffCooldown(BLM.Amplifier) && gauge.PolyglotStacks < 2)
-                            {
-                                return BLM.Amplifier;
-                            }
-                        }
-
-                        if (IsEnabled(CustomComboPreset.BlackSimpleBuffsLeylinesFeature))
-                        {
-                            if (level >= BLM.Levels.LeyLines && IsOffCooldown(BLM.LeyLines))
-                            {
-                                return BLM.LeyLines;
-                            }
-                        }
-
-                        if (IsEnabled(CustomComboPreset.BlackSimpleBuffsFeature))
-                        {
-                            if (IsOffCooldown(BLM.Manafont) && gauge.InAstralFire)
-                            {
-                                if (level >= BLM.Levels.Despair)
-                                {
-                                    if (currentMP < BLM.MP.Despair)
-                                    {
-                                        return BLM.Manafont;
-                                    }
-                                }
-                                else if (currentMP < BLM.MP.AspectFire)
-                                {
-                                    return BLM.Manafont;
-                                }
-                            }
-                            if (level >= BLM.Levels.Sharpcast && lastComboMove != BLM.Thunder3 && GetRemainingCharges(BLM.Sharpcast) >= 1 && !HasEffect(BLM.Buffs.Sharpcast))
-                            {
-                                // Try to only sharpcast Thunder 3
-                                if (thunder3Recast(7) ||
-                                   (thunder3Recast(15) && (gauge.InUmbralIce || (gauge.InAstralFire && !gauge.IsParadoxActive))))
-                                {
-                                    return BLM.Sharpcast;
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Handle initial cast
-                if ((level >= BLM.Levels.Blizzard4 && !gauge.IsEnochianActive) || gauge.ElementTimeRemaining <= 0)
-                {
-                    if (level >= BLM.Levels.Fire3)
-                    {
-                        return (currentMP >= BLM.MP.Fire3) ? BLM.Fire3 : BLM.Blizzard3;
-                    }
-                    return (currentMP >= BLM.MP.Fire) ? BLM.Fire : BLM.Blizzard;
-                }
-
-                // Before Blizzard 3; Fire until 0 MP, then Blizzard until max MP.
-                if (level < BLM.Levels.Blizzard3)
-                {
-                    if (gauge.InAstralFire)
-                    {
-                        return (currentMP < BLM.MP.AspectFire) ? BLM.Transpose : BLM.Fire;
-                    }
-                    if (gauge.InUmbralIce)
-                    {
-                        return (currentMP >= BLM.MP.MaxMP - BLM.MP.AspectThunder) ? BLM.Transpose : BLM.Blizzard;
-                    }
-                }
-
-                // Before Fire4; Fire until 0 MP (w/ Firestarter), then Blizzard 3 and Blizzard/Blizzard4 until max MP.
-                if (level < BLM.Levels.Fire4)
-                {
-                    if (gauge.InAstralFire)
-                    {
-                        if (HasEffect(BLM.Buffs.Firestarter))
-                        {
-                            return BLM.Fire3;
-                        }
-                        return (currentMP < BLM.MP.AspectFire) ? BLM.Blizzard3 : BLM.Fire;
-                    }
-                    if (gauge.InUmbralIce)
-                    {
-                        if (level >= BLM.Levels.Blizzard4 && gauge.UmbralHearts < 3)
-                        {
-                            return BLM.Blizzard4;
-                        }
-                        return (currentMP >= BLM.MP.MaxMP || gauge.UmbralHearts == 3) ? BLM.Fire3 : BLM.Blizzard;
-                    }
-                }
-
-                // Use polyglot stacks if we don't need it for a future weave
-                if (gauge.PolyglotStacks > 0 && gauge.ElementTimeRemaining >= 5000 &&  (gauge.InUmbralIce || (gauge.InAstralFire && gauge.UmbralHearts == 0)))
-                {
-                    if (level >= BLM.Levels.Xenoglossy)
-                    {
-                        // Check leylines and triplecast cooldown
-                        if (gauge.PolyglotStacks == 2 && GetCooldown(BLM.LeyLines).CooldownRemaining >= 20 && GetCooldown(BLM.Triplecast).ChargeCooldownRemaining >= 20 && !thunder3Recast(15))
-                        {
-                            if (!IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature))
-                            {
-                                return BLM.Xenoglossy;
-                            }
-                            if (IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature) && GetRemainingCharges(BLM.Triplecast) == 0)
-                            {
-                                return BLM.Xenoglossy;
-                            }
-                        }
-                    }
-                    else if (level >= BLM.Levels.Foul)
-                    {
-                        return BLM.Foul;
-                    }
-                }
-
-                if (gauge.InAstralFire)
-                {
-                    // Refresh AF
-                    if (gauge.ElementTimeRemaining <= 3000 && HasEffect(BLM.Buffs.Firestarter))
-                    {
-                        return BLM.Fire3;
-                    }
-                    if (gauge.ElementTimeRemaining <= astralFireRefresh && !HasEffect(BLM.Buffs.Firestarter) && currentMP >= BLM.MP.AspectFire)
-                    {
-                        return (level >= BLM.Levels.Paradox && gauge.IsParadoxActive) ? BLM.Paradox : (level >= BLM.Levels.Despair ? BLM.Despair : BLM.Fire);
-                    }
-
-                    // Use Xenoglossy if Amplifier/Triplecast/Leylines/Manafont is available to weave
-                    if (lastComboMove != BLM.Xenoglossy && gauge.PolyglotStacks > 0 && level >= BLM.Levels.Xenoglossy)
-                    {
-                        var pooledPolyglotStacks = IsEnabled(CustomComboPreset.BlackSimplePoolingFeature) ? 1 : 0;
-                        if (IsEnabled(CustomComboPreset.BlackSimpleBuffsFeature) && level >= BLM.Levels.Amplifier && IsOffCooldown(BLM.Amplifier))
-                        {
-                            return BLM.Xenoglossy;
-                        }
-                        if (gauge.PolyglotStacks > pooledPolyglotStacks)
-                        {
-                            if (IsEnabled(CustomComboPreset.BlackSimpleBuffsLeylinesFeature))
-                            {
-                                if (level >= BLM.Levels.LeyLines && IsOffCooldown(BLM.LeyLines))
-                                {
-                                    return BLM.Xenoglossy;
-                                }
-                            }
-                            if (IsEnabled(CustomComboPreset.BlackSimpleBuffsFeature))
-                            {
-                                if (level >= BLM.Levels.Triplecast && !HasEffect(BLM.Buffs.Triplecast) && GetRemainingCharges(BLM.Triplecast) > 0 &&
-                                    (!IsEnabled(CustomComboPreset.BlackSimpleCastPoolingFeature) || GetRemainingCharges(BLM.Triplecast) > 1))
-                                {
-                                    return BLM.Xenoglossy;
-                                }
-                                if (level >= BLM.Levels.Manafont && IsOffCooldown(BLM.Manafont) && currentMP < BLM.MP.Despair)
-                                {
-                                    return BLM.Xenoglossy;
-                                }
-                                if (level >= BLM.Levels.Sharpcast && GetRemainingCharges(BLM.Sharpcast) >= 1 && !HasEffect(BLM.Buffs.Sharpcast) && 
-                                    thunder3Recast(15) && lastComboMove != BLM.Thunder3 && gauge.InAstralFire && !gauge.IsParadoxActive)
-                                {
-                                    return BLM.Xenoglossy;
-                                }
-                            }
-                        }
-                    }
-
-                    // Blizzard3/Despair when below Fire 4 + Despair MP
-                    if (currentMP < (BLM.MP.AspectFire + BLM.MP.Despair))
-                    {
-                        return (level >= BLM.Levels.Despair && currentMP >= BLM.MP.Despair) ? BLM.Despair : BLM.Blizzard3;
-                    }
-
-                    return BLM.Fire4;
-                }
-
-                if (gauge.InUmbralIce)
-                {
-                    // Use Paradox when available
-                    if (level >= BLM.Levels.Paradox && gauge.IsParadoxActive)
-                    {
-                        return BLM.Paradox;
-                    }
-
-                    // Fire3 when at max umbral hearts
-                    return gauge.UmbralHearts == 3 ? BLM.Fire3 : BLM.Blizzard4;
-                }
-            }
-
-            return actionID;
-        }
-    }
-    
-    internal class BlackSimpleTranposeFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackSimpleTransposeFeature;
-
-        internal static bool inOpener = false;
-        internal static bool openerFinished = false;
-
-        internal delegate bool DotRecast(int value);
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BLM.Scathe)
-            {
-                var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var gauge = GetJobGauge<BLMGauge>();
-                var canWeave = CanSpellWeave(actionID);
-                var canDelayedWeave = CanWeave(actionID, 0.0) && GetCooldown(actionID).CooldownRemaining < 0.7;
-                var currentMP = LocalPlayer.CurrentMp;
-                var astralFireRefresh = Service.Configuration.GetCustomFloatValue(BLM.Config.BlmAstralFireRefresh) * 1000;
-                var thunder3 = TargetHasEffect(BLM.Debuffs.Thunder3);
-                var thunder3Duration = FindTargetEffect(BLM.Debuffs.Thunder3);
-
-                DotRecast thunder3Recast = delegate (int duration)
-                {
-                    return !thunder3 || (thunder3 && thunder3Duration.RemainingTime < duration);
-                };
-
-                // Only enable sharpcast if it's available
-                if (!inOpener && !HasEffect(BLM.Buffs.Sharpcast) && GetRemainingCharges(BLM.Sharpcast) >= 1 && lastComboMove != BLM.Thunder3)
-                {
-                    return BLM.Sharpcast;
-                }
-
-                if (!inCombat && (inOpener || openerFinished))
-                {
-                    inOpener = false;
-                    openerFinished = false;
-                }
-
-                if (inCombat && !inOpener)
-                {
-                    inOpener = true;
-                }
-
-                if (inCombat && inOpener && !openerFinished)
-                {
-                    // Exit out of opener if Enochian is lost
-                    if (!gauge.IsEnochianActive)
-                    {
-                        openerFinished = true;
-                        return BLM.Blizzard3;
-                    }
-
-                    if (gauge.InAstralFire)
-                    {
-                        // First Triplecast
-                        if (lastComboMove != BLM.Triplecast && !HasEffect(BLM.Buffs.Triplecast) && GetRemainingCharges(BLM.Triplecast) >= 1)
-                        {
-                            if (currentMP <= 6000)
-                            {
-                                return BLM.Triplecast;
-                            }
-                        }
-
-                        // Weave other oGCDs
+                        // Buffs
                         if (canWeave)
                         {
-                            // Weave Amplifier and Ley Lines
-                            if (currentMP <= 2800)
+                            // Use Triplecast only with Astral Fire/Umbral Hearts, and we have enough MP to cast Fire IV twice
+                            if (!HasEffect(Buffs.Triplecast) && GetRemainingCharges(Triplecast) > 0 &&
+                                (gauge.InAstralFire || gauge.UmbralHearts >= 1) && currentMP >= MP.AspectFire * 2)
                             {
-                                if (level >= BLM.Levels.Amplifier && IsOffCooldown(BLM.Amplifier))
+                                if (!IsEnabled(CustomComboPreset.BlackSimpleTransposePoolingFeature) || GetRemainingCharges(Triplecast) > 1)
                                 {
-                                    return BLM.Amplifier;
-                                }
-                                if (level >= BLM.Levels.LeyLines && IsOffCooldown(BLM.LeyLines))
-                                {
-                                    return BLM.LeyLines;
+                                    return Triplecast;
                                 }
                             }
 
-                            if (IsOnCooldown(BLM.LeyLines))
+                            if (IsOffCooldown(Amplifier) && gauge.PolyglotStacks < 2)
                             {
-                                // Swiftcast
+                                return Amplifier;
+                            }
+
+                            if (IsOffCooldown(LeyLines))
+                            {
+                                return LeyLines;
+                            }
+
+                            if (IsOffCooldown(Manafont) && gauge.InAstralFire && currentMP < MP.Despair)
+                            {
+                                return Manafont;
+                            }
+
+                            if (GetRemainingCharges(Sharpcast) > 0 && !HasEffect(Buffs.Sharpcast))
+                            {
+                                return Sharpcast;
+                            }
+                        }
+                    }
+
+                    if (gauge.InUmbralIce)
+                    {
+                        // Standard
+                        if (gauge.UmbralIceStacks == 3)
+                        {
+                            if (gauge.PolyglotStacks == 2)
+                            {
+                                return Xenoglossy;
+                            }
+                            if (gauge.IsParadoxActive)
+                            {
+                                return Paradox;
+                            }
+                            if (gauge.UmbralHearts < 3)
+                            {
+                                return Blizzard4;
+                            }
+                            return Fire3;
+                        }
+
+                        // Transpose Instant F3
+                        if (canWeave)
+                        {
+                            if (!HasEffect(Buffs.Firestarter) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Triplecast))
+                            {
                                 if (IsOffCooldown(All.Swiftcast))
                                 {
                                     return All.Swiftcast;
                                 }
-
-                                // Sharpcast
-                                if (!HasEffect(BLM.Buffs.Sharpcast) && GetRemainingCharges(BLM.Sharpcast) >= 1 && IsOnCooldown(BLM.LeyLines))
-                                {
-                                    return BLM.Sharpcast;
-                                }
                             }
-
-
-                            // Manafont
-                            if (IsOffCooldown(BLM.Manafont) && lastComboMove == BLM.Despair)
-                            {
-                                if (level >= BLM.Levels.Despair)
-                                {
-                                    if (currentMP < BLM.MP.Despair)
-                                    {
-                                        return BLM.Manafont;
-                                    }
-                                }
-                                else if (currentMP < BLM.MP.AspectFire)
-                                {
-                                    return BLM.Manafont;
-                                }
-                            }
-
-                            // Second Triplecast
-                            if (!HasEffect(BLM.Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast) && IsOnCooldown(All.Swiftcast) &&
-                                lastComboMove != All.Swiftcast && GetRemainingCharges(BLM.Triplecast) >= 1 && currentMP < 6000)
-                            {
-                                return BLM.Triplecast;
-                            }
-
-                            // Lucid Dreaming
-                            if (GetRemainingCharges(BLM.Triplecast) == 0 && IsOffCooldown(All.LucidDreaming))
+                            if (IsOffCooldown(All.LucidDreaming))
                             {
                                 return All.LucidDreaming;
                             }
                         }
 
-                        // Cast Despair
-                        if (currentMP < BLM.MP.AspectFire && currentMP >= BLM.MP.Despair)
-                        {
-                            return BLM.Despair;
-                        }
-                        if (currentMP >= BLM.MP.AspectFire)
-                        {
-                            return BLM.Fire4;
-                        }
-                        return BLM.Transpose;
-                    }
-
-                    if (gauge.InUmbralIce)
-                    {
+                        // Paradox for Transpose Lines
                         if (gauge.IsParadoxActive)
                         {
-                            return BLM.Paradox;
+                            return Paradox;
                         }
-                        if (gauge.PolyglotStacks >= 1 && lastComboMove != BLM.Xenoglossy)
-                        {
-                            return BLM.Xenoglossy;
-                        }
-                        if (HasEffect(BLM.Buffs.Thundercloud) && lastComboMove != BLM.Thunder3)
-                        {
-                            return BLM.Thunder3;
-                        }
-                        openerFinished = true;
-                    }
-                }
-                
-                if (gauge.ElementTimeRemaining == 0 || !gauge.IsEnochianActive)
-                {
-                    if (currentMP >= BLM.MP.Fire3)
-                    {
-                        return BLM.Fire3;
-                    }
-                    return BLM.Blizzard3;
-                }
 
-                if (gauge.ElementTimeRemaining > 0)
-                {
-                    // Thunder
-                    if (lastComboMove != BLM.Thunder3 && currentMP >= BLM.MP.AspectThunder && 
-                        thunder3Recast(4) && !TargetHasEffect(BLM.Debuffs.Thunder2) && !TargetHasEffect(BLM.Debuffs.Thunder4))
-                    {
-                        return BLM.Thunder3;
-                    }
-
-                    // Buffs
-                    if (canWeave)
-                    {
-                        // Use Triplecast only with Astral Fire/Umbral Hearts, and we have enough MP to cast Fire IV twice
-                        if (!HasEffect(BLM.Buffs.Triplecast) && GetRemainingCharges(BLM.Triplecast) > 0 &&
-                            (gauge.InAstralFire || gauge.UmbralHearts >= 1) && currentMP >= BLM.MP.AspectFire * 2)
+                        // Filler GCDs
+                        if (currentMP <= MP.MaxMP - MP.AspectFire)
                         {
-                            if (!IsEnabled(CustomComboPreset.BlackSimpleTransposePoolingFeature) || GetRemainingCharges(BLM.Triplecast) > 1)
+                            if (lastComboMove != Xenoglossy && gauge.PolyglotStacks >= 1)
                             {
-                                return BLM.Triplecast;
+                                return Xenoglossy;
+                            }
+                            if (lastComboMove != Thunder3 && thunder3Recast(7))
+                            {
+                                return Thunder3;
+                            }
+                            if (gauge.PolyglotStacks >= 1)
+                            {
+                                return Xenoglossy;
                             }
                         }
 
-                        if (IsOffCooldown(BLM.Amplifier) && gauge.PolyglotStacks < 2)
+                        if (IsOffCooldown(Transpose) && (canDelayedWeave || currentMP >= MP.MaxMP - MP.AspectFire))
                         {
-                            return BLM.Amplifier;
+                            return Transpose;
+                        }
+                        if (HasEffect(All.Buffs.Swiftcast))
+                        {
+                            return Fire3;
+                        }
+                        if (gauge.PolyglotStacks >= 1)
+                        {
+                            return Xenoglossy;
+                        }
+                        return Blizzard4;
+                    }
+
+                    if (gauge.InAstralFire)
+                    {
+                        // F3
+                        if (gauge.AstralFireStacks < 3)
+                        {
+                            return Fire3;
                         }
 
-                        if (IsOffCooldown(BLM.LeyLines))
+                        // Xenoglossy for Manafont weave
+                        if (gauge.PolyglotStacks >= 1 && IsOffCooldown(Manafont) && currentMP < MP.Despair)
                         {
-                            return BLM.LeyLines;
+                            return Xenoglossy;
                         }
 
-                        if (IsOffCooldown(BLM.Manafont) && gauge.InAstralFire && currentMP < BLM.MP.Despair)
+                        // Early Despair
+                        if (currentMP < (MP.AspectFire + MP.Despair) && currentMP >= MP.Despair)
                         {
-                            return BLM.Manafont;
+                            return Despair;
                         }
 
-                        if (GetRemainingCharges(BLM.Sharpcast) > 0 && !HasEffect(BLM.Buffs.Sharpcast))
+                        // Transpose if F3 is available, or Thundercloud + Xenoglossy is available
+                        if (currentMP < MP.AspectFire && lastComboMove != Manafont && IsOnCooldown(Manafont) && GetCooldownRemainingTime(Manafont) <= 118)
                         {
-                            return BLM.Sharpcast;
+                            if ((HasEffect(Buffs.LeyLines) && FindEffect(Buffs.LeyLines).RemainingTime >= 15) || HasEffect(Buffs.Firestarter) ||
+                                 lastComboMove == Xenoglossy || lastComboMove == Thunder3 || (IsOffCooldown(All.Swiftcast) && (gauge.PolyglotStacks == 2)))
+                            {
+                                if (lastComboMove != Despair && lastComboMove != Fire4)
+                                {
+                                    return Transpose;
+                                }
+                                if (lastComboMove == Despair)
+                                {
+                                    if (gauge.PolyglotStacks >= 1)
+                                    {
+                                        return Xenoglossy;
+                                    }
+                                    if (HasEffect(Buffs.Thundercloud))
+                                    {
+                                        return Thunder3;
+                                    }
+                                }
+                            }
                         }
+
+                        // Regular Despair / Paradox
+                        if (gauge.ElementTimeRemaining <= astralFireRefresh)
+                        {
+                            return !gauge.IsParadoxActive ? Despair : Paradox;
+                        }
+                        if (currentMP >= MP.AspectFire)
+                        {
+                            return Fire4;
+                        }
+                        return Blizzard3;
                     }
                 }
 
-                if (gauge.InUmbralIce)
+                return actionID;
+            }
+        }
+        internal class BlackSimpleParadoxFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackSimpleParadoxFeature;
+
+            internal static bool inOpener = false;
+            internal static bool openerFinished = false;
+
+            internal delegate bool DotRecast(int value);
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Scathe)
                 {
-                    // Standard
-                    if (gauge.UmbralIceStacks == 3)
+                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var gauge = GetJobGauge<BLMGauge>();
+                    var canWeave = CanSpellWeave(actionID);
+                    var canDelayedWeave = CanWeave(actionID, 0.0) && GetCooldown(actionID).CooldownRemaining < 0.7;
+                    var currentMP = LocalPlayer.CurrentMp;
+                    var thunder3 = TargetHasEffect(Debuffs.Thunder3);
+                    var thunder3Duration = FindTargetEffect(Debuffs.Thunder3);
+
+                    DotRecast thunder3Recast = delegate (int duration)
                     {
-                        if (gauge.PolyglotStacks == 2)
-                        {
-                            return BLM.Xenoglossy;
-                        }
-                        if (gauge.IsParadoxActive)
-                        {
-                            return BLM.Paradox;
-                        }
-                        if (gauge.UmbralHearts < 3)
-                        {
-                            return BLM.Blizzard4;
-                        }
-                        return BLM.Fire3;
+                        return !thunder3 || (thunder3 && thunder3Duration.RemainingTime < duration);
+                    };
+
+                    // Only enable sharpcast if it's available
+                    if (!inOpener && !HasEffect(Buffs.Sharpcast) && GetRemainingCharges(Sharpcast) >= 1 && lastComboMove != Thunder3)
+                    {
+                        return Sharpcast;
                     }
 
-                    // Transpose Instant F3
-                    if (canWeave)
+                    if (!inCombat && (inOpener || openerFinished))
                     {
-                        if (!HasEffect(BLM.Buffs.Firestarter) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(BLM.Buffs.Triplecast))
+                        inOpener = false;
+                        openerFinished = false;
+                    }
+
+                    if (inCombat && !inOpener)
+                    {
+                        inOpener = true;
+                    }
+
+                    if (inCombat && inOpener && !openerFinished)
+                    {
+                        if (inCombat && inOpener && !openerFinished)
                         {
+                            // Exit out of opener if Enochian is lost
+                            if (!gauge.IsEnochianActive)
+                            {
+                                openerFinished = true;
+                                return Blizzard3;
+                            }
+
+                            if (gauge.InAstralFire)
+                            {
+                                // First Triplecast
+                                if (lastComboMove != Triplecast && !HasEffect(Buffs.Triplecast) && GetRemainingCharges(Triplecast) >= 1)
+                                {
+                                    var triplecastMP = 7600;
+                                    if (currentMP <= triplecastMP)
+                                    {
+                                        return Triplecast;
+                                    }
+                                }
+
+                                // Weave other oGCDs
+                                if (canWeave)
+                                {
+                                    // Weave Amplifier and Ley Lines
+                                    if (currentMP <= 4400)
+                                    {
+                                        if (level >= Levels.Amplifier && IsOffCooldown(Amplifier))
+                                        {
+                                            return Amplifier;
+                                        }
+                                        if (level >= Levels.LeyLines && IsOffCooldown(LeyLines))
+                                        {
+                                            return LeyLines;
+                                        }
+                                    }
+
+                                    // Swiftcast
+                                    if (IsOffCooldown(All.Swiftcast) && IsOnCooldown(LeyLines))
+                                    {
+                                        return All.Swiftcast;
+                                    }
+
+                                    // Manafont
+                                    if (IsOffCooldown(Manafont) && (lastComboMove == Despair || lastComboMove == Fire))
+                                    {
+                                        if (level >= Levels.Despair)
+                                        {
+                                            if (currentMP < MP.Despair)
+                                            {
+                                                return Manafont;
+                                            }
+                                        }
+                                        else if (currentMP < MP.AspectFire)
+                                        {
+                                            return Manafont;
+                                        }
+                                    }
+
+                                    // Second Triplecast / Sharpcast
+                                    if (!IsEnabled(CustomComboPreset.BlackSimpleAltOpenerFeature))
+                                    {
+                                        if (!HasEffect(Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast) && IsOnCooldown(All.Swiftcast) &&
+                                            lastComboMove != All.Swiftcast && GetRemainingCharges(Triplecast) >= 1 && currentMP < MP.AspectFire)
+                                        {
+                                            return Triplecast;
+                                        }
+
+                                        if (!HasEffect(Buffs.Sharpcast) && GetRemainingCharges(Sharpcast) >= 1 && IsOnCooldown(Manafont) &&
+                                            lastComboMove == Fire4)
+                                        {
+                                            return Sharpcast;
+                                        }
+                                    }
+                                }
+
+                                // Cast Despair
+                                if ((currentMP < MP.AspectFire || gauge.ElementTimeRemaining <= 4000) && currentMP >= MP.Despair)
+                                {
+                                    return Despair;
+                                }
+
+                                // Fire4 / Umbral Ice
+                                return (currentMP >= MP.AspectFire || lastComboMove == Manafont) ? Fire4 : Blizzard3;
+                            }
+
+                            if (gauge.InUmbralIce)
+                            {
+                                // Dump Polyglot Stacks
+                                if (gauge.PolyglotStacks >= 1 && gauge.ElementTimeRemaining >= 6000)
+                                {
+                                    return Xenoglossy;
+                                }
+                                if (gauge.IsParadoxActive && level >= Levels.Paradox)
+                                {
+                                    return Paradox;
+                                }
+                                if (gauge.UmbralHearts < 3 && lastComboMove != Blizzard4)
+                                {
+                                    return Blizzard4;
+                                }
+
+                                // Refresh Thunder3
+                                if (HasEffect(Buffs.Thundercloud) && lastComboMove != Thunder3)
+                                {
+                                    return Thunder3;
+                                }
+
+                                openerFinished = true;
+                            }
+                        }
+                    }
+
+                    if (gauge.ElementTimeRemaining == 0 || !gauge.IsEnochianActive)
+                    {
+                        if (currentMP >= MP.Fire3)
+                        {
+                            return Fire3;
+                        }
+                        return Blizzard3;
+                    }
+
+                    if (gauge.ElementTimeRemaining > 0)
+                    {
+                        // Thunder
+                        if (lastComboMove != Thunder3 && currentMP >= MP.AspectThunder &&
+                            thunder3Recast(4) && !TargetHasEffect(Debuffs.Thunder2) && !TargetHasEffect(Debuffs.Thunder4))
+                        {
+                            return Thunder3;
+                        }
+
+                        // Buffs
+                        if (canWeave)
+                        {
+                            if (!HasEffect(Buffs.Triplecast) && GetRemainingCharges(Triplecast) > 0)
+                            {
+                                return Triplecast;
+                            }
+
+                            if (IsOffCooldown(Amplifier) && gauge.PolyglotStacks < 2)
+                            {
+                                return Amplifier;
+                            }
+
+                            if (IsOffCooldown(LeyLines))
+                            {
+                                return LeyLines;
+                            }
+
+                            if (IsOffCooldown(Manafont) && gauge.InAstralFire && currentMP < MP.Despair)
+                            {
+                                return Manafont;
+                            }
+
                             if (IsOffCooldown(All.Swiftcast))
                             {
                                 return All.Swiftcast;
                             }
-                        }
-                        if (IsOffCooldown(All.LucidDreaming))
-                        {
-                            return All.LucidDreaming;
-                        }
-                    }
 
-                    // Paradox for Transpose Lines
-                    if (gauge.IsParadoxActive)
-                    {
-                        return BLM.Paradox;
-                    }
-
-                    // Filler GCDs
-                    if (currentMP <= BLM.MP.MaxMP - BLM.MP.AspectFire)
-                    {
-                        if (lastComboMove != BLM.Xenoglossy && gauge.PolyglotStacks >= 1)
-                        {
-                            return BLM.Xenoglossy;
-                        }
-                        if (lastComboMove != BLM.Thunder3 && thunder3Recast(7))
-                        {
-                            return BLM.Thunder3;
-                        }
-                        if (gauge.PolyglotStacks >= 1)
-                        {
-                            return BLM.Xenoglossy;
-                        }
-                    }
-
-                    if (IsOffCooldown(BLM.Transpose) && (canDelayedWeave || currentMP >= BLM.MP.MaxMP - BLM.MP.AspectFire))
-                    {
-                        return BLM.Transpose;
-                    }
-                    if (HasEffect(All.Buffs.Swiftcast))
-                    {
-                        return BLM.Fire3;
-                    }
-                    if (gauge.PolyglotStacks >= 1)
-                    {
-                        return BLM.Xenoglossy;
-                    }
-                    return BLM.Blizzard4;
-                }
-
-                if (gauge.InAstralFire)
-                {
-                    // F3
-                    if (gauge.AstralFireStacks < 3)
-                    {
-                        return BLM.Fire3;
-                    }
-
-                    // Xenoglossy for Manafont weave
-                    if (gauge.PolyglotStacks >= 1 && IsOffCooldown(BLM.Manafont) && currentMP < BLM.MP.Despair)
-                    {
-                        return BLM.Xenoglossy;
-                    }
-
-                    // Early Despair
-                    if (currentMP < (BLM.MP.AspectFire + BLM.MP.Despair) && currentMP >= BLM.MP.Despair)
-                    {
-                        return BLM.Despair;
-                    }
-
-                    // Transpose if F3 is available, or Thundercloud + Xenoglossy is available
-                    if (currentMP < BLM.MP.AspectFire && lastComboMove != BLM.Manafont && IsOnCooldown(BLM.Manafont) && GetCooldownRemainingTime(BLM.Manafont) <= 118)
-                    {
-                        if ((HasEffect(BLM.Buffs.LeyLines) && FindEffect(BLM.Buffs.LeyLines).RemainingTime >= 15) || HasEffect(BLM.Buffs.Firestarter) ||
-                             lastComboMove == BLM.Xenoglossy || lastComboMove == BLM.Thunder3 || (IsOffCooldown(All.Swiftcast) && (gauge.PolyglotStacks == 2)))
-                        {
-                            if (lastComboMove != BLM.Despair && lastComboMove != BLM.Fire4)
+                            if (GetRemainingCharges(Sharpcast) > 0 && !HasEffect(Buffs.Sharpcast))
                             {
-                                return BLM.Transpose;
-                            }
-                            if (lastComboMove == BLM.Despair)
-                            {
-                                if (gauge.PolyglotStacks >= 1)
-                                {
-                                    return BLM.Xenoglossy;
-                                }
-                                if (HasEffect(BLM.Buffs.Thundercloud))
-                                {
-                                    return BLM.Thunder3;
-                                }
+                                return Sharpcast;
                             }
                         }
                     }
 
-                    // Regular Despair / Paradox
-                    if (gauge.ElementTimeRemaining <= astralFireRefresh)
+                    // Play standard while inside of leylines
+                    if (HasEffect(Buffs.LeyLines))
                     {
-                        return !gauge.IsParadoxActive ? BLM.Despair : BLM.Paradox;
-                    }
-                    if (currentMP >= BLM.MP.AspectFire)
-                    {
-                        return BLM.Fire4;
-                    }
-                    return BLM.Blizzard3;
-                }
-            }
-
-            return actionID;
-        }
-    }
-    internal class BlackSimpleParadoxFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BlackSimpleParadoxFeature;
-
-        internal static bool inOpener = false;
-        internal static bool openerFinished = false;
-
-        internal delegate bool DotRecast(int value);
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BLM.Scathe)
-            {
-                var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var gauge = GetJobGauge<BLMGauge>();
-                var canWeave = CanSpellWeave(actionID);
-                var canDelayedWeave = CanWeave(actionID, 0.0) && GetCooldown(actionID).CooldownRemaining < 0.7;
-                var currentMP = LocalPlayer.CurrentMp;
-                var thunder3 = TargetHasEffect(BLM.Debuffs.Thunder3);
-                var thunder3Duration = FindTargetEffect(BLM.Debuffs.Thunder3);
-
-                DotRecast thunder3Recast = delegate (int duration)
-                {
-                    return !thunder3 || (thunder3 && thunder3Duration.RemainingTime < duration);
-                };
-
-                // Only enable sharpcast if it's available
-                if (!inOpener && !HasEffect(BLM.Buffs.Sharpcast) && GetRemainingCharges(BLM.Sharpcast) >= 1 && lastComboMove != BLM.Thunder3)
-                {
-                    return BLM.Sharpcast;
-                }
-
-                if (!inCombat && (inOpener || openerFinished))
-                {
-                    inOpener = false;
-                    openerFinished = false;
-                }
-
-                if (inCombat && !inOpener)
-                {
-                    inOpener = true;
-                }
-
-                if (inCombat && inOpener && !openerFinished)
-                {
-                    if (inCombat && inOpener && !openerFinished)
-                    {
-                        // Exit out of opener if Enochian is lost
-                        if (!gauge.IsEnochianActive)
-                        {
-                            openerFinished = true;
-                            return BLM.Blizzard3;
-                        }
-
                         if (gauge.InAstralFire)
                         {
-                            // First Triplecast
-                            if (lastComboMove != BLM.Triplecast && !HasEffect(BLM.Buffs.Triplecast) && GetRemainingCharges(BLM.Triplecast) >= 1)
+                            if (gauge.ElementTimeRemaining <= 3000 && HasEffect(Buffs.Firestarter))
                             {
-                                var triplecastMP = 7600;
-                                if (currentMP <= triplecastMP)
-                                {
-                                    return BLM.Triplecast;
-                                }
+                                return Fire3;
                             }
-
-                            // Weave other oGCDs
-                            if (canWeave)
+                            if (gauge.ElementTimeRemaining <= 6000 && !HasEffect(Buffs.Firestarter) && currentMP >= MP.AspectFire)
                             {
-                                // Weave Amplifier and Ley Lines
-                                if (currentMP <= 4400)
-                                {
-                                    if (level >= BLM.Levels.Amplifier && IsOffCooldown(BLM.Amplifier))
-                                    {
-                                        return BLM.Amplifier;
-                                    }
-                                    if (level >= BLM.Levels.LeyLines && IsOffCooldown(BLM.LeyLines))
-                                    {
-                                        return BLM.LeyLines;
-                                    }
-                                }
-
-                                // Swiftcast
-                                if (IsOffCooldown(All.Swiftcast) && IsOnCooldown(BLM.LeyLines))
-                                {
-                                    return All.Swiftcast;
-                                }
-
-                                // Manafont
-                                if (IsOffCooldown(BLM.Manafont) && (lastComboMove == BLM.Despair || lastComboMove == BLM.Fire))
-                                {
-                                    if (level >= BLM.Levels.Despair)
-                                    {
-                                        if (currentMP < BLM.MP.Despair)
-                                        {
-                                            return BLM.Manafont;
-                                        }
-                                    }
-                                    else if (currentMP < BLM.MP.AspectFire)
-                                    {
-                                        return BLM.Manafont;
-                                    }
-                                }
-
-                                // Second Triplecast / Sharpcast
-                                if (!IsEnabled(CustomComboPreset.BlackSimpleAltOpenerFeature))
-                                {
-                                    if (!HasEffect(BLM.Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast) && IsOnCooldown(All.Swiftcast) &&
-                                        lastComboMove != All.Swiftcast && GetRemainingCharges(BLM.Triplecast) >= 1 && currentMP < BLM.MP.AspectFire)
-                                    {
-                                        return BLM.Triplecast;
-                                    }
-
-                                    if (!HasEffect(BLM.Buffs.Sharpcast) && GetRemainingCharges(BLM.Sharpcast) >= 1 && IsOnCooldown(BLM.Manafont) &&
-                                        lastComboMove == BLM.Fire4)
-                                    {
-                                        return BLM.Sharpcast;
-                                    }
-                                }
+                                return gauge.IsParadoxActive ? Paradox : Despair;
                             }
-
-                            // Cast Despair
-                            if ((currentMP < BLM.MP.AspectFire || gauge.ElementTimeRemaining <= 4000) && currentMP >= BLM.MP.Despair)
-                            {
-                                return BLM.Despair;
-                            }
-
-                            // Fire4 / Umbral Ice
-                            return (currentMP >= BLM.MP.AspectFire || lastComboMove == BLM.Manafont) ? BLM.Fire4 : BLM.Blizzard3;
+                            return (currentMP >= MP.AspectFire + MP.Despair) ? Fire4 : (currentMP >= MP.Despair ? Despair : Blizzard3);
                         }
 
                         if (gauge.InUmbralIce)
                         {
-                            // Dump Polyglot Stacks
-                            if (gauge.PolyglotStacks >= 1 && gauge.ElementTimeRemaining >= 6000)
+                            if (gauge.PolyglotStacks == 2)
                             {
-                                return BLM.Xenoglossy;
+                                return Xenoglossy;
                             }
-                            if (gauge.IsParadoxActive && level >= BLM.Levels.Paradox)
-                            {
-                                return BLM.Paradox;
-                            }
-                            if (gauge.UmbralHearts < 3 && lastComboMove != BLM.Blizzard4)
-                            {
-                                return BLM.Blizzard4;
-                            }
-
-                            // Refresh Thunder3
-                            if (HasEffect(BLM.Buffs.Thundercloud) && lastComboMove != BLM.Thunder3)
-                            {
-                                return BLM.Thunder3;
-                            }
-
-                            openerFinished = true;
+                            return gauge.IsParadoxActive ? Paradox : (gauge.UmbralHearts == 3 ? Fire3 : Blizzard4);
                         }
-                    }
-                }
-
-                if (gauge.ElementTimeRemaining == 0 || !gauge.IsEnochianActive)
-                {
-                    if (currentMP >= BLM.MP.Fire3)
-                    {
-                        return BLM.Fire3;
-                    }
-                    return BLM.Blizzard3;
-                }
-
-                if (gauge.ElementTimeRemaining > 0)
-                {
-                    // Thunder
-                    if (lastComboMove != BLM.Thunder3 && currentMP >= BLM.MP.AspectThunder &&
-                        thunder3Recast(4) && !TargetHasEffect(BLM.Debuffs.Thunder2) && !TargetHasEffect(BLM.Debuffs.Thunder4))
-                    {
-                        return BLM.Thunder3;
-                    }
-
-                    // Buffs
-                    if (canWeave)
-                    {
-                        if (!HasEffect(BLM.Buffs.Triplecast) && GetRemainingCharges(BLM.Triplecast) > 0)
-                        {
-                            return BLM.Triplecast;
-                        }
-
-                        if (IsOffCooldown(BLM.Amplifier) && gauge.PolyglotStacks < 2)
-                        {
-                            return BLM.Amplifier;
-                        }
-
-                        if (IsOffCooldown(BLM.LeyLines))
-                        {
-                            return BLM.LeyLines;
-                        }
-
-                        if (IsOffCooldown(BLM.Manafont) && gauge.InAstralFire && currentMP < BLM.MP.Despair)
-                        {
-                            return BLM.Manafont;
-                        }
-
-                        if (IsOffCooldown(All.Swiftcast))
-                        {
-                            return All.Swiftcast;
-                        }
-
-                        if (GetRemainingCharges(BLM.Sharpcast) > 0 && !HasEffect(BLM.Buffs.Sharpcast))
-                        {
-                            return BLM.Sharpcast;
-                        }
-                    }
-                }
-
-                // Play standard while inside of leylines
-                if (HasEffect(BLM.Buffs.LeyLines))
-                {
-                    if (gauge.InAstralFire)
-                    {
-                        if (gauge.ElementTimeRemaining <= 3000 && HasEffect(BLM.Buffs.Firestarter))
-                        {
-                            return BLM.Fire3;
-                        }
-                        if (gauge.ElementTimeRemaining <= 6000 && !HasEffect(BLM.Buffs.Firestarter) && currentMP >= BLM.MP.AspectFire)
-                        {
-                            return gauge.IsParadoxActive ? BLM.Paradox : BLM.Despair;
-                        }
-                        return (currentMP >= BLM.MP.AspectFire + BLM.MP.Despair) ? BLM.Fire4 : (currentMP >= BLM.MP.Despair ? BLM.Despair : BLM.Blizzard3);
                     }
 
                     if (gauge.InUmbralIce)
                     {
-                        if (gauge.PolyglotStacks == 2)
+                        if (gauge.IsParadoxActive)
                         {
-                            return BLM.Xenoglossy;
+                            return Paradox;
                         }
-                        return gauge.IsParadoxActive ? BLM.Paradox : (gauge.UmbralHearts == 3 ? BLM.Fire3 : BLM.Blizzard4);
-                    }
-                }
-
-                if (gauge.InUmbralIce)
-                {
-                    if (gauge.IsParadoxActive)
-                    {
-                        return BLM.Paradox;
-                    }
-                    if (currentMP >= BLM.MP.Despair && (HasEffect(BLM.Buffs.Firestarter) || HasEffect(BLM.Buffs.Triplecast) || HasEffect(All.Buffs.Swiftcast)))
-                    {
-                        return BLM.Fire3;
-                    }
-                    if (gauge.UmbralIceStacks < 3)
-                    {
-                        return BLM.UmbralSoul;
-                    }
-                    if (IsOffCooldown(BLM.Transpose))
-                    {
-                        return BLM.Transpose;
-                    }
-                }
-
-                if (gauge.InAstralFire)
-                {
-                    if (gauge.AstralFireStacks < 3 && HasEffect(BLM.Buffs.Firestarter) && !HasEffect(BLM.Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast))
-                    {
-                        return BLM.Fire3;
-                    }
-                    if (HasEffect(BLM.Buffs.Triplecast) || HasEffect(All.Buffs.Swiftcast) || HasEffect(BLM.Buffs.Sharpcast))
-                    {
-                        if (!HasEffect(BLM.Buffs.Firestarter) && currentMP >= BLM.MP.AspectFire)
+                        if (currentMP >= MP.Despair && (HasEffect(Buffs.Firestarter) || HasEffect(Buffs.Triplecast) || HasEffect(All.Buffs.Swiftcast)))
                         {
-                            if (gauge.IsParadoxActive)
+                            return Fire3;
+                        }
+                        if (gauge.UmbralIceStacks < 3)
+                        {
+                            return UmbralSoul;
+                        }
+                        if (IsOffCooldown(Transpose))
+                        {
+                            return Transpose;
+                        }
+                    }
+
+                    if (gauge.InAstralFire)
+                    {
+                        if (gauge.AstralFireStacks < 3 && HasEffect(Buffs.Firestarter) && !HasEffect(Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast))
+                        {
+                            return Fire3;
+                        }
+                        if (HasEffect(Buffs.Triplecast) || HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Sharpcast))
+                        {
+                            if (!HasEffect(Buffs.Firestarter) && currentMP >= MP.AspectFire)
                             {
-                                return BLM.Paradox;
+                                if (gauge.IsParadoxActive)
+                                {
+                                    return Paradox;
+                                }
+                                if (!HasEffect(Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast))
+                                {
+                                    return Fire;
+                                }
                             }
-                            if (!HasEffect(BLM.Buffs.Triplecast) && !HasEffect(All.Buffs.Swiftcast))
+                            if (currentMP >= MP.Despair)
                             {
-                                return BLM.Fire;
+                                return Despair;
                             }
                         }
-                        if (currentMP >= BLM.MP.Despair)
+                        if (IsOffCooldown(Transpose) && openerFinished)
                         {
-                            return BLM.Despair;
+                            return Transpose;
                         }
                     }
-                    if (IsOffCooldown(BLM.Transpose) && openerFinished)
+
+                    if (gauge.ElementTimeRemaining > 0)
                     {
-                        return BLM.Transpose;
+                        if (gauge.PolyglotStacks >= 1)
+                        {
+                            return Xenoglossy;
+                        }
+                        if (HasEffect(Buffs.Thundercloud) && lastComboMove != Thunder3)
+                        {
+                            return Thunder3;
+                        }
+                        return currentMP <= MP.Despair ? (gauge.InAstralFire ? Transpose : UmbralSoul) : Scathe;
                     }
                 }
 
-                if (gauge.ElementTimeRemaining > 0)
-                {
-                    if (gauge.PolyglotStacks >= 1)
-                    {
-                        return BLM.Xenoglossy;
-                    }
-                    if (HasEffect(BLM.Buffs.Thundercloud) && lastComboMove != BLM.Thunder3)
-                    {
-                        return BLM.Thunder3;
-                    }
-                    return currentMP <= BLM.MP.Despair ? (gauge.InAstralFire ? BLM.Transpose : BLM.UmbralSoul) : BLM.Scathe;
-                }
+                return actionID;
             }
-
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/Combos/BLU.cs
+++ b/XIVSlothCombo/Combos/BLU.cs
@@ -65,251 +65,252 @@ namespace XIVSlothComboPlugin.Combos
             public const byte
                 Placeholder = 1;
         }
-    }
 
-    internal class BluBuffedSoT : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluBuffedSoT;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BluBuffedSoT : CustomCombo
         {
-            if (actionID == BLU.SongOfTorment)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluBuffedSoT;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (!HasEffect(BLU.Buffs.Bristle))
-                    return BLU.Bristle;
-                return BLU.SongOfTorment;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class BluOpener : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluOpener;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BLU.MoonFlute || actionID == BLU.Whistle)
-            {
-                if (GetCooldown(BLU.TripleTrident).CooldownRemaining < 3)
+                if (actionID == SongOfTorment)
                 {
-                    if (!HasEffect(BLU.Buffs.Whistle))
-                        return BLU.Whistle;
-                    if (!HasEffect(BLU.Buffs.Tingle))
-                        return BLU.Tingle;
-                    if (!HasEffect(BLU.Buffs.MoonFlute))
-                        return BLU.MoonFlute;
-                    if (!GetCooldown(BLU.JKick).IsCooldown)
-                        return BLU.JKick;
-                    if (!GetCooldown(BLU.TripleTrident).IsCooldown)
-                        return BLU.TripleTrident;
+                    if (!HasEffect(Buffs.Bristle))
+                        return Bristle;
+                    return SongOfTorment;
                 }
 
-                if (!HasEffect(BLU.Buffs.Whistle) && !GetCooldown(BLU.JKick).IsCooldown)
-                    return BLU.Whistle;
-                if (!HasEffect(BLU.Buffs.MoonFlute))
-                    return BLU.MoonFlute;
-                if (!GetCooldown(BLU.JKick).IsCooldown)
-                    return BLU.JKick;
-                if (!GetCooldown(BLU.Nightbloom).IsCooldown)
-                    return BLU.Nightbloom;
-                if (!GetCooldown(BLU.RoseOfDestruction).IsCooldown)
-                    return BLU.RoseOfDestruction;
-                if (!GetCooldown(BLU.FeatherRain).IsCooldown)
-                    return BLU.FeatherRain;
-                if (!HasEffect(BLU.Buffs.Bristle) && !GetCooldown(All.Swiftcast).IsCooldown)
-                    return BLU.Bristle;
-                if (!GetCooldown(All.Swiftcast).IsCooldown)
-                    return All.Swiftcast;
-                if (!GetCooldown(BLU.GlassDance).IsCooldown)
-                    return BLU.GlassDance;
-                if (GetCooldown(BLU.Surpanakha).CooldownRemaining < 95)
-                    return BLU.Surpanakha;
-                if (!GetCooldown(BLU.MatraMagic).IsCooldown && HasEffect(BLU.Buffs.DPSMimicry))
-                    return BLU.MatraMagic;
-                if (!GetCooldown(BLU.ShockStrike).IsCooldown)
-                    return BLU.ShockStrike;
-                return BLU.PhantomFlurry;
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class BluFinalSting : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluFinalSting;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BluOpener : CustomCombo
         {
-            if (actionID == BLU.FinalSting)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluOpener;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-
-                if (!HasEffect(BLU.Buffs.MoonFlute))
-                    return BLU.MoonFlute;
-                if (IsEnabled(CustomComboPreset.BluPrimals))
+                if (actionID == MoonFlute || actionID == Whistle)
                 {
+                    if (GetCooldown(TripleTrident).CooldownRemaining < 3)
+                    {
+                        if (!HasEffect(Buffs.Whistle))
+                            return Whistle;
+                        if (!HasEffect(Buffs.Tingle))
+                            return Tingle;
+                        if (!HasEffect(Buffs.MoonFlute))
+                            return MoonFlute;
+                        if (!GetCooldown(JKick).IsCooldown)
+                            return JKick;
+                        if (!GetCooldown(TripleTrident).IsCooldown)
+                            return TripleTrident;
+                    }
 
-                    if (!GetCooldown(BLU.RoseOfDestruction).IsCooldown)
-                        return BLU.RoseOfDestruction;
-                    if (!GetCooldown(BLU.FeatherRain).IsCooldown)
-                        return BLU.FeatherRain;
-                    if (!GetCooldown(BLU.GlassDance).IsCooldown)
-                        return BLU.GlassDance;
-                    if (!GetCooldown(BLU.JKick).IsCooldown)
-                        return BLU.JKick;
-                }
-
-                if (!HasEffect(BLU.Buffs.Tingle))
-                    return BLU.Tingle;
-                if (!GetCooldown(BLU.ShockStrike).IsCooldown && IsEnabled(CustomComboPreset.BluPrimals))
-                    return BLU.ShockStrike;
-                if (!HasEffect(BLU.Buffs.Whistle))
-                    return BLU.Whistle;
-                if (!GetCooldown(All.Swiftcast).IsCooldown)
-                    return All.Swiftcast;
-                return BLU.FinalSting;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class BluUltravibrationCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluUltravibrate;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BLU.Ultravibration)
-            {
-                var freezeDebuff = FindTargetEffect(BLU.Debuffs.DeepFreeze);
-                var swiftCD = GetCooldown(All.Swiftcast);
-                var ultraCD = GetCooldown(BLU.Ultravibration);
-
-                if (freezeDebuff is null && !ultraCD.IsCooldown)
-                    return BLU.RamsVoice;
-                if (freezeDebuff is not null)
-                {
-                    if (!swiftCD.IsCooldown)
+                    if (!HasEffect(Buffs.Whistle) && !GetCooldown(JKick).IsCooldown)
+                        return Whistle;
+                    if (!HasEffect(Buffs.MoonFlute))
+                        return MoonFlute;
+                    if (!GetCooldown(JKick).IsCooldown)
+                        return JKick;
+                    if (!GetCooldown(Nightbloom).IsCooldown)
+                        return Nightbloom;
+                    if (!GetCooldown(RoseOfDestruction).IsCooldown)
+                        return RoseOfDestruction;
+                    if (!GetCooldown(FeatherRain).IsCooldown)
+                        return FeatherRain;
+                    if (!HasEffect(Buffs.Bristle) && !GetCooldown(All.Swiftcast).IsCooldown)
+                        return Bristle;
+                    if (!GetCooldown(All.Swiftcast).IsCooldown)
                         return All.Swiftcast;
-                    return BLU.Ultravibration;
+                    if (!GetCooldown(GlassDance).IsCooldown)
+                        return GlassDance;
+                    if (GetCooldown(Surpanakha).CooldownRemaining < 95)
+                        return Surpanakha;
+                    if (!GetCooldown(MatraMagic).IsCooldown && HasEffect(Buffs.DPSMimicry))
+                        return MatraMagic;
+                    if (!GetCooldown(ShockStrike).IsCooldown)
+                        return ShockStrike;
+                    return PhantomFlurry;
                 }
-            }
 
-            return actionID;
+                return actionID;
+            }
         }
-    }
 
-    internal class BluDebuffCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluDebuffCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BluFinalSting : CustomCombo
         {
-            if (actionID == BLU.Devour || actionID == BLU.Offguard || actionID == BLU.BadBreath)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluFinalSting;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var devourCD = GetCooldown(BLU.Devour);
-                var offguardDebuff = FindTargetEffect(BLU.Debuffs.Offguard);
-                var offguardCD = GetCooldown(BLU.Offguard);
-                var lucidCD = GetCooldown(All.LucidDreaming);
+                if (actionID == FinalSting)
+                {
 
-                if (offguardDebuff is null && !offguardCD.IsCooldown)
-                    return BLU.Offguard;
-                if (TargetHasEffect(BLU.Debuffs.Malodorous) && HasEffect(BLU.Buffs.TankMimicry))
-                    return BLU.BadBreath;
-                if (!devourCD.IsCooldown && HasEffect(BLU.Buffs.TankMimicry))
-                    return BLU.Devour;
-                if (!lucidCD.IsCooldown && LocalPlayer.CurrentMp <= 9000 & level >= All.Levels.LucidDreaming)
-                    return All.LucidDreaming;
+                    if (!HasEffect(Buffs.MoonFlute))
+                        return MoonFlute;
+                    if (IsEnabled(CustomComboPreset.BluPrimals))
+                    {
+
+                        if (!GetCooldown(RoseOfDestruction).IsCooldown)
+                            return RoseOfDestruction;
+                        if (!GetCooldown(FeatherRain).IsCooldown)
+                            return FeatherRain;
+                        if (!GetCooldown(GlassDance).IsCooldown)
+                            return GlassDance;
+                        if (!GetCooldown(JKick).IsCooldown)
+                            return JKick;
+                    }
+
+                    if (!HasEffect(Buffs.Tingle))
+                        return Tingle;
+                    if (!GetCooldown(ShockStrike).IsCooldown && IsEnabled(CustomComboPreset.BluPrimals))
+                        return ShockStrike;
+                    if (!HasEffect(Buffs.Whistle))
+                        return Whistle;
+                    if (!GetCooldown(All.Swiftcast).IsCooldown)
+                        return All.Swiftcast;
+                    return FinalSting;
+                }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class BluAddleFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluAddleFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BluUltravibrationCombo : CustomCombo
         {
-            if (actionID == BLU.MagicHammer)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluUltravibrate;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var addleCD = GetCooldown(All.Addle);
-                var hammerCD = GetCooldown(BLU.MagicHammer);
+                if (actionID == Ultravibration)
+                {
+                    var freezeDebuff = FindTargetEffect(Debuffs.DeepFreeze);
+                    var swiftCD = GetCooldown(All.Swiftcast);
+                    var ultraCD = GetCooldown(Ultravibration);
 
-                if (hammerCD.IsCooldown&& !addleCD.IsCooldown && !TargetHasEffect(All.Debuffs.Addle) && !TargetHasEffect(BLU.Debuffs.Conked))
-                    return All.Addle;
+                    if (freezeDebuff is null && !ultraCD.IsCooldown)
+                        return RamsVoice;
+                    if (freezeDebuff is not null)
+                    {
+                        if (!swiftCD.IsCooldown)
+                            return All.Swiftcast;
+                        return Ultravibration;
+                    }
+                }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class BluPrimalFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluPrimalFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BluDebuffCombo : CustomCombo
         {
-            if (actionID == BLU.FeatherRain)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluDebuffCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var rainCD = GetCooldown(BLU.FeatherRain);
-                var shockCD = GetCooldown(BLU.ShockStrike);
-                var glassCD = GetCooldown(BLU.GlassDance);
-                var kickCD = GetCooldown(BLU.JKick);
-                var roseCD = GetCooldown(BLU.RoseOfDestruction);
+                if (actionID == Devour || actionID == Offguard || actionID == BadBreath)
+                {
+                    var devourCD = GetCooldown(Devour);
+                    var offguardDebuff = FindTargetEffect(Debuffs.Offguard);
+                    var offguardCD = GetCooldown(Offguard);
+                    var lucidCD = GetCooldown(All.LucidDreaming);
 
-                if (!rainCD.IsCooldown)
-                    return BLU.FeatherRain;
-                if (!shockCD.IsCooldown)
-                    return BLU.ShockStrike;
-                if (!roseCD.IsCooldown)
-                    return BLU.RoseOfDestruction;
-                if (!glassCD.IsCooldown)
-                    return BLU.GlassDance;
-                if (!kickCD.IsCooldown)
-                    return BLU.JKick;
+                    if (offguardDebuff is null && !offguardCD.IsCooldown)
+                        return Offguard;
+                    if (TargetHasEffect(Debuffs.Malodorous) && HasEffect(Buffs.TankMimicry))
+                        return BadBreath;
+                    if (!devourCD.IsCooldown && HasEffect(Buffs.TankMimicry))
+                        return Devour;
+                    if (!lucidCD.IsCooldown && LocalPlayer.CurrentMp <= 9000 & level >= All.Levels.LucidDreaming)
+                        return All.LucidDreaming;
+                }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class BluKnightCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluKnightFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BluAddleFeature : CustomCombo
         {
-            if (actionID == BLU.WhiteKnightsTour || actionID == BLU.BlackKnightsTour)
-            {
-                if (TargetHasEffect(BLU.Debuffs.Slow))
-                    return BLU.BlackKnightsTour;
-                if (TargetHasEffect(BLU.Debuffs.Bind))
-                    return BLU.WhiteKnightsTour;
-            }
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluAddleFeature;
 
-            return actionID;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == MagicHammer)
+                {
+                    var addleCD = GetCooldown(All.Addle);
+                    var hammerCD = GetCooldown(MagicHammer);
+
+                    if (hammerCD.IsCooldown && !addleCD.IsCooldown && !TargetHasEffect(All.Debuffs.Addle) && !TargetHasEffect(Debuffs.Conked))
+                        return All.Addle;
+                }
+
+                return actionID;
+            }
         }
-    }
-    internal class BluLightheadedCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluLightheadedCombo;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BluPrimalFeature : CustomCombo
         {
-            if (actionID == BLU.PeripheralSynthesis)
-            {
-                if (!TargetHasEffect(BLU.Debuffs.Lightheaded))
-                    return BLU.PeripheralSynthesis;
-                if (TargetHasEffect(BLU.Debuffs.Lightheaded))
-                    return BLU.MustardBomb;
-            }
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluPrimalFeature;
 
-            return actionID;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == FeatherRain)
+                {
+                    var rainCD = GetCooldown(FeatherRain);
+                    var shockCD = GetCooldown(ShockStrike);
+                    var glassCD = GetCooldown(GlassDance);
+                    var kickCD = GetCooldown(JKick);
+                    var roseCD = GetCooldown(RoseOfDestruction);
+
+                    if (!rainCD.IsCooldown)
+                        return FeatherRain;
+                    if (!shockCD.IsCooldown)
+                        return ShockStrike;
+                    if (!roseCD.IsCooldown)
+                        return RoseOfDestruction;
+                    if (!glassCD.IsCooldown)
+                        return GlassDance;
+                    if (!kickCD.IsCooldown)
+                        return JKick;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class BluKnightCombo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluKnightFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == WhiteKnightsTour || actionID == BlackKnightsTour)
+                {
+                    if (TargetHasEffect(Debuffs.Slow))
+                        return BlackKnightsTour;
+                    if (TargetHasEffect(Debuffs.Bind))
+                        return WhiteKnightsTour;
+                }
+
+                return actionID;
+            }
+        }
+        internal class BluLightheadedCombo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BluLightheadedCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == PeripheralSynthesis)
+                {
+                    if (!TargetHasEffect(Debuffs.Lightheaded))
+                        return PeripheralSynthesis;
+                    if (TargetHasEffect(Debuffs.Lightheaded))
+                        return MustardBomb;
+                }
+
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -106,7 +106,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             return value != Song.NONE;
         }
-        
+
         internal static bool SongIsNone(Song value)
         {
             return value == Song.NONE;
@@ -116,754 +116,756 @@ namespace XIVSlothComboPlugin.Combos
         {
             return value == Song.WANDERER;
         }
-    }
 
-    // Replace HS/BS with SS/RA when procced.
-    internal class BardStraightShotUpgradeFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardStraightShotUpgradeFeature;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        // Replace HS/BS with SS/RA when procced.
+        internal class BardStraightShotUpgradeFeature : CustomCombo
         {
-            if (actionID == BRD.HeavyShot || actionID == BRD.BurstShot)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardStraightShotUpgradeFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (IsEnabled(CustomComboPreset.BardApexFeature))
+                if (actionID == HeavyShot || actionID == BurstShot)
+                {
+                    if (IsEnabled(CustomComboPreset.BardApexFeature))
+                    {
+                        var gauge = GetJobGauge<BRDGauge>();
+
+                        if (gauge.SoulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
+                            return ApexArrow;
+                        if (level >= Levels.BlastArrow && HasEffect(Buffs.BlastArrowReady))
+                            return BlastArrow;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.BardDoTMaintain))
+                    {
+                        var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                        var venomous = TargetHasEffect(Debuffs.VenomousBite);
+                        var windbite = TargetHasEffect(Debuffs.Windbite);
+                        var caustic = TargetHasEffect(Debuffs.CausticBite);
+                        var stormbite = TargetHasEffect(Debuffs.Stormbite);
+                        var venomousDuration = FindTargetEffect(Debuffs.VenomousBite);
+                        var windbiteDuration = FindTargetEffect(Debuffs.Windbite);
+                        var causticDuration = FindTargetEffect(Debuffs.CausticBite);
+                        var stormbiteDuration = FindTargetEffect(Debuffs.Stormbite);
+
+                        if (inCombat)
+                        {
+                            var useIronJaws = (
+                                level >= Levels.IronJaws &&
+                                ((venomous && venomousDuration.RemainingTime < 4) || (caustic && causticDuration.RemainingTime < 4)) ||
+                                ((windbite && windbiteDuration.RemainingTime < 4) || (stormbite && stormbiteDuration.RemainingTime < 4))
+                            );
+
+                            if (useIronJaws)
+                                return IronJaws;
+                            if (level < Levels.IronJaws && venomous && venomousDuration.RemainingTime < 4)
+                                return VenomousBite;
+                            if (level < Levels.IronJaws && windbite && windbiteDuration.RemainingTime < 4)
+                                return Windbite;
+                        }
+
+                    }
+
+                    if (HasEffect(Buffs.StraightShotReady))
+                    {
+                        return (level >= Levels.RefulgentArrow) ? RefulgentArrow : StraightShot;
+                    }
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class BardIronJawsFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardIronJawsFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == IronJaws)
+                {
+                    if (IsEnabled(CustomComboPreset.BardIronJawsApexFeature) && level >= Levels.ApexArrow)
+                    {
+                        var gauge = GetJobGauge<BRDGauge>();
+
+                        if (level >= Levels.BlastArrow && HasEffect(Buffs.BlastArrowReady)) return BlastArrow;
+                        if (gauge.SoulVoice == 100 && IsOffCooldown(ApexArrow)) return ApexArrow;
+                    }
+
+
+                    if (level < Levels.IronJaws)
+                    {
+                        var venomous = FindTargetEffect(Debuffs.VenomousBite);
+                        var windbite = FindTargetEffect(Debuffs.Windbite);
+
+                        if (venomous is not null && windbite is not null)
+                        {
+                            if (level >= Levels.VenomousBite && venomous.RemainingTime < windbite.RemainingTime)
+                            {
+                                return VenomousBite;
+                            }
+
+                            if (level >= Levels.Windbite)
+                            {
+                                return Windbite;
+                            }
+                        }
+
+                        if (level >= Levels.VenomousBite && (level < Levels.Windbite || windbite is not null))
+                        {
+                            return VenomousBite;
+                        }
+
+                        if (level >= Levels.Windbite)
+                        {
+                            return Windbite;
+                        }
+                    }
+
+                    if (level < Levels.BiteUpgrade)
+                    {
+                        var venomous = TargetHasEffect(Debuffs.VenomousBite);
+                        var windbite = TargetHasEffect(Debuffs.Windbite);
+                        var venomousDuration = FindTargetEffect(Debuffs.VenomousBite);
+                        var windbiteDuration = FindTargetEffect(Debuffs.Windbite);
+
+                        if (level >= Levels.IronJaws && venomous && windbite)
+                        {
+                            return IronJaws;
+                        }
+
+                        if (level >= Levels.VenomousBite && windbite)
+                        {
+                            return VenomousBite;
+                        }
+
+                        if (level >= Levels.Windbite)
+                        {
+                            return Windbite;
+                        }
+                    }
+
+                    var caustic = TargetHasEffect(Debuffs.CausticBite);
+                    var stormbite = TargetHasEffect(Debuffs.Stormbite);
+                    var causticDuration = FindTargetEffect(Debuffs.CausticBite);
+                    var stormbiteDuration = FindTargetEffect(Debuffs.Stormbite);
+
+                    if (level >= Levels.IronJaws && caustic && stormbite)
+                    {
+                        return IronJaws;
+                    }
+
+                    if (level >= Levels.CausticBite && stormbite)
+                    {
+                        return CausticBite;
+                    }
+
+                    if (level >= Levels.StormBite)
+                    {
+                        return Stormbite;
+                    }
+                }
+
+                return actionID;
+            }
+        }
+        internal class BardIronJawsAlternateFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardIronJawsAlternateFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == IronJaws)
+                {
+                    if (level < Levels.IronJaws)
+                    {
+                        var venomous = FindTargetEffect(Debuffs.VenomousBite);
+                        var windbite = FindTargetEffect(Debuffs.Windbite);
+
+                        if (venomous is not null && windbite is not null)
+                        {
+                            if (level >= Levels.VenomousBite && venomous.RemainingTime < windbite.RemainingTime)
+                            {
+                                return VenomousBite;
+                            }
+
+                            if (level >= Levels.Windbite)
+                            {
+                                return Windbite;
+                            }
+                        }
+
+                        if (level >= Levels.VenomousBite && (level < Levels.Windbite || windbite is not null))
+                        {
+                            return VenomousBite;
+                        }
+
+                        if (level >= Levels.Windbite)
+                        {
+                            return Windbite;
+                        }
+                    }
+
+                    if (level < Levels.BiteUpgrade)
+                    {
+                        var venomous = TargetHasEffect(Debuffs.VenomousBite);
+                        var windbite = TargetHasEffect(Debuffs.Windbite);
+                        var venomousDuration = FindTargetEffect(Debuffs.VenomousBite);
+                        var windbiteDuration = FindTargetEffect(Debuffs.Windbite);
+
+                        if (level >= Levels.IronJaws && venomous && windbite && (venomousDuration.RemainingTime < 4 || windbiteDuration.RemainingTime < 4))
+                        {
+                            return IronJaws;
+                        }
+
+                        if (level >= Levels.VenomousBite && windbite)
+                        {
+                            return VenomousBite;
+                        }
+
+                        if (level >= Levels.Windbite)
+                        {
+                            return Windbite;
+                        }
+                    }
+
+                    var caustic = TargetHasEffect(Debuffs.CausticBite);
+                    var stormbite = TargetHasEffect(Debuffs.Stormbite);
+                    var causticDuration = FindTargetEffect(Debuffs.CausticBite);
+                    var stormbiteDuration = FindTargetEffect(Debuffs.Stormbite);
+
+                    if (level >= Levels.IronJaws && caustic && stormbite && (causticDuration.RemainingTime < 4 || stormbiteDuration.RemainingTime < 4))
+                    {
+                        return IronJaws;
+                    }
+
+                    if (level >= Levels.CausticBite && stormbite)
+                    {
+                        return CausticBite;
+                    }
+
+                    if (level >= Levels.StormBite)
+                    {
+                        return Stormbite;
+                    }
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class BardApexFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardApexFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == QuickNock)
                 {
                     var gauge = GetJobGauge<BRDGauge>();
 
-                    if (gauge.SoulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
-                        return BRD.ApexArrow;
-                    if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady))
-                        return BRD.BlastArrow;
+                    if (level >= Levels.ApexArrow && gauge.SoulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
+                        return ApexArrow;
                 }
 
-                if (IsEnabled(CustomComboPreset.BardDoTMaintain))
-                {
-                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                    var venomous = TargetHasEffect(BRD.Debuffs.VenomousBite);
-                    var windbite = TargetHasEffect(BRD.Debuffs.Windbite);
-                    var caustic = TargetHasEffect(BRD.Debuffs.CausticBite);
-                    var stormbite = TargetHasEffect(BRD.Debuffs.Stormbite);
-                    var venomousDuration = FindTargetEffect(BRD.Debuffs.VenomousBite);
-                    var windbiteDuration = FindTargetEffect(BRD.Debuffs.Windbite);
-                    var causticDuration = FindTargetEffect(BRD.Debuffs.CausticBite);
-                    var stormbiteDuration = FindTargetEffect(BRD.Debuffs.Stormbite);
-
-                    if (inCombat)
-                    {
-                        var useIronJaws = (
-                            level >= BRD.Levels.IronJaws &&
-                            ((venomous && venomousDuration.RemainingTime < 4) || (caustic && causticDuration.RemainingTime < 4)) ||
-                            ((windbite && windbiteDuration.RemainingTime < 4) || (stormbite && stormbiteDuration.RemainingTime < 4))
-                        );
-
-                        if (useIronJaws)
-                            return BRD.IronJaws;
-                        if (level < BRD.Levels.IronJaws && venomous && venomousDuration.RemainingTime < 4)
-                            return BRD.VenomousBite;
-                        if (level < BRD.Levels.IronJaws && windbite && windbiteDuration.RemainingTime < 4)
-                            return BRD.Windbite;
-                    }
-
-                }
-
-                if (HasEffect(BRD.Buffs.StraightShotReady))
-                {
-                    return (level >= BRD.Levels.RefulgentArrow) ? BRD.RefulgentArrow : BRD.StraightShot;
-                }
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class BardIronJawsFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardIronJawsFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BardoGCDAoEFeature : CustomCombo
         {
-            if (actionID == BRD.IronJaws)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardoGCDAoEFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (IsEnabled(CustomComboPreset.BardIronJawsApexFeature) && level >= BRD.Levels.ApexArrow)
+                if (actionID == RainOfDeath)
                 {
                     var gauge = GetJobGauge<BRDGauge>();
 
-                    if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady)) return BRD.BlastArrow;
-                    if (gauge.SoulVoice == 100 && IsOffCooldown(BRD.ApexArrow)) return BRD.ApexArrow;
+                    if (level >= Levels.WanderersMinuet && gauge.Song == Song.WANDERER && gauge.Repertoire == 3)
+                        return OriginalHook(WanderersMinuet);
+                    if (level >= Levels.EmpyrealArrow && IsOffCooldown(EmpyrealArrow))
+                        return EmpyrealArrow;
+                    if (level >= Levels.Bloodletter && IsOffCooldown(Bloodletter))
+                        return RainOfDeath;
+                    if (level >= Levels.Sidewinder && IsOffCooldown(Sidewinder))
+                        return Sidewinder;
+
                 }
 
-
-                if (level < BRD.Levels.IronJaws)
-                {
-                    var venomous = FindTargetEffect(BRD.Debuffs.VenomousBite);
-                    var windbite = FindTargetEffect(BRD.Debuffs.Windbite);
-
-                    if (venomous is not null && windbite is not null)
-                    {
-                        if (level >= BRD.Levels.VenomousBite && venomous.RemainingTime < windbite.RemainingTime)
-                        {
-                            return BRD.VenomousBite;
-                        }
-
-                        if (level >= BRD.Levels.Windbite)
-                        {
-                            return BRD.Windbite;
-                        }
-                    }
-
-                    if (level >= BRD.Levels.VenomousBite && (level < BRD.Levels.Windbite || windbite is not null))
-                    {
-                        return BRD.VenomousBite;
-                    }
-
-                    if (level >= BRD.Levels.Windbite)
-                    {
-                        return BRD.Windbite;
-                    }
-                }
-
-                if (level < BRD.Levels.BiteUpgrade)
-                {
-                    var venomous = TargetHasEffect(BRD.Debuffs.VenomousBite);
-                    var windbite = TargetHasEffect(BRD.Debuffs.Windbite);
-                    var venomousDuration = FindTargetEffect(BRD.Debuffs.VenomousBite);
-                    var windbiteDuration = FindTargetEffect(BRD.Debuffs.Windbite);
-
-                    if (level >= BRD.Levels.IronJaws && venomous && windbite)
-                    {
-                        return BRD.IronJaws;
-                    }
-
-                    if (level >= BRD.Levels.VenomousBite && windbite)
-                    {
-                        return BRD.VenomousBite;
-                    }
-
-                    if (level >= BRD.Levels.Windbite)
-                    {
-                        return BRD.Windbite;
-                    }
-                }
-
-                var caustic = TargetHasEffect(BRD.Debuffs.CausticBite);
-                var stormbite = TargetHasEffect(BRD.Debuffs.Stormbite);
-                var causticDuration = FindTargetEffect(BRD.Debuffs.CausticBite);
-                var stormbiteDuration = FindTargetEffect(BRD.Debuffs.Stormbite);
-
-                if (level >= BRD.Levels.IronJaws && caustic && stormbite)
-                {
-                    return BRD.IronJaws;
-                }
-
-                if (level >= BRD.Levels.CausticBite && stormbite)
-                {
-                    return BRD.CausticBite;
-                }
-
-                if (level >= BRD.Levels.StormBite)
-                {
-                    return BRD.Stormbite;
-                }
+                return actionID;
             }
-
-            return actionID;
         }
-    }
-    internal class BardIronJawsAlternateFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardIronJawsAlternateFeature;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BardSimpleAoEFeature : CustomCombo
         {
-            if (actionID == BRD.IronJaws)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardSimpleAoEFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (level < BRD.Levels.IronJaws)
+                if (actionID == Ladonsbite || actionID == QuickNock)
                 {
-                    var venomous = FindTargetEffect(BRD.Debuffs.VenomousBite);
-                    var windbite = FindTargetEffect(BRD.Debuffs.Windbite);
-
-                    if (venomous is not null && windbite is not null)
-                    {
-                        if (level >= BRD.Levels.VenomousBite && venomous.RemainingTime < windbite.RemainingTime)
-                        {
-                            return BRD.VenomousBite;
-                        }
-
-                        if (level >= BRD.Levels.Windbite)
-                        {
-                            return BRD.Windbite;
-                        }
-                    }
-
-                    if (level >= BRD.Levels.VenomousBite && (level < BRD.Levels.Windbite || windbite is not null))
-                    {
-                        return BRD.VenomousBite;
-                    }
-
-                    if (level >= BRD.Levels.Windbite)
-                    {
-                        return BRD.Windbite;
-                    }
-                }
-
-                if (level < BRD.Levels.BiteUpgrade)
-                {
-                    var venomous = TargetHasEffect(BRD.Debuffs.VenomousBite);
-                    var windbite = TargetHasEffect(BRD.Debuffs.Windbite);
-                    var venomousDuration = FindTargetEffect(BRD.Debuffs.VenomousBite);
-                    var windbiteDuration = FindTargetEffect(BRD.Debuffs.Windbite);
-
-                    if (level >= BRD.Levels.IronJaws && venomous && windbite && (venomousDuration.RemainingTime < 4 || windbiteDuration.RemainingTime < 4))
-                    {
-                        return BRD.IronJaws;
-                    }
-
-                    if (level >= BRD.Levels.VenomousBite && windbite)
-                    {
-                        return BRD.VenomousBite;
-                    }
-
-                    if (level >= BRD.Levels.Windbite)
-                    {
-                        return BRD.Windbite;
-                    }
-                }
-
-                var caustic = TargetHasEffect(BRD.Debuffs.CausticBite);
-                var stormbite = TargetHasEffect(BRD.Debuffs.Stormbite);
-                var causticDuration = FindTargetEffect(BRD.Debuffs.CausticBite);
-                var stormbiteDuration = FindTargetEffect(BRD.Debuffs.Stormbite);
-
-                if (level >= BRD.Levels.IronJaws && caustic && stormbite && (causticDuration.RemainingTime < 4 || stormbiteDuration.RemainingTime < 4))
-                {
-                    return BRD.IronJaws;
-                }
-
-                if (level >= BRD.Levels.CausticBite && stormbite)
-                {
-                    return BRD.CausticBite;
-                }
-
-                if (level >= BRD.Levels.StormBite)
-                {
-                    return BRD.Stormbite;
-                }
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class BardApexFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardApexFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BRD.QuickNock)
-            {
-                var gauge = GetJobGauge<BRDGauge>();
-
-                if (level >= BRD.Levels.ApexArrow && gauge.SoulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
-                    return BRD.ApexArrow;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class BardoGCDAoEFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardoGCDAoEFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BRD.RainOfDeath)
-            {
-                var gauge = GetJobGauge<BRDGauge>();
-
-                if (level >= BRD.Levels.WanderersMinuet && gauge.Song == Song.WANDERER && gauge.Repertoire == 3)
-                    return OriginalHook(BRD.WanderersMinuet);
-                if (level >= BRD.Levels.EmpyrealArrow && IsOffCooldown(BRD.EmpyrealArrow))
-                    return BRD.EmpyrealArrow;
-                if (level >= BRD.Levels.Bloodletter && IsOffCooldown(BRD.Bloodletter))
-                    return BRD.RainOfDeath;
-                if (level >= BRD.Levels.Sidewinder && IsOffCooldown(BRD.Sidewinder))
-                    return BRD.Sidewinder;
-
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class BardSimpleAoEFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardSimpleAoEFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BRD.Ladonsbite || actionID == BRD.QuickNock)
-            {
-                var gauge = GetJobGauge<BRDGauge>();
-                var soulVoice = gauge.SoulVoice;
-                var canWeave = CanWeave(actionID);
-
-                if (IsEnabled(CustomComboPreset.SimpleAoESongOption) && canWeave)
-                {
-                    var songTimerInSeconds = gauge.SongTimer / 1000;
-
-                    if (songTimerInSeconds < 3 || gauge.Song == Song.NONE)
-                    {
-                        if (level >= BRD.Levels.WanderersMinuet && 
-                            IsOffCooldown(BRD.WanderersMinuet) && !(JustUsed(BRD.MagesBallad) || JustUsed(BRD.ArmysPaeon)) && !IsEnabled(CustomComboPreset.SimpleAoESongOptionExcludeWM))
-                            return BRD.WanderersMinuet;
-                        if (level >= BRD.Levels.MagesBallad &&
-                            IsOffCooldown(BRD.MagesBallad) && !(JustUsed(BRD.WanderersMinuet) || JustUsed(BRD.ArmysPaeon)))
-                            return BRD.MagesBallad;
-                        if (level >= BRD.Levels.ArmysPaeon &&
-                            IsOffCooldown(BRD.ArmysPaeon) && !(JustUsed(BRD.MagesBallad) || JustUsed(BRD.WanderersMinuet)))
-                            return BRD.ArmysPaeon;
-                    }
-                }
-
-                if (canWeave)
-                {
-                    if (level >= BRD.Levels.PitchPerfect && gauge.Song == Song.WANDERER && gauge.Repertoire == 3)
-                        return OriginalHook(BRD.WanderersMinuet);
-                    if (level >= BRD.Levels.EmpyrealArrow && IsOffCooldown(BRD.EmpyrealArrow))
-                        return BRD.EmpyrealArrow;
-                    if (level >= BRD.Levels.RainOfDeath && GetRemainingCharges(BRD.RainOfDeath) > 0)
-                        return BRD.RainOfDeath;
-                    if (level >= BRD.Levels.Sidewinder && IsOffCooldown(BRD.Sidewinder))
-                        return BRD.Sidewinder;
-                }
-
-                if (level >= BRD.Levels.Shadowbite && HasEffect(BRD.Buffs.ShadowbiteReady))
-                    return BRD.Shadowbite;
-                if (level >= BRD.Levels.ApexArrow && soulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
-                    return BRD.ApexArrow;
-                if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady))
-                    return BRD.BlastArrow;
-
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class BardoGCDSingleTargetFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardoGCDSingleTargetFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BRD.Bloodletter)
-            {
-                var gauge = GetJobGauge<BRDGauge>();
-
-                if (IsEnabled(CustomComboPreset.BardSongsFeature) && (gauge.SongTimer < 1 || gauge.Song == Song.ARMY))
-                {
-                    if (level >= BRD.Levels.WanderersMinuet && IsOffCooldown(BRD.WanderersMinuet))
-                        return BRD.WanderersMinuet;
-                    if (level >= BRD.Levels.MagesBallad && IsOffCooldown(BRD.MagesBallad))
-                        return BRD.MagesBallad;
-                    if (level >= BRD.Levels.ArmysPaeon && IsOffCooldown(BRD.ArmysPaeon))
-                        return BRD.ArmysPaeon;
-                }
-
-                if (gauge.Song == Song.WANDERER && gauge.Repertoire == 3)
-                    return OriginalHook(BRD.WanderersMinuet);
-                if (level >= BRD.Levels.EmpyrealArrow && IsOffCooldown(BRD.EmpyrealArrow))
-                    return BRD.EmpyrealArrow;
-                if (level >= BRD.Levels.Bloodletter && IsOffCooldown(BRD.Bloodletter))
-                    return BRD.Bloodletter;
-                if (level >= BRD.Levels.Sidewinder && IsOffCooldown(BRD.Sidewinder))
-                    return BRD.Sidewinder;
-            }
-
-            return actionID;
-        }
-    }
-    internal class BardAoEComboFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardAoEComboFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BRD.QuickNock || actionID == BRD.Ladonsbite)
-            {
-                if (IsEnabled(CustomComboPreset.BardApexFeature))
-                {
-                    if (level >= BRD.Levels.ApexArrow && GetJobGauge<BRDGauge>().SoulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
-                        return BRD.ApexArrow;
-
-                    if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady))
-                        return BRD.BlastArrow;
-                }
-
-                if (IsEnabled(CustomComboPreset.BardAoEComboFeature) && level >= BRD.Levels.Shadowbite && HasEffectAny(BRD.Buffs.ShadowbiteReady))
-                {
-                    return BRD.Shadowbite;
-                }
-            }
-
-            return actionID;
-        }
-    }
-    internal class SimpleBardFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SimpleBardFeature;
-        internal static bool inOpener = false;
-        internal static bool openerFinished = false;
-        internal static byte step = 0;
-        internal static byte subStep = 0;
-
-        internal static bool usedStraightShotReady = false;
-        internal static bool usedPitchPerfect = false;
-
-        internal delegate bool DotRecast(int value);
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == BRD.HeavyShot || actionID == BRD.BurstShot)
-            {
-                var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var gauge = GetJobGauge<BRDGauge>();
-
-                var canWeave = CanWeave(actionID);
-                var canWeaveBuffs = CanWeave(actionID, 0.6);
-                var canWeaveDelayed = CanDelayedWeave(actionID, 0.9);
-
-                if (!inCombat && (inOpener || openerFinished))
-                {
-                    openerFinished = false;
-                }
-
-                if (IsEnabled(CustomComboPreset.BardSimpleInterrupt) && CanInterruptEnemy() && IsOffCooldown(All.HeadGraze))
-                {
-                    return All.HeadGraze;
-                }
-                
-                var isEnemyHealthHigh = IsEnabled(CustomComboPreset.BardSimpleNoWasteMode) ?
-                    CustomCombo.EnemyHealthPercentage() > Service.Configuration.GetCustomIntValue(BRD.Config.NoWasteHPPercentage) : true;
-
-                if (IsEnabled(CustomComboPreset.SimpleSongOption) && isEnemyHealthHigh)
-                {
-                    var songTimerInSeconds = gauge.SongTimer / 1000;
-
-                    // Limit optimisation to only when you are high enough to benefit from it.
-                    if (level >= BRD.Levels.WanderersMinuet)
-                    {
-                        // 43s of Wanderer's Minute, ~36s of Mage's Ballad, and ~43s of Army Peon    
-                        var minuetOffCooldown = IsOffCooldown(BRD.WanderersMinuet);
-                        var balladOffCooldown = IsOffCooldown(BRD.MagesBallad);
-                        var paeonOffCooldown = IsOffCooldown(BRD.ArmysPaeon);
-
-                        if (gauge.Song == Song.NONE && canWeave)
-                        {
-                            // Do logic to determine first song
-
-                            if (minuetOffCooldown && !(JustUsed(BRD.MagesBallad)        || JustUsed(BRD.ArmysPaeon)) )      return BRD.WanderersMinuet;
-                            if (balladOffCooldown && !(JustUsed(BRD.WanderersMinuet)    || JustUsed(BRD.ArmysPaeon)) )      return BRD.MagesBallad;
-                            if (paeonOffCooldown  && !(JustUsed(BRD.MagesBallad)        || JustUsed(BRD.WanderersMinuet)) ) return BRD.ArmysPaeon;
-                        }
-
-                        if (gauge.Song == Song.WANDERER && canWeave)
-                        {
-                            // Spend any repertoire before switching to next song
-                            if (songTimerInSeconds < 3 && gauge.Repertoire > 0)
-                            {
-                                return OriginalHook(BRD.WanderersMinuet);
-                            }
-                            // Move to Mage's Ballad if < 3 seconds left on song
-                            if (songTimerInSeconds < 3 && balladOffCooldown)
-                            {
-                                return BRD.MagesBallad;
-                            }
-                        }
-
-                        if (gauge.Song == Song.MAGE && canWeave)
-                        {
-                            // Move to Army's Paeon if < 12 seconds left on song
-                            if (songTimerInSeconds < 12 && paeonOffCooldown)
-                            {
-                                // Very special case for Empyreal, it needs to be cast before you change to it to avoid drift!!!
-                                if (level >= BRD.Levels.EmpyrealArrow && IsOffCooldown(BRD.EmpyrealArrow)) 
-                                    return BRD.EmpyrealArrow;
-
-                                return BRD.ArmysPaeon;
-                            }
-                        }
-
-                        if (gauge.Song == Song.ARMY && canWeaveDelayed)
-                        {
-                            // Move to Wanderer's Minuet if < 3 seconds left on song or WM off CD and have 4 repertoires of AP
-                            if (songTimerInSeconds < 3 || (minuetOffCooldown && gauge.Repertoire == 4))
-                            {
-                                return BRD.WanderersMinuet;
-                            }
-                        }
-                    }
-                    else if ( songTimerInSeconds < 3 )
-                    {
-                        if (level >= BRD.Levels.MagesBallad && IsOffCooldown(BRD.MagesBallad))
-                            return BRD.MagesBallad;
-                        if (level >= BRD.Levels.ArmysPaeon && IsOffCooldown(BRD.ArmysPaeon))
-                            return BRD.ArmysPaeon;
-                    }
-                }
-
-                if (IsEnabled(CustomComboPreset.BardSimpleBuffsFeature)  && ( gauge.Song != Song.NONE || level < BRD.Levels.MagesBallad ) && isEnemyHealthHigh)
-                {
-                    if (((canWeaveBuffs && CombatEngageDuration().Minutes == 0 ) || (canWeaveDelayed && CombatEngageDuration().Minutes > 0)) && level >= BRD.Levels.RagingStrikes && IsOffCooldown(BRD.RagingStrikes) &&
-                        (GetCooldown(BRD.BattleVoice).CooldownRemaining <= 5.38 || IsOffCooldown(BRD.BattleVoice) || level < BRD.Levels.BattleVoice))
-                    {
-                        return BRD.RagingStrikes;
-                    }
-                    if (canWeaveBuffs && IsEnabled(CustomComboPreset.BardSimpleBuffsRadiantFeature) && level >= BRD.Levels.RadiantFinale &&
-                        IsOffCooldown(BRD.RadiantFinale) && (Array.TrueForAll(gauge.Coda, BRD.SongIsNotNone) || Array.Exists(gauge.Coda, BRD.SongIsWandererMinuet)) &&
-                        (IsOffCooldown(BRD.BattleVoice) || GetCooldownRemainingTime(BRD.BattleVoice) < 0.7) && (GetBuffRemainingTime(BRD.Buffs.RagingStrikes) <= 16.5 || openerFinished ) && IsOnCooldown(BRD.RagingStrikes))
-                    { 
-                        if (!JustUsed(BRD.RagingStrikes)) return BRD.RadiantFinale;
-                    }
-
-                    if (canWeaveBuffs && level >= BRD.Levels.BattleVoice && IsOffCooldown(BRD.BattleVoice) && (GetBuffRemainingTime(BRD.Buffs.RagingStrikes) <= 16.5 || openerFinished ) && IsOnCooldown(BRD.RagingStrikes))
-                    {
-                        if (!JustUsed(BRD.RagingStrikes)) return BRD.BattleVoice; 
-                    }
-                    if (canWeaveBuffs && level >= BRD.Levels.Barrage && IsOffCooldown(BRD.Barrage) && !HasEffect(BRD.Buffs.StraightShotReady) && HasEffect(BRD.Buffs.RagingStrikes))
-                    {
-                        if (level >= BRD.Levels.RadiantFinale && HasEffect(BRD.Buffs.RadiantFinale))
-                            return BRD.Barrage;
-                        else if (level >= BRD.Levels.BattleVoice && HasEffect(BRD.Buffs.BattleVoice))
-                            return BRD.Barrage;
-                        else if (level < BRD.Levels.BattleVoice && HasEffect(BRD.Buffs.RagingStrikes))
-                            return BRD.Barrage;
-                    }
-                }
-
-                
-                if (canWeave)
-                {
-                    if (level >= BRD.Levels.EmpyrealArrow && IsOffCooldown(BRD.EmpyrealArrow) &&
-                        (!openerFinished || (openerFinished && GetCooldownRemainingTime(BRD.BattleVoice) >= 3.5)))
-                    {
-                        return BRD.EmpyrealArrow;
-                    }
-
-                    if (level >= BRD.Levels.PitchPerfect && gauge.Song == Song.WANDERER &&
-                        (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && GetCooldown(BRD.EmpyrealArrow).CooldownRemaining < 2)) &&
-                        (!openerFinished || (openerFinished && GetCooldownRemainingTime(BRD.BattleVoice) >= 3.5)))
-                    {
-                        return OriginalHook(BRD.WanderersMinuet);
-                    }
-
-                    if (level >= BRD.Levels.Sidewinder && IsOffCooldown(BRD.Sidewinder) && 
-                        (!openerFinished || (openerFinished && GetCooldownRemainingTime(BRD.BattleVoice) >= 3.5)))
-                    {
-                        if (IsEnabled(CustomComboPreset.BardSimplePooling))
-                        {
-                            if (gauge.Song == Song.WANDERER)
-                            {
-                                if (
-                                    (HasEffect(BRD.Buffs.RagingStrikes) || GetCooldown(BRD.RagingStrikes).CooldownRemaining > 10) &&
-                                    (HasEffect(BRD.Buffs.BattleVoice) || GetCooldown(BRD.BattleVoice).CooldownRemaining > 10) &&
-                                    (
-                                        HasEffect(BRD.Buffs.RadiantFinale) || GetCooldown(BRD.RadiantFinale).CooldownRemaining > 10 ||
-                                        level < BRD.Levels.RadiantFinale
-                                    )
-                                    )
-                                {
-                                    return BRD.Sidewinder;
-                                }
-                            }
-                            else return BRD.Sidewinder;
-                        }
-                        else return BRD.Sidewinder;
-                    }
-
-                    if (level >= BRD.Levels.Bloodletter)
-                    {
-                        var bloodletterCharges = GetRemainingCharges(BRD.Bloodletter);
-
-                        if (IsEnabled(CustomComboPreset.BardSimplePooling) && level >= BRD.Levels.WanderersMinuet)
-                        {
-                            if (gauge.Song == Song.WANDERER)
-                            {
-                                if (
-                                    ((HasEffect(BRD.Buffs.RagingStrikes) || GetCooldown(BRD.RagingStrikes).CooldownRemaining > 10) &&
-                                    (
-                                        HasEffect(BRD.Buffs.BattleVoice)   || GetCooldown(BRD.BattleVoice).CooldownRemaining > 10 ||
-                                        level < BRD.Levels.BattleVoice
-                                    ) && 
-                                    (
-                                        HasEffect(BRD.Buffs.RadiantFinale) || GetCooldown(BRD.RadiantFinale).CooldownRemaining > 10 ||
-                                        level < BRD.Levels.RadiantFinale
-                                    ) &&
-                                    bloodletterCharges > 0) ||
-                                    bloodletterCharges > 2
-                                )
-                                {
-                                    return BRD.Bloodletter;
-                                }
-                            }
-                            if (gauge.Song == Song.ARMY && (bloodletterCharges == 3 || ((gauge.SongTimer / 1000) > 30 && bloodletterCharges > 0))) return BRD.Bloodletter;
-                            if (gauge.Song == Song.MAGE && bloodletterCharges > 0) return BRD.Bloodletter;
-                            if (gauge.Song == Song.NONE && bloodletterCharges == 3) return BRD.Bloodletter;
-                        }
-                        else if (bloodletterCharges > 0)
-                        {
-                            return BRD.Bloodletter;
-                        }
-                    }
-                }
-                
-
-                if (isEnemyHealthHigh)
-                {
-                    var venomous = TargetHasEffect(BRD.Debuffs.VenomousBite);
-                    var windbite = TargetHasEffect(BRD.Debuffs.Windbite);
-                    var caustic = TargetHasEffect(BRD.Debuffs.CausticBite);
-                    var stormbite = TargetHasEffect(BRD.Debuffs.Stormbite);
-
-                    var venomousDuration = FindTargetEffect(BRD.Debuffs.VenomousBite);
-                    var windbiteDuration = FindTargetEffect(BRD.Debuffs.Windbite);
-                    var causticDuration = FindTargetEffect(BRD.Debuffs.CausticBite);
-                    var stormbiteDuration = FindTargetEffect(BRD.Debuffs.Stormbite);
-
-                    var ragingStrikesDuration = FindEffect(BRD.Buffs.RagingStrikes);
-
-                    var ragingJawsRenewTime = Service.Configuration.GetCustomIntValue(BRD.Config.RagingJawsRenewTime);
-
-                    DotRecast poisonRecast = delegate (int duration)
-                    {
-                        return (venomous && venomousDuration.RemainingTime < duration) || (caustic && causticDuration.RemainingTime < duration);
-                    };
-                    DotRecast windRecast = delegate (int duration)
-                    {
-                        return (windbite && windbiteDuration.RemainingTime < duration) || (stormbite && stormbiteDuration.RemainingTime < duration);
-                    };
-
-                    var useIronJaws = (
-                        (level >= BRD.Levels.IronJaws && poisonRecast(4)) ||
-                        (level >= BRD.Levels.IronJaws && windRecast(4)) ||
-                        (level >= BRD.Levels.IronJaws && IsEnabled(CustomComboPreset.BardSimpleRagingJaws) &&
-                            HasEffect(BRD.Buffs.RagingStrikes) && ragingStrikesDuration.RemainingTime < ragingJawsRenewTime &&
-                            poisonRecast(40) && windRecast(40))
-                    );
-
-                    var dotOpener = (IsEnabled(CustomComboPreset.BardSimpleDotOpener) && !openerFinished || !IsEnabled(CustomComboPreset.BardSimpleDotOpener));
-
-                    if (level < BRD.Levels.BiteUpgrade)
-                    {
-                        if (useIronJaws)
-                        {
-                            openerFinished = true;
-                            return BRD.IronJaws;
-                        }
-
-                        if (level < BRD.Levels.IronJaws)
-                        {
-                            if (windbite && windbiteDuration.RemainingTime < 4)
-                            {
-                                openerFinished = true;
-                                return BRD.Windbite;
-                            }
-                            if (venomous && venomousDuration.RemainingTime < 4)
-                            {
-                                openerFinished = true;
-                                return BRD.VenomousBite;
-                            }
-                        }
-
-                        if (IsEnabled(CustomComboPreset.SimpleDoTOption))
-                        {
-                            if (level >= BRD.Levels.Windbite && !windbite && dotOpener )
-                                return BRD.Windbite;
-                            if (level >= BRD.Levels.VenomousBite && !venomous && dotOpener)
-                                return BRD.VenomousBite;
-                        }
-                    }
-                    else { 
-
-                        if (useIronJaws)
-                        {
-                            openerFinished = true;
-                            return BRD.IronJaws;
-                        }
-
-                        if (IsEnabled(CustomComboPreset.SimpleDoTOption))
-                        {
-                            if (level >= BRD.Levels.StormBite && !stormbite && dotOpener )
-                                return BRD.Stormbite;
-                            if (level >= BRD.Levels.CausticBite && !caustic && dotOpener )
-                                return BRD.CausticBite;
-                                
-                        }
-                    }
-                }
-
-                if (!IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
-                {
-                    if (level >= BRD.Levels.BlastArrow && HasEffect(BRD.Buffs.BlastArrowReady))
-                        return BRD.BlastArrow;
-                    if (level >= BRD.Levels.ApexArrow)
+                    var gauge = GetJobGauge<BRDGauge>();
+                    var soulVoice = gauge.SoulVoice;
+                    var canWeave = CanWeave(actionID);
+
+                    if (IsEnabled(CustomComboPreset.SimpleAoESongOption) && canWeave)
                     {
                         var songTimerInSeconds = gauge.SongTimer / 1000;
 
-                        if (gauge.Song == Song.MAGE && gauge.SoulVoice == 100) return BRD.ApexArrow;
-                        if (gauge.Song == Song.MAGE && gauge.SoulVoice >= 80 && songTimerInSeconds > 18 && songTimerInSeconds < 22) return BRD.ApexArrow;
-                        if (gauge.Song == Song.WANDERER && HasEffect(BRD.Buffs.RagingStrikes) && HasEffect(BRD.Buffs.BattleVoice) && 
-                            (HasEffect(BRD.Buffs.RadiantFinale) || level < BRD.Levels.RadiantFinale) && gauge.SoulVoice >= 80) return BRD.ApexArrow;
+                        if (songTimerInSeconds < 3 || gauge.Song == Song.NONE)
+                        {
+                            if (level >= Levels.WanderersMinuet &&
+                                IsOffCooldown(WanderersMinuet) && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon)) && !IsEnabled(CustomComboPreset.SimpleAoESongOptionExcludeWM))
+                                return WanderersMinuet;
+                            if (level >= Levels.MagesBallad &&
+                                IsOffCooldown(MagesBallad) && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon)))
+                                return MagesBallad;
+                            if (level >= Levels.ArmysPaeon &&
+                                IsOffCooldown(ArmysPaeon) && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet)))
+                                return ArmysPaeon;
+                        }
+                    }
+
+                    if (canWeave)
+                    {
+                        if (level >= Levels.PitchPerfect && gauge.Song == Song.WANDERER && gauge.Repertoire == 3)
+                            return OriginalHook(WanderersMinuet);
+                        if (level >= Levels.EmpyrealArrow && IsOffCooldown(EmpyrealArrow))
+                            return EmpyrealArrow;
+                        if (level >= Levels.RainOfDeath && GetRemainingCharges(RainOfDeath) > 0)
+                            return RainOfDeath;
+                        if (level >= Levels.Sidewinder && IsOffCooldown(Sidewinder))
+                            return Sidewinder;
+                    }
+
+                    if (level >= Levels.Shadowbite && HasEffect(Buffs.ShadowbiteReady))
+                        return Shadowbite;
+                    if (level >= Levels.ApexArrow && soulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
+                        return ApexArrow;
+                    if (level >= Levels.BlastArrow && HasEffect(Buffs.BlastArrowReady))
+                        return BlastArrow;
+
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class BardoGCDSingleTargetFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardoGCDSingleTargetFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Bloodletter)
+                {
+                    var gauge = GetJobGauge<BRDGauge>();
+
+                    if (IsEnabled(CustomComboPreset.BardSongsFeature) && (gauge.SongTimer < 1 || gauge.Song == Song.ARMY))
+                    {
+                        if (level >= Levels.WanderersMinuet && IsOffCooldown(WanderersMinuet))
+                            return WanderersMinuet;
+                        if (level >= Levels.MagesBallad && IsOffCooldown(MagesBallad))
+                            return MagesBallad;
+                        if (level >= Levels.ArmysPaeon && IsOffCooldown(ArmysPaeon))
+                            return ArmysPaeon;
+                    }
+
+                    if (gauge.Song == Song.WANDERER && gauge.Repertoire == 3)
+                        return OriginalHook(WanderersMinuet);
+                    if (level >= Levels.EmpyrealArrow && IsOffCooldown(EmpyrealArrow))
+                        return EmpyrealArrow;
+                    if (level >= Levels.Bloodletter && IsOffCooldown(Bloodletter))
+                        return Bloodletter;
+                    if (level >= Levels.Sidewinder && IsOffCooldown(Sidewinder))
+                        return Sidewinder;
+                }
+
+                return actionID;
+            }
+        }
+        internal class BardAoEComboFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardAoEComboFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == QuickNock || actionID == Ladonsbite)
+                {
+                    if (IsEnabled(CustomComboPreset.BardApexFeature))
+                    {
+                        if (level >= Levels.ApexArrow && GetJobGauge<BRDGauge>().SoulVoice == 100 && !IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
+                            return ApexArrow;
+
+                        if (level >= Levels.BlastArrow && HasEffect(Buffs.BlastArrowReady))
+                            return BlastArrow;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.BardAoEComboFeature) && level >= Levels.Shadowbite && HasEffectAny(Buffs.ShadowbiteReady))
+                    {
+                        return Shadowbite;
                     }
                 }
 
-                if (HasEffect(BRD.Buffs.StraightShotReady))
+                return actionID;
+            }
+        }
+        internal class SimpleBardFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SimpleBardFeature;
+            internal static bool inOpener = false;
+            internal static bool openerFinished = false;
+            internal static byte step = 0;
+            internal static byte subStep = 0;
+
+            internal static bool usedStraightShotReady = false;
+            internal static bool usedPitchPerfect = false;
+
+            internal delegate bool DotRecast(int value);
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == HeavyShot || actionID == BurstShot)
                 {
-                    return (level >= BRD.Levels.RefulgentArrow) ? BRD.RefulgentArrow : BRD.StraightShot;
+                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var gauge = GetJobGauge<BRDGauge>();
+
+                    var canWeave = CanWeave(actionID);
+                    var canWeaveBuffs = CanWeave(actionID, 0.6);
+                    var canWeaveDelayed = CanDelayedWeave(actionID, 0.9);
+
+                    if (!inCombat && (inOpener || openerFinished))
+                    {
+                        openerFinished = false;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.BardSimpleInterrupt) && CanInterruptEnemy() && IsOffCooldown(All.HeadGraze))
+                    {
+                        return All.HeadGraze;
+                    }
+
+                    var isEnemyHealthHigh = IsEnabled(CustomComboPreset.BardSimpleNoWasteMode) ?
+                        EnemyHealthPercentage() > Service.Configuration.GetCustomIntValue(Config.NoWasteHPPercentage) : true;
+
+                    if (IsEnabled(CustomComboPreset.SimpleSongOption) && isEnemyHealthHigh)
+                    {
+                        var songTimerInSeconds = gauge.SongTimer / 1000;
+
+                        // Limit optimisation to only when you are high enough to benefit from it.
+                        if (level >= Levels.WanderersMinuet)
+                        {
+                            // 43s of Wanderer's Minute, ~36s of Mage's Ballad, and ~43s of Army Peon    
+                            var minuetOffCooldown = IsOffCooldown(WanderersMinuet);
+                            var balladOffCooldown = IsOffCooldown(MagesBallad);
+                            var paeonOffCooldown = IsOffCooldown(ArmysPaeon);
+
+                            if (gauge.Song == Song.NONE && canWeave)
+                            {
+                                // Do logic to determine first song
+
+                                if (minuetOffCooldown && !(JustUsed(MagesBallad) || JustUsed(ArmysPaeon))) return WanderersMinuet;
+                                if (balladOffCooldown && !(JustUsed(WanderersMinuet) || JustUsed(ArmysPaeon))) return MagesBallad;
+                                if (paeonOffCooldown && !(JustUsed(MagesBallad) || JustUsed(WanderersMinuet))) return ArmysPaeon;
+                            }
+
+                            if (gauge.Song == Song.WANDERER && canWeave)
+                            {
+                                // Spend any repertoire before switching to next song
+                                if (songTimerInSeconds < 3 && gauge.Repertoire > 0)
+                                {
+                                    return OriginalHook(WanderersMinuet);
+                                }
+                                // Move to Mage's Ballad if < 3 seconds left on song
+                                if (songTimerInSeconds < 3 && balladOffCooldown)
+                                {
+                                    return MagesBallad;
+                                }
+                            }
+
+                            if (gauge.Song == Song.MAGE && canWeave)
+                            {
+                                // Move to Army's Paeon if < 12 seconds left on song
+                                if (songTimerInSeconds < 12 && paeonOffCooldown)
+                                {
+                                    // Very special case for Empyreal, it needs to be cast before you change to it to avoid drift!!!
+                                    if (level >= Levels.EmpyrealArrow && IsOffCooldown(EmpyrealArrow))
+                                        return EmpyrealArrow;
+
+                                    return ArmysPaeon;
+                                }
+                            }
+
+                            if (gauge.Song == Song.ARMY && canWeaveDelayed)
+                            {
+                                // Move to Wanderer's Minuet if < 3 seconds left on song or WM off CD and have 4 repertoires of AP
+                                if (songTimerInSeconds < 3 || (minuetOffCooldown && gauge.Repertoire == 4))
+                                {
+                                    return WanderersMinuet;
+                                }
+                            }
+                        }
+                        else if (songTimerInSeconds < 3)
+                        {
+                            if (level >= Levels.MagesBallad && IsOffCooldown(MagesBallad))
+                                return MagesBallad;
+                            if (level >= Levels.ArmysPaeon && IsOffCooldown(ArmysPaeon))
+                                return ArmysPaeon;
+                        }
+                    }
+
+                    if (IsEnabled(CustomComboPreset.BardSimpleBuffsFeature) && (gauge.Song != Song.NONE || level < Levels.MagesBallad) && isEnemyHealthHigh)
+                    {
+                        if (((canWeaveBuffs && CombatEngageDuration().Minutes == 0) || (canWeaveDelayed && CombatEngageDuration().Minutes > 0)) && level >= Levels.RagingStrikes && IsOffCooldown(RagingStrikes) &&
+                            (GetCooldown(BattleVoice).CooldownRemaining <= 5.38 || IsOffCooldown(BattleVoice) || level < Levels.BattleVoice))
+                        {
+                            return RagingStrikes;
+                        }
+                        if (canWeaveBuffs && IsEnabled(CustomComboPreset.BardSimpleBuffsRadiantFeature) && level >= Levels.RadiantFinale &&
+                            IsOffCooldown(RadiantFinale) && (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
+                            (IsOffCooldown(BattleVoice) || GetCooldownRemainingTime(BattleVoice) < 0.7) && (GetBuffRemainingTime(Buffs.RagingStrikes) <= 16.5 || openerFinished) && IsOnCooldown(RagingStrikes))
+                        {
+                            if (!JustUsed(RagingStrikes)) return RadiantFinale;
+                        }
+
+                        if (canWeaveBuffs && level >= Levels.BattleVoice && IsOffCooldown(BattleVoice) && (GetBuffRemainingTime(Buffs.RagingStrikes) <= 16.5 || openerFinished) && IsOnCooldown(RagingStrikes))
+                        {
+                            if (!JustUsed(RagingStrikes)) return BattleVoice;
+                        }
+                        if (canWeaveBuffs && level >= Levels.Barrage && IsOffCooldown(Barrage) && !HasEffect(Buffs.StraightShotReady) && HasEffect(Buffs.RagingStrikes))
+                        {
+                            if (level >= Levels.RadiantFinale && HasEffect(Buffs.RadiantFinale))
+                                return Barrage;
+                            else if (level >= Levels.BattleVoice && HasEffect(Buffs.BattleVoice))
+                                return Barrage;
+                            else if (level < Levels.BattleVoice && HasEffect(Buffs.RagingStrikes))
+                                return Barrage;
+                        }
+                    }
+
+
+                    if (canWeave)
+                    {
+                        if (level >= Levels.EmpyrealArrow && IsOffCooldown(EmpyrealArrow) &&
+                            (!openerFinished || (openerFinished && GetCooldownRemainingTime(BattleVoice) >= 3.5)))
+                        {
+                            return EmpyrealArrow;
+                        }
+
+                        if (level >= Levels.PitchPerfect && gauge.Song == Song.WANDERER &&
+                            (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && GetCooldown(EmpyrealArrow).CooldownRemaining < 2)) &&
+                            (!openerFinished || (openerFinished && GetCooldownRemainingTime(BattleVoice) >= 3.5)))
+                        {
+                            return OriginalHook(WanderersMinuet);
+                        }
+
+                        if (level >= Levels.Sidewinder && IsOffCooldown(Sidewinder) &&
+                            (!openerFinished || (openerFinished && GetCooldownRemainingTime(BattleVoice) >= 3.5)))
+                        {
+                            if (IsEnabled(CustomComboPreset.BardSimplePooling))
+                            {
+                                if (gauge.Song == Song.WANDERER)
+                                {
+                                    if (
+                                        (HasEffect(Buffs.RagingStrikes) || GetCooldown(RagingStrikes).CooldownRemaining > 10) &&
+                                        (HasEffect(Buffs.BattleVoice) || GetCooldown(BattleVoice).CooldownRemaining > 10) &&
+                                        (
+                                            HasEffect(Buffs.RadiantFinale) || GetCooldown(RadiantFinale).CooldownRemaining > 10 ||
+                                            level < Levels.RadiantFinale
+                                        )
+                                        )
+                                    {
+                                        return Sidewinder;
+                                    }
+                                }
+                                else return Sidewinder;
+                            }
+                            else return Sidewinder;
+                        }
+
+                        if (level >= Levels.Bloodletter)
+                        {
+                            var bloodletterCharges = GetRemainingCharges(Bloodletter);
+
+                            if (IsEnabled(CustomComboPreset.BardSimplePooling) && level >= Levels.WanderersMinuet)
+                            {
+                                if (gauge.Song == Song.WANDERER)
+                                {
+                                    if (
+                                        ((HasEffect(Buffs.RagingStrikes) || GetCooldown(RagingStrikes).CooldownRemaining > 10) &&
+                                        (
+                                            HasEffect(Buffs.BattleVoice) || GetCooldown(BattleVoice).CooldownRemaining > 10 ||
+                                            level < Levels.BattleVoice
+                                        ) &&
+                                        (
+                                            HasEffect(Buffs.RadiantFinale) || GetCooldown(RadiantFinale).CooldownRemaining > 10 ||
+                                            level < Levels.RadiantFinale
+                                        ) &&
+                                        bloodletterCharges > 0) ||
+                                        bloodletterCharges > 2
+                                    )
+                                    {
+                                        return Bloodletter;
+                                    }
+                                }
+                                if (gauge.Song == Song.ARMY && (bloodletterCharges == 3 || ((gauge.SongTimer / 1000) > 30 && bloodletterCharges > 0))) return Bloodletter;
+                                if (gauge.Song == Song.MAGE && bloodletterCharges > 0) return Bloodletter;
+                                if (gauge.Song == Song.NONE && bloodletterCharges == 3) return Bloodletter;
+                            }
+                            else if (bloodletterCharges > 0)
+                            {
+                                return Bloodletter;
+                            }
+                        }
+                    }
+
+
+                    if (isEnemyHealthHigh)
+                    {
+                        var venomous = TargetHasEffect(Debuffs.VenomousBite);
+                        var windbite = TargetHasEffect(Debuffs.Windbite);
+                        var caustic = TargetHasEffect(Debuffs.CausticBite);
+                        var stormbite = TargetHasEffect(Debuffs.Stormbite);
+
+                        var venomousDuration = FindTargetEffect(Debuffs.VenomousBite);
+                        var windbiteDuration = FindTargetEffect(Debuffs.Windbite);
+                        var causticDuration = FindTargetEffect(Debuffs.CausticBite);
+                        var stormbiteDuration = FindTargetEffect(Debuffs.Stormbite);
+
+                        var ragingStrikesDuration = FindEffect(Buffs.RagingStrikes);
+
+                        var ragingJawsRenewTime = Service.Configuration.GetCustomIntValue(Config.RagingJawsRenewTime);
+
+                        DotRecast poisonRecast = delegate (int duration)
+                        {
+                            return (venomous && venomousDuration.RemainingTime < duration) || (caustic && causticDuration.RemainingTime < duration);
+                        };
+                        DotRecast windRecast = delegate (int duration)
+                        {
+                            return (windbite && windbiteDuration.RemainingTime < duration) || (stormbite && stormbiteDuration.RemainingTime < duration);
+                        };
+
+                        var useIronJaws = (
+                            (level >= Levels.IronJaws && poisonRecast(4)) ||
+                            (level >= Levels.IronJaws && windRecast(4)) ||
+                            (level >= Levels.IronJaws && IsEnabled(CustomComboPreset.BardSimpleRagingJaws) &&
+                                HasEffect(Buffs.RagingStrikes) && ragingStrikesDuration.RemainingTime < ragingJawsRenewTime &&
+                                poisonRecast(40) && windRecast(40))
+                        );
+
+                        var dotOpener = (IsEnabled(CustomComboPreset.BardSimpleDotOpener) && !openerFinished || !IsEnabled(CustomComboPreset.BardSimpleDotOpener));
+
+                        if (level < Levels.BiteUpgrade)
+                        {
+                            if (useIronJaws)
+                            {
+                                openerFinished = true;
+                                return IronJaws;
+                            }
+
+                            if (level < Levels.IronJaws)
+                            {
+                                if (windbite && windbiteDuration.RemainingTime < 4)
+                                {
+                                    openerFinished = true;
+                                    return Windbite;
+                                }
+                                if (venomous && venomousDuration.RemainingTime < 4)
+                                {
+                                    openerFinished = true;
+                                    return VenomousBite;
+                                }
+                            }
+
+                            if (IsEnabled(CustomComboPreset.SimpleDoTOption))
+                            {
+                                if (level >= Levels.Windbite && !windbite && dotOpener)
+                                    return Windbite;
+                                if (level >= Levels.VenomousBite && !venomous && dotOpener)
+                                    return VenomousBite;
+                            }
+                        }
+                        else
+                        {
+
+                            if (useIronJaws)
+                            {
+                                openerFinished = true;
+                                return IronJaws;
+                            }
+
+                            if (IsEnabled(CustomComboPreset.SimpleDoTOption))
+                            {
+                                if (level >= Levels.StormBite && !stormbite && dotOpener)
+                                    return Stormbite;
+                                if (level >= Levels.CausticBite && !caustic && dotOpener)
+                                    return CausticBite;
+
+                            }
+                        }
+                    }
+
+                    if (!IsEnabled(CustomComboPreset.BardRemoveApexArrowFeature))
+                    {
+                        if (level >= Levels.BlastArrow && HasEffect(Buffs.BlastArrowReady))
+                            return BlastArrow;
+                        if (level >= Levels.ApexArrow)
+                        {
+                            var songTimerInSeconds = gauge.SongTimer / 1000;
+
+                            if (gauge.Song == Song.MAGE && gauge.SoulVoice == 100) return ApexArrow;
+                            if (gauge.Song == Song.MAGE && gauge.SoulVoice >= 80 && songTimerInSeconds > 18 && songTimerInSeconds < 22) return ApexArrow;
+                            if (gauge.Song == Song.WANDERER && HasEffect(Buffs.RagingStrikes) && HasEffect(Buffs.BattleVoice) &&
+                                (HasEffect(Buffs.RadiantFinale) || level < Levels.RadiantFinale) && gauge.SoulVoice >= 80) return ApexArrow;
+                        }
+                    }
+
+                    if (HasEffect(Buffs.StraightShotReady))
+                    {
+                        return (level >= Levels.RefulgentArrow) ? RefulgentArrow : StraightShot;
+                    }
+
                 }
 
+                return actionID;
             }
-
-            return actionID;
         }
-    }
-    internal class BardBuffsFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardBuffsFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BardBuffsFeature : CustomCombo
         {
-            if (actionID == BRD.Barrage)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardBuffsFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (level >= BRD.Levels.RagingStrikes && IsOffCooldown(BRD.RagingStrikes))
-                    return BRD.RagingStrikes;
-                if (level >= BRD.Levels.BattleVoice && IsOffCooldown(BRD.BattleVoice))
-                    return BRD.BattleVoice;
-            }
+                if (actionID == Barrage)
+                {
+                    if (level >= Levels.RagingStrikes && IsOffCooldown(RagingStrikes))
+                        return RagingStrikes;
+                    if (level >= Levels.BattleVoice && IsOffCooldown(BattleVoice))
+                        return BattleVoice;
+                }
 
-            return actionID;
+                return actionID;
+            }
         }
-    }
-    internal class BardOneButtonSongs : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardOneButtonSongs;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class BardOneButtonSongs : CustomCombo
         {
-            if (actionID == BRD.WanderersMinuet)
-            { // Doesn't display the lowest cooldown song if they have been used out of order and are all on cooldown.
-                if (level >= BRD.Levels.WanderersMinuet && IsOffCooldown(BRD.WanderersMinuet))
-                    return BRD.WanderersMinuet;
-                if (level >= BRD.Levels.MagesBallad && IsOffCooldown(BRD.MagesBallad))
-                    return BRD.MagesBallad;
-                if (level >= BRD.Levels.ArmysPaeon && IsOffCooldown(BRD.ArmysPaeon))
-                    return BRD.ArmysPaeon;
-            }
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BardOneButtonSongs;
 
-            return actionID;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == WanderersMinuet)
+                { // Doesn't display the lowest cooldown song if they have been used out of order and are all on cooldown.
+                    if (level >= Levels.WanderersMinuet && IsOffCooldown(WanderersMinuet))
+                        return WanderersMinuet;
+                    if (level >= Levels.MagesBallad && IsOffCooldown(MagesBallad))
+                        return MagesBallad;
+                    if (level >= Levels.ArmysPaeon && IsOffCooldown(ArmysPaeon))
+                        return ArmysPaeon;
+                }
+
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -97,7 +97,7 @@ namespace XIVSlothComboPlugin.Combos
                 FanDance4 = 86,
                 StarfallDance = 90;
         }
-    }
+    
 
     internal class DancerDanceComboCompatibility : CustomCombo
     {
@@ -111,17 +111,17 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var actionIDs = Service.Configuration.DancerDanceCompatActionIDs;
 
-                if (actionID == actionIDs[0] || (actionIDs[0] == 0 && actionID == DNC.Cascade))
-                    return OriginalHook(DNC.Cascade);
+                if (actionID == actionIDs[0] || (actionIDs[0] == 0 && actionID == Cascade))
+                    return OriginalHook(Cascade);
 
-                if (actionID == actionIDs[1] || (actionIDs[1] == 0 && actionID == DNC.Flourish))
-                    return OriginalHook(DNC.Fountain);
+                if (actionID == actionIDs[1] || (actionIDs[1] == 0 && actionID == Flourish))
+                    return OriginalHook(Fountain);
 
-                if (actionID == actionIDs[2] || (actionIDs[2] == 0 && actionID == DNC.FanDance1))
-                    return OriginalHook(DNC.ReverseCascade);
+                if (actionID == actionIDs[2] || (actionIDs[2] == 0 && actionID == FanDance1))
+                    return OriginalHook(ReverseCascade);
 
-                if (actionID == actionIDs[3] || (actionIDs[3] == 0 && actionID == DNC.FanDance2))
-                    return OriginalHook(DNC.Fountainfall);
+                if (actionID == actionIDs[3] || (actionIDs[3] == 0 && actionID == FanDance2))
+                    return OriginalHook(Fountainfall);
             }
 
             return actionID;
@@ -135,29 +135,29 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            var FD3Ready = HasEffect(DNC.Buffs.ThreeFoldFanDance);
-            var FD4Ready = HasEffect(DNC.Buffs.FourFoldFanDance);
+            var FD3Ready = HasEffect(Buffs.ThreeFoldFanDance);
+            var FD4Ready = HasEffect(Buffs.FourFoldFanDance);
 
             if (actionID is DNC.FanDance1)
             {
                 // FD 1 -> 3
                 if (FD3Ready && IsEnabled(CustomComboPreset.DancerFanDance1_3Combo))
-                    return DNC.FanDance3;
+                    return FanDance3;
 
                 // FD 1 -> 4
                 if (FD4Ready && IsEnabled(CustomComboPreset.DancerFanDance1_4Combo))
-                    return DNC.FanDance4;
+                    return FanDance4;
             }
 
             if (actionID is DNC.FanDance2)
             {
                 // FD 2 -> 3
                 if (FD3Ready && IsEnabled(CustomComboPreset.DancerFanDance2_3Combo))
-                    return DNC.FanDance3;
+                    return FanDance3;
 
                 // FD 2 -> 4
                 if (FD4Ready && IsEnabled(CustomComboPreset.DancerFanDance2_4Combo))
-                    return DNC.FanDance4;
+                    return FanDance4;
             }
 
             return actionID;
@@ -175,24 +175,24 @@ namespace XIVSlothComboPlugin.Combos
             // Standard Step
             if (actionID is DNC.StandardStep)
             {
-                if (gauge.IsDancing && HasEffect(DNC.Buffs.StandardStep))
+                if (gauge.IsDancing && HasEffect(Buffs.StandardStep))
                 {
                     if (gauge.CompletedSteps < 2)
                         return (uint)gauge.NextStep;
 
-                    return DNC.StandardFinish2;
+                    return StandardFinish2;
                 }
             }
 
             // Technical Step
-            if ((actionID is DNC.TechnicalStep) && level >= DNC.Levels.TechnicalStep)
+            if ((actionID is DNC.TechnicalStep) && level >= Levels.TechnicalStep)
             {
-                if (gauge.IsDancing && HasEffect(DNC.Buffs.TechnicalStep))
+                if (gauge.IsDancing && HasEffect(Buffs.TechnicalStep))
                 {
                     if (gauge.CompletedSteps < 4)
                         return (uint)gauge.NextStep;
 
-                    return DNC.TechnicalFinish4;
+                    return TechnicalFinish4;
                 }
             }
 
@@ -211,11 +211,11 @@ namespace XIVSlothComboPlugin.Combos
             // Fan Dance 3 & 4 on Flourish when relevant
             if (actionID is DNC.Flourish && canWeave)
             {
-                if (HasEffect(DNC.Buffs.ThreeFoldFanDance))
-                    return DNC.FanDance3;
+                if (HasEffect(Buffs.ThreeFoldFanDance))
+                    return FanDance3;
 
-                if (HasEffect(DNC.Buffs.FourFoldFanDance))
-                    return DNC.FanDance4;
+                if (HasEffect(Buffs.FourFoldFanDance))
+                    return FanDance4;
             }
 
             return actionID;
@@ -231,46 +231,46 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID is DNC.Cascade)
             {
                 var gauge = GetJobGauge<DNCGauge>();
-                var flow = (HasEffect(DNC.Buffs.SilkenFlow) || HasEffect(DNC.Buffs.FlourishingFlow));
-                var symmetry = (HasEffect(DNC.Buffs.SilkenSymmetry) || HasEffect(DNC.Buffs.FlourishingSymmetry));
+                var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
+                var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
                 var canWeave = CanWeave(actionID);
 
                 // ST Esprit overcap options
-                if (level >= DNC.Levels.SaberDance &&
+                if (level >= Levels.SaberDance &&
                    (gauge.Esprit >= 50 && IsEnabled(CustomComboPreset.DancerEspritOvercapSTInstantOption) ||
                     gauge.Esprit >= 85 && IsEnabled(CustomComboPreset.DancerEspritOvercapSTFeature)))
-                        return DNC.SaberDance;
+                        return SaberDance;
 
                 if (canWeave)
                 {
                     // ST Fan Dance overcap protection
-                    if (gauge.Feathers is 4 && level >= DNC.Levels.FanDance1 && IsEnabled(CustomComboPreset.DancerFanDanceMainComboOvercapFeature))
-                        return DNC.FanDance1;
+                    if (gauge.Feathers is 4 && level >= Levels.FanDance1 && IsEnabled(CustomComboPreset.DancerFanDanceMainComboOvercapFeature))
+                        return FanDance1;
 
                     // ST Fan Dance 3/4 on combo
                     if (IsEnabled(CustomComboPreset.DancerFanDance34OnMainComboFeature))
                     {
-                        if (HasEffect(DNC.Buffs.ThreeFoldFanDance) && level >= DNC.Levels.FanDance3)
-                            return DNC.FanDance3;
+                        if (HasEffect(Buffs.ThreeFoldFanDance) && level >= Levels.FanDance3)
+                            return FanDance3;
 
-                        if (HasEffect(DNC.Buffs.FourFoldFanDance) && level >= DNC.Levels.FanDance4)
-                            return DNC.FanDance4;
+                        if (HasEffect(Buffs.FourFoldFanDance) && level >= Levels.FanDance4)
+                            return FanDance4;
                     }
                 }
 
                 // ST From Fountain
-                if (level >= DNC.Levels.Fountainfall && flow)
-                    return DNC.Fountainfall;
+                if (level >= Levels.Fountainfall && flow)
+                    return Fountainfall;
 
                 // ST From Cascade
-                if (level >= DNC.Levels.ReverseCascade && symmetry)
-                    return DNC.ReverseCascade;
+                if (level >= Levels.ReverseCascade && symmetry)
+                    return ReverseCascade;
 
                 // ST Cascade Combo
-                if (lastComboMove is DNC.Cascade && level >= DNC.Levels.Fountain)
-                    return DNC.Fountain;
+                if (lastComboMove is DNC.Cascade && level >= Levels.Fountain)
+                    return Fountain;
 
-                return DNC.Cascade;
+                return Cascade;
             }
 
             return actionID;
@@ -286,46 +286,46 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID is DNC.Windmill)
             {
                 var gauge = GetJobGauge<DNCGauge>();
-                var flow = (HasEffect(DNC.Buffs.SilkenFlow) || HasEffect(DNC.Buffs.FlourishingFlow));
-                var symmetry = (HasEffect(DNC.Buffs.SilkenSymmetry) || HasEffect(DNC.Buffs.FlourishingSymmetry));
+                var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
+                var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
                 var canWeave = CanWeave(actionID);
 
                 // AoE Esprit overcap options
-                if (level >= DNC.Levels.SaberDance &&
+                if (level >= Levels.SaberDance &&
                    (gauge.Esprit >= 50 && IsEnabled(CustomComboPreset.DancerEspritOvercapAoEInstantOption) ||
                     gauge.Esprit >= 85 && IsEnabled(CustomComboPreset.DancerEspritOvercapAoEFeature)))
-                    return DNC.SaberDance;
+                    return SaberDance;
 
                 if (canWeave)
                 {
                     // AoE Fan Dance overcap protection
-                    if (gauge.Feathers is 4 && level >= DNC.Levels.FanDance2 && IsEnabled(CustomComboPreset.DancerFanDanceAoEComboOvercapFeature))
-                        return DNC.FanDance2;
+                    if (gauge.Feathers is 4 && level >= Levels.FanDance2 && IsEnabled(CustomComboPreset.DancerFanDanceAoEComboOvercapFeature))
+                        return FanDance2;
 
                     // AoE Fan Dance 3/4 on combo
                     if (IsEnabled(CustomComboPreset.DancerFanDance34OnMainComboFeature))
                     {
-                        if (HasEffect(DNC.Buffs.ThreeFoldFanDance))
-                            return DNC.FanDance3;
+                        if (HasEffect(Buffs.ThreeFoldFanDance))
+                            return FanDance3;
 
-                        if (HasEffect(DNC.Buffs.FourFoldFanDance))
-                            return DNC.FanDance4;
+                        if (HasEffect(Buffs.FourFoldFanDance))
+                            return FanDance4;
                     }
                 }
 
                 // AoE From Bladeshower
-                if (level >= DNC.Levels.Bloodshower && flow)
-                    return DNC.Bloodshower;
+                if (level >= Levels.Bloodshower && flow)
+                    return Bloodshower;
 
                 // AoE From Windmill
-                if (level >= DNC.Levels.RisingWindmill && symmetry)
-                    return DNC.RisingWindmill;
+                if (level >= Levels.RisingWindmill && symmetry)
+                    return RisingWindmill;
 
                 // AoE Windmill Combo
-                if (lastComboMove is DNC.Windmill && level >= DNC.Levels.Bladeshower)
-                    return DNC.Bladeshower;
+                if (lastComboMove is DNC.Windmill && level >= Levels.Bladeshower)
+                    return Bladeshower;
 
-                return DNC.Windmill;
+                return Windmill;
             }
 
             return actionID;
@@ -338,8 +338,8 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is DNC.Devilment && HasEffect(DNC.Buffs.FlourishingStarfall))
-                    return DNC.StarfallDance;
+            if (actionID is DNC.Devilment && HasEffect(Buffs.FlourishingStarfall))
+                    return StarfallDance;
 
             return actionID;
         }
@@ -355,48 +355,48 @@ namespace XIVSlothComboPlugin.Combos
             if (actionID is DNC.StandardStep)
             {
                 var gauge = GetJobGauge<DNCGauge>();
-                var standardCD = GetCooldown(DNC.StandardStep);
-                var techstepCD = GetCooldown(DNC.TechnicalStep);
-                var devilmentCD = GetCooldown(DNC.Devilment);
-                var flourishCD = GetCooldown(DNC.Flourish);
+                var standardCD = GetCooldown(StandardStep);
+                var techstepCD = GetCooldown(TechnicalStep);
+                var devilmentCD = GetCooldown(Devilment);
+                var flourishCD = GetCooldown(Flourish);
                 var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
 
                 if (IsEnabled(CustomComboPreset.DancerDevilmentOnCombinedDanceFeature) && standardCD.IsCooldown && !devilmentCD.IsCooldown && !gauge.IsDancing)
                 {
-                    if ((level >= DNC.Levels.Devilment && level < DNC.Levels.TechnicalStep) ||
-                        (level >= DNC.Levels.TechnicalStep && techstepCD.IsCooldown))
-                        return DNC.Devilment;
+                    if ((level >= Levels.Devilment && level < Levels.TechnicalStep) ||
+                        (level >= Levels.TechnicalStep && techstepCD.IsCooldown))
+                        return Devilment;
                 }
 
                 if (IsEnabled(CustomComboPreset.DancerFlourishOnCombinedDanceFeature) && !gauge.IsDancing && !flourishCD.IsCooldown &&
-                    incombat && level >= DNC.Levels.Flourish && standardCD.IsCooldown)
-                    return DNC.Flourish;
+                    incombat && level >= Levels.Flourish && standardCD.IsCooldown)
+                    return Flourish;
 
-                if (HasEffect(DNC.Buffs.FlourishingStarfall))
-                    return DNC.StarfallDance;
+                if (HasEffect(Buffs.FlourishingStarfall))
+                    return StarfallDance;
 
-                if (HasEffect(DNC.Buffs.FlourishingFinish))
-                    return DNC.Tillana;
+                if (HasEffect(Buffs.FlourishingFinish))
+                    return Tillana;
 
-                if (standardCD.IsCooldown && !techstepCD.IsCooldown && !gauge.IsDancing && !HasEffect(DNC.Buffs.StandardStep))
-                    return DNC.TechnicalStep;
+                if (standardCD.IsCooldown && !techstepCD.IsCooldown && !gauge.IsDancing && !HasEffect(Buffs.StandardStep))
+                    return TechnicalStep;
 
                 if (gauge.IsDancing)
                 {
-                    if (HasEffect(DNC.Buffs.StandardStep))
+                    if (HasEffect(Buffs.StandardStep))
                     {
                         if (gauge.CompletedSteps < 2)
                             return (uint)gauge.NextStep;
 
-                        return DNC.StandardFinish2;
+                        return StandardFinish2;
                     }
 
-                    if (HasEffect(DNC.Buffs.TechnicalStep))
+                    if (HasEffect(Buffs.TechnicalStep))
                     {
                         if (gauge.CompletedSteps < 4)
                             return (uint)gauge.NextStep;
 
-                        return DNC.TechnicalFinish4;
+                        return TechnicalFinish4;
                     }
                 }
 
@@ -415,14 +415,14 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var gauge = GetJobGauge<DNCGauge>();
                 var canWeave = CanWeave(actionID);
-                var flow = (HasEffect(DNC.Buffs.SilkenFlow) || HasEffect(DNC.Buffs.FlourishingFlow));
-                var symmetry = (HasEffect(DNC.Buffs.SilkenSymmetry) || HasEffect(DNC.Buffs.FlourishingSymmetry));
-                var techBurstTimer = FindEffect(DNC.Buffs.TechnicalFinish);
-                var techBurst = HasEffect(DNC.Buffs.TechnicalFinish);
-                var flourishReady = level >= DNC.Levels.Flourish && IsOffCooldown(DNC.Flourish);
-                var devilmentReady = level >= DNC.Levels.Devilment && IsOffCooldown(DNC.Devilment);
-                var improvisationReady = level >= DNC.Levels.Improvisation && IsOffCooldown(DNC.Improvisation);
-                var curingWaltzReady = level >= DNC.Levels.CuringWaltz && IsOffCooldown(DNC.CuringWaltz);
+                var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
+                var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
+                var techBurstTimer = FindEffect(Buffs.TechnicalFinish);
+                var techBurst = HasEffect(Buffs.TechnicalFinish);
+                var flourishReady = level >= Levels.Flourish && IsOffCooldown(Flourish);
+                var devilmentReady = level >= Levels.Devilment && IsOffCooldown(Devilment);
+                var improvisationReady = level >= Levels.Improvisation && IsOffCooldown(Improvisation);
+                var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
                 var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
                 var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
 
@@ -432,24 +432,24 @@ namespace XIVSlothComboPlugin.Combos
                     // Standard Step
                     if (actionID is DNC.StandardStep)
                     {
-                        if (gauge.IsDancing && HasEffect(DNC.Buffs.StandardStep))
+                        if (gauge.IsDancing && HasEffect(Buffs.StandardStep))
                         {
                             if (gauge.CompletedSteps < 2)
                                 return (uint)gauge.NextStep;
 
-                            return DNC.StandardFinish2;
+                            return StandardFinish2;
                         }
                     }
 
                     // Technical Step
-                    if ((actionID is DNC.TechnicalStep) && level >= DNC.Levels.TechnicalStep)
+                    if ((actionID is DNC.TechnicalStep) && level >= Levels.TechnicalStep)
                     {
-                        if (gauge.IsDancing && HasEffect(DNC.Buffs.TechnicalStep))
+                        if (gauge.IsDancing && HasEffect(Buffs.TechnicalStep))
                         {
                             if (gauge.CompletedSteps < 4)
                                 return (uint)gauge.NextStep;
 
-                            return DNC.TechnicalFinish4;
+                            return TechnicalFinish4;
                         }
                     }
                 }
@@ -459,28 +459,28 @@ namespace XIVSlothComboPlugin.Combos
                         return All.HeadGraze;
 
                 // Simple ST Tech Steps
-                if (HasEffect(DNC.Buffs.TechnicalStep) && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature))
+                if (HasEffect(Buffs.TechnicalStep) && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature))
                     return gauge.CompletedSteps < 4
                         ? (uint)gauge.NextStep
-                        : DNC.TechnicalFinish4;
+                        : TechnicalFinish4;
 
                 // Simple ST Standard Steps
-                if (HasEffect(DNC.Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature))
+                if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature))
                     return gauge.CompletedSteps < 2
                         ? (uint)gauge.NextStep
-                        : DNC.StandardFinish2;
+                        : StandardFinish2;
 
                 // Simple ST Standard/Tech (activates dances with no target, or when target is over 2% HP)
                 if (!HasTarget() || EnemyHealthPercentage() > 2)
                 {
-                    if (level >= DNC.Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) &&
-                        IsOffCooldown(DNC.StandardStep) && ((!HasEffect(DNC.Buffs.TechnicalStep) && !techBurst) ||
+                    if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) &&
+                        IsOffCooldown(StandardStep) && ((!HasEffect(Buffs.TechnicalStep) && !techBurst) ||
                         techBurstTimer.RemainingTime > 5))
-                        return DNC.StandardStep;
+                        return StandardStep;
 
-                    if (level >= DNC.Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) &&
-                        !HasEffect(DNC.Buffs.StandardStep) && IsOffCooldown(DNC.TechnicalStep))
-                        return DNC.TechnicalStep;
+                    if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) &&
+                        !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
+                        return TechnicalStep;
                 }
 
                 if (canWeave)
@@ -488,46 +488,46 @@ namespace XIVSlothComboPlugin.Combos
                     // Simple ST Devilment
                     if (IsEnabled(CustomComboPreset.DancerSimpleDevilmentFeature) && devilmentReady)
                     {
-                        if (techBurst || (level < DNC.Levels.TechnicalStep))
-                            return DNC.Devilment;
+                        if (techBurst || (level < Levels.TechnicalStep))
+                            return Devilment;
                     }
 
                     // Simple ST Flourish
                     if (IsEnabled(CustomComboPreset.DancerSimpleFlourishFeature) && flourishReady)
-                        return DNC.Flourish;
+                        return Flourish;
                 }
                 
                 // Simple ST Saber Dance
-                if (level >= DNC.Levels.SaberDance && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
-                    return DNC.SaberDance;
+                if (level >= Levels.SaberDance && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
+                    return SaberDance;
 
                 // Occurring within weave windows
                 if (canWeave)
                 {
                     // Simple ST Feathers
-                    if (level >= DNC.Levels.FanDance1 && IsEnabled(CustomComboPreset.DancerSimpleFeatherFeature))
+                    if (level >= Levels.FanDance1 && IsEnabled(CustomComboPreset.DancerSimpleFeatherFeature))
                     {
                         // Simple ST FD3
-                        if (HasEffect(DNC.Buffs.ThreeFoldFanDance))
-                            return DNC.FanDance3;
+                        if (HasEffect(Buffs.ThreeFoldFanDance))
+                            return FanDance3;
 
                         // Simple ST Feather Pooling
-                        var minFeathers = IsEnabled(CustomComboPreset.DancerSimpleFeatherPoolingFeature) && level >= DNC.Levels.TechnicalStep ? 3 : 0;
+                        var minFeathers = IsEnabled(CustomComboPreset.DancerSimpleFeatherPoolingFeature) && level >= Levels.TechnicalStep ? 3 : 0;
 
                         // Simple ST Feather Overcap & Burst
-                        if (gauge.Feathers > minFeathers || (HasEffect(DNC.Buffs.TechnicalFinish) && gauge.Feathers > 0) || EnemyHealthPercentage() < 2)
-                            return DNC.FanDance1;
+                        if (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) || EnemyHealthPercentage() < 2)
+                            return FanDance1;
                     }
 
                     // Simple ST FD4 
-                    if (HasEffect(DNC.Buffs.FourFoldFanDance))
-                        return DNC.FanDance4;
+                    if (HasEffect(Buffs.FourFoldFanDance))
+                        return FanDance4;
                     
                     // Simple ST Panic Heals
                     if (IsEnabled(CustomComboPreset.DancerSimplePanicHealsFeature))
                     {
                         if (PlayerHealthPercentageHp() < 30 && curingWaltzReady)
-                            return DNC.CuringWaltz;
+                            return CuringWaltz;
 
                         if (PlayerHealthPercentageHp() < 50 && secondWindReady)
                             return All.SecondWind;
@@ -535,197 +535,198 @@ namespace XIVSlothComboPlugin.Combos
                     
                     // Simple ST Improvisation
                     if (IsEnabled(CustomComboPreset.DancerSimpleImprovFeature) && improvisationReady)
-                        return DNC.Improvisation;
+                        return Improvisation;
                 }
 
                 // Simple ST Combos and burst attacks
-                if (level >= DNC.Levels.Fountain && lastComboMove is DNC.Cascade && comboTime < 2 && comboTime > 0)
-                    return DNC.Fountain;
+                if (level >= Levels.Fountain && lastComboMove is DNC.Cascade && comboTime < 2 && comboTime > 0)
+                    return Fountain;
 
                 // Tillana
-                if (HasEffect(DNC.Buffs.FlourishingFinish))
-                    return DNC.Tillana;
+                if (HasEffect(Buffs.FlourishingFinish))
+                    return Tillana;
 
                 // Starfall Dance
-                if (HasEffect(DNC.Buffs.FlourishingStarfall))
-                    return DNC.StarfallDance;
+                if (HasEffect(Buffs.FlourishingStarfall))
+                    return StarfallDance;
 
-                if (level >= DNC.Levels.Fountainfall && flow)
-                    return DNC.Fountainfall;
+                if (level >= Levels.Fountainfall && flow)
+                    return Fountainfall;
 
-                if (level >= DNC.Levels.ReverseCascade && symmetry)
-                    return DNC.ReverseCascade;
+                if (level >= Levels.ReverseCascade && symmetry)
+                    return ReverseCascade;
                 
-                if (level >= DNC.Levels.Fountain && lastComboMove is DNC.Cascade && comboTime > 0)
-                    return DNC.Fountain;
+                if (level >= Levels.Fountain && lastComboMove is DNC.Cascade && comboTime > 0)
+                    return Fountain;
 
-                return DNC.Cascade;
+                return Cascade;
             }
 
             return actionID;
         }
     }
 
-    internal class DancerSimpleAoeFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DancerSimpleAoEFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class DancerSimpleAoeFeature : CustomCombo
         {
-            if (actionID is DNC.Windmill) 
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DancerSimpleAoEFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<DNCGauge>();
-                var canWeave = CanWeave(actionID);
-                var flow = (HasEffect(DNC.Buffs.SilkenFlow) || HasEffect(DNC.Buffs.FlourishingFlow));
-                var symmetry = (HasEffect(DNC.Buffs.SilkenSymmetry) || HasEffect(DNC.Buffs.FlourishingSymmetry));
-                var techBurstTimer = FindEffect(DNC.Buffs.TechnicalFinish);
-                var techBurst = HasEffect(DNC.Buffs.TechnicalFinish);
-                var flourishReady = level >= DNC.Levels.Flourish && IsOffCooldown(DNC.Flourish);
-                var devilmentReady = level >= DNC.Levels.Devilment && IsOffCooldown(DNC.Devilment);
-                var improvisationReady = level >= DNC.Levels.Improvisation && IsOffCooldown(DNC.Improvisation);
-                var curingWaltzReady = level >= DNC.Levels.CuringWaltz && IsOffCooldown(DNC.CuringWaltz);
-                var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
-                var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
-
-                // Simple AoE Dance Step Replacement
-                if (IsEnabled(CustomComboPreset.DancerSimpleAoEDanceStepFeature))
+                if (actionID is DNC.Windmill)
                 {
-                    // Simple AoE Standard Steps
-                    if (actionID is DNC.StandardStep)
-                    {
-                        if (gauge.IsDancing && HasEffect(DNC.Buffs.StandardStep))
-                        {
-                            if (gauge.CompletedSteps < 2)
-                                return (uint)gauge.NextStep;
+                    var gauge = GetJobGauge<DNCGauge>();
+                    var canWeave = CanWeave(actionID);
+                    var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
+                    var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
+                    var techBurstTimer = FindEffect(Buffs.TechnicalFinish);
+                    var techBurst = HasEffect(Buffs.TechnicalFinish);
+                    var flourishReady = level >= Levels.Flourish && IsOffCooldown(Flourish);
+                    var devilmentReady = level >= Levels.Devilment && IsOffCooldown(Devilment);
+                    var improvisationReady = level >= Levels.Improvisation && IsOffCooldown(Improvisation);
+                    var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
+                    var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
+                    var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
 
-                            return DNC.StandardFinish2;
+                    // Simple AoE Dance Step Replacement
+                    if (IsEnabled(CustomComboPreset.DancerSimpleAoEDanceStepFeature))
+                    {
+                        // Simple AoE Standard Steps
+                        if (actionID is DNC.StandardStep)
+                        {
+                            if (gauge.IsDancing && HasEffect(Buffs.StandardStep))
+                            {
+                                if (gauge.CompletedSteps < 2)
+                                    return (uint)gauge.NextStep;
+
+                                return StandardFinish2;
+                            }
+                        }
+
+                        // Simple AoE Technical Steps
+                        if ((actionID is DNC.TechnicalStep) && level >= Levels.TechnicalStep)
+                        {
+                            if (gauge.IsDancing && HasEffect(Buffs.TechnicalStep))
+                            {
+                                if (gauge.CompletedSteps < 4)
+                                    return (uint)gauge.NextStep;
+
+                                return TechnicalFinish4;
+                            }
                         }
                     }
 
-                    // Simple AoE Technical Steps
-                    if ((actionID is DNC.TechnicalStep) && level >= DNC.Levels.TechnicalStep)
-                    {
-                        if (gauge.IsDancing && HasEffect(DNC.Buffs.TechnicalStep))
-                        {
-                            if (gauge.CompletedSteps < 4)
-                                return (uint)gauge.NextStep;
-
-                            return DNC.TechnicalFinish4;
-                        }
-                    }
-                }
-
-                // Simple AoE Interrupt
-                if (IsEnabled(CustomComboPreset.DancerSimpleAoEInterruptFeature) && interruptable)
+                    // Simple AoE Interrupt
+                    if (IsEnabled(CustomComboPreset.DancerSimpleAoEInterruptFeature) && interruptable)
                         return All.HeadGraze;
 
-                // Simple AoE Standard Step (step function)
-                if (HasEffect(DNC.Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature))
-                    return gauge.CompletedSteps < 2
-                        ? (uint)gauge.NextStep
-                        : DNC.StandardFinish2;
+                    // Simple AoE Standard Step (step function)
+                    if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature))
+                        return gauge.CompletedSteps < 2
+                            ? (uint)gauge.NextStep
+                            : StandardFinish2;
 
-                // Simple AoE Tech Step (step function)
-                if (HasEffect(DNC.Buffs.TechnicalStep) && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature))
-                    return gauge.CompletedSteps < 4
-                        ? (uint)gauge.NextStep
-                        : DNC.TechnicalFinish4;
+                    // Simple AoE Tech Step (step function)
+                    if (HasEffect(Buffs.TechnicalStep) && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature))
+                        return gauge.CompletedSteps < 4
+                            ? (uint)gauge.NextStep
+                            : TechnicalFinish4;
 
-                // Simple AoE Standard/Tech (activates dances with no target, or when target is over 5% HP)
-                if (!HasTarget() || EnemyHealthPercentage() > 5)
-                {
-                    if (level >= DNC.Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) &&
-                        IsOffCooldown(DNC.StandardStep) && ((!HasEffect(DNC.Buffs.TechnicalStep) && !techBurst) ||
-                        techBurstTimer.RemainingTime > 5))
-                        return DNC.StandardStep;
-
-                    if (level >= DNC.Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) &&
-                        !HasEffect(DNC.Buffs.StandardStep) && IsOffCooldown(DNC.TechnicalStep))
-                        return DNC.TechnicalStep;
-                }
-
-                if (canWeave)
-                {
-                    // Simple AoE Tech Devilment
-                    if (IsEnabled(CustomComboPreset.DancerSimpleAoEDevilmentFeature) && devilmentReady)
+                    // Simple AoE Standard/Tech (activates dances with no target, or when target is over 5% HP)
+                    if (!HasTarget() || EnemyHealthPercentage() > 5)
                     {
-                        if (HasEffect(DNC.Buffs.TechnicalFinish) || (level < DNC.Levels.TechnicalStep))
-                            return DNC.Devilment;
+                        if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) &&
+                            IsOffCooldown(StandardStep) && ((!HasEffect(Buffs.TechnicalStep) && !techBurst) ||
+                            techBurstTimer.RemainingTime > 5))
+                            return StandardStep;
+
+                        if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) &&
+                            !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
+                            return TechnicalStep;
                     }
 
-                    // Simple AoE Flourish
-                    if (IsEnabled(CustomComboPreset.DancerSimpleAoEFlourishFeature) && flourishReady)
-                        return DNC.Flourish;
-                }
-                
-                // Simple AoE Saber Dance
-                if (level >= DNC.Levels.SaberDance && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
-                    return DNC.SaberDance;
-
-                // Occurring within weave windows
-                if (canWeave)
-                {
-                    // Simple AoE Feathers
-                    if (level >= DNC.Levels.FanDance1 && IsEnabled(CustomComboPreset.DancerSimpleAoEFeatherFeature))
+                    if (canWeave)
                     {
-
-                        // Simple AoE Feather Pooling
-                        var minFeathers = IsEnabled(CustomComboPreset.DancerSimpleAoEFeatherPoolingFeature) && level >= DNC.Levels.TechnicalStep ? 3 : 0;
-
-                        // Simple AoE FD3
-                        if (HasEffect(DNC.Buffs.ThreeFoldFanDance))
-                            return DNC.FanDance3;
-
-                        // Simple AoE Overcap & Burst
-                        if (level >= DNC.Levels.FanDance2)
+                        // Simple AoE Tech Devilment
+                        if (IsEnabled(CustomComboPreset.DancerSimpleAoEDevilmentFeature) && devilmentReady)
                         {
-                            if (gauge.Feathers > minFeathers || (techBurst && gauge.Feathers > 0))
-                                return DNC.FanDance2;
+                            if (HasEffect(Buffs.TechnicalFinish) || (level < Levels.TechnicalStep))
+                                return Devilment;
                         }
+
+                        // Simple AoE Flourish
+                        if (IsEnabled(CustomComboPreset.DancerSimpleAoEFlourishFeature) && flourishReady)
+                            return Flourish;
                     }
 
-                    // Simple AoE FD4 
-                    if (HasEffect(DNC.Buffs.FourFoldFanDance))
-                        return DNC.FanDance4;
+                    // Simple AoE Saber Dance
+                    if (level >= Levels.SaberDance && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
+                        return SaberDance;
 
-                    // Simple AoE Panic Heals
-                    if (IsEnabled(CustomComboPreset.DancerSimpleAoEPanicHealsFeature))
+                    // Occurring within weave windows
+                    if (canWeave)
                     {
-                        if (PlayerHealthPercentageHp() < 30 && curingWaltzReady)
-                            return DNC.CuringWaltz;
+                        // Simple AoE Feathers
+                        if (level >= Levels.FanDance1 && IsEnabled(CustomComboPreset.DancerSimpleAoEFeatherFeature))
+                        {
 
-                        if (PlayerHealthPercentageHp() < 50 && secondWindReady)
-                            return All.SecondWind;
+                            // Simple AoE Feather Pooling
+                            var minFeathers = IsEnabled(CustomComboPreset.DancerSimpleAoEFeatherPoolingFeature) && level >= Levels.TechnicalStep ? 3 : 0;
+
+                            // Simple AoE FD3
+                            if (HasEffect(Buffs.ThreeFoldFanDance))
+                                return FanDance3;
+
+                            // Simple AoE Overcap & Burst
+                            if (level >= Levels.FanDance2)
+                            {
+                                if (gauge.Feathers > minFeathers || (techBurst && gauge.Feathers > 0))
+                                    return FanDance2;
+                            }
+                        }
+
+                        // Simple AoE FD4 
+                        if (HasEffect(Buffs.FourFoldFanDance))
+                            return FanDance4;
+
+                        // Simple AoE Panic Heals
+                        if (IsEnabled(CustomComboPreset.DancerSimpleAoEPanicHealsFeature))
+                        {
+                            if (PlayerHealthPercentageHp() < 30 && curingWaltzReady)
+                                return CuringWaltz;
+
+                            if (PlayerHealthPercentageHp() < 50 && secondWindReady)
+                                return All.SecondWind;
+                        }
+
+                        // Simple AoE Improvisation
+                        if (IsEnabled(CustomComboPreset.DancerSimpleAoEImprovFeature) && improvisationReady)
+                            return Improvisation;
                     }
 
-                    // Simple AoE Improvisation
-                    if (IsEnabled(CustomComboPreset.DancerSimpleAoEImprovFeature) && improvisationReady)
-                        return DNC.Improvisation;
+                    // Simple AoE Combos and burst attacks
+                    if (level >= Levels.Bladeshower && lastComboMove is DNC.Windmill && comboTime < 2 && comboTime > 0)
+                        return Bladeshower;
+
+                    // Tillana
+                    if (HasEffect(Buffs.FlourishingFinish))
+                        return Tillana;
+
+                    // Starfall Dance
+                    if (HasEffect(Buffs.FlourishingStarfall))
+                        return StarfallDance;
+
+                    if (level >= Levels.Bloodshower && flow)
+                        return Bloodshower;
+
+                    if (level >= Levels.RisingWindmill && symmetry)
+                        return RisingWindmill;
+
+                    if (level >= Levels.Bladeshower && lastComboMove is DNC.Windmill && comboTime > 0)
+                        return Bladeshower;
                 }
 
-                // Simple AoE Combos and burst attacks
-                if (level >= DNC.Levels.Bladeshower && lastComboMove is DNC.Windmill && comboTime < 2 && comboTime > 0)
-                    return DNC.Bladeshower;
-
-                // Tillana
-                if (HasEffect(DNC.Buffs.FlourishingFinish))
-                    return DNC.Tillana;
-
-                // Starfall Dance
-                if (HasEffect(DNC.Buffs.FlourishingStarfall))
-                    return DNC.StarfallDance;
-
-                if (level >= DNC.Levels.Bloodshower && flow)
-                    return DNC.Bloodshower;
-
-                if (level >= DNC.Levels.RisingWindmill && symmetry)
-                    return DNC.RisingWindmill;
-
-                if (level >= DNC.Levels.Bladeshower && lastComboMove is DNC.Windmill && comboTime > 0)
-                    return DNC.Bladeshower;
+                return actionID;
             }
-
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/Combos/DOL.cs
+++ b/XIVSlothCombo/Combos/DOL.cs
@@ -50,7 +50,7 @@ namespace XIVSlothComboPlugin.Combos
                 PrizeCatch = 81,
                 WiseToTheWorld = 90;
         }
-    }
+    
 
     internal class MinerEurekaFeature : CustomCombo
     {
@@ -58,80 +58,81 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == DOL.SolidReason)
+            if (actionID == SolidReason)
             {
-                if (level >= DOL.Levels.WiseToTheWorld && HasEffect(DOL.Buffs.EurekaMoment))
-                    return DOL.MinWiseToTheWorld;
+                if (level >= Levels.WiseToTheWorld && HasEffect(Buffs.EurekaMoment))
+                    return MinWiseToTheWorld;
             }
 
-            if (actionID == DOL.AgelessWords)
+            if (actionID == AgelessWords)
             {
-                if (level >= DOL.Levels.WiseToTheWorld && HasEffect(DOL.Buffs.EurekaMoment))
-                    return DOL.BtnWiseToTheWorld;
+                if (level >= Levels.WiseToTheWorld && HasEffect(Buffs.EurekaMoment))
+                    return BtnWiseToTheWorld;
             }
 
             return actionID;
         }
     }
 
-    internal class FisherCast : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DolAny;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class FisherCast : CustomCombo
         {
-            if (actionID == DOL.Cast)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DolAny;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (IsEnabled(CustomComboPreset.DolCastHookFeature))
+                if (actionID == Cast)
                 {
-                    if (HasCondition(ConditionFlag.Fishing))
-                        return DOL.Hook;
+                    if (IsEnabled(CustomComboPreset.DolCastHookFeature))
+                    {
+                        if (HasCondition(ConditionFlag.Fishing))
+                            return Hook;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.DolCastGigFeature))
+                    {
+                        if (HasCondition(ConditionFlag.Diving))
+                            return Gig;
+                    }
                 }
 
-                if (IsEnabled(CustomComboPreset.DolCastGigFeature))
+                if (actionID == SurfaceSlap)
                 {
-                    if (HasCondition(ConditionFlag.Diving))
-                        return DOL.Gig;
+                    if (IsEnabled(CustomComboPreset.DolSurfaceTradeFeature))
+                    {
+                        if (HasCondition(ConditionFlag.Diving))
+                            return VeteranTrade;
+                    }
                 }
+
+                if (actionID == PrizeCatch)
+                {
+                    if (IsEnabled(CustomComboPreset.DolPrizeBountyFeature))
+                    {
+                        if (HasCondition(ConditionFlag.Diving))
+                            return NaturesBounty;
+                    }
+                }
+
+                if (actionID == Snagging)
+                {
+                    if (IsEnabled(CustomComboPreset.DolSnaggingSalvageFeature))
+                    {
+                        if (HasCondition(ConditionFlag.Diving))
+                            return Salvage;
+                    }
+                }
+
+                if (actionID == CastLight)
+                {
+                    if (IsEnabled(CustomComboPreset.DolCastLightElectricCurrentFeature))
+                    {
+                        if (HasCondition(ConditionFlag.Diving))
+                            return ElectricCurrent;
+                    }
+                }
+
+                return actionID;
             }
-
-            if (actionID == DOL.SurfaceSlap)
-            {
-                if (IsEnabled(CustomComboPreset.DolSurfaceTradeFeature))
-                {
-                    if (HasCondition(ConditionFlag.Diving))
-                        return DOL.VeteranTrade;
-                }
-            }
-
-            if (actionID == DOL.PrizeCatch)
-            {
-                if (IsEnabled(CustomComboPreset.DolPrizeBountyFeature))
-                {
-                    if (HasCondition(ConditionFlag.Diving))
-                        return DOL.NaturesBounty;
-                }
-            }
-
-            if (actionID == DOL.Snagging)
-            {
-                if (IsEnabled(CustomComboPreset.DolSnaggingSalvageFeature))
-                {
-                    if (HasCondition(ConditionFlag.Diving))
-                        return DOL.Salvage;
-                }
-            }
-
-            if (actionID == DOL.CastLight)
-            {
-                if (IsEnabled(CustomComboPreset.DolCastLightElectricCurrentFeature))
-                {
-                    if (HasCondition(ConditionFlag.Diving))
-                        return DOL.ElectricCurrent;
-                }
-            }
-
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/Combos/DRG.cs
+++ b/XIVSlothCombo/Combos/DRG.cs
@@ -91,841 +91,803 @@ namespace XIVSlothComboPlugin.Combos
                 ChaoticSpring = 86,
                 HeavensThrust = 86;
         }
-    }
 
-    internal class DragoonCoerthanTormentCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonCoerthanTormentCombo;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class DragoonCoerthanTormentCombo : CustomCombo
         {
-            if (actionID is DRG.CoerthanTorment)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonCoerthanTormentCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (comboTime > 0)
+                if (actionID is DRG.CoerthanTorment)
                 {
-                    if ((lastComboMove is DRG.DoomSpike or DRG.DraconianFury) && level >= DRG.Levels.SonicThrust)
-                        return DRG.SonicThrust;
-                    if (lastComboMove is DRG.SonicThrust && level >= DRG.Levels.CoerthanTorment)
-                        return DRG.CoerthanTorment;
+                    if (comboTime > 0)
+                    {
+                        if ((lastComboMove is DoomSpike or DraconianFury) && level >= Levels.SonicThrust)
+                            return SonicThrust;
+                        if (lastComboMove is DRG.SonicThrust && level >= Levels.CoerthanTorment)
+                            return CoerthanTorment;
+                    }
+                    return OriginalHook(DoomSpike);
                 }
-                return OriginalHook(DRG.DoomSpike);
+                return actionID;
             }
-            return actionID;
         }
-    }
 
-    internal class DragoonChaosThrustCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonChaosThrustCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class DragoonChaosThrustCombo : CustomCombo
         {
-            if (actionID is DRG.ChaosThrust or DRG.ChaoticSpring)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonChaosThrustCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-
-                //Piercing Talon Uptime Feature
-                if (IsEnabled(CustomComboPreset.DragoonPiercingTalonChaosFeature) && level >= DRG.Levels.PiercingTalon)
+                if (actionID is ChaosThrust or ChaoticSpring)
                 {
-                    if (!InMeleeRange())
-                        return DRG.PiercingTalon;
+
+                    //Piercing Talon Uptime Feature
+                    if (IsEnabled(CustomComboPreset.DragoonPiercingTalonChaosFeature) && level >= Levels.PiercingTalon)
+                    {
+                        if (!InMeleeRange())
+                            return PiercingTalon;
+                    }
+
+                    if (comboTime > 0)
+                    {
+                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.Disembowel)
+                            return Disembowel;
+
+                        if (lastComboMove is DRG.Disembowel && level >= Levels.ChaosThrust)
+                            return OriginalHook(ChaosThrust);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.DragoonFangThrustFeature) && (HasEffect(Buffs.SharperFangAndClaw) || HasEffect(Buffs.EnhancedWheelingThrust)))
+                        return WheelingThrust;
+
+                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
+                        return FangAndClaw;
+
+                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
+                        return WheelingThrust;
+
+                    return TrueThrust;
                 }
 
-                if (comboTime > 0)
-                {
-                    if ((lastComboMove is DRG.TrueThrust or DRG.RaidenThrust) && level >= DRG.Levels.Disembowel)
-                        return DRG.Disembowel;
-
-                    if (lastComboMove is DRG.Disembowel && level >= DRG.Levels.ChaosThrust)
-                        return OriginalHook(DRG.ChaosThrust);
-                }
-
-                if (IsEnabled(CustomComboPreset.DragoonFangThrustFeature) && (HasEffect(DRG.Buffs.SharperFangAndClaw) || HasEffect(DRG.Buffs.EnhancedWheelingThrust)))
-                    return DRG.WheelingThrust;
-
-                if (HasEffect(DRG.Buffs.SharperFangAndClaw) && level >= DRG.Levels.FangAndClaw)
-                    return DRG.FangAndClaw;
-
-                if (HasEffect(DRG.Buffs.EnhancedWheelingThrust) && level >= DRG.Levels.WheelingThrust)
-                    return DRG.WheelingThrust;
-
-                return DRG.TrueThrust;
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class DragoonFullThrustCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonFullThrustCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class DragoonFullThrustCombo : CustomCombo
         {
-            if (actionID is DRG.FullThrust)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonFullThrustCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-
-                //Piercing Talon Uptime Feature
-                if (IsEnabled(CustomComboPreset.DragoonPiercingTalonFullFeature) && level >= DRG.Levels.PiercingTalon)
+                if (actionID is DRG.FullThrust)
                 {
-                    if (!InMeleeRange())
-                        return DRG.PiercingTalon;
+
+                    //Piercing Talon Uptime Feature
+                    if (IsEnabled(CustomComboPreset.DragoonPiercingTalonFullFeature) && level >= Levels.PiercingTalon)
+                    {
+                        if (!InMeleeRange())
+                            return PiercingTalon;
+                    }
+
+                    if (comboTime > 0)
+                    {
+                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.VorpalThrust)
+                            return VorpalThrust;
+
+                        if (lastComboMove is DRG.VorpalThrust && level >= Levels.FullThrust)
+                            return FullThrust;
+                    }
+
+                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
+                        return FangAndClaw;
+
+                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
+                        return WheelingThrust;
+
+                    return OriginalHook(TrueThrust);
                 }
 
-                if (comboTime > 0)
-                {
-                    if ((lastComboMove is DRG.TrueThrust or DRG.RaidenThrust) && level >= DRG.Levels.VorpalThrust)
-                        return DRG.VorpalThrust;
-
-                    if (lastComboMove is DRG.VorpalThrust && level >= DRG.Levels.FullThrust)
-                        return DRG.FullThrust;
-                }
-
-                if (HasEffect(DRG.Buffs.SharperFangAndClaw) && level >= DRG.Levels.FangAndClaw)
-                    return DRG.FangAndClaw;
-
-                if (HasEffect(DRG.Buffs.EnhancedWheelingThrust) && level >= DRG.Levels.WheelingThrust)
-                    return DRG.WheelingThrust;
-
-                return OriginalHook(DRG.TrueThrust);
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class DragoonFullThrustComboPlus : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonFullThrustComboPlus;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class DragoonFullThrustComboPlus : CustomCombo
         {
-            if (actionID is DRG.FullThrust)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonFullThrustComboPlus;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var canWeave = CanWeave(actionID);
-
-                //Piercing Talon Uptime Feature
-                if (IsEnabled(CustomComboPreset.DragoonPiercingTalonPlusFeature) && level >= DRG.Levels.PiercingTalon)
+                if (actionID is DRG.FullThrust)
                 {
-                    if (!InMeleeRange())
-                        return DRG.PiercingTalon;
-                }
+                    var canWeave = CanWeave(actionID);
 
-                //(High) Jump Plus Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonHighJumpPlusFeature))
+                    //Piercing Talon Uptime Feature
+                    if (IsEnabled(CustomComboPreset.DragoonPiercingTalonPlusFeature) && level >= Levels.PiercingTalon)
                     {
-                        if (
-                            level >= DRG.Levels.HighJump &&
-                            IsOffCooldown(DRG.HighJump) && canWeave
-                           ) return DRG.HighJump;
-
-                        if (
-                            level >= DRG.Levels.Jump && level <= DRG.Levels.HighJump &&
-                            IsOffCooldown(DRG.Jump) && canWeave
-                           ) return DRG.Jump;
+                        if (!InMeleeRange())
+                            return PiercingTalon;
                     }
-                }
 
-                //Life Surge Plus Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonLifeSurgePlusFeature) && HasEffect(DRG.Buffs.PowerSurge) && !HasEffect(DRG.Buffs.LifeSurge) && CanWeave(actionID, 0.001) && GetRemainingCharges(DRG.LifeSurge) > 0)
+                    //(High) Jump Plus Feature
+                    if (canWeave)
                     {
-                        if (lastComboMove is DRG.VorpalThrust)
+                        if (IsEnabled(CustomComboPreset.DragoonHighJumpPlusFeature))
                         {
-                            if (HasEffect(DRG.Buffs.LanceCharge))
-                                return DRG.LifeSurge;
+                            if (
+                                level >= Levels.HighJump &&
+                                IsOffCooldown(HighJump) && canWeave
+                               ) return HighJump;
 
-                            if (HasEffect(DRG.Buffs.RightEye))
-                                return DRG.LifeSurge;
-                        }
-
-                        if (HasEffect(DRG.Buffs.BattleLitany))
-                        {
-
-                            if (HasEffect(DRG.Buffs.EnhancedWheelingThrust))
-                                return DRG.LifeSurge;
-
-                            if (HasEffect(DRG.Buffs.SharperFangAndClaw))
-                                return DRG.LifeSurge;
+                            if (
+                                level >= Levels.Jump && level <= Levels.HighJump &&
+                                IsOffCooldown(Jump) && canWeave
+                               ) return Jump;
                         }
                     }
-                }
 
-                //Mirage Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonMiragePlusFeature))
+                    //Life Surge Plus Feature
+                    if (canWeave)
                     {
-                        if (level >= DRG.Levels.MirageDive && HasEffect(DRG.Buffs.DiveReady) && canWeave)
-                            return DRG.MirageDive;
+                        if (IsEnabled(CustomComboPreset.DragoonLifeSurgePlusFeature) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && CanWeave(actionID, 0.001) && GetRemainingCharges(LifeSurge) > 0)
+                        {
+                            if (lastComboMove is DRG.VorpalThrust)
+                            {
+                                if (HasEffect(Buffs.LanceCharge))
+                                    return LifeSurge;
+
+                                if (HasEffect(Buffs.RightEye))
+                                    return LifeSurge;
+                            }
+
+                            if (HasEffect(Buffs.BattleLitany))
+                            {
+
+                                if (HasEffect(Buffs.EnhancedWheelingThrust))
+                                    return LifeSurge;
+
+                                if (HasEffect(Buffs.SharperFangAndClaw))
+                                    return LifeSurge;
+                            }
+                        }
                     }
+
+                    //Mirage Feature
+                    if (canWeave)
+                    {
+                        if (IsEnabled(CustomComboPreset.DragoonMiragePlusFeature))
+                        {
+                            if (level >= Levels.MirageDive && HasEffect(Buffs.DiveReady) && canWeave)
+                                return MirageDive;
+                        }
+                    }
+
+                    var Disembowel = FindEffectAny(Buffs.PowerSurge);
+                    if (comboTime > 0)
+                    {
+                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.Disembowel && (Disembowel is null || (Disembowel.RemainingTime < 10)))
+                            return DRG.Disembowel;
+
+                        if (lastComboMove is DRG.Disembowel && level >= Levels.ChaoticSpring)
+                            return ChaoticSpring;
+
+                        if (lastComboMove is DRG.Disembowel && level >= Levels.ChaosThrust)
+                            return ChaosThrust;
+
+                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.VorpalThrust)
+                            return VorpalThrust;
+
+                        if (lastComboMove is DRG.VorpalThrust && !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0)
+                            return LifeSurge;
+
+                        if (lastComboMove is DRG.VorpalThrust && level >= Levels.FullThrust)
+                            return FullThrust;
+                    }
+
+                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
+                        return FangAndClaw;
+
+                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
+                        return WheelingThrust;
+
+                    return OriginalHook(TrueThrust);
                 }
 
-                var Disembowel = FindEffectAny(DRG.Buffs.PowerSurge);
-                if (comboTime > 0)
-                {
-                    if ((lastComboMove is DRG.TrueThrust or DRG.RaidenThrust) && level >= DRG.Levels.Disembowel && (Disembowel is null || (Disembowel.RemainingTime < 10)))
-                        return DRG.Disembowel;
-
-                    if (lastComboMove is DRG.Disembowel && level >= DRG.Levels.ChaoticSpring)
-                        return DRG.ChaoticSpring;
-
-                    if (lastComboMove is DRG.Disembowel && level >= DRG.Levels.ChaosThrust)
-                        return DRG.ChaosThrust;
-
-                    if ((lastComboMove is DRG.TrueThrust or DRG.RaidenThrust) && level >= DRG.Levels.VorpalThrust)
-                        return DRG.VorpalThrust;
-
-                    if (lastComboMove is DRG.VorpalThrust && !HasEffect(DRG.Buffs.LifeSurge) && GetRemainingCharges(DRG.LifeSurge) > 0)
-                        return DRG.LifeSurge;
-
-                    if (lastComboMove is DRG.VorpalThrust && level >= DRG.Levels.FullThrust)
-                        return DRG.FullThrust;
-                }
-
-                if (HasEffect(DRG.Buffs.SharperFangAndClaw) && level >= DRG.Levels.FangAndClaw)
-                    return DRG.FangAndClaw;
-
-                if (HasEffect(DRG.Buffs.EnhancedWheelingThrust) && level >= DRG.Levels.WheelingThrust)
-                    return DRG.WheelingThrust;
-
-                return OriginalHook(DRG.TrueThrust);
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class DragoonSimple : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonSimple;
-        internal static bool inOpener = false;
-        internal static bool openerFinished = false;
-        internal static byte step = 0;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class DragoonSimple : CustomCombo
         {
-            var Disembowel = FindEffect(DRG.Buffs.PowerSurge);
-            var gauge = GetJobGauge<DRGGauge>();
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonSimple;
+            internal static bool inOpener = false;
+            internal static bool openerFinished = false;
+            internal static byte step = 0;
 
-            if (actionID is DRG.FullThrust)
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var canWeave = CanWeave(actionID);
+                var Disembowel = FindEffect(Buffs.PowerSurge);
+                var gauge = GetJobGauge<DRGGauge>();
 
-                // Lvl88+ Opener
-                if (IsEnabled(CustomComboPreset.DragoonOpenerFeature) && level >= 88)
+                if (actionID is DRG.FullThrust)
                 {
-                    if (inCombat && HasEffect(DRG.Buffs.TrueNorth) && !inOpener)
-                    {
-                        inOpener = true;
-                    }
+                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var canWeave = CanWeave(actionID);
 
-                    if (!inCombat && (inOpener || openerFinished))
+                    // Lvl88+ Opener
+                    if (IsEnabled(CustomComboPreset.DragoonOpenerFeature) && level >= 88)
                     {
-                        inOpener = false;
-                        step = 0;
-                        openerFinished = false;
-
-                        return OriginalHook(DRG.TrueThrust);
-                    }
-
-                    if (inCombat && inOpener && !openerFinished)
-                    {
-                        if (step is 0)
+                        if (inCombat && HasEffect(Buffs.TrueNorth) && !inOpener)
                         {
-                            if (gauge.EyeCount > 0) openerFinished = true;
-                            else step++;
+                            inOpener = true;
                         }
 
-                        if (step is 1)
+                        if (!inCombat && (inOpener || openerFinished))
                         {
-                            if (lastComboMove is DRG.TrueThrust) step++;
-                            else return DRG.TrueThrust;
+                            inOpener = false;
+                            step = 0;
+                            openerFinished = false;
+
+                            return OriginalHook(TrueThrust);
                         }
 
-                        if (step is 2)
+                        if (inCombat && inOpener && !openerFinished)
                         {
-                            if (lastComboMove is DRG.Disembowel) step++;
-                            else return DRG.Disembowel;
-                        }
+                            if (step is 0)
+                            {
+                                if (gauge.EyeCount > 0) openerFinished = true;
+                                else step++;
+                            }
 
-                        if (step is 3)
-                        {
-                            if (IsOnCooldown(DRG.LanceCharge)) step++;
-                            else return DRG.LanceCharge;
-                        }
+                            if (step is 1)
+                            {
+                                if (lastComboMove is DRG.TrueThrust) step++;
+                                else return TrueThrust;
+                            }
 
-                        if (step is 4)
-                        {
-                            if (IsOnCooldown(DRG.DragonSight)) step++;
-                            else return DRG.DragonSight;
-                        }
+                            if (step is 2)
+                            {
+                                if (lastComboMove is DRG.Disembowel) step++;
+                                else return DRG.Disembowel;
+                            }
 
-                        if (step is 5)
-                        {
-                            if (TargetHasEffect(DRG.Debuffs.ChaoticSpring)) step++;
-                            return DRG.ChaoticSpring;
-                        }
+                            if (step is 3)
+                            {
+                                if (IsOnCooldown(LanceCharge)) step++;
+                                else return LanceCharge;
+                            }
 
-                        if (step is 6)
-                        {
-                            if (IsOnCooldown(DRG.BattleLitany)) step++;
-                            else return DRG.BattleLitany;
-                        }
+                            if (step is 4)
+                            {
+                                if (IsOnCooldown(DragonSight)) step++;
+                                else return DragonSight;
+                            }
 
-                        if (step is 7)
-                        {
-                            if (IsOnCooldown(DRG.Geirskogul)) step++;
-                            else return DRG.Geirskogul;
-                        }
+                            if (step is 5)
+                            {
+                                if (TargetHasEffect(Debuffs.ChaoticSpring)) step++;
+                                return ChaoticSpring;
+                            }
 
-                        if (step is 8)
-                        {
-                            if (!HasEffect(DRG.Buffs.EnhancedWheelingThrust)) step++;
-                            else return DRG.WheelingThrust;
-                        }
+                            if (step is 6)
+                            {
+                                if (IsOnCooldown(BattleLitany)) step++;
+                                else return BattleLitany;
+                            }
 
-                        if (step is 9)
-                        {
-                            if (IsOnCooldown(DRG.HighJump)) step++;
-                            else return DRG.HighJump;
-                        }
+                            if (step is 7)
+                            {
+                                if (IsOnCooldown(Geirskogul)) step++;
+                                else return Geirskogul;
+                            }
 
-                        if (step is 10)
-                        {
-                            if (GetRemainingCharges(DRG.LifeSurge) is 0 or 1) step++;
-                            else return DRG.LifeSurge;
-                        }
+                            if (step is 8)
+                            {
+                                if (!HasEffect(Buffs.EnhancedWheelingThrust)) step++;
+                                else return WheelingThrust;
+                            }
 
-                        if (step is 11)
-                        {
-                            if (!HasEffect(DRG.Buffs.SharperFangAndClaw)) step++;
-                            else return DRG.FangAndClaw;
-                        }
+                            if (step is 9)
+                            {
+                                if (IsOnCooldown(HighJump)) step++;
+                                else return HighJump;
+                            }
 
-                        if (step is 12)
-                        {
-                            if (IsOnCooldown(DRG.DragonfireDive)) step++;
-                            else return DRG.DragonfireDive;
-                        }
+                            if (step is 10)
+                            {
+                                if (GetRemainingCharges(LifeSurge) is 0 or 1) step++;
+                                else return LifeSurge;
+                            }
 
-                        if (step is 13)
-                        {
-                            if (lastComboMove is (DRG.RaidenThrust)) step++;
-                            else return DRG.RaidenThrust;
-                        }
+                            if (step is 11)
+                            {
+                                if (!HasEffect(Buffs.SharperFangAndClaw)) step++;
+                                else return FangAndClaw;
+                            }
 
-                        if (step is 14)
-                        {
-                            if (GetRemainingCharges(DRG.SpineshatterDive) is 0 or 1) step++;
-                            else return DRG.SpineshatterDive;
-                        }
+                            if (step is 12)
+                            {
+                                if (IsOnCooldown(DragonfireDive)) step++;
+                                else return DragonfireDive;
+                            }
 
-                        if (step is 15)
-                        {
-                            if (lastComboMove is DRG.VorpalThrust) step++;
-                            else return DRG.VorpalThrust;
-                        }
+                            if (step is 13)
+                            {
+                                if (lastComboMove is (RaidenThrust)) step++;
+                                else return RaidenThrust;
+                            }
 
-                        if (step is 16)
-                        {
-                            if (GetRemainingCharges(DRG.LifeSurge) is 0) step++;
-                            else return DRG.LifeSurge;
-                        }
+                            if (step is 14)
+                            {
+                                if (GetRemainingCharges(SpineshatterDive) is 0 or 1) step++;
+                                else return SpineshatterDive;
+                            }
 
-                        if (step is 17)
-                        {
-                            if (IsOnCooldown(DRG.MirageDive)) step++;
-                            else return DRG.MirageDive;
-                        }
+                            if (step is 15)
+                            {
+                                if (lastComboMove is DRG.VorpalThrust) step++;
+                                else return VorpalThrust;
+                            }
 
-                        if (step is 18)
-                        {
-                            if (lastComboMove is DRG.HeavensThrust) step++;
-                            else return DRG.HeavensThrust;
-                        }
+                            if (step is 16)
+                            {
+                                if (GetRemainingCharges(LifeSurge) is 0) step++;
+                                else return LifeSurge;
+                            }
 
-                        if (step is 19)
-                        {
-                            if (GetRemainingCharges(DRG.SpineshatterDive) is 0) step++;
-                            else return DRG.SpineshatterDive;
-                        }
+                            if (step is 17)
+                            {
+                                if (IsOnCooldown(MirageDive)) step++;
+                                else return MirageDive;
+                            }
 
-                        if (step is 20)
-                        {
-                            if (!HasEffect(DRG.Buffs.SharperFangAndClaw)) step++;
-                            else return DRG.FangAndClaw;
-                        }
+                            if (step is 18)
+                            {
+                                if (lastComboMove is DRG.HeavensThrust) step++;
+                                else return HeavensThrust;
+                            }
 
-                        if (step is 21)
-                        {
-                            if (!HasEffect(DRG.Buffs.EnhancedWheelingThrust)) step++;
-                            else return DRG.WheelingThrust;
-                        }
+                            if (step is 19)
+                            {
+                                if (GetRemainingCharges(SpineshatterDive) is 0) step++;
+                                else return SpineshatterDive;
+                            }
 
-                        openerFinished = true;
-                    }
-                }
+                            if (step is 20)
+                            {
+                                if (!HasEffect(Buffs.SharperFangAndClaw)) step++;
+                                else return FangAndClaw;
+                            }
 
-                // Piercing Talon Uptime Option
-                if (IsEnabled(CustomComboPreset.DRGSimpleRangedUptimeST) && level >= DRG.Levels.PiercingTalon && !InMeleeRange())
-                        return DRG.PiercingTalon;
+                            if (step is 21)
+                            {
+                                if (!HasEffect(Buffs.EnhancedWheelingThrust)) step++;
+                                else return WheelingThrust;
+                            }
 
-                //Lance Charge Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonLanceFeature))
-                    {
-                        if (HasEffect(DRG.Buffs.PowerSurge) && canWeave)
-                        {
-                            if (level >= DRG.Levels.LanceCharge && IsOffCooldown(DRG.LanceCharge))
-                                return DRG.LanceCharge;
-                        }
-                    }
-                }
-
-                //Dragon Sight Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonDragonSightFeature))
-                    {
-                        if (level >= DRG.Levels.DragonSight && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.DragonSight) && canWeave)
-                            return DRG.DragonSight;
-                    }
-                }
-
-                //Battle Litany Feature
-                if (CanWeave(actionID, 1.3))
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonLitanyFeature))
-                    {
-                        if (HasEffect(DRG.Buffs.PowerSurge))
-                        {
-                            if (level >= DRG.Levels.BattleLitany && IsOffCooldown(DRG.BattleLitany))
-                                return DRG.BattleLitany;
+                            openerFinished = true;
                         }
                     }
-                }
 
-                //Geirskogul and Nastrond Feature Part 1
-                if (CanWeave(actionID, 0.001))
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonGeirskogulNastrondFeature))
-                    {
-                        if (level >= DRG.Levels.Geirskogul && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Geirskogul))
-                            return DRG.Geirskogul;
-                    }
-                }
+                    // Piercing Talon Uptime Option
+                    if (IsEnabled(CustomComboPreset.DRGSimpleRangedUptimeST) && level >= Levels.PiercingTalon && !InMeleeRange())
+                        return PiercingTalon;
 
-                //(High) Jump Feature
-                if (CanWeave(actionID, 0.5))
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonHighJumpFeature))
+                    //Lance Charge Feature
+                    if (canWeave)
                     {
-                        if (HasEffect(DRG.Buffs.PowerSurge))
+                        if (IsEnabled(CustomComboPreset.DragoonLanceFeature))
                         {
-
-                            if (level >= DRG.Levels.HighJump && IsOffCooldown(DRG.HighJump))
-                                return DRG.HighJump;
-
-                            if (level >= DRG.Levels.Jump && level < DRG.Levels.HighJump && IsOffCooldown(DRG.Jump))
-                                return DRG.Jump;
+                            if (HasEffect(Buffs.PowerSurge) && canWeave)
+                            {
+                                if (level >= Levels.LanceCharge && IsOffCooldown(LanceCharge))
+                                    return LanceCharge;
+                            }
                         }
                     }
-                }
 
-                //Life Surge Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonLifeSurgeFeature))
+                    //Dragon Sight Feature
+                    if (canWeave)
                     {
-                        if (HasEffect(DRG.Buffs.LanceCharge) && HasEffect(DRG.Buffs.PowerSurge) && !HasEffect(DRG.Buffs.LifeSurge) && lastComboMove is DRG.VorpalThrust && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, 0.001))
-                            return DRG.LifeSurge;
-
-                        if (HasEffect(DRG.Buffs.RightEye) && HasEffect(DRG.Buffs.PowerSurge) && !HasEffect(DRG.Buffs.LifeSurge) && lastComboMove is DRG.VorpalThrust && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, 0.001))
-                            return DRG.LifeSurge;
-
-                        if (HasEffect(DRG.Buffs.BattleLitany) && HasEffect(DRG.Buffs.PowerSurge) && !HasEffect(DRG.Buffs.LifeSurge) && lastComboMove is DRG.FangAndClaw && HasEffect(DRG.Buffs.EnhancedWheelingThrust) && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, 0.001))
-                            return DRG.LifeSurge;
-
-                        if (HasEffect(DRG.Buffs.BattleLitany) && HasEffect(DRG.Buffs.PowerSurge) && !HasEffect(DRG.Buffs.LifeSurge) && lastComboMove is DRG.WheelingThrust && HasEffect(DRG.Buffs.SharperFangAndClaw) && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, 0.001))
-                            return DRG.LifeSurge;
+                        if (IsEnabled(CustomComboPreset.DragoonDragonSightFeature))
+                        {
+                            if (level >= Levels.DragonSight && HasEffect(Buffs.PowerSurge) && IsOffCooldown(DragonSight) && canWeave)
+                                return DragonSight;
+                        }
                     }
-                }
 
-                //Wyrmwind Thrust Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonWyrmwindFeature))
+                    //Battle Litany Feature
+                    if (CanWeave(actionID, 1.3))
                     {
-                        if (
-                            gauge.FirstmindsFocusCount is 2 && canWeave
-                           ) return DRG.WyrmwindThrust;
+                        if (IsEnabled(CustomComboPreset.DragoonLitanyFeature))
+                        {
+                            if (HasEffect(Buffs.PowerSurge))
+                            {
+                                if (level >= Levels.BattleLitany && IsOffCooldown(BattleLitany))
+                                    return BattleLitany;
+                            }
+                        }
                     }
-                }
 
-                //Geirskogul and Nastrond Feature Part 2
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonGeirskogulNastrondFeature))
+                    //Geirskogul and Nastrond Feature Part 1
+                    if (CanWeave(actionID, 0.001))
                     {
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.Nastrond && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Nastrond) && CanWeave(actionID, 0.001))
-                            return DRG.Nastrond;
+                        if (IsEnabled(CustomComboPreset.DragoonGeirskogulNastrondFeature))
+                        {
+                            if (level >= Levels.Geirskogul && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Geirskogul))
+                                return Geirskogul;
+                        }
                     }
-                }
 
-                //Dives under Litany and Life of the Dragon Feature
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonLifeLitanyDiveFeature))
+                    //(High) Jump Feature
+                    if (CanWeave(actionID, 0.5))
                     {
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.DragonfireDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.BattleLitany) && IsOffCooldown(DRG.DragonfireDive) && canWeave)
-                            return DRG.DragonfireDive;
+                        if (IsEnabled(CustomComboPreset.DragoonHighJumpFeature))
+                        {
+                            if (HasEffect(Buffs.PowerSurge))
+                            {
 
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.Stardiver && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Stardiver) && CanWeave(actionID, 1.3))
-                            return DRG.Stardiver;
+                                if (level >= Levels.HighJump && IsOffCooldown(HighJump))
+                                    return HighJump;
 
-                        if (HasEffect(DRG.Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= DRG.Levels.SpineshatterDive && HasEffect(DRG.Buffs.PowerSurge) && GetRemainingCharges(DRG.SpineshatterDive) == 2 && canWeave)
-                            return DRG.SpineshatterDive;
+                                if (level >= Levels.Jump && level < Levels.HighJump && IsOffCooldown(Jump))
+                                    return Jump;
+                            }
+                        }
                     }
-                }
 
-                //Dives under Litany Feature
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonLitanyDiveFeature))
+                    //Life Surge Feature
+                    if (canWeave)
                     {
-                        if (level >= DRG.Levels.DragonfireDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.BattleLitany) && IsOffCooldown(DRG.DragonfireDive) && canWeave)
-                            return DRG.DragonfireDive;
+                        if (IsEnabled(CustomComboPreset.DragoonLifeSurgeFeature))
+                        {
+                            if (HasEffect(Buffs.LanceCharge) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && lastComboMove is DRG.VorpalThrust && GetRemainingCharges(LifeSurge) > 0 && CanWeave(actionID, 0.001))
+                                return LifeSurge;
 
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.Stardiver && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Stardiver) && CanWeave(actionID, 1.5))
-                            return DRG.Stardiver;
+                            if (HasEffect(Buffs.RightEye) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && lastComboMove is DRG.VorpalThrust && GetRemainingCharges(LifeSurge) > 0 && CanWeave(actionID, 0.001))
+                                return LifeSurge;
 
-                        if (level >= DRG.Levels.SpineshatterDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.BattleLitany) && GetRemainingCharges(DRG.SpineshatterDive) > 0 && canWeave)
-                            return DRG.SpineshatterDive;
+                            if (HasEffect(Buffs.BattleLitany) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && lastComboMove is DRG.FangAndClaw && HasEffect(Buffs.EnhancedWheelingThrust) && GetRemainingCharges(LifeSurge) > 0 && CanWeave(actionID, 0.001))
+                                return LifeSurge;
+
+                            if (HasEffect(Buffs.BattleLitany) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && lastComboMove is DRG.WheelingThrust && HasEffect(Buffs.SharperFangAndClaw) && GetRemainingCharges(LifeSurge) > 0 && CanWeave(actionID, 0.001))
+                                return LifeSurge;
+                        }
                     }
-                }
 
-                //Dives Feature
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonLifeLitanyDiveFeature))
+                    //Wyrmwind Thrust Feature
+                    if (canWeave)
                     {
-                        if (level >= DRG.Levels.DragonfireDive && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.DragonfireDive) && canWeave)
-                            return DRG.DragonfireDive;
-
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.Stardiver && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Stardiver) && CanWeave(actionID, 1.5))
-                            return DRG.Stardiver;
-
-                        if (level >= DRG.Levels.SpineshatterDive && HasEffect(DRG.Buffs.PowerSurge) && GetRemainingCharges(DRG.SpineshatterDive) > 0 && canWeave)
-                            return DRG.SpineshatterDive;
+                        if (IsEnabled(CustomComboPreset.DragoonWyrmwindFeature))
+                        {
+                            if (
+                                gauge.FirstmindsFocusCount is 2 && canWeave
+                               ) return WyrmwindThrust;
+                        }
                     }
-                }
 
-                //Dives under Lance Charge Feature
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonLanceDiveFeature))
+                    //Geirskogul and Nastrond Feature Part 2
+                    if (canWeave)
                     {
-                        if (level >= DRG.Levels.DragonfireDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.LanceCharge) && IsOffCooldown(DRG.DragonfireDive) && canWeave)
-                            return DRG.DragonfireDive;
 
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.Stardiver && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Stardiver) && CanWeave(actionID, 1.5))
-                            return DRG.Stardiver;
-
-                        if (level >= DRG.Levels.SpineshatterDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.LanceCharge) && GetRemainingCharges(DRG.SpineshatterDive) > 0 && canWeave)
-                            return DRG.SpineshatterDive;
+                        if (IsEnabled(CustomComboPreset.DragoonGeirskogulNastrondFeature))
+                        {
+                            if (gauge.IsLOTDActive is true && level >= Levels.Nastrond && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Nastrond) && CanWeave(actionID, 0.001))
+                                return Nastrond;
+                        }
                     }
-                }
 
-                //Mirage Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonMirageFeature))
+                    //Dives under Litany and Life of the Dragon Feature
+                    if (canWeave)
                     {
-                        if (level >= DRG.Levels.MirageDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.DiveReady) && CanWeave(actionID, 0.001))
-                            return DRG.MirageDive;
-                    }
-                }
 
-                if (comboTime > 0)
-                {
-                    if ((lastComboMove is DRG.TrueThrust or DRG.RaidenThrust) && level >= DRG.Levels.Disembowel && (Disembowel is null || (Disembowel.RemainingTime < 10)))
-                        return DRG.Disembowel;
-
-                    if (lastComboMove is DRG.Disembowel && level >= DRG.Levels.ChaoticSpring)
-                        return DRG.ChaoticSpring;
-
-                    if (lastComboMove is DRG.Disembowel && level >= DRG.Levels.ChaosThrust)
-                        return DRG.ChaosThrust;
-
-                    if ((lastComboMove is DRG.TrueThrust or DRG.RaidenThrust) && level >= DRG.Levels.VorpalThrust)
-                        return DRG.VorpalThrust;
-
-                    if (lastComboMove is DRG.VorpalThrust && level >= DRG.Levels.FullThrust)
-                        return DRG.FullThrust;
-                }
-
-                if (HasEffect(DRG.Buffs.SharperFangAndClaw) && level >= DRG.Levels.FangAndClaw)
-                    return DRG.FangAndClaw;
-
-                if (HasEffect(DRG.Buffs.EnhancedWheelingThrust) && level >= DRG.Levels.WheelingThrust)
-                    return DRG.WheelingThrust;
-
-                return OriginalHook(DRG.TrueThrust);
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class DragoonSimpleAoE : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonSimpleAoE;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var canWeave = CanWeave(actionID);
-            var gauge = GetJobGauge<DRGGauge>();
-            if (actionID is DRG.CoerthanTorment)
-            {
-                // Piercing Talon Uptime Option
-                if (IsEnabled(CustomComboPreset.DRGSimpleRangedUptimeAoE) && level >= DRG.Levels.PiercingTalon && !InMeleeRange())
-                    return DRG.PiercingTalon;
-
-                //Buffs AoE Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonAoEBuffsFeature))
-                    {
-                        if (
-                            level >= DRG.Levels.LanceCharge &&
-                            IsOffCooldown(DRG.LanceCharge) && CanWeave(actionID)
-                           ) return DRG.LanceCharge;
-
-                        if (
-                            level >= DRG.Levels.BattleLitany &&
-                            IsOffCooldown(DRG.BattleLitany) && CanWeave(actionID)
-                           ) return DRG.BattleLitany;
-                    }
-                }
-
-                //Dragon Sight AoE Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonAoEDragonSightFeature))
-                    {
-                        if (
-                            level >= DRG.Levels.DragonSight &&
-                            IsOffCooldown(DRG.DragonSight) && CanWeave(actionID)
-                           ) return DRG.DragonSight;
-                    }
-                }
-
-                //Geirskogul and Nastrond AoE Feature Part 1
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonAoEGeirskogulNastrondFeature))
-                    {
-                        if (
-                            level >= DRG.Levels.Geirskogul &&
-                            IsOffCooldown(DRG.Geirskogul) && CanWeave(actionID)
-                           ) return DRG.Geirskogul;
-                    }
-                }
-
-                //(High) Jump AoE Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonAoEHighJumpFeature))
-                    {
-                        if (
-                            level >= DRG.Levels.HighJump &&
-                            IsOffCooldown(DRG.HighJump) && CanWeave(actionID, 1)
-                           ) return DRG.HighJump;
-
-                        if (
-                            level >= DRG.Levels.Jump && level <= DRG.Levels.HighJump &&
-                            IsOffCooldown(DRG.Jump) && CanWeave(actionID, 1)
-                           ) return DRG.Jump;
-                    }
-                }
-
-                //Life Surge AoE Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonAoELifeSurgeFeature))
-                    {
-                        if (HasEffect(DRG.Buffs.LanceCharge) && lastComboMove is DRG.CoerthanTorment && level >= DRG.Levels.CoerthanTorment && !HasEffect(DRG.Buffs.LifeSurge) && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, weaveTime: 0.3))
-                            return DRG.LifeSurge;
-
-                        if (HasEffect(DRG.Buffs.RightEye) && lastComboMove is DRG.CoerthanTorment && level >= DRG.Levels.CoerthanTorment && !HasEffect(DRG.Buffs.LifeSurge) && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, weaveTime: 0.3))
-                            return DRG.LifeSurge;
-
-                        if (HasEffect(DRG.Buffs.LanceCharge) && lastComboMove is DRG.SonicThrust && level >= DRG.Levels.SonicThrust && level <= DRG.Levels.CoerthanTorment && !HasEffect(DRG.Buffs.LifeSurge) && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, weaveTime: 0.3))
-                            return DRG.LifeSurge;
-
-                        if (HasEffect(DRG.Buffs.RightEye) && lastComboMove is DRG.SonicThrust && level >= DRG.Levels.SonicThrust && level <= DRG.Levels.CoerthanTorment && !HasEffect(DRG.Buffs.LifeSurge) && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, weaveTime: 0.3))
-                            return DRG.LifeSurge;
-
-                        if (HasEffect(DRG.Buffs.LanceCharge) && lastComboMove == OriginalHook(DRG.DoomSpike) && level <= DRG.Levels.SonicThrust && !HasEffect(DRG.Buffs.LifeSurge) && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, weaveTime: 0.3))
-                            return DRG.LifeSurge;
-
-                        if (HasEffect(DRG.Buffs.RightEye) && lastComboMove == OriginalHook(DRG.DoomSpike) && level <= DRG.Levels.SonicThrust && !HasEffect(DRG.Buffs.LifeSurge) && GetRemainingCharges(DRG.LifeSurge) > 0 && CanWeave(actionID, weaveTime: 0.3))
-                            return DRG.LifeSurge;
-
-                    }
-                }
-
-                //Wyrmwind Thrust AoE Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonAoEWyrmwindFeature))
-                    {
-                        if (
-                            gauge.FirstmindsFocusCount is 2 && CanWeave(actionID)
-                           ) return DRG.WyrmwindThrust;
-                    }
-                }
-
-                //Geirskogul and Nastrond AoE Feature Part 2
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonAoEGeirskogulNastrondFeature))
-                    {
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.Nastrond && IsOffCooldown(DRG.Nastrond) && CanWeave(actionID))
-                            return DRG.Nastrond;
-                    }
-                }
-
-                //Dives under Litany and Life of the Dragon AoE Feature
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonAoELifeLitanyDiveFeature))
-                    {
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.DragonfireDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.BattleLitany) && IsOffCooldown(DRG.DragonfireDive) && canWeave)
-                            return DRG.DragonfireDive;
-
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.Stardiver && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Stardiver) && CanWeave(actionID, 1.3))
-                            return DRG.Stardiver;
-
-                        if (HasEffect(DRG.Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= DRG.Levels.SpineshatterDive && HasEffect(DRG.Buffs.PowerSurge) && GetRemainingCharges(DRG.SpineshatterDive) == 2 && canWeave)
-                            return DRG.SpineshatterDive;
-
-                    }
-                }
-
-                //Dives under Litany AoE Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonAoELitanyDiveFeature))
-                    {
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.DragonfireDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.BattleLitany) && IsOffCooldown(DRG.DragonfireDive) && canWeave)
-                            return DRG.DragonfireDive;
-
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.Stardiver && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Stardiver) && CanWeave(actionID, 1.3))
-                            return DRG.Stardiver;
-
-                        if (HasEffect(DRG.Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= DRG.Levels.SpineshatterDive && HasEffect(DRG.Buffs.PowerSurge) && GetRemainingCharges(DRG.SpineshatterDive) == 2 && canWeave)
-                            return DRG.SpineshatterDive;
-                    }
-                }
-
-                //Dives AoE Feature
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonAoEDiveFeature))
-                    {
                         if (IsEnabled(CustomComboPreset.DragoonLifeLitanyDiveFeature))
                         {
-                            if (level >= DRG.Levels.DragonfireDive && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.DragonfireDive) && canWeave)
-                                return DRG.DragonfireDive;
+                            if (gauge.IsLOTDActive is true && level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && IsOffCooldown(DragonfireDive) && canWeave)
+                                return DragonfireDive;
 
-                            if (gauge.IsLOTDActive is true && level >= DRG.Levels.Stardiver && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Stardiver) && CanWeave(actionID, 1.5))
-                                return DRG.Stardiver;
+                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
+                                return Stardiver;
 
-                            if (level >= DRG.Levels.SpineshatterDive && HasEffect(DRG.Buffs.PowerSurge) && GetRemainingCharges(DRG.SpineshatterDive) > 0 && canWeave)
-                                return DRG.SpineshatterDive;
+                            if (HasEffect(Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) == 2 && canWeave)
+                                return SpineshatterDive;
                         }
                     }
-                }
 
-                //Dives under Lance Charge AoE Feature
-                if (canWeave)
-                {
-
-                    if (IsEnabled(CustomComboPreset.DragoonLanceDiveFeature))
+                    //Dives under Litany Feature
+                    if (canWeave)
                     {
-                        if (level >= DRG.Levels.DragonfireDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.LanceCharge) && IsOffCooldown(DRG.DragonfireDive) && canWeave)
-                            return DRG.DragonfireDive;
 
-                        if (gauge.IsLOTDActive is true && level >= DRG.Levels.Stardiver && HasEffect(DRG.Buffs.PowerSurge) && IsOffCooldown(DRG.Stardiver) && CanWeave(actionID, 1.5))
-                            return DRG.Stardiver;
+                        if (IsEnabled(CustomComboPreset.DragoonLitanyDiveFeature))
+                        {
+                            if (level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && IsOffCooldown(DragonfireDive) && canWeave)
+                                return DragonfireDive;
 
-                        if (level >= DRG.Levels.SpineshatterDive && HasEffect(DRG.Buffs.PowerSurge) && HasEffect(DRG.Buffs.LanceCharge) && GetRemainingCharges(DRG.SpineshatterDive) > 0 && canWeave)
-                            return DRG.SpineshatterDive;
+                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
+                                return Stardiver;
+
+                            if (level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && GetRemainingCharges(SpineshatterDive) > 0 && canWeave)
+                                return SpineshatterDive;
+                        }
                     }
-                }
 
-                //Mirage AoE Feature
-                if (canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.DragoonAoEMirageFeature))
+                    //Dives Feature
+                    if (canWeave)
                     {
-                        if (
-                            level >= DRG.Levels.MirageDive &&
-                            HasEffect(DRG.Buffs.DiveReady) && CanWeave(actionID)
-                           ) return DRG.MirageDive;
+
+                        if (IsEnabled(CustomComboPreset.DragoonLifeLitanyDiveFeature))
+                        {
+                            if (level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && IsOffCooldown(DragonfireDive) && canWeave)
+                                return DragonfireDive;
+
+                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
+                                return Stardiver;
+
+                            if (level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) > 0 && canWeave)
+                                return SpineshatterDive;
+                        }
                     }
+
+                    //Dives under Lance Charge Feature
+                    if (canWeave)
+                    {
+
+                        if (IsEnabled(CustomComboPreset.DragoonLanceDiveFeature))
+                        {
+                            if (level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.LanceCharge) && IsOffCooldown(DragonfireDive) && canWeave)
+                                return DragonfireDive;
+
+                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
+                                return Stardiver;
+
+                            if (level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.LanceCharge) && GetRemainingCharges(SpineshatterDive) > 0 && canWeave)
+                                return SpineshatterDive;
+                        }
+                    }
+
+                    //Mirage Feature
+                    if (canWeave)
+                    {
+                        if (IsEnabled(CustomComboPreset.DragoonMirageFeature))
+                        {
+                            if (level >= Levels.MirageDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.DiveReady) && CanWeave(actionID, 0.001))
+                                return MirageDive;
+                        }
+                    }
+
+                    if (comboTime > 0)
+                    {
+                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.Disembowel && (Disembowel is null || (Disembowel.RemainingTime < 10)))
+                            return DRG.Disembowel;
+
+                        if (lastComboMove is DRG.Disembowel && level >= Levels.ChaoticSpring)
+                            return ChaoticSpring;
+
+                        if (lastComboMove is DRG.Disembowel && level >= Levels.ChaosThrust)
+                            return ChaosThrust;
+
+                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.VorpalThrust)
+                            return VorpalThrust;
+
+                        if (lastComboMove is DRG.VorpalThrust && level >= Levels.FullThrust)
+                            return FullThrust;
+                    }
+
+                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
+                        return FangAndClaw;
+
+                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
+                        return WheelingThrust;
+
+                    return OriginalHook(TrueThrust);
                 }
 
-                if (comboTime > 0)
-                {
-                    if (lastComboMove == OriginalHook(DRG.DoomSpike) && level >= DRG.Levels.SonicThrust)
-                        return DRG.SonicThrust;
-
-                    if (lastComboMove is DRG.SonicThrust && level >= DRG.Levels.CoerthanTorment)
-                        return DRG.CoerthanTorment;
-
-                    if ((lastComboMove is DRG.DraconianFury))
-                        return DRG.SonicThrust;
-                }
-
-                return OriginalHook(DRG.DoomSpike);
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class DragoonFangAndClawFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonFangAndClawFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class DragoonSimpleAoE : CustomCombo
         {
-            if (actionID is DRG.FangAndClaw)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonSimpleAoE;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (HasEffect(DRG.Buffs.EnhancedWheelingThrust) && level >= DRG.Levels.WheelingThrust)
-                    return DRG.WheelingThrust;
-                if (HasEffect(DRG.Buffs.SharperFangAndClaw) && level >= DRG.Levels.FangAndClaw)
-                    return DRG.FangAndClaw;
+                var canWeave = CanWeave(actionID);
+                var gauge = GetJobGauge<DRGGauge>();
+                if (actionID is DRG.CoerthanTorment)
+                {
+                    // Piercing Talon Uptime Option
+                    if (IsEnabled(CustomComboPreset.DRGSimpleRangedUptimeAoE) && level >= Levels.PiercingTalon && !InMeleeRange())
+                        return PiercingTalon;
 
+                    if (canWeave)
+                    {
+                        //Buffs AoE Feature
+                        if (IsEnabled(CustomComboPreset.DragoonAoEBuffsFeature))
+                        {
+
+                            if (level >= Levels.LanceCharge &&
+                                IsOffCooldown(LanceCharge))
+                                return LanceCharge;
+
+                            if (level >= Levels.BattleLitany &&
+                                IsOffCooldown(BattleLitany))
+                                return BattleLitany;
+
+                            //Dragon Sight AoE Feature
+                            if (IsEnabled(CustomComboPreset.DragoonAoEDragonSightFeature))
+                            {
+                                if (level >= Levels.DragonSight &&
+                                    IsOffCooldown(DragonSight))
+                                    return DragonSight;
+                            }
+                        }
+
+                        //Geirskogul and Nastrond AoE Feature Part 1
+                        if (IsEnabled(CustomComboPreset.DragoonAoEGeirskogulNastrondFeature))
+                        {
+                            if (level >= Levels.Geirskogul &&
+                                IsOffCooldown(Geirskogul))
+                                return Geirskogul;
+
+                        }
+
+                        //(High) Jump AoE Feature
+                        if (IsEnabled(CustomComboPreset.DragoonAoEHighJumpFeature))
+                        {
+                            if (level >= Levels.HighJump &&
+                                IsOffCooldown(HighJump) && CanWeave(actionID, 1))
+                                return HighJump;
+
+                            if (level >= Levels.Jump && level <= Levels.HighJump &&
+                                IsOffCooldown(Jump) && CanWeave(actionID, 1))
+                                return Jump;
+                        }
+
+                        //Life Surge AoE Feature
+                        if (IsEnabled(CustomComboPreset.DragoonAoELifeSurgeFeature))
+                        {
+                            if ((HasEffect(Buffs.LanceCharge) || HasEffect(Buffs.RightEye)) &&
+                                ((lastComboMove is DRG.CoerthanTorment && level >= Levels.CoerthanTorment) ||
+                                (lastComboMove is DRG.SonicThrust && level >= Levels.SonicThrust && level <= Levels.CoerthanTorment) ||
+                                (lastComboMove is DRG.DoomSpike && level <= Levels.SonicThrust)) &&
+                                !HasEffect(Buffs.LifeSurge) &&
+                                GetRemainingCharges(LifeSurge) > 0 &&
+                                CanWeave(actionID, weaveTime: 0.3))
+                                return LifeSurge;
+
+                        }
+
+
+                        //Wyrmwind Thrust AoE Feature
+                        if (IsEnabled(CustomComboPreset.DragoonAoEWyrmwindFeature))
+                        {
+                            if (gauge.FirstmindsFocusCount is 2)
+                                return WyrmwindThrust;
+                        }
+
+                        //Geirskogul and Nastrond AoE Feature Part 2
+                        if (IsEnabled(CustomComboPreset.DragoonAoEGeirskogulNastrondFeature))
+                        {
+                            if (gauge.IsLOTDActive is true && level >= Levels.Nastrond && IsOffCooldown(Nastrond))
+                                return Nastrond;
+
+                        }
+
+                        //Dives AoE Feature
+                        if (IsEnabled(CustomComboPreset.DragoonAoEDiveFeature))
+                        {
+                            if (level >= Levels.DragonfireDive && IsOffCooldown(DragonfireDive))
+                                return DragonfireDive;
+
+                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
+                                return Stardiver;
+
+                            if (level >= Levels.SpineshatterDive && GetRemainingCharges(SpineshatterDive) > 0 && canWeave)
+                                return SpineshatterDive;
+
+                        }
+
+                        //Dives under Lance Charge
+                        if (IsEnabled(CustomComboPreset.DragoonAoELanceDiveFeature))
+                        {
+                            if (level >= Levels.DragonfireDive && IsOffCooldown(DragonfireDive) && HasEffect(Buffs.LanceCharge))
+                                return DragonfireDive;
+
+                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && IsOffCooldown(Stardiver) && HasEffect(Buffs.LanceCharge) && CanWeave(actionID, 1.5))
+                                return Stardiver;
+
+                            if (level >= Levels.SpineshatterDive && GetRemainingCharges(SpineshatterDive) > 0 && HasEffect(Buffs.LanceCharge))
+                                return SpineshatterDive;
+                        }
+
+                        //Dives under Litany AoE Feature
+                        if (IsEnabled(CustomComboPreset.DragoonAoELitanyDiveFeature))
+                        {
+                            if (gauge.IsLOTDActive is true && level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && IsOffCooldown(DragonfireDive))
+                                return DragonfireDive;
+
+                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
+                                return Stardiver;
+
+                            if (HasEffect(Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) == 2)
+                                return SpineshatterDive;
+
+                        }
+
+                        //Dives under Litany and Life of the Dragon AoE Feature
+                        if (IsEnabled(CustomComboPreset.DragoonAoELifeLitanyDiveFeature))
+                        {
+                            if (gauge.IsLOTDActive is true && level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && IsOffCooldown(DragonfireDive))
+                                return DragonfireDive;
+
+                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
+                                return Stardiver;
+
+                            if (HasEffect(Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) == 2)
+                                return SpineshatterDive;
+
+                        }
+
+                        //Dives under Lance Charge AoE Feature
+                        if (IsEnabled(CustomComboPreset.DragoonAoELitanyDiveFeature))
+                        {
+                            if (level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.LanceCharge) && IsOffCooldown(DragonfireDive))
+                                return DragonfireDive;
+
+                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
+                                return Stardiver;
+
+                            if (level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.LanceCharge) && GetRemainingCharges(SpineshatterDive) > 0)
+                                return SpineshatterDive;
+
+                        }
+
+                        //Mirage AoE Feature
+                        if (IsEnabled(CustomComboPreset.DragoonAoEMirageFeature))
+                        {
+                            if (level >= Levels.MirageDive &&
+                                HasEffect(Buffs.DiveReady))
+                                return MirageDive;
+                        }
+                    }
+                    if (comboTime > 0)
+                    {
+                        if (lastComboMove == OriginalHook(DoomSpike) && level >= Levels.SonicThrust)
+                            return SonicThrust;
+
+                        if (lastComboMove is DRG.SonicThrust && level >= Levels.CoerthanTorment)
+                            return CoerthanTorment;
+
+                        if ((lastComboMove is DRG.DraconianFury))
+                            return SonicThrust;
+                    }
+
+                    return OriginalHook(DoomSpike);
+                }
+
+                return actionID;
             }
+        }
 
-            return actionID;
+        internal class DragoonFangAndClawFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DragoonFangAndClawFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is DRG.FangAndClaw)
+                {
+                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
+                        return WheelingThrust;
+                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
+                        return FangAndClaw;
+
+                }
+
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/Combos/DRK.cs
+++ b/XIVSlothCombo/Combos/DRK.cs
@@ -76,7 +76,7 @@ namespace XIVSlothComboPlugin.Combos
                 DrkKeepPlungeCharges = "DrkKeepPlungeCharges",
                 DrkMPManagement = "DrkMPManagement";
         }
-    }
+    
 
     internal class DarkSouleaterCombo : CustomCombo
     {
@@ -84,16 +84,16 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == DRK.Souleater)
+            if (actionID == Souleater)
             {
                 var gauge = GetJobGauge<DRKGauge>();
-                var plungeChargesRemaining = Service.Configuration.GetCustomIntValue(DRK.Config.DrkKeepPlungeCharges);
-                var mpRemaining = Service.Configuration.GetCustomIntValue(DRK.Config.DrkMPManagement);
+                var plungeChargesRemaining = Service.Configuration.GetCustomIntValue(Config.DrkKeepPlungeCharges);
+                var mpRemaining = Service.Configuration.GetCustomIntValue(Config.DrkMPManagement);
 
-                if (IsEnabled(CustomComboPreset.DarkRangedUptimeFeature) && level >= DRK.Levels.Unmend)
+                if (IsEnabled(CustomComboPreset.DarkRangedUptimeFeature) && level >= Levels.Unmend)
                 {
                     if (!InMeleeRange())
-                        return DRK.Unmend;
+                        return Unmend;
                 }
 
                 if (InCombat())
@@ -104,14 +104,14 @@ namespace XIVSlothComboPlugin.Combos
                         //Mana Features
                         if (IsEnabled(CustomComboPreset.DarkManaOvercapFeature))
                         {
-                            if (IsEnabled(CustomComboPreset.DarkEoSPoolOption) && gauge.ShadowTimeRemaining >= 1 && (gauge.HasDarkArts || LocalPlayer.CurrentMp > (mpRemaining + 3000)) && level >= DRK.Levels.EdgeOfDarkness && CanDelayedWeave(actionID))
-                                return OriginalHook(DRK.EdgeOfDarkness);
+                            if (IsEnabled(CustomComboPreset.DarkEoSPoolOption) && gauge.ShadowTimeRemaining >= 1 && (gauge.HasDarkArts || LocalPlayer.CurrentMp > (mpRemaining + 3000)) && level >= Levels.EdgeOfDarkness && CanDelayedWeave(actionID))
+                                return OriginalHook(EdgeOfDarkness);
                             if (gauge.HasDarkArts || LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10)
                             {
-                                if (level >= DRK.Levels.EdgeOfDarkness)
-                                    return OriginalHook(DRK.EdgeOfDarkness);
-                                if (level >= DRK.Levels.FloodOfDarkness && level < DRK.Levels.EdgeOfDarkness)
-                                    return DRK.FloodOfDarkness;
+                                if (level >= Levels.EdgeOfDarkness)
+                                    return OriginalHook(EdgeOfDarkness);
+                                if (level >= Levels.FloodOfDarkness && level < Levels.EdgeOfDarkness)
+                                    return FloodOfDarkness;
                             }
                         }
 
@@ -120,75 +120,75 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             if (IsEnabled(CustomComboPreset.DarkMainComboBuffsGroup))
                             {
-                                if (IsEnabled(CustomComboPreset.DarkBloodWeaponOption) && IsOffCooldown(DRK.BloodWeapon) && level >= DRK.Levels.BloodWeapon)
-                                    return DRK.BloodWeapon;
-                                if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && IsOffCooldown(DRK.Delirium) && level >= DRK.Levels.Delirium)
-                                    return DRK.Delirium;
+                                if (IsEnabled(CustomComboPreset.DarkBloodWeaponOption) && IsOffCooldown(BloodWeapon) && level >= Levels.BloodWeapon)
+                                    return BloodWeapon;
+                                if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && IsOffCooldown(Delirium) && level >= Levels.Delirium)
+                                    return Delirium;
                             }
 
                             if (IsEnabled(CustomComboPreset.DarkMainComboCDsGroup))
                             {
-                                if (IsEnabled(CustomComboPreset.DRKLivingShadowFeature) && gauge.Blood >= 50 && IsOffCooldown(DRK.LivingShadow) && level >= DRK.Levels.LivingShadow)
-                                    return DRK.LivingShadow;
-                                if (IsEnabled(CustomComboPreset.DarkSaltedEarthFeature) && level >= DRK.Levels.SaltedEarth)
+                                if (IsEnabled(CustomComboPreset.DRKLivingShadowFeature) && gauge.Blood >= 50 && IsOffCooldown(LivingShadow) && level >= Levels.LivingShadow)
+                                    return LivingShadow;
+                                if (IsEnabled(CustomComboPreset.DarkSaltedEarthFeature) && level >= Levels.SaltedEarth)
                                 {
-                                    if ((IsOffCooldown(DRK.SaltedEarth) && !HasEffect(DRK.Buffs.SaltedEarth)) || //Salted Earth
-                                        (HasEffect(DRK.Buffs.SaltedEarth) && IsOffCooldown(DRK.SaltAndDarkness) && IsOnCooldown(DRK.SaltedEarth) && level >= DRK.Levels.SaltAndDarkness)) //Salt and Darkness
-                                        return OriginalHook(DRK.SaltedEarth);
+                                    if ((IsOffCooldown(SaltedEarth) && !HasEffect(Buffs.SaltedEarth)) || //Salted Earth
+                                        (HasEffect(Buffs.SaltedEarth) && IsOffCooldown(SaltAndDarkness) && IsOnCooldown(SaltedEarth) && level >= Levels.SaltAndDarkness)) //Salt and Darkness
+                                        return OriginalHook(SaltedEarth);
                                 }
 
-                                if (level >= DRK.Levels.Shadowbringer && IsEnabled(CustomComboPreset.DarkShBFeature))
+                                if (level >= Levels.Shadowbringer && IsEnabled(CustomComboPreset.DarkShBFeature))
                                 {
-                                    if ((GetRemainingCharges(DRK.Shadowbringer) > 0 && IsNotEnabled(CustomComboPreset.DarkBurstShBOption)) ||
-                                        (IsEnabled(CustomComboPreset.DarkBurstShBOption) && GetRemainingCharges(DRK.Shadowbringer) > 0 && gauge.ShadowTimeRemaining > 1 && IsOnCooldown(DRK.Delirium))) //burst feature
-                                        return DRK.Shadowbringer;
+                                    if ((GetRemainingCharges(Shadowbringer) > 0 && IsNotEnabled(CustomComboPreset.DarkBurstShBOption)) ||
+                                        (IsEnabled(CustomComboPreset.DarkBurstShBOption) && GetRemainingCharges(Shadowbringer) > 0 && gauge.ShadowTimeRemaining > 1 && IsOnCooldown(Delirium))) //burst feature
+                                        return Shadowbringer;
                                 }
 
-                                if (IsEnabled(CustomComboPreset.DarkCnSFeature) && IsOffCooldown(DRK.CarveAndSpit) && level >= DRK.Levels.CarveAndSpit)
-                                    return DRK.CarveAndSpit;
-                                if (level >= DRK.Levels.Plunge && IsEnabled(CustomComboPreset.DarkPlungeFeature) && GetRemainingCharges(DRK.Plunge) > plungeChargesRemaining)
+                                if (IsEnabled(CustomComboPreset.DarkCnSFeature) && IsOffCooldown(CarveAndSpit) && level >= Levels.CarveAndSpit)
+                                    return CarveAndSpit;
+                                if (level >= Levels.Plunge && IsEnabled(CustomComboPreset.DarkPlungeFeature) && GetRemainingCharges(Plunge) > plungeChargesRemaining)
                                 {
                                     if (IsNotEnabled(CustomComboPreset.DarkMeleePlungeOption) ||
-                                        (IsEnabled(CustomComboPreset.DarkMeleePlungeOption) && GetCooldownRemainingTime(DRK.Delirium) >= 45 && GetTargetDistance() <= 1))
-                                        return DRK.Plunge;
+                                        (IsEnabled(CustomComboPreset.DarkMeleePlungeOption) && GetCooldownRemainingTime(Delirium) >= 45 && GetTargetDistance() <= 1))
+                                        return Plunge;
                                 }
                             }
                         }
                     }
 
                     //Delirium Features
-                    if (level >= DRK.Levels.Delirium && IsEnabled(CustomComboPreset.DeliriumFeature) && IsEnabled(CustomComboPreset.DarkMainComboCDsGroup))
+                    if (level >= Levels.Delirium && IsEnabled(CustomComboPreset.DeliriumFeature) && IsEnabled(CustomComboPreset.DarkMainComboCDsGroup))
                     {
                         //Regular Delirium
-                        if (GetBuffStacks(DRK.Buffs.Delirium) > 0 && (level < DRK.Levels.LivingShadow || IsNotEnabled(CustomComboPreset.DelayedDeliriumFeatureOption)))
-                            return DRK.Bloodspiller;
+                        if (GetBuffStacks(Buffs.Delirium) > 0 && (level < Levels.LivingShadow || IsNotEnabled(CustomComboPreset.DelayedDeliriumFeatureOption)))
+                            return Bloodspiller;
 
                         //Delayed Delirium
-                        if (IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption) && GetBuffStacks(DRK.Buffs.Delirium) > 0 &&
-                            (GetBuffStacks(DRK.Buffs.BloodWeapon) is 0 or 1 or 2))
-                            return DRK.Bloodspiller;
+                        if (IsEnabled(CustomComboPreset.DelayedDeliriumFeatureOption) && GetBuffStacks(Buffs.Delirium) > 0 &&
+                            (GetBuffStacks(Buffs.BloodWeapon) is 0 or 1 or 2))
+                            return Bloodspiller;
 
                         //Blood management before Delirium
-                        if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && ((gauge.Blood >= 50 && GetCooldownRemainingTime(DRK.BloodWeapon) < 6 && GetCooldownRemainingTime(DRK.Delirium) > 0) || (IsOffCooldown(DRK.Delirium) && gauge.Blood >= 50)))
-                            return DRK.Bloodspiller;
+                        if (IsEnabled(CustomComboPreset.DarkDeliriumOnCD) && ((gauge.Blood >= 50 && GetCooldownRemainingTime(BloodWeapon) < 6 && GetCooldownRemainingTime(Delirium) > 0) || (IsOffCooldown(Delirium) && gauge.Blood >= 50)))
+                            return Bloodspiller;
                     }
 
                     // 1-2-3 combo
                     if (comboTime > 0)
                     {
-                        if (lastComboMove == DRK.HardSlash && level >= DRK.Levels.SyphonStrike)
-                            return DRK.SyphonStrike;
+                        if (lastComboMove == HardSlash && level >= Levels.SyphonStrike)
+                            return SyphonStrike;
 
-                        if (lastComboMove == DRK.SyphonStrike && level >= DRK.Levels.Souleater)
+                        if (lastComboMove == SyphonStrike && level >= Levels.Souleater)
                         {
-                            if (IsEnabled(CustomComboPreset.DarkBloodGaugeOvercapFeature) && level >= DRK.Levels.Bloodpiller && gauge.Blood >= 90)
-                                return DRK.Bloodspiller;
-                            return DRK.Souleater;
+                            if (IsEnabled(CustomComboPreset.DarkBloodGaugeOvercapFeature) && level >= Levels.Bloodpiller && gauge.Blood >= 90)
+                                return Bloodspiller;
+                            return Souleater;
                         }
                     }
 
                 }
-                return DRK.HardSlash;
+                return HardSlash;
             }
 
             return actionID;
@@ -201,80 +201,81 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == DRK.StalwartSoul)
+            if (actionID == StalwartSoul)
             {
                 var gauge = GetJobGauge<DRKGauge>();
 
                 if (CanWeave(actionID))
                 {
-                    if (IsEnabled(CustomComboPreset.DarkManaOvercapAoEFeature) && level >= DRK.Levels.FloodOfDarkness && (gauge.HasDarkArts || LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10))
-                            return OriginalHook(DRK.FloodOfDarkness);
+                    if (IsEnabled(CustomComboPreset.DarkManaOvercapAoEFeature) && level >= Levels.FloodOfDarkness && (gauge.HasDarkArts || LocalPlayer.CurrentMp > 8500 || gauge.DarksideTimeRemaining < 10))
+                            return OriginalHook(FloodOfDarkness);
                     if (gauge.DarksideTimeRemaining > 1)
                     {
-                        if (IsEnabled(CustomComboPreset.DarkBloodWeaponAOEOption) && IsOffCooldown(DRK.BloodWeapon) && level >= DRK.Levels.BloodWeapon)
-                            return DRK.BloodWeapon;
-                        if (IsEnabled(CustomComboPreset.DarkDeliriumAOEOption) && IsOffCooldown(DRK.Delirium) && level >= DRK.Levels.Delirium)
-                            return DRK.Delirium;
-                        if (IsEnabled(CustomComboPreset.DarkLivingShadowAOEOption) && gauge.Blood >= 50 && IsOffCooldown(DRK.LivingShadow) && level >= DRK.Levels.LivingShadow)
-                            return DRK.LivingShadow;
-                        if (IsEnabled(CustomComboPreset.DarkSaltedEarthAOEOption) && level >= DRK.Levels.SaltedEarth)
+                        if (IsEnabled(CustomComboPreset.DarkBloodWeaponAOEOption) && IsOffCooldown(BloodWeapon) && level >= Levels.BloodWeapon)
+                            return BloodWeapon;
+                        if (IsEnabled(CustomComboPreset.DarkDeliriumAOEOption) && IsOffCooldown(Delirium) && level >= Levels.Delirium)
+                            return Delirium;
+                        if (IsEnabled(CustomComboPreset.DarkLivingShadowAOEOption) && gauge.Blood >= 50 && IsOffCooldown(LivingShadow) && level >= Levels.LivingShadow)
+                            return LivingShadow;
+                        if (IsEnabled(CustomComboPreset.DarkSaltedEarthAOEOption) && level >= Levels.SaltedEarth)
                         {
-                            if ((IsOffCooldown(DRK.SaltedEarth) && !HasEffect(DRK.Buffs.SaltedEarth)) || //Salted Earth
-                                (HasEffect(DRK.Buffs.SaltedEarth) && IsOffCooldown(DRK.SaltAndDarkness) && IsOnCooldown(DRK.SaltedEarth) && level >= DRK.Levels.SaltAndDarkness)) //Salt and Darkness
-                                return OriginalHook(DRK.SaltedEarth);
+                            if ((IsOffCooldown(SaltedEarth) && !HasEffect(Buffs.SaltedEarth)) || //Salted Earth
+                                (HasEffect(Buffs.SaltedEarth) && IsOffCooldown(SaltAndDarkness) && IsOnCooldown(SaltedEarth) && level >= Levels.SaltAndDarkness)) //Salt and Darkness
+                                return OriginalHook(SaltedEarth);
                         }
 
-                        if (IsEnabled(CustomComboPreset.DRKStalwartabyssalDrainFeature) && level >= DRK.Levels.AbyssalDrain && IsOffCooldown(DRK.AbyssalDrain) && PlayerHealthPercentageHp() <= 60)
-                            return DRK.AbyssalDrain;
-                        if (IsEnabled(CustomComboPreset.DRKStalwartShadowbringerFeature) && level >= DRK.Levels.Shadowbringer && GetRemainingCharges(DRK.Shadowbringer) > 0)
-                            return DRK.Shadowbringer;
+                        if (IsEnabled(CustomComboPreset.DRKStalwartabyssalDrainFeature) && level >= Levels.AbyssalDrain && IsOffCooldown(AbyssalDrain) && PlayerHealthPercentageHp() <= 60)
+                            return AbyssalDrain;
+                        if (IsEnabled(CustomComboPreset.DRKStalwartShadowbringerFeature) && level >= Levels.Shadowbringer && GetRemainingCharges(Shadowbringer) > 0)
+                            return Shadowbringer;
                     }
                 }
 
                 if (IsEnabled(CustomComboPreset.DeliriumFeature))
                 {
-                    if (level >= DRK.Levels.Delirium && HasEffect(DRK.Buffs.Delirium) && gauge.DarksideTimeRemaining > 0)
-                        return DRK.Quietus;
+                    if (level >= Levels.Delirium && HasEffect(Buffs.Delirium) && gauge.DarksideTimeRemaining > 0)
+                        return Quietus;
                 }
 
                 if (comboTime > 0)
                 {
-                    if (lastComboMove == DRK.Unleash && level >= DRK.Levels.StalwartSoul)
+                    if (lastComboMove == Unleash && level >= Levels.StalwartSoul)
                     {
-                        if (IsEnabled(CustomComboPreset.DRKOvercapFeature) && gauge.Blood >= 90 && level >= DRK.Levels.Quietus && gauge.DarksideTimeRemaining > 0)
-                            return DRK.Quietus;
-                        return DRK.StalwartSoul;
+                        if (IsEnabled(CustomComboPreset.DRKOvercapFeature) && gauge.Blood >= 90 && level >= Levels.Quietus && gauge.DarksideTimeRemaining > 0)
+                            return Quietus;
+                        return StalwartSoul;
                     }
                 }
 
-                return DRK.Unleash;
+                return Unleash;
             }
 
             return actionID;
         }
     }
-    internal class DarkoGCDFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DarkoGCDFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class DarkoGCDFeature : CustomCombo
         {
-            var gauge = GetJobGauge<DRKGauge>();
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DarkoGCDFeature;
 
-            if (actionID == DRK.CarveAndSpit || actionID == DRK.AbyssalDrain)
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (gauge.Blood >= 50 && IsOffCooldown(DRK.LivingShadow) && level >= DRK.Levels.LivingShadow)
-                    return DRK.LivingShadow;
-                if (IsOffCooldown(DRK.SaltedEarth) && level >= DRK.Levels.SaltedEarth)
-                    return DRK.SaltedEarth;
-                if (IsOffCooldown(DRK.CarveAndSpit) && level >= DRK.Levels.AbyssalDrain)
-                    return actionID;
-                if (IsOffCooldown(DRK.SaltAndDarkness) && HasEffect(DRK.Buffs.SaltedEarth) && level >= DRK.Levels.SaltAndDarkness)
-                    return DRK.SaltAndDarkness;
-                if (IsEnabled(CustomComboPreset.DarkShadowbringeroGCDFeature) && GetCooldownRemainingTime(DRK.Shadowbringer) < 60 && level >= DRK.Levels.Shadowbringer && gauge.DarksideTimeRemaining > 0)
-                    return DRK.Shadowbringer;
+                var gauge = GetJobGauge<DRKGauge>();
+
+                if (actionID == CarveAndSpit || actionID == AbyssalDrain)
+                {
+                    if (gauge.Blood >= 50 && IsOffCooldown(LivingShadow) && level >= Levels.LivingShadow)
+                        return LivingShadow;
+                    if (IsOffCooldown(SaltedEarth) && level >= Levels.SaltedEarth)
+                        return SaltedEarth;
+                    if (IsOffCooldown(CarveAndSpit) && level >= Levels.AbyssalDrain)
+                        return actionID;
+                    if (IsOffCooldown(SaltAndDarkness) && HasEffect(Buffs.SaltedEarth) && level >= Levels.SaltAndDarkness)
+                        return SaltAndDarkness;
+                    if (IsEnabled(CustomComboPreset.DarkShadowbringeroGCDFeature) && GetCooldownRemainingTime(Shadowbringer) < 60 && level >= Levels.Shadowbringer && gauge.DarksideTimeRemaining > 0)
+                        return Shadowbringer;
+                }
+                return actionID;
             }
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/Combos/GNB.cs
+++ b/XIVSlothCombo/Combos/GNB.cs
@@ -80,327 +80,327 @@ namespace XIVSlothComboPlugin.Combos
             public const string
                 GnbKeepRoughDivideCharges = "GnbKeepRoughDivideCharges";
         }
-    }
 
-    internal class GunbreakerSolidBarrelCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerSolidBarrelCombo;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class GunbreakerSolidBarrelCombo : CustomCombo
         {
-            if (actionID == GNB.SolidBarrel)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerSolidBarrelCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<GNBGauge>();
-                var roughDivideChargesRemaining = Service.Configuration.GetCustomIntValue(GNB.Config.GnbKeepRoughDivideCharges);
-                var quarterWeave = GetCooldown(actionID).CooldownRemaining < 1 && GetCooldown(actionID).CooldownRemaining > 0;
-
-                if (IsEnabled(CustomComboPreset.GunbreakerRangedUptimeFeature))
+                if (actionID == SolidBarrel)
                 {
-                    if (!InMeleeRange())
-                        return GNB.LightningShot;
-                }
-                
-                if (comboTime > 0)
-                {
-                    if (quarterWeave && IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup) && IsEnabled(CustomComboPreset.GunbreakerNoMercyonST))
+                    var gauge = GetJobGauge<GNBGauge>();
+                    var roughDivideChargesRemaining = Service.Configuration.GetCustomIntValue(Config.GnbKeepRoughDivideCharges);
+                    var quarterWeave = GetCooldown(actionID).CooldownRemaining < 1 && GetCooldown(actionID).CooldownRemaining > 0;
+
+                    if (IsEnabled(CustomComboPreset.GunbreakerRangedUptimeFeature))
                     {
-                        if (level >= GNB.Levels.NoMercy && IsOffCooldown(GNB.NoMercy))
-                        {
-                            if (level >= GNB.Levels.BurstStrike && 
-                                ((gauge.Ammo == 1 && IsOffCooldown(GNB.GnashingFang) && IsOffCooldown(GNB.Bloodfest)) || //Opener Conditions
-                                (gauge.Ammo == 2 && IsOnCooldown(GNB.GnashingFang) && GetCooldownRemainingTime(GNB.Bloodfest) < 3) || //GFNM windows
-                                gauge.Ammo == GNB.MaxCartridges(level) && GetCooldownRemainingTime(GNB.GnashingFang) < 2)) //Regular NMGF
-                                return GNB.NoMercy;
-                            if (level < GNB.Levels.BurstStrike) //no cartridges unlocked
-                                return GNB.NoMercy;
-                        }
+                        if (!InMeleeRange())
+                            return LightningShot;
                     }
 
-                    //oGCDs
-                    if (CanWeave(actionID))
+                    if (comboTime > 0)
                     {
-                        if (IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup) && IsEnabled(CustomComboPreset.GunbreakerBloodfestonST))
+                        if (quarterWeave && IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup) && IsEnabled(CustomComboPreset.GunbreakerNoMercyonST))
                         {
-                            if (gauge.Ammo == 0 && IsOffCooldown(GNB.Bloodfest) && level >= GNB.Levels.Bloodfest && IsOnCooldown(GNB.GnashingFang))
-                                    return GNB.Bloodfest;
-                        }
-
-                        //Blasting Zone outside of NM
-                        if (IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup) && level >= GNB.Levels.DangerZone && IsOffCooldown(GNB.DangerZone))
-                        {
-                            if (IsEnabled(CustomComboPreset.GunbreakerDZOnMainComboFeature) && !HasEffect(GNB.Buffs.NoMercy)  &&
-                                ((IsOnCooldown(GNB.GnashingFang) && gauge.AmmoComboStep != 1 && GetCooldown(GNB.GnashingFang).CooldownRemaining > 20) || //Post Gnashing Fang
-                                (level < GNB.Levels.GnashingFang) && IsOnCooldown(GNB.NoMercy))) //Pre Gnashing Fang
-                                return OriginalHook(GNB.DangerZone);
-                        }
-
-                        //60 second weaves
-                        if (IsOnCooldown(GNB.DoubleDown))
-                        {
-                            if (IsEnabled(CustomComboPreset.GunbreakerDZOnMainComboFeature) && IsOffCooldown(GNB.DangerZone))
-                                return OriginalHook(GNB.DangerZone);
-                            if (IsEnabled(CustomComboPreset.GunbreakerBSOnMainComboFeature) && IsOffCooldown(GNB.BowShock))
-                                return GNB.BowShock;
-                        }
-
-                        //30 second weaves
-                        if (IsOnCooldown(GNB.SonicBreak))
-                        {
-                            if (IsEnabled(CustomComboPreset.GunbreakerBSOnMainComboFeature) && level >= GNB.Levels.BowShock && IsOffCooldown(GNB.BowShock))
-                                return GNB.BowShock;
-                            if (IsEnabled(CustomComboPreset.GunbreakerDZOnMainComboFeature) && level >= GNB.Levels.DangerZone && IsOffCooldown(GNB.DangerZone))
-                                return OriginalHook(GNB.DangerZone);
-                        }
-
-                        //Continuation
-                        if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.Continuation &&
-                            (HasEffect(GNB.Buffs.ReadyToRip) || HasEffect(GNB.Buffs.ReadyToTear) || HasEffect(GNB.Buffs.ReadyToGouge)) && level >= GNB.Levels.Continuation)
-                                return OriginalHook(GNB.Continuation);
-
-                        //Rough Divide Feature
-                        if (level >= GNB.Levels.RoughDivide && IsEnabled(CustomComboPreset.GunbreakerRoughDivideFeature) && GetRemainingCharges(GNB.RoughDivide) > roughDivideChargesRemaining)
-                        {
-                            if (IsNotEnabled(CustomComboPreset.GunbreakerMeleeRoughDivideOption) ||
-                                (IsEnabled(CustomComboPreset.GunbreakerMeleeRoughDivideOption) && GetTargetDistance() <= 1 && HasEffect(GNB.Buffs.NoMercy) && IsOnCooldown(OriginalHook(GNB.DangerZone)) && IsOnCooldown(GNB.BowShock) && IsOnCooldown(GNB.Bloodfest)))
-                                return GNB.RoughDivide;
-                        }
-                    }
-
-                    // 60s window features
-                    if (GetCooldownRemainingTime(GNB.NoMercy) > 57 || HasEffect(GNB.Buffs.NoMercy) && IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup))
-                    {
-                        if (level >= GNB.Levels.DoubleDown)
-                        {
-                            if (IsEnabled(CustomComboPreset.GunbreakerDDonMain) && IsOffCooldown(GNB.DoubleDown) && gauge.Ammo >= 2 && !HasEffect(GNB.Buffs.ReadyToRip) && gauge.AmmoComboStep >= 1)
-                                return GNB.DoubleDown;
-                            if (IsEnabled(CustomComboPreset.GunbreakerSBOnMainComboFeature) && IsOffCooldown(GNB.SonicBreak) && IsOnCooldown(GNB.DoubleDown))
-                                return GNB.SonicBreak;
-                        }
-
-                        if (level < GNB.Levels.DoubleDown)
-                        {
-                            if (IsEnabled(CustomComboPreset.GunbreakerSBOnMainComboFeature) && level >= GNB.Levels.SonicBreak && IsOffCooldown(GNB.SonicBreak) && !HasEffect(GNB.Buffs.ReadyToRip))
-                                return GNB.SonicBreak;
-
-                            //sub level 54 functionality
-                            if (IsEnabled(CustomComboPreset.GunbreakerDZOnMainComboFeature) && level >= GNB.Levels.DangerZone && level < GNB.Levels.SonicBreak && IsOffCooldown(GNB.DangerZone))
-                                return OriginalHook(GNB.DangerZone);
-                        }
-                    }
-
-                    //Pre Gnashing Fang stuff
-                    if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= GNB.Levels.GnashingFang)
-                    {
-                        if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && IsOffCooldown(GNB.GnashingFang) && gauge.AmmoComboStep == 0 &&
-                            (gauge.Ammo == GNB.MaxCartridges(level) && GetCooldownRemainingTime(GNB.NoMercy) > 55 || //Regular 60 second GF/NM timing
-                            (gauge.Ammo > 0 && GetCooldownRemainingTime(GNB.NoMercy) > 17 && GetCooldownRemainingTime(GNB.NoMercy) < 35) || //Regular 30 second window                                                                        
-                            (gauge.Ammo == 3 && GetCooldownRemainingTime(GNB.Bloodfest) < 2 && GetCooldownRemainingTime(GNB.NoMercy) < 2) || //3 minute window
-                            (gauge.Ammo == 1 && GetCooldownRemainingTime(GNB.NoMercy) > 55 && IsOffCooldown(GNB.Bloodfest)))) //Opener Conditions
-                                return GNB.GnashingFang;
-                        if (gauge.AmmoComboStep is 1 or 2)
-                            return OriginalHook(GNB.GnashingFang);
-                    }
-
-                    if ((HasEffect(GNB.Buffs.NoMercy)|| HasEffect(All.Buffs.Medicated)) && gauge.AmmoComboStep == 0 && level >= GNB.Levels.BurstStrike)
-                    {
-                        if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
-                            return GNB.Hypervelocity;
-                        if (IsEnabled(CustomComboPreset.GunbreakerBSinNMFeature) && IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup) && gauge.Ammo != 0 && IsOnCooldown(GNB.GnashingFang))
-                            return GNB.BurstStrike;
-                    }
-
-                    //final check if Burst Strike is used right before No Mercy ends
-                    if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
-                        return GNB.Hypervelocity;
-
-                    // Regular 1-2-3 combo with overcap feature
-                    if (lastComboMove == GNB.KeenEdge && level >= GNB.Levels.BrutalShell)
-                        return GNB.BrutalShell;
-                    if (lastComboMove == GNB.BrutalShell && level >= GNB.Levels.SolidBarrel)
-                    {
-                        if (IsEnabled(CustomComboPreset.GunbreakerAmmoOvercapFeature))
-                        {
-                            if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
-                                return GNB.Hypervelocity;
-                            if (level >= GNB.Levels.BurstStrike && (gauge.Ammo == GNB.MaxCartridges(level) ||
-                                (IsEnabled(CustomComboPreset.GunbreakerBloodfestonST) && GetCooldownRemainingTime(GNB.Bloodfest) < 6 && gauge.Ammo != 0 && IsOnCooldown(GNB.NoMercy)))) //Burns Ammo for Bloodfest
-                                return GNB.BurstStrike;
-                        }
-
-                        return GNB.SolidBarrel;
-                    }
-                }
-
-                return GNB.KeenEdge;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class GunbreakerGnashingFangCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerGnashingFangCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == GNB.GnashingFang)
-            {
-                var gauge = GetJobGauge<GNBGauge>();
-
-                if (IsOffCooldown(GNB.NoMercy) &&CanDelayedWeave(actionID) && IsOffCooldown(GNB.GnashingFang) && IsEnabled(CustomComboPreset.GunbreakerNoMercyonGF))
-                    return GNB.NoMercy;
-
-                if (HasEffect(GNB.Buffs.NoMercy) && IsOnCooldown(GNB.GnashingFang))
-                {
-                    if (level >= GNB.Levels.DoubleDown)
-                    {
-                        if (IsEnabled(CustomComboPreset.GunbreakerDDOnGF) && IsOffCooldown(GNB.DoubleDown) && gauge.Ammo is 2 or 3 && !HasEffect(GNB.Buffs.ReadyToRip))
-                            return GNB.DoubleDown;
-                        if (IsOnCooldown(GNB.DoubleDown) && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF))
-                        {
-                            if (CanWeave(actionID))
+                            if (level >= Levels.NoMercy && IsOffCooldown(NoMercy))
                             {
-                                if (IsOffCooldown(GNB.DangerZone))
-                                    return OriginalHook(GNB.DangerZone);
-                                if (IsOffCooldown(GNB.BowShock))
-                                    return GNB.BowShock;
+                                if (level >= Levels.BurstStrike &&
+                                    ((gauge.Ammo == 1 && IsOffCooldown(GnashingFang) && IsOffCooldown(Bloodfest)) || //Opener Conditions
+                                    (gauge.Ammo == 2 && IsOnCooldown(GnashingFang) && GetCooldownRemainingTime(Bloodfest) < 3) || //GFNM windows
+                                    gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(GnashingFang) < 2)) //Regular NMGF
+                                    return NoMercy;
+                                if (level < Levels.BurstStrike) //no cartridges unlocked
+                                    return NoMercy;
+                            }
+                        }
+
+                        //oGCDs
+                        if (CanWeave(actionID))
+                        {
+                            if (IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup) && IsEnabled(CustomComboPreset.GunbreakerBloodfestonST))
+                            {
+                                if (gauge.Ammo == 0 && IsOffCooldown(Bloodfest) && level >= Levels.Bloodfest && IsOnCooldown(GnashingFang))
+                                    return Bloodfest;
                             }
 
-                            if (IsOffCooldown(GNB.SonicBreak))
-                                return GNB.SonicBreak;
-                        }
-                    }
+                            //Blasting Zone outside of NM
+                            if (IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup) && level >= Levels.DangerZone && IsOffCooldown(DangerZone))
+                            {
+                                if (IsEnabled(CustomComboPreset.GunbreakerDZOnMainComboFeature) && !HasEffect(Buffs.NoMercy) &&
+                                    ((IsOnCooldown(GnashingFang) && gauge.AmmoComboStep != 1 && GetCooldown(GnashingFang).CooldownRemaining > 20) || //Post Gnashing Fang
+                                    (level < Levels.GnashingFang) && IsOnCooldown(NoMercy))) //Pre Gnashing Fang
+                                    return OriginalHook(DangerZone);
+                            }
 
-                    if (level < GNB.Levels.DoubleDown && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF))
-                    {
-                        if (level >= GNB.Levels.SonicBreak && IsOffCooldown(GNB.SonicBreak) && !HasEffect(GNB.Buffs.ReadyToRip))
-                            return GNB.SonicBreak;
-                        if (IsOnCooldown(GNB.SonicBreak) && CanWeave(actionID))
+                            //60 second weaves
+                            if (IsOnCooldown(DoubleDown))
+                            {
+                                if (IsEnabled(CustomComboPreset.GunbreakerDZOnMainComboFeature) && IsOffCooldown(DangerZone))
+                                    return OriginalHook(DangerZone);
+                                if (IsEnabled(CustomComboPreset.GunbreakerBSOnMainComboFeature) && IsOffCooldown(BowShock))
+                                    return BowShock;
+                            }
+
+                            //30 second weaves
+                            if (IsOnCooldown(SonicBreak))
+                            {
+                                if (IsEnabled(CustomComboPreset.GunbreakerBSOnMainComboFeature) && level >= Levels.BowShock && IsOffCooldown(BowShock))
+                                    return BowShock;
+                                if (IsEnabled(CustomComboPreset.GunbreakerDZOnMainComboFeature) && level >= Levels.DangerZone && IsOffCooldown(DangerZone))
+                                    return OriginalHook(DangerZone);
+                            }
+
+                            //Continuation
+                            if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= Levels.Continuation &&
+                                (HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)) && level >= Levels.Continuation)
+                                return OriginalHook(Continuation);
+
+                            //Rough Divide Feature
+                            if (level >= Levels.RoughDivide && IsEnabled(CustomComboPreset.GunbreakerRoughDivideFeature) && GetRemainingCharges(RoughDivide) > roughDivideChargesRemaining)
+                            {
+                                if (IsNotEnabled(CustomComboPreset.GunbreakerMeleeRoughDivideOption) ||
+                                    (IsEnabled(CustomComboPreset.GunbreakerMeleeRoughDivideOption) && GetTargetDistance() <= 1 && HasEffect(Buffs.NoMercy) && IsOnCooldown(OriginalHook(DangerZone)) && IsOnCooldown(BowShock) && IsOnCooldown(Bloodfest)))
+                                    return RoughDivide;
+                            }
+                        }
+
+                        // 60s window features
+                        if (GetCooldownRemainingTime(NoMercy) > 57 || HasEffect(Buffs.NoMercy) && IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup))
                         {
-                            if (level >= GNB.Levels.BowShock && IsOffCooldown(GNB.BowShock))
-                                return GNB.BowShock;
-                            if (level >= GNB.Levels.DangerZone && IsOffCooldown(GNB.DangerZone))
-                                return OriginalHook(GNB.DangerZone);
+                            if (level >= Levels.DoubleDown)
+                            {
+                                if (IsEnabled(CustomComboPreset.GunbreakerDDonMain) && IsOffCooldown(DoubleDown) && gauge.Ammo >= 2 && !HasEffect(Buffs.ReadyToRip) && gauge.AmmoComboStep >= 1)
+                                    return DoubleDown;
+                                if (IsEnabled(CustomComboPreset.GunbreakerSBOnMainComboFeature) && IsOffCooldown(SonicBreak) && IsOnCooldown(DoubleDown))
+                                    return SonicBreak;
+                            }
+
+                            if (level < Levels.DoubleDown)
+                            {
+                                if (IsEnabled(CustomComboPreset.GunbreakerSBOnMainComboFeature) && level >= Levels.SonicBreak && IsOffCooldown(SonicBreak) && !HasEffect(Buffs.ReadyToRip))
+                                    return SonicBreak;
+
+                                //sub level 54 functionality
+                                if (IsEnabled(CustomComboPreset.GunbreakerDZOnMainComboFeature) && level >= Levels.DangerZone && level < Levels.SonicBreak && IsOffCooldown(DangerZone))
+                                    return OriginalHook(DangerZone);
+                            }
+                        }
+
+                        //Pre Gnashing Fang stuff
+                        if (IsEnabled(CustomComboPreset.GunbreakerGnashingFangOnMain) && level >= Levels.GnashingFang)
+                        {
+                            if (IsEnabled(CustomComboPreset.GunbreakerGFStartonMain) && IsOffCooldown(GnashingFang) && gauge.AmmoComboStep == 0 &&
+                                (gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(NoMercy) > 55 || //Regular 60 second GF/NM timing
+                                (gauge.Ammo > 0 && GetCooldownRemainingTime(NoMercy) > 17 && GetCooldownRemainingTime(NoMercy) < 35) || //Regular 30 second window                                                                        
+                                (gauge.Ammo == 3 && GetCooldownRemainingTime(Bloodfest) < 2 && GetCooldownRemainingTime(NoMercy) < 2) || //3 minute window
+                                (gauge.Ammo == 1 && GetCooldownRemainingTime(NoMercy) > 55 && IsOffCooldown(Bloodfest)))) //Opener Conditions
+                                return GnashingFang;
+                            if (gauge.AmmoComboStep is 1 or 2)
+                                return OriginalHook(GnashingFang);
+                        }
+
+                        if ((HasEffect(Buffs.NoMercy) || HasEffect(All.Buffs.Medicated)) && gauge.AmmoComboStep == 0 && level >= Levels.BurstStrike)
+                        {
+                            if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                                return Hypervelocity;
+                            if (IsEnabled(CustomComboPreset.GunbreakerBSinNMFeature) && IsEnabled(CustomComboPreset.GunbreakerMainComboCDsGroup) && gauge.Ammo != 0 && IsOnCooldown(GnashingFang))
+                                return BurstStrike;
+                        }
+
+                        //final check if Burst Strike is used right before No Mercy ends
+                        if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                            return Hypervelocity;
+
+                        // Regular 1-2-3 combo with overcap feature
+                        if (lastComboMove == KeenEdge && level >= Levels.BrutalShell)
+                            return BrutalShell;
+                        if (lastComboMove == BrutalShell && level >= Levels.SolidBarrel)
+                        {
+                            if (IsEnabled(CustomComboPreset.GunbreakerAmmoOvercapFeature))
+                            {
+                                if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                                    return Hypervelocity;
+                                if (level >= Levels.BurstStrike && (gauge.Ammo == MaxCartridges(level) ||
+                                    (IsEnabled(CustomComboPreset.GunbreakerBloodfestonST) && GetCooldownRemainingTime(Bloodfest) < 6 && gauge.Ammo != 0 && IsOnCooldown(NoMercy)))) //Burns Ammo for Bloodfest
+                                    return BurstStrike;
+                            }
+
+                            return SolidBarrel;
                         }
                     }
 
+                    return KeenEdge;
                 }
 
-                if (CanWeave(actionID))
-                {
-                    if (level >= GNB.Levels.DangerZone && IsOnCooldown(GNB.GnashingFang) && !HasEffect(GNB.Buffs.NoMercy) && IsOffCooldown(GNB.DangerZone) && gauge.AmmoComboStep != 1 && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF))
-                        return OriginalHook(GNB.DangerZone);
-                    if ((HasEffect(GNB.Buffs.ReadyToRip) || HasEffect(GNB.Buffs.ReadyToTear) || HasEffect(GNB.Buffs.ReadyToGouge)) && level >= GNB.Levels.Continuation)
-                        return OriginalHook(GNB.Continuation);
-                }
-
-                if ((gauge.AmmoComboStep == 0 && IsOffCooldown(GNB.GnashingFang)) || gauge.AmmoComboStep is 1 or 2)
-                    return OriginalHook(GNB.GnashingFang);
-                if (HasEffect(GNB.Buffs.NoMercy) && HasEffect(All.Buffs.Medicated) && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF) && gauge.AmmoComboStep == 0)
-                {
-                    if (level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast) && IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature))
-                        return GNB.Hypervelocity;
-                    if ((gauge.Ammo != 0) && level >= GNB.Levels.BurstStrike)
-                        return GNB.BurstStrike;
-                }
-                //final check if Burst Strike is used right before No Mercy ends
-                if (level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast) && IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature))
-                    return GNB.Hypervelocity;
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class GunbreakerBurstStrikeConFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerBurstStrikeConFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class GunbreakerGnashingFangCombo : CustomCombo
         {
-            if (actionID == GNB.BurstStrike)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerGnashingFangCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
-                    return GNB.Hypervelocity;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class GunbreakerDemonSlaughterCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerDemonSlaughterCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gauge = GetJobGauge<GNBGauge>();
-            if (actionID == GNB.DemonSlaughter)
-            {
-                if (CanWeave(actionID))
+                if (actionID == GnashingFang)
                 {
-                    if (IsEnabled(CustomComboPreset.GunbreakerNoMercyAOEOption) && IsOffCooldown(GNB.NoMercy) && level >= GNB.Levels.NoMercy)
-                        return GNB.NoMercy;
-                    if (IsEnabled(CustomComboPreset.GunbreakerBloodfestAOEOption) && gauge.Ammo == 0 && IsOffCooldown(GNB.Bloodfest) && level >= GNB.Levels.Bloodfest)
-                        return GNB.Bloodfest;
+                    var gauge = GetJobGauge<GNBGauge>();
+
+                    if (IsOffCooldown(NoMercy) && CanDelayedWeave(actionID) && IsOffCooldown(GnashingFang) && IsEnabled(CustomComboPreset.GunbreakerNoMercyonGF))
+                        return NoMercy;
+
+                    if (HasEffect(Buffs.NoMercy) && IsOnCooldown(GnashingFang))
+                    {
+                        if (level >= Levels.DoubleDown)
+                        {
+                            if (IsEnabled(CustomComboPreset.GunbreakerDDOnGF) && IsOffCooldown(DoubleDown) && gauge.Ammo is 2 or 3 && !HasEffect(Buffs.ReadyToRip))
+                                return DoubleDown;
+                            if (IsOnCooldown(DoubleDown) && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF))
+                            {
+                                if (CanWeave(actionID))
+                                {
+                                    if (IsOffCooldown(DangerZone))
+                                        return OriginalHook(DangerZone);
+                                    if (IsOffCooldown(BowShock))
+                                        return BowShock;
+                                }
+
+                                if (IsOffCooldown(SonicBreak))
+                                    return SonicBreak;
+                            }
+                        }
+
+                        if (level < Levels.DoubleDown && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF))
+                        {
+                            if (level >= Levels.SonicBreak && IsOffCooldown(SonicBreak) && !HasEffect(Buffs.ReadyToRip))
+                                return SonicBreak;
+                            if (IsOnCooldown(SonicBreak) && CanWeave(actionID))
+                            {
+                                if (level >= Levels.BowShock && IsOffCooldown(BowShock))
+                                    return BowShock;
+                                if (level >= Levels.DangerZone && IsOffCooldown(DangerZone))
+                                    return OriginalHook(DangerZone);
+                            }
+                        }
+
+                    }
+
+                    if (CanWeave(actionID))
+                    {
+                        if (level >= Levels.DangerZone && IsOnCooldown(GnashingFang) && !HasEffect(Buffs.NoMercy) && IsOffCooldown(DangerZone) && gauge.AmmoComboStep != 1 && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF))
+                            return OriginalHook(DangerZone);
+                        if ((HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)) && level >= Levels.Continuation)
+                            return OriginalHook(Continuation);
+                    }
+
+                    if ((gauge.AmmoComboStep == 0 && IsOffCooldown(GnashingFang)) || gauge.AmmoComboStep is 1 or 2)
+                        return OriginalHook(GnashingFang);
+                    if (HasEffect(Buffs.NoMercy) && HasEffect(All.Buffs.Medicated) && IsEnabled(CustomComboPreset.GunbreakerCDsOnGF) && gauge.AmmoComboStep == 0)
+                    {
+                        if (level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast) && IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature))
+                            return Hypervelocity;
+                        if ((gauge.Ammo != 0) && level >= Levels.BurstStrike)
+                            return BurstStrike;
+                    }
+                    //final check if Burst Strike is used right before No Mercy ends
+                    if (level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast) && IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature))
+                        return Hypervelocity;
                 }
 
-                if (IsEnabled(CustomComboPreset.GunbreakerDoubleDownAOEOption) && gauge.Ammo >= 2 && IsOffCooldown(GNB.DoubleDown) && level >= GNB.Levels.DoubleDown)
-                    return GNB.DoubleDown;
-                if (IsEnabled(CustomComboPreset.GunbreakerBloodfestAOEOption) && gauge.Ammo != 0 && GetCooldownRemainingTime(GNB.Bloodfest) < 6 &&  level >= GNB.Levels.FatedCircle)
-                    return GNB.FatedCircle;
+                return actionID;
+            }
+        }
 
-                if (comboTime > 0 && lastComboMove == GNB.DemonSlice && level >= GNB.Levels.DemonSlaughter)
+        internal class GunbreakerBurstStrikeConFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerBurstStrikeConFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == BurstStrike)
                 {
-                    if (IsEnabled(CustomComboPreset.GunbreakerAmmoOvercapFeature) && level >= GNB.Levels.FatedCircle && gauge.Ammo == GNB.MaxCartridges(level))
-                            return GNB.FatedCircle;
-                    if (IsEnabled(CustomComboPreset.GunbreakerBowShockFeature) && level >= GNB.Levels.BowShock && IsOffCooldown(GNB.BowShock))
-                            return GNB.BowShock;
-                    return GNB.DemonSlaughter;
+                    if (level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                        return Hypervelocity;
                 }
 
-                return GNB.DemonSlice;
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class GunbreakerBloodfestOvercapFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerBloodfestOvercapFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class GunbreakerDemonSlaughterCombo : CustomCombo
         {
-            var gauge = GetJobGauge<GNBGauge>().Ammo;
-            if (actionID == GNB.BurstStrike)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerDemonSlaughterCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= GNB.Levels.EnhancedContinuation && HasEffect(GNB.Buffs.ReadyToBlast))
-                    return GNB.Hypervelocity;
-                if (gauge == 0 && level >= GNB.Levels.Bloodfest)
-                    return GNB.Bloodfest;
+                var gauge = GetJobGauge<GNBGauge>();
+                if (actionID == DemonSlaughter)
+                {
+                    if (CanWeave(actionID))
+                    {
+                        if (IsEnabled(CustomComboPreset.GunbreakerNoMercyAOEOption) && IsOffCooldown(NoMercy) && level >= Levels.NoMercy)
+                            return NoMercy;
+                        if (IsEnabled(CustomComboPreset.GunbreakerBloodfestAOEOption) && gauge.Ammo == 0 && IsOffCooldown(Bloodfest) && level >= Levels.Bloodfest)
+                            return Bloodfest;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.GunbreakerDoubleDownAOEOption) && gauge.Ammo >= 2 && IsOffCooldown(DoubleDown) && level >= Levels.DoubleDown)
+                        return DoubleDown;
+                    if (IsEnabled(CustomComboPreset.GunbreakerBloodfestAOEOption) && gauge.Ammo != 0 && GetCooldownRemainingTime(Bloodfest) < 6 && level >= Levels.FatedCircle)
+                        return FatedCircle;
+
+                    if (comboTime > 0 && lastComboMove == DemonSlice && level >= Levels.DemonSlaughter)
+                    {
+                        if (IsEnabled(CustomComboPreset.GunbreakerAmmoOvercapFeature) && level >= Levels.FatedCircle && gauge.Ammo == MaxCartridges(level))
+                            return FatedCircle;
+                        if (IsEnabled(CustomComboPreset.GunbreakerBowShockFeature) && level >= Levels.BowShock && IsOffCooldown(BowShock))
+                            return BowShock;
+                        return DemonSlaughter;
+                    }
+
+                    return DemonSlice;
+                }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class GunbreakerDDonBurstStrikeFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerDDonBurstStrikeFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class GunbreakerBloodfestOvercapFeature : CustomCombo
         {
-            var gauge = GetJobGauge<GNBGauge>().Ammo;
-            if (actionID == GNB.BurstStrike)
-            {
-                if (HasEffect(GNB.Buffs.NoMercy) && IsOffCooldown(GNB.DoubleDown) && gauge >= 2)
-                    return GNB.DoubleDown;
-            }
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerBloodfestOvercapFeature;
 
-            return actionID;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var gauge = GetJobGauge<GNBGauge>().Ammo;
+                if (actionID == BurstStrike)
+                {
+                    if (IsEnabled(CustomComboPreset.GunbreakerBurstStrikeConFeature) && level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                        return Hypervelocity;
+                    if (gauge == 0 && level >= Levels.Bloodfest)
+                        return Bloodfest;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class GunbreakerDDonBurstStrikeFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GunbreakerDDonBurstStrikeFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var gauge = GetJobGauge<GNBGauge>().Ammo;
+                if (actionID == BurstStrike)
+                {
+                    if (HasEffect(Buffs.NoMercy) && IsOffCooldown(DoubleDown) && gauge >= 2)
+                        return DoubleDown;
+                }
+
+                return actionID;
+            }
         }
     }
-    
 }

--- a/XIVSlothCombo/Combos/MCH.cs
+++ b/XIVSlothCombo/Combos/MCH.cs
@@ -73,521 +73,523 @@ namespace XIVSlothComboPlugin.Combos
                 BarrelStabilizer = 66,
                 ChainSaw = 90;
         }
-    }
 
-    internal class MachinistMainCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistMainCombo;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class MachinistMainCombo : CustomCombo
         {
-            if (actionID == MCH.CleanShot || actionID == MCH.HeatedCleanShot || actionID == MCH.SplitShot || actionID == MCH.HeatedSplitShot)
-            {
-                var gauge = GetJobGauge<MCHGauge>();
-                var drillCD = GetCooldown(MCH.Drill);
-                var airAnchorCD = GetCooldown(MCH.AirAnchor);
-                var hotshotCD = GetCooldown(MCH.HotShot);
-                var reassembleCD = GetCooldown(MCH.Reassemble);
-                var heatBlastCD = GetCooldown(MCH.HeatBlast);
-                var gaussCD = GetCooldown(MCH.GaussRound);
-                var ricochetCD = GetCooldown(MCH.Ricochet);
-                var chainsawCD = GetCooldown(MCH.ChainSaw);
-                var barrelCD = GetCooldown(MCH.BarrelStabilizer);
-                var battery = GetJobGauge<MCHGauge>().Battery;
-                var heat = GetJobGauge<MCHGauge>().Heat;
-                if (IsEnabled(CustomComboPreset.BarrelStabilizerDrift))
-                {
-                    if (level >= MCH.Levels.BarrelStabilizer && heat < 20 && GetCooldown(actionID).CooldownRemaining > 0.7 && IsOffCooldown(MCH.BarrelStabilizer))
-                        return MCH.BarrelStabilizer;
-                }
-
-                if (IsEnabled(CustomComboPreset.MachinistHeatBlastOnMainCombo) && gauge.IsOverheated)
-                {
-                    if (heatBlastCD.CooldownRemaining < 0.7 && level >= MCH.Levels.HeatBlast ) // prioritize heatblast
-                        return MCH.HeatBlast;
-                    if (level <= 49)
-                        return MCH.GaussRound;
-                    if (gaussCD.CooldownRemaining < ricochetCD.CooldownRemaining)
-                        return MCH.GaussRound;
-                    else
-                        return MCH.Ricochet;
-                }
-                if (IsEnabled(CustomComboPreset.MachinistDrillAirOnMainCombo))
-                {
-                    if (HasEffect(MCH.Buffs.Reassembled) && !airAnchorCD.IsCooldown && level >= MCH.Levels.AirAnchor)
-                        return MCH.AirAnchor;
-                    if (airAnchorCD.IsCooldown && !drillCD.IsCooldown && level >= MCH.Levels.Drill)
-                        return MCH.Drill;
-                    if (HasEffect(MCH.Buffs.Reassembled) && !chainsawCD.IsCooldown && level >= 90)
-                        return MCH.ChainSaw;
-                }
-                if (IsEnabled(CustomComboPreset.MachinistRicochetGaussChargesMainCombo))
-                {
-                    if (level >= MCH.Levels.Ricochet && HasCharges(MCH.Ricochet) && GetCooldown(MCH.CleanShot).CooldownRemaining > 0.6) //0.6 instead of 0.7 to more easily fit opener. a
-                        return MCH.Ricochet;
-                    if (level >= MCH.Levels.GaussRound && HasCharges(MCH.GaussRound) && GetCooldown(MCH.CleanShot).CooldownRemaining > 0.6)
-                        return MCH.GaussRound;
-
-                }
-                if (IsEnabled(CustomComboPreset.MachinistRicochetGaussMainCombo))
-                {
-                    if (level >= MCH.Levels.Ricochet && ricochetCD.CooldownRemaining <= 30 && GetCooldown(MCH.CleanShot).CooldownRemaining > 0.6) //0.6 instead of 0.7 to more easily fit opener. a
-                        return MCH.Ricochet;
-                    if (level >= MCH.Levels.GaussRound && gaussCD.CooldownRemaining <= 30 && GetCooldown(MCH.CleanShot).CooldownRemaining > 0.6)
-                        return MCH.GaussRound;
-
-                }
-                if (IsEnabled(CustomComboPreset.MachinistAlternateMainCombo))
-                {
-                    if (reassembleCD.CooldownRemaining >= 55 && !airAnchorCD.IsCooldown && level >= 76)
-                        return MCH.AirAnchor;
-                    if (reassembleCD.CooldownRemaining >= 55 && !drillCD.IsCooldown && level >= 58)
-                        return MCH.Drill;
-                    if (reassembleCD.CooldownRemaining >= 55 && !hotshotCD.IsCooldown && level <= 75)
-                        return MCH.HotShot;
-                    else
-                    if (level >= 84)
-                    {
-                        if (HasEffect(MCH.Buffs.Reassembled) && reassembleCD.CooldownRemaining <= 55 && !airAnchorCD.IsCooldown)
-                            return MCH.AirAnchor;
-                        if (reassembleCD.CooldownRemaining >= 55 && !chainsawCD.IsCooldown && level >= 90)
-                            return MCH.ChainSaw;
-                        if (HasEffect(MCH.Buffs.Reassembled) && reassembleCD.CooldownRemaining <= 110 && !drillCD.IsCooldown)
-                            return MCH.Drill;
-                    }
-                }
-                if (IsEnabled(CustomComboPreset.MachinistOverChargeOption))
-                {
-                    if (battery == 100 && level >= 40 && level <= 79 && GetCooldown(MCH.CleanShot).CooldownRemaining > 0.7)
-                        return MCH.RookAutoturret;
-                    if (battery == 100 && level >= 80 && GetCooldown(MCH.CleanShot).CooldownRemaining > 0.7)
-                        return MCH.AutomatonQueen;
-                }
-                if (comboTime > 0)
-                {
-                    if (lastComboMove == MCH.SplitShot && level >= MCH.Levels.SlugShot)
-                        return OriginalHook(MCH.SlugShot);
-
-                    if (lastComboMove == MCH.SlugShot && level >= MCH.Levels.CleanShot)
-                        return OriginalHook(MCH.CleanShot);
-                }
-                return OriginalHook(MCH.SplitShot);
-            }
-            return actionID;
-
-        }
-    }
-    internal class MachinistHeatblastGaussRicochetFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistHeatblastGaussRicochetFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MCH.HeatBlast)
-            {
-                var wildfireCD = GetCooldown(MCH.Wildfire);
-                var heatBlastCD = GetCooldown(MCH.HeatBlast);
-                var gaussCD = GetCooldown(MCH.GaussRound);
-                var ricochetCD = GetCooldown(MCH.Ricochet);
-
-                var gauge = GetJobGauge<MCHGauge>();
-                var heat = GetJobGauge<MCHGauge>().Heat;
-                if (IsEnabled(CustomComboPreset.MachinistAutoBarrel) && heat < 50 && IsOffCooldown(MCH.BarrelStabilizer) && level >= 66)
-                    return MCH.BarrelStabilizer;
-
-                if (!wildfireCD.IsCooldown && level >= MCH.Levels.Wildfire && heat >= 50 && IsEnabled(CustomComboPreset.MachinistWildfireFeature))
-                    return MCH.Wildfire;
-
-                if (!gauge.IsOverheated && level >= MCH.Levels.Hypercharge)
-                    return MCH.Hypercharge;
-
-                if (heatBlastCD.CooldownRemaining < 0.7 && level >= MCH.Levels.HeatBlast) // Prioritize Heat Blast
-                    return MCH.HeatBlast;
-
-                if (level <= 49)
-                    return MCH.GaussRound;
-
-                if (gaussCD.CooldownRemaining < ricochetCD.CooldownRemaining)
-                    return MCH.GaussRound;
-                    return MCH.Ricochet;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class MachinistGaussRoundRicochetFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistGaussRoundRicochetFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MCH.GaussRound || actionID == MCH.Ricochet)
-            {
-                var gaussCd = GetCooldown(MCH.GaussRound);
-                var ricochetCd = GetCooldown(MCH.Ricochet);
-
-                // Prioritize the original if both are off cooldown
-                if (level <= 49)
-                    return MCH.GaussRound;
-
-                if (!gaussCd.IsCooldown && !ricochetCd.IsCooldown)
-                    return actionID;
-
-                if (gaussCd.CooldownRemaining < ricochetCd.CooldownRemaining)
-                    return MCH.GaussRound;
-                else
-                    return MCH.Ricochet;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class MachinistSpreadShotFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistSpreadShotFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MCH.SpreadShot || actionID == MCH.Scattergun)
-            {
-                var canWeave = CanWeave(actionID);
-
-                var battery = GetJobGauge<MCHGauge>().Battery;
-                if (IsEnabled(CustomComboPreset.MachinistAoEOverChargeOption) && canWeave)
-                {
-                    if (battery == 100 && level >= MCH.Levels.QueenOverdrive)
-                        return MCH.AutomatonQueen;
-                    if (battery == 100 && level >= MCH.Levels.RookOverdrive)
-                        return MCH.RookAutoturret;
-                }
-                var gauge = GetJobGauge<MCHGauge>();
-
-                if (IsEnabled(CustomComboPreset.MachinistAoEHyperchargeFeature) && canWeave)
-                {
-                    if (gauge.Heat >= 50 && level >= MCH.Levels.Hypercharge && !gauge.IsOverheated)
-                        return MCH.Hypercharge;
-                }
-
-                if (IsEnabled(CustomComboPreset.MachinistAoEGaussRicochetFeature) && canWeave && (IsEnabled(CustomComboPreset.MachinistAoEGaussOption) || gauge.IsOverheated) && (HasCharges(MCH.Ricochet) || HasCharges(MCH.GaussRound)))
-                {
-                    var gaussCharges = GetRemainingCharges(MCH.GaussRound);
-                    var ricochetCharges = GetRemainingCharges(MCH.Ricochet);
-
-                    if ((gaussCharges >= ricochetCharges || level < MCH.Levels.Ricochet) &&
-                        level >= MCH.Levels.GaussRound)
-                        return MCH.GaussRound;
-                    else if (ricochetCharges > 0 && level >= MCH.Levels.Ricochet)
-                        return MCH.Ricochet;
-
-                }
-
-                if (gauge.IsOverheated && level >= MCH.Levels.AutoCrossbow)
-                    return MCH.AutoCrossbow;
-
-                var bioblaster = GetCooldown(MCH.BioBlaster);
-                if (!bioblaster.IsCooldown && level >= MCH.Levels.BioBlaster && !gauge.IsOverheated && IsEnabled(CustomComboPreset.MachinistBioblasterFeature))
-                    return MCH.BioBlaster;
-
-
-
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class MachinistOverdriveFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistOverdriveFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MCH.RookAutoturret || actionID == MCH.AutomatonQueen)
-            {
-                var gauge = GetJobGauge<MCHGauge>();
-                if (gauge.IsRobotActive)
-                    return OriginalHook(MCH.QueenOverdrive);
-            }
-
-            return actionID;
-        }
-
-        internal class MachinistHotShotDrillChainsawFeature : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistHotShotDrillChainsawFeature;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistMainCombo;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID == MCH.Drill || actionID == MCH.HotShot || actionID == MCH.AirAnchor)
+                if (actionID == CleanShot || actionID == HeatedCleanShot || actionID == SplitShot || actionID == HeatedSplitShot)
                 {
-                    if (level >= MCH.Levels.ChainSaw)
-                        return CalcBestAction(actionID, MCH.ChainSaw, MCH.AirAnchor, MCH.Drill);
+                    var gauge = GetJobGauge<MCHGauge>();
+                    var drillCD = GetCooldown(Drill);
+                    var airAnchorCD = GetCooldown(AirAnchor);
+                    var hotshotCD = GetCooldown(HotShot);
+                    var reassembleCD = GetCooldown(Reassemble);
+                    var heatBlastCD = GetCooldown(HeatBlast);
+                    var gaussCD = GetCooldown(GaussRound);
+                    var ricochetCD = GetCooldown(Ricochet);
+                    var chainsawCD = GetCooldown(ChainSaw);
+                    var barrelCD = GetCooldown(BarrelStabilizer);
+                    var battery = GetJobGauge<MCHGauge>().Battery;
+                    var heat = GetJobGauge<MCHGauge>().Heat;
+                    if (IsEnabled(CustomComboPreset.BarrelStabilizerDrift))
+                    {
+                        if (level >= Levels.BarrelStabilizer && heat < 20 && GetCooldown(actionID).CooldownRemaining > 0.7 && IsOffCooldown(BarrelStabilizer))
+                            return BarrelStabilizer;
+                    }
 
-                    if (level >= MCH.Levels.AirAnchor)
-                        return CalcBestAction(actionID, MCH.AirAnchor, MCH.Drill);
+                    if (IsEnabled(CustomComboPreset.MachinistHeatBlastOnMainCombo) && gauge.IsOverheated)
+                    {
+                        if (heatBlastCD.CooldownRemaining < 0.7 && level >= Levels.HeatBlast) // prioritize heatblast
+                            return HeatBlast;
+                        if (level <= 49)
+                            return GaussRound;
+                        if (gaussCD.CooldownRemaining < ricochetCD.CooldownRemaining)
+                            return GaussRound;
+                        else
+                            return Ricochet;
+                    }
+                    if (IsEnabled(CustomComboPreset.MachinistDrillAirOnMainCombo))
+                    {
+                        if (HasEffect(Buffs.Reassembled) && !airAnchorCD.IsCooldown && level >= Levels.AirAnchor)
+                            return AirAnchor;
+                        if (airAnchorCD.IsCooldown && !drillCD.IsCooldown && level >= Levels.Drill)
+                            return Drill;
+                        if (HasEffect(Buffs.Reassembled) && !chainsawCD.IsCooldown && level >= 90)
+                            return ChainSaw;
+                    }
+                    if (IsEnabled(CustomComboPreset.MachinistRicochetGaussChargesMainCombo))
+                    {
+                        if (level >= Levels.Ricochet && HasCharges(Ricochet) && GetCooldown(CleanShot).CooldownRemaining > 0.6) //0.6 instead of 0.7 to more easily fit opener. a
+                            return Ricochet;
+                        if (level >= Levels.GaussRound && HasCharges(GaussRound) && GetCooldown(CleanShot).CooldownRemaining > 0.6)
+                            return GaussRound;
 
-                    if (level >= MCH.Levels.Drill)
-                        return CalcBestAction(actionID, MCH.Drill, MCH.HotShot);
+                    }
+                    if (IsEnabled(CustomComboPreset.MachinistRicochetGaussMainCombo))
+                    {
+                        if (level >= Levels.Ricochet && ricochetCD.CooldownRemaining <= 30 && GetCooldown(CleanShot).CooldownRemaining > 0.6) //0.6 instead of 0.7 to more easily fit opener. a
+                            return Ricochet;
+                        if (level >= Levels.GaussRound && gaussCD.CooldownRemaining <= 30 && GetCooldown(CleanShot).CooldownRemaining > 0.6)
+                            return GaussRound;
 
-                    return MCH.HotShot;
+                    }
+                    if (IsEnabled(CustomComboPreset.MachinistAlternateMainCombo))
+                    {
+                        if (reassembleCD.CooldownRemaining >= 55 && !airAnchorCD.IsCooldown && level >= 76)
+                            return AirAnchor;
+                        if (reassembleCD.CooldownRemaining >= 55 && !drillCD.IsCooldown && level >= 58)
+                            return Drill;
+                        if (reassembleCD.CooldownRemaining >= 55 && !hotshotCD.IsCooldown && level <= 75)
+                            return HotShot;
+                        else
+                        if (level >= 84)
+                        {
+                            if (HasEffect(Buffs.Reassembled) && reassembleCD.CooldownRemaining <= 55 && !airAnchorCD.IsCooldown)
+                                return AirAnchor;
+                            if (reassembleCD.CooldownRemaining >= 55 && !chainsawCD.IsCooldown && level >= 90)
+                                return ChainSaw;
+                            if (HasEffect(Buffs.Reassembled) && reassembleCD.CooldownRemaining <= 110 && !drillCD.IsCooldown)
+                                return Drill;
+                        }
+                    }
+                    if (IsEnabled(CustomComboPreset.MachinistOverChargeOption))
+                    {
+                        if (battery == 100 && level >= 40 && level <= 79 && GetCooldown(CleanShot).CooldownRemaining > 0.7)
+                            return RookAutoturret;
+                        if (battery == 100 && level >= 80 && GetCooldown(CleanShot).CooldownRemaining > 0.7)
+                            return AutomatonQueen;
+                    }
+                    if (comboTime > 0)
+                    {
+                        if (lastComboMove == SplitShot && level >= Levels.SlugShot)
+                            return OriginalHook(SlugShot);
+
+                        if (lastComboMove == SlugShot && level >= Levels.CleanShot)
+                            return OriginalHook(CleanShot);
+                    }
+                    return OriginalHook(SplitShot);
+                }
+                return actionID;
+
+            }
+        }
+        internal class MachinistHeatblastGaussRicochetFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistHeatblastGaussRicochetFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == HeatBlast)
+                {
+                    var wildfireCD = GetCooldown(Wildfire);
+                    var heatBlastCD = GetCooldown(HeatBlast);
+                    var gaussCD = GetCooldown(GaussRound);
+                    var ricochetCD = GetCooldown(Ricochet);
+
+                    var gauge = GetJobGauge<MCHGauge>();
+                    var heat = GetJobGauge<MCHGauge>().Heat;
+                    if (IsEnabled(CustomComboPreset.MachinistAutoBarrel) && heat < 50 && IsOffCooldown(BarrelStabilizer) && level >= 66)
+                        return BarrelStabilizer;
+
+                    if (!wildfireCD.IsCooldown && level >= Levels.Wildfire && heat >= 50 && IsEnabled(CustomComboPreset.MachinistWildfireFeature))
+                        return Wildfire;
+
+                    if (!gauge.IsOverheated && level >= Levels.Hypercharge)
+                        return Hypercharge;
+
+                    if (heatBlastCD.CooldownRemaining < 0.7 && level >= Levels.HeatBlast) // Prioritize Heat Blast
+                        return HeatBlast;
+
+                    if (level <= 49)
+                        return GaussRound;
+
+                    if (gaussCD.CooldownRemaining < ricochetCD.CooldownRemaining)
+                        return GaussRound;
+                    return Ricochet;
                 }
 
                 return actionID;
             }
         }
-    }
-    internal class MachinistAutoCrossBowGaussRicochetFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistAutoCrossBowGaussRicochetFeature;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class MachinistGaussRoundRicochetFeature : CustomCombo
         {
-            if (actionID == MCH.AutoCrossbow)
-            {
-                var heatBlastCD = GetCooldown(MCH.HeatBlast);
-                var gaussCD = GetCooldown(MCH.GaussRound);
-                var ricochetCD = GetCooldown(MCH.Ricochet);
-                var heat = GetJobGauge<MCHGauge>().Heat;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistGaussRoundRicochetFeature;
 
-                var gauge = GetJobGauge<MCHGauge>();
-                if (IsEnabled(CustomComboPreset.MachinistAutoBarrel) && heat < 50 && IsOffCooldown(MCH.BarrelStabilizer) && level >= 66)
-                    return MCH.BarrelStabilizer;
-                if (!gauge.IsOverheated && level >= MCH.Levels.Hypercharge)
-                    return MCH.Hypercharge;
-                if (heatBlastCD.CooldownRemaining < 0.7 && level >= MCH.Levels.AutoCrossbow) // prioritize autocrossbow
-                    return MCH.AutoCrossbow;
-                if (level <= 49)
-                    return MCH.GaussRound;
-                if (gaussCD.CooldownRemaining < ricochetCD.CooldownRemaining)
-                    return MCH.GaussRound;
-                else
-                    return MCH.Ricochet;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == GaussRound || actionID == Ricochet)
+                {
+                    var gaussCd = GetCooldown(GaussRound);
+                    var ricochetCd = GetCooldown(Ricochet);
+
+                    // Prioritize the original if both are off cooldown
+                    if (level <= 49)
+                        return GaussRound;
+
+                    if (!gaussCd.IsCooldown && !ricochetCd.IsCooldown)
+                        return actionID;
+
+                    if (gaussCd.CooldownRemaining < ricochetCd.CooldownRemaining)
+                        return GaussRound;
+                    else
+                        return Ricochet;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class MachinistSpreadShotFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistSpreadShotFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == SpreadShot || actionID == Scattergun)
+                {
+                    var canWeave = CanWeave(actionID);
+
+                    var battery = GetJobGauge<MCHGauge>().Battery;
+                    if (IsEnabled(CustomComboPreset.MachinistAoEOverChargeOption) && canWeave)
+                    {
+                        if (battery == 100 && level >= Levels.QueenOverdrive)
+                            return AutomatonQueen;
+                        if (battery == 100 && level >= Levels.RookOverdrive)
+                            return RookAutoturret;
+                    }
+                    var gauge = GetJobGauge<MCHGauge>();
+
+                    if (IsEnabled(CustomComboPreset.MachinistAoEHyperchargeFeature) && canWeave)
+                    {
+                        if (gauge.Heat >= 50 && level >= Levels.Hypercharge && !gauge.IsOverheated)
+                            return Hypercharge;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.MachinistAoEGaussRicochetFeature) && canWeave && (IsEnabled(CustomComboPreset.MachinistAoEGaussOption) || gauge.IsOverheated) && (HasCharges(Ricochet) || HasCharges(GaussRound)))
+                    {
+                        var gaussCharges = GetRemainingCharges(GaussRound);
+                        var ricochetCharges = GetRemainingCharges(Ricochet);
+
+                        if ((gaussCharges >= ricochetCharges || level < Levels.Ricochet) &&
+                            level >= Levels.GaussRound)
+                            return GaussRound;
+                        else if (ricochetCharges > 0 && level >= Levels.Ricochet)
+                            return Ricochet;
+
+                    }
+
+                    if (gauge.IsOverheated && level >= Levels.AutoCrossbow)
+                        return AutoCrossbow;
+
+                    var bioblaster = GetCooldown(BioBlaster);
+                    if (!bioblaster.IsCooldown && level >= Levels.BioBlaster && !gauge.IsOverheated && IsEnabled(CustomComboPreset.MachinistBioblasterFeature))
+                        return BioBlaster;
+
+
+
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class MachinistOverdriveFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistOverdriveFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == RookAutoturret || actionID == AutomatonQueen)
+                {
+                    var gauge = GetJobGauge<MCHGauge>();
+                    if (gauge.IsRobotActive)
+                        return OriginalHook(QueenOverdrive);
+                }
+
+                return actionID;
             }
 
-            return actionID;
-        }
-    }
-
-    internal class MachinistSimpleFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistSimpleFeature;
-        internal static bool openerFinished = false;
-        
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if ( actionID is MCH.SplitShot or MCH.HeatedSplitShot )
+            internal class MachinistHotShotDrillChainsawFeature : CustomCombo
             {
-                var inCombat = InCombat();
-                var gauge = GetJobGauge<MCHGauge>();
-                var canWeaveNormal = CanWeave(actionID);
+                protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistHotShotDrillChainsawFeature;
 
-                if (!inCombat)
+                protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
                 {
-                    openerFinished = false;
-                    
-                }
-
-                if (canWeaveNormal && IsEnabled(CustomComboPreset.MachinistSimpleStabilizer) && gauge.Heat <= 55 &&
-                        IsOffCooldown(MCH.BarrelStabilizer) && level >= MCH.Levels.BarrelStabilizer &&
-                        GetCooldown(MCH.Wildfire).CooldownRemaining < 8)
-                    return MCH.BarrelStabilizer;
-
-                if (canWeaveNormal && IsEnabled(CustomComboPreset.MachinistSimpleInterrupt) && CanInterruptEnemy() && IsOffCooldown(All.HeadGraze))
-                {
-                    return All.HeadGraze;
-                }
-
-                if (canWeaveNormal && openerFinished && !gauge.IsRobotActive && IsEnabled(CustomComboPreset.MachinistSimpleGadget))
-                {
-                    //overflow protection
-                    if (gauge.Battery == 100)
+                    if (actionID == Drill || actionID == HotShot || actionID == AirAnchor)
                     {
-                        if (level >= MCH.Levels.QueenOverdrive)
-                        {
-                            return MCH.AutomatonQueen;
-                        }
+                        if (level >= Levels.ChainSaw)
+                            return CalcBestAction(actionID, ChainSaw, AirAnchor, Drill);
 
-                        if (level >= MCH.Levels.RookOverdrive)
-                        {
-                            return MCH.RookAutoturret;
-                        }
-                    }
-                    else if (gauge.Battery >= 50 && (CombatEngageDuration().Seconds >= 55 || CombatEngageDuration().Seconds <= 05))
-                    {
-                        if (level >= MCH.Levels.QueenOverdrive)
-                        {
-                            return MCH.AutomatonQueen;
-                        }
+                        if (level >= Levels.AirAnchor)
+                            return CalcBestAction(actionID, AirAnchor, Drill);
 
-                        if (level >= MCH.Levels.RookOverdrive)
-                        {
-                            return MCH.RookAutoturret;
-                        }
-                    }
-                    else if (gauge.LastSummonBatteryPower == 0 && gauge.Battery >= 50)
-                    {
-                        if (level >= MCH.Levels.QueenOverdrive)
-                        {
-                            return MCH.AutomatonQueen;
-                        }
+                        if (level >= Levels.Drill)
+                            return CalcBestAction(actionID, Drill, HotShot);
 
-                        if (level >= MCH.Levels.RookOverdrive)
-                        {
-                            return MCH.RookAutoturret;
-                        }
+                        return HotShot;
                     }
 
+                    return actionID;
+                }
+            }
+        }
+        internal class MachinistAutoCrossBowGaussRicochetFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistAutoCrossBowGaussRicochetFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == AutoCrossbow)
+                {
+                    var heatBlastCD = GetCooldown(HeatBlast);
+                    var gaussCD = GetCooldown(GaussRound);
+                    var ricochetCD = GetCooldown(Ricochet);
+                    var heat = GetJobGauge<MCHGauge>().Heat;
+
+                    var gauge = GetJobGauge<MCHGauge>();
+                    if (IsEnabled(CustomComboPreset.MachinistAutoBarrel) && heat < 50 && IsOffCooldown(BarrelStabilizer) && level >= 66)
+                        return BarrelStabilizer;
+                    if (!gauge.IsOverheated && level >= Levels.Hypercharge)
+                        return Hypercharge;
+                    if (heatBlastCD.CooldownRemaining < 0.7 && level >= Levels.AutoCrossbow) // prioritize autocrossbow
+                        return AutoCrossbow;
+                    if (level <= 49)
+                        return GaussRound;
+                    if (gaussCD.CooldownRemaining < ricochetCD.CooldownRemaining)
+                        return GaussRound;
+                    else
+                        return Ricochet;
                 }
 
-                if (canWeaveNormal && gauge.Heat >= 50 && openerFinished && IsOffCooldown(MCH.Wildfire) && level >= MCH.Levels.Wildfire &&
-                        IsEnabled(CustomComboPreset.MachinistSimpleWildCharge))
-                {
-                    if (CombatEngageDuration().Minutes == 0 && GetRemainingCharges(MCH.Reassemble) == 0 && CanDelayedWeave(actionID) ) return MCH.Wildfire;
-                    else if (CombatEngageDuration().Minutes > 0 && (GetCooldownRemainingTime(MCH.ChainSaw) > 50 || level < MCH.Levels.ChainSaw) ) return MCH.Wildfire;
-                }     
+                return actionID;
+            }
+        }
 
-                if (gauge.IsOverheated && level >= MCH.Levels.HeatBlast)
+        internal class MachinistSimpleFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MachinistSimpleFeature;
+            internal static bool openerFinished = false;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is SplitShot or HeatedSplitShot)
                 {
+                    var inCombat = InCombat();
+                    var gauge = GetJobGauge<MCHGauge>();
+                    var canWeaveNormal = CanWeave(actionID);
+
+                    if (!inCombat)
+                    {
+                        openerFinished = false;
+
+                    }
+
+                    if (canWeaveNormal && IsEnabled(CustomComboPreset.MachinistSimpleStabilizer) && gauge.Heat <= 55 &&
+                            IsOffCooldown(BarrelStabilizer) && level >= Levels.BarrelStabilizer &&
+                            GetCooldown(Wildfire).CooldownRemaining < 8)
+                        return BarrelStabilizer;
+
+                    if (canWeaveNormal && IsEnabled(CustomComboPreset.MachinistSimpleInterrupt) && CanInterruptEnemy() && IsOffCooldown(All.HeadGraze))
+                    {
+                        return All.HeadGraze;
+                    }
+
+                    if (canWeaveNormal && openerFinished && !gauge.IsRobotActive && IsEnabled(CustomComboPreset.MachinistSimpleGadget))
+                    {
+                        //overflow protection
+                        if (gauge.Battery == 100)
+                        {
+                            if (level >= Levels.QueenOverdrive)
+                            {
+                                return AutomatonQueen;
+                            }
+
+                            if (level >= Levels.RookOverdrive)
+                            {
+                                return RookAutoturret;
+                            }
+                        }
+                        else if (gauge.Battery >= 50 && (CombatEngageDuration().Seconds >= 55 || CombatEngageDuration().Seconds <= 05))
+                        {
+                            if (level >= Levels.QueenOverdrive)
+                            {
+                                return AutomatonQueen;
+                            }
+
+                            if (level >= Levels.RookOverdrive)
+                            {
+                                return RookAutoturret;
+                            }
+                        }
+                        else if (gauge.LastSummonBatteryPower == 0 && gauge.Battery >= 50)
+                        {
+                            if (level >= Levels.QueenOverdrive)
+                            {
+                                return AutomatonQueen;
+                            }
+
+                            if (level >= Levels.RookOverdrive)
+                            {
+                                return RookAutoturret;
+                            }
+                        }
+
+                    }
+
+                    if (canWeaveNormal && gauge.Heat >= 50 && openerFinished && IsOffCooldown(Wildfire) && level >= Levels.Wildfire &&
+                            IsEnabled(CustomComboPreset.MachinistSimpleWildCharge))
+                    {
+                        if (CombatEngageDuration().Minutes == 0 && GetRemainingCharges(Reassemble) == 0 && CanDelayedWeave(actionID)) return Wildfire;
+                        else if (CombatEngageDuration().Minutes > 0 && (GetCooldownRemainingTime(ChainSaw) > 50 || level < Levels.ChainSaw)) return Wildfire;
+                    }
+
+                    if (gauge.IsOverheated && level >= Levels.HeatBlast)
+                    {
+                        if (IsEnabled(CustomComboPreset.MachinistSimpleGaussRicochet) && CanWeave(actionID, 0.6)) //gauss and ricochet weave
+                        {
+                            var gaussCharges = GetRemainingCharges(GaussRound);
+                            var ricochetCharges = GetRemainingCharges(Ricochet);
+                            var usingReasmSoon = IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && GetRemainingCharges(Reassemble) > 0 && openerFinished &&
+                                (
+                                 (GetCooldownRemainingTime(Drill) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
+                                 (GetCooldownRemainingTime(AirAnchor) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
+                                 (GetCooldownRemainingTime(ChainSaw) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5))
+                                );
+
+                            //var chargeLimit = openerFinished || level < MCH.Levels.Ricochet ? 0 : 1;
+
+                            if ((gaussCharges >= ricochetCharges || level < Levels.Ricochet) && gaussCharges > 0 &&
+                                level >= Levels.GaussRound && !usingReasmSoon)
+                                return GaussRound;
+                            else if (ricochetCharges > 0 && level >= Levels.Ricochet && !usingReasmSoon)
+                                return Ricochet;
+                        }
+
+                        return HeatBlast;
+                    }
+
+                    if ((IsOffCooldown(AirAnchor) || GetCooldownRemainingTime(AirAnchor) < 1) && level >= Levels.AirAnchor)
+                    {
+                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && !HasEffect(Buffs.Reassembled) && IsEnabled(CustomComboPreset.MachinistSimpleAssemblingAirAnchor) &&
+                            GetRemainingCharges(Reassemble) > 0)
+                        {
+                            if (IsEnabled(CustomComboPreset.MachinistSimpleAssemblingAirAnchorMaxCharges) && GetRemainingCharges(Reassemble) == GetMaxCharges(Reassemble)) return Reassemble;
+                            else if (!IsEnabled(CustomComboPreset.MachinistSimpleAssemblingAirAnchorMaxCharges)) return Reassemble;
+
+                        }
+                        return AirAnchor;
+                    }
+                    else if ((IsOffCooldown(HotShot) || GetCooldownRemainingTime(HotShot) < 1) && level >= Levels.Hotshot && level < Levels.AirAnchor)
+                        return HotShot;
+
+                    if ((IsOffCooldown(Drill) || GetCooldownRemainingTime(Drill) < 1) && level >= Levels.Drill)
+                    {
+                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && IsEnabled(CustomComboPreset.MachinistSimpleAssemblingDrill) &&
+                            !HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) > 0)
+                        {
+                            if (IsEnabled(CustomComboPreset.MachinistSimpleAssemblingDrillMaxCharges) && GetRemainingCharges(Reassemble) == GetMaxCharges(Reassemble)) return Reassemble;
+                            else if (!IsEnabled(CustomComboPreset.MachinistSimpleAssemblingDrillMaxCharges)) return Reassemble;
+                        }
+                        return Drill;
+                    }
+
+                    if ((IsOffCooldown(ChainSaw) || GetCooldownRemainingTime(ChainSaw) < 1) && level >= Levels.ChainSaw && openerFinished)
+                    {
+                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && IsEnabled(CustomComboPreset.MachinistSimpleAssemblingChainSaw) && !HasEffect(Buffs.Reassembled) &&
+                            GetRemainingCharges(Reassemble) > 0)
+                        {
+                            if (IsEnabled(CustomComboPreset.MachinistSimpleAssemblingChainSawMaxCharges) && GetRemainingCharges(Reassemble) == GetMaxCharges(Reassemble)) return Reassemble;
+                            else if (!IsEnabled(CustomComboPreset.MachinistSimpleAssemblingChainSawMaxCharges)) return Reassemble;
+                        }
+                        return ChainSaw;
+                    }
+
+                    if (canWeaveNormal && gauge.Heat >= 50 && openerFinished && IsEnabled(CustomComboPreset.MachinistSimpleWildCharge))
+                    {
+                        if (level >= Levels.Hypercharge && !gauge.IsOverheated)
+                        {
+                            //protection
+                            if (HasEffect(Buffs.Wildfire) || level < Levels.Wildfire) return Hypercharge;
+
+                            if (level >= Levels.Drill && GetCooldown(Drill).CooldownRemaining > 8)
+                            {
+                                if (level >= Levels.AirAnchor && GetCooldown(AirAnchor).CooldownRemaining > 8)
+                                {
+                                    if (level >= Levels.ChainSaw && (GetCooldown(ChainSaw).CooldownRemaining > 8 || CombatEngageDuration().Minutes % 2 == 0))
+                                    {
+                                        if (CombatEngageDuration().Minutes % 2 == 1 && gauge.Heat >= 90)
+                                        {
+                                            return Hypercharge;
+                                        }
+                                        else if (CombatEngageDuration().Minutes % 2 == 0)
+                                        {
+                                            if (CombatEngageDuration().Minutes != 0)
+                                            {
+                                                return Hypercharge;
+                                            }
+                                        }
+                                    }
+                                    else if (level < Levels.ChainSaw)
+                                    {
+                                        if (GetCooldown(Wildfire).CooldownRemaining > 8) return Hypercharge;
+                                    }
+                                }
+                                else if (level < Levels.AirAnchor)
+                                {
+                                    if (GetCooldown(Wildfire).CooldownRemaining > 8) return Hypercharge;
+                                }
+                            }
+                            else if (level < Levels.Drill)
+                            {
+                                if (GetCooldown(Wildfire).CooldownRemaining > 8 || level < Levels.Wildfire) return Hypercharge;
+                            }
+                        }
+                    }
+
                     if (IsEnabled(CustomComboPreset.MachinistSimpleGaussRicochet) && CanWeave(actionID, 0.6)) //gauss and ricochet weave
                     {
-                        var gaussCharges = GetRemainingCharges(MCH.GaussRound);
-                        var ricochetCharges = GetRemainingCharges(MCH.Ricochet);
-                        var usingReasmSoon = IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && GetRemainingCharges(MCH.Reassemble) > 0 && openerFinished &&
+                        var gaussCharges = GetRemainingCharges(GaussRound);
+                        var ricochetCharges = GetRemainingCharges(Ricochet);
+                        var usingReasmSoon = IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && GetRemainingCharges(Reassemble) > 0 && openerFinished &&
                             (
-                             (GetCooldownRemainingTime(MCH.Drill) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
-                             (GetCooldownRemainingTime(MCH.AirAnchor) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
-                             (GetCooldownRemainingTime(MCH.ChainSaw) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5))
+                             (GetCooldownRemainingTime(Drill) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
+                             (GetCooldownRemainingTime(AirAnchor) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
+                             (GetCooldownRemainingTime(ChainSaw) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5))
                             );
 
                         //var chargeLimit = openerFinished || level < MCH.Levels.Ricochet ? 0 : 1;
 
-                        if ((gaussCharges >= ricochetCharges || level < MCH.Levels.Ricochet) && gaussCharges > 0 &&
-                            level >= MCH.Levels.GaussRound && !usingReasmSoon)
-                            return MCH.GaussRound;
-                        else if (ricochetCharges > 0 && level >= MCH.Levels.Ricochet && !usingReasmSoon)
-                            return MCH.Ricochet;
+                        if ((gaussCharges >= ricochetCharges || level < Levels.Ricochet) && gaussCharges > 0 &&
+                            level >= Levels.GaussRound && !usingReasmSoon)
+                            return GaussRound;
+                        else if (ricochetCharges > 0 && level >= Levels.Ricochet && !usingReasmSoon)
+                            return Ricochet;
                     }
 
-                    return MCH.HeatBlast;
-                }
 
-                if ((IsOffCooldown(MCH.AirAnchor) || GetCooldownRemainingTime(MCH.AirAnchor) < 1) && level >= MCH.Levels.AirAnchor)
-                {
-                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && !HasEffect(MCH.Buffs.Reassembled) && IsEnabled(CustomComboPreset.MachinistSimpleAssemblingAirAnchor) &&
-                        GetRemainingCharges(MCH.Reassemble) > 0)
+                    if (lastComboMove == SplitShot && level >= Levels.SlugShot)
+                        return OriginalHook(SlugShot);
+
+                    if (lastComboMove == SlugShot && level >= Levels.CleanShot)
                     {
-                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssemblingAirAnchorMaxCharges) && GetRemainingCharges(MCH.Reassemble) == GetMaxCharges(MCH.Reassemble)) return MCH.Reassemble;
-                        else if (!IsEnabled(CustomComboPreset.MachinistSimpleAssemblingAirAnchorMaxCharges)) return MCH.Reassemble;
-
-                    }
-                    return MCH.AirAnchor;
-                }
-                else if ((IsOffCooldown(MCH.HotShot) || GetCooldownRemainingTime(MCH.HotShot) < 1) && level >= MCH.Levels.Hotshot && level < MCH.Levels.AirAnchor)
-                    return MCH.HotShot;
-
-                if ((IsOffCooldown(MCH.Drill) || GetCooldownRemainingTime(MCH.Drill) < 1) && level >= MCH.Levels.Drill)
-                {
-                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && IsEnabled(CustomComboPreset.MachinistSimpleAssemblingDrill) &&
-                        !HasEffect(MCH.Buffs.Reassembled) && GetRemainingCharges(MCH.Reassemble) > 0)
-                    {
-                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssemblingDrillMaxCharges) && GetRemainingCharges(MCH.Reassemble) == GetMaxCharges(MCH.Reassemble)) return MCH.Reassemble;
-                        else if (!IsEnabled(CustomComboPreset.MachinistSimpleAssemblingDrillMaxCharges)) return MCH.Reassemble;
-                    }
-                    return MCH.Drill;
-                }
-
-                if ((IsOffCooldown(MCH.ChainSaw) || GetCooldownRemainingTime(MCH.ChainSaw) < 1) && level >= MCH.Levels.ChainSaw && openerFinished)
-                {
-                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && IsEnabled(CustomComboPreset.MachinistSimpleAssemblingChainSaw) && !HasEffect(MCH.Buffs.Reassembled) &&
-                        GetRemainingCharges(MCH.Reassemble) > 0)
-                    {
-                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssemblingChainSawMaxCharges) && GetRemainingCharges(MCH.Reassemble) == GetMaxCharges(MCH.Reassemble)) return MCH.Reassemble;
-                        else if (!IsEnabled(CustomComboPreset.MachinistSimpleAssemblingChainSawMaxCharges)) return MCH.Reassemble;
-                    }
-                    return MCH.ChainSaw;
-                }
-
-                if (canWeaveNormal && gauge.Heat >= 50 && openerFinished && IsEnabled(CustomComboPreset.MachinistSimpleWildCharge) )
-                {
-                    if (level >= MCH.Levels.Hypercharge && !gauge.IsOverheated )
-                    {
-                        //protection
-                        if (HasEffect(MCH.Buffs.Wildfire) || level < MCH.Levels.Wildfire) return MCH.Hypercharge;
-
-                        if (level >= MCH.Levels.Drill && GetCooldown(MCH.Drill).CooldownRemaining > 8)
+                        if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) &&
+                            level < Levels.Drill && !HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) > 0)
                         {
-                            if (level >= MCH.Levels.AirAnchor && GetCooldown(MCH.AirAnchor).CooldownRemaining > 8)
-                            {
-                                if (level >= MCH.Levels.ChainSaw && (GetCooldown(MCH.ChainSaw).CooldownRemaining > 8 || CombatEngageDuration().Minutes % 2 == 0) )
-                                {
-                                    if (CombatEngageDuration().Minutes % 2 == 1 && gauge.Heat >= 90 )
-                                    {
-                                        return MCH.Hypercharge;
-                                    } else if (CombatEngageDuration().Minutes % 2 == 0)
-                                    {
-                                        if (CombatEngageDuration().Minutes != 0)
-                                        {
-                                            return MCH.Hypercharge;
-                                        } 
-                                    }
-                                }
-                                else if (level < MCH.Levels.ChainSaw)
-                                {
-                                    if (GetCooldown(MCH.Wildfire).CooldownRemaining > 8) return MCH.Hypercharge;
-                                }
-                            }
-                            else if (level < MCH.Levels.AirAnchor)
-                            {
-                                if (GetCooldown(MCH.Wildfire).CooldownRemaining > 8) return MCH.Hypercharge;
-                            }
+                            return Reassemble;
                         }
-                        else if (level < MCH.Levels.Drill)
-                        {
-                            if (GetCooldown(MCH.Wildfire).CooldownRemaining > 8 || level < MCH.Levels.Wildfire)  return MCH.Hypercharge;
-                        }
-                    }       
-                }
-
-                if (IsEnabled(CustomComboPreset.MachinistSimpleGaussRicochet) && CanWeave(actionID, 0.6)) //gauss and ricochet weave
-                {
-                    var gaussCharges = GetRemainingCharges(MCH.GaussRound);
-                    var ricochetCharges = GetRemainingCharges(MCH.Ricochet);
-                    var usingReasmSoon = IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && GetRemainingCharges(MCH.Reassemble) > 0 && openerFinished &&
-                        (
-                         (GetCooldownRemainingTime(MCH.Drill) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
-                         (GetCooldownRemainingTime(MCH.AirAnchor) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5)) ||
-                         (GetCooldownRemainingTime(MCH.ChainSaw) < 2.5 && (!gauge.IsOverheated || gauge.OverheatTimeRemaining < 2.5))
-                        );
-
-                    //var chargeLimit = openerFinished || level < MCH.Levels.Ricochet ? 0 : 1;
-
-                    if ((gaussCharges >= ricochetCharges || level < MCH.Levels.Ricochet) && gaussCharges > 0 &&
-                        level >= MCH.Levels.GaussRound && !usingReasmSoon)
-                        return MCH.GaussRound;
-                    else if (ricochetCharges > 0 && level >= MCH.Levels.Ricochet && !usingReasmSoon)
-                        return MCH.Ricochet;
-                }
-
-
-                if (lastComboMove == MCH.SplitShot && level >= MCH.Levels.SlugShot)
-                    return OriginalHook(MCH.SlugShot);
-
-                if (lastComboMove == MCH.SlugShot && level >= MCH.Levels.CleanShot)
-                {
-                    if (IsEnabled(CustomComboPreset.MachinistSimpleAssembling) && 
-                        level < MCH.Levels.Drill && !HasEffect(MCH.Buffs.Reassembled) && GetRemainingCharges(MCH.Reassemble) > 0)
-                    {
-                        return MCH.Reassemble;
+                        return OriginalHook(CleanShot);
                     }
-                    return OriginalHook(MCH.CleanShot);
+
+                    if (lastComboMove == CleanShot) openerFinished = true;
                 }
-                
-                if (lastComboMove == MCH.CleanShot) openerFinished = true;
+
+                return actionID;
             }
-
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -87,571 +87,572 @@ namespace XIVSlothComboPlugin.Combos
             public const string
                 MnkDisciplinedFistApply = "MnkDisciplinedFistApply";
         }
-    }
 
-    internal class MnkAoECombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkArmOfTheDestroyerCombo;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class MnkAoECombo : CustomCombo
         {
-            if (actionID == MNK.ArmOfTheDestroyer || actionID == MNK.ShadowOfTheDestroyer)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkArmOfTheDestroyerCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var gauge = GetJobGauge<MNKGauge>();
-                var canWeave = CanWeave(actionID, 0.5);
-                var canWeaveChakra = CanWeave(actionID);
-
-                var pbStacks = FindEffectAny(MNK.Buffs.PerfectBalance);
-                var lunarNadi = gauge.Nadi == Nadi.LUNAR;
-                var solarNadi = gauge.Nadi == Nadi.SOLAR;
-                var nadiNONE = gauge.Nadi == Nadi.NONE;
-
-                if (!inCombat)
+                if (actionID == ArmOfTheDestroyer || actionID == ShadowOfTheDestroyer)
                 {
-                    if (gauge.Chakra < 5)
-                    {
-                        return MNK.Meditation;
-                    }
-                    if (level >= MNK.Levels.FormShift && !HasEffect(MNK.Buffs.FormlessFist) && comboTime <= 0)
-                    {
-                        return MNK.FormShift;
-                    }
-                    if (IsEnabled(CustomComboPreset.MnkThunderclapOnAoEComboFeature) && !InMeleeRange() && gauge.Chakra == 5 && HasEffect(MNK.Buffs.FormlessFist))
-                    {
-                        return MNK.Thunderclap;
-                    }
-                }
+                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var gauge = GetJobGauge<MNKGauge>();
+                    var canWeave = CanWeave(actionID, 0.5);
+                    var canWeaveChakra = CanWeave(actionID);
 
-                // Buffs
-                if (inCombat && canWeave)
-                {
-                    if (IsEnabled(CustomComboPreset.MnkCDsOnAoEComboFeature))
-                    {
-                        if (level >= MNK.Levels.RiddleOfFire && !IsOnCooldown(MNK.RiddleOfFire))
-                        {
-                            return MNK.RiddleOfFire;
-                        }
-                        if (IsEnabled(CustomComboPreset.MnkPerfectBalanceOnAoEComboFeature) &&
-                            level >= MNK.Levels.PerfectBalance && !HasEffect(MNK.Buffs.PerfectBalance) && OriginalHook(MNK.MasterfulBlitz) == MNK.MasterfulBlitz)
-                        {
-                            // Use Perfect Balance if:
-                            // 1. It's after Bootshine/Dragon Kick.
-                            // 2. At max stacks / before overcap.
-                            // 3. During Brotherhood.
-                            // 4. During Riddle of Fire.
-                            // 5. Prepare Masterful Blitz for the Riddle of Fire & Brotherhood window.
-                            if (((GetRemainingCharges(MNK.PerfectBalance) == 2) ||
-                                (GetRemainingCharges(MNK.PerfectBalance) == 1 && GetCooldownChargeRemainingTime(MNK.PerfectBalance) < 4) ||
-                                (GetRemainingCharges(MNK.PerfectBalance) >= 1 && HasEffect(MNK.Buffs.Brotherhood)) ||
-                                (GetRemainingCharges(MNK.PerfectBalance) >= 1 && HasEffect(MNK.Buffs.RiddleOfFire) && FindEffect(MNK.Buffs.RiddleOfFire).RemainingTime < 10) ||
-                                (GetRemainingCharges(MNK.PerfectBalance) >= 1 && GetCooldownRemainingTime(MNK.RiddleOfFire) < 4 && GetCooldownRemainingTime(MNK.Brotherhood) < 8)))
-                            {
-                                return MNK.PerfectBalance;
-                            }
-                        }
-                        if (IsEnabled(CustomComboPreset.MnkBrotherhoodOnAoEComboFeature) && level >= MNK.Levels.Brotherhood && !IsOnCooldown(MNK.Brotherhood))
-                        {
-                            return MNK.Brotherhood;
-                        }
-                        if (IsEnabled(CustomComboPreset.MnkRiddleOfWindOnAoEComboFeature) && level >= MNK.Levels.RiddleOfWind && !IsOnCooldown(MNK.RiddleOfWind))
-                        {
-                            return MNK.RiddleOfWind;
-                        }
-                    }
-                    if (IsEnabled(CustomComboPreset.MnkMeditationOnAoEComboFeature) && level >= MNK.Levels.Meditation && gauge.Chakra == 5 && HasEffect(MNK.Buffs.DisciplinedFist) && canWeaveChakra)
-                    {
-                        return level >= MNK.Levels.Enlightenment ? OriginalHook(MNK.Enlightenment) : OriginalHook(MNK.Meditation);
-                    }
-                }
-
-                // Masterful Blitz
-                if (IsEnabled(CustomComboPreset.MonkMasterfulBlitzOnAoECombo) &&
-                    level >= MNK.Levels.MasterfulBlitz && !HasEffect(MNK.Buffs.PerfectBalance) && OriginalHook(MNK.MasterfulBlitz) != MNK.MasterfulBlitz)
-                {
-                    return OriginalHook(MNK.MasterfulBlitz);
-                }
-
-                // Perfect Balance
-                if (HasEffect(MNK.Buffs.PerfectBalance))
-                {
-                    if (nadiNONE || !lunarNadi)
-                    {
-                        if (pbStacks.StackCount > 0)
-                        {
-                            return level >= MNK.Levels.ShadowOfTheDestroyer ? MNK.ShadowOfTheDestroyer : MNK.Rockbreaker;
-                        }
-                    }
-                    if (lunarNadi)
-                    {
-                        switch (pbStacks.StackCount)
-                        {
-                            case 3:
-                                return OriginalHook(MNK.ArmOfTheDestroyer);
-                            case 2:
-                                return MNK.FourPointFury;
-                            case 1:
-                                return MNK.Rockbreaker;
-                        }
-                    }
-                }
-
-                // Monk Rotation
-                if (HasEffect(MNK.Buffs.OpoOpoForm))
-                {
-                    return OriginalHook(MNK.ArmOfTheDestroyer);
-                }
-
-                if (HasEffect(MNK.Buffs.RaptorForm) && level >= MNK.Levels.FourPointFury)
-                {
-                    return MNK.FourPointFury;
-                }
-
-                if (HasEffect(MNK.Buffs.CoerlForm) && level >= MNK.Levels.Rockbreaker)
-                {
-                    return MNK.Rockbreaker;
-                }
-            }
-            return actionID;
-        }
-    }
-
-    internal class MnkBootshineFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkBootshineFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MNK.DragonKick)
-            {
-                if (IsEnabled(CustomComboPreset.MnkBootshineBalanceFeature) && OriginalHook(MNK.MasterfulBlitz) != MNK.MasterfulBlitz)
-                    return OriginalHook(MNK.MasterfulBlitz);
-
-                if (HasEffect(MNK.Buffs.LeadenFist) && (
-                    HasEffect(MNK.Buffs.FormlessFist) || HasEffect(MNK.Buffs.PerfectBalance) ||
-                    HasEffect(MNK.Buffs.OpoOpoForm) || HasEffect(MNK.Buffs.RaptorForm) || HasEffect(MNK.Buffs.CoerlForm)))
-                    return MNK.Bootshine;
-
-                if (level < MNK.Levels.DragonKick)
-                    return MNK.Bootshine;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class MnkTwinSnakesFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkTwinSnakesFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MNK.TrueStrike)
-            {
-                var disciplinedFistBuff = HasEffect(MNK.Buffs.DisciplinedFist);
-                var disciplinedFistDuration = FindEffect(MNK.Buffs.DisciplinedFist);
-
-                if (level >= MNK.Levels.TrueStrike)
-                {
-                    if ((!disciplinedFistBuff && level >= MNK.Levels.TwinSnakes) || (disciplinedFistDuration.RemainingTime < 6 && level >= MNK.Levels.TwinSnakes))
-                        return MNK.TwinSnakes;
-                    return MNK.TrueStrike;
-                }
-
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class MnkBasicCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkBasicCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MNK.Bootshine)
-            {
-                var gauge = GetJobGauge<MNKGauge>();
-                if (HasEffect(MNK.Buffs.RaptorForm) && level >= MNK.Levels.TrueStrike)
-                {
-                    if (!HasEffect(MNK.Buffs.DisciplinedFist) && level >= MNK.Levels.TwinSnakes)
-                        return MNK.TwinSnakes;
-                    return MNK.TrueStrike;
-                }
-
-                if (HasEffect(MNK.Buffs.CoerlForm) && level >= MNK.Levels.SnapPunch)
-                {
-                    if (!TargetHasEffect(MNK.Debuffs.Demolish) && level >= MNK.Levels.Demolish)
-                        return MNK.Demolish;
-                    return MNK.SnapPunch;
-                }
-
-                if (!HasEffect(MNK.Buffs.LeadenFist) && HasEffect(MNK.Buffs.OpoOpoForm) && level >= MNK.Levels.DragonKick)
-                    return MNK.DragonKick;
-                return MNK.Bootshine;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class MonkPerfectBalanceFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MonkPerfectBalanceFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MNK.PerfectBalance)
-            {
-                if (OriginalHook(MNK.MasterfulBlitz) != MNK.MasterfulBlitz && level >= 60)
-                    return OriginalHook(MNK.MasterfulBlitz);
-            }
-
-            return actionID;
-        }
-    }
-    internal class MnkBootshineCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkBootshineCombo;
-
-        internal static bool inOpener = false;
-        internal static bool openerFinished = false;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MNK.Bootshine)
-            {
-                var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var gauge = GetJobGauge<MNKGauge>();
-                var canWeave = CanWeave(actionID, 0.5);
-                var canDelayedWeave = CanWeave(actionID, 0.0) && GetCooldown(actionID).CooldownRemaining < 0.7;
-
-                var twinsnakeDuration = FindEffect(MNK.Buffs.DisciplinedFist);
-                var demolishDuration = FindTargetEffect(MNK.Debuffs.Demolish);
-
-                var pbStacks = FindEffectAny(MNK.Buffs.PerfectBalance);
-                var lunarNadi = gauge.Nadi == Nadi.LUNAR;
-                var solarNadi = gauge.Nadi == Nadi.SOLAR;
-
-                // Opener for MNK
-                if (IsEnabled(CustomComboPreset.MnkLunarSolarOpenerOnMainComboFeature))
-                {
-                    // Re-enter opener when Brotherhood is used
-                    if (lastComboMove == MNK.Brotherhood)
-                    {
-                        inOpener = true;
-                        openerFinished = false;
-                    }
+                    var pbStacks = FindEffectAny(Buffs.PerfectBalance);
+                    var lunarNadi = gauge.Nadi == Nadi.LUNAR;
+                    var solarNadi = gauge.Nadi == Nadi.SOLAR;
+                    var nadiNONE = gauge.Nadi == Nadi.NONE;
 
                     if (!inCombat)
                     {
-                        if (inOpener || openerFinished)
+                        if (gauge.Chakra < 5)
                         {
-                            inOpener = false;
-                            openerFinished = false;
+                            return Meditation;
                         }
-                    }
-                    else
-                    {
-                        if (!inOpener && !openerFinished)
+                        if (level >= Levels.FormShift && !HasEffect(Buffs.FormlessFist) && comboTime <= 0)
                         {
-                            inOpener = true;
+                            return FormShift;
+                        }
+                        if (IsEnabled(CustomComboPreset.MnkThunderclapOnAoEComboFeature) && !InMeleeRange() && gauge.Chakra == 5 && HasEffect(Buffs.FormlessFist))
+                        {
+                            return Thunderclap;
                         }
                     }
 
-                    if (inCombat && inOpener && !openerFinished)
+                    // Buffs
+                    if (inCombat && canWeave)
                     {
-                        if (level >= MNK.Levels.RiddleOfFire)
+                        if (IsEnabled(CustomComboPreset.MnkCDsOnAoEComboFeature))
                         {
-                            // Early exit out of opener
-                            if (IsOnCooldown(MNK.RiddleOfFire) && GetCooldownRemainingTime(MNK.RiddleOfFire) <= 40)
+                            if (level >= Levels.RiddleOfFire && !IsOnCooldown(RiddleOfFire))
                             {
-                                inOpener = false;
-                                openerFinished = true;
+                                return RiddleOfFire;
                             }
-
-                            // Delayed weave for Riddle of Fire specifically
-                            if (canDelayedWeave)
-                            {
-                                if ((HasEffect(MNK.Buffs.CoerlForm) || lastComboMove == MNK.TwinSnakes) && !IsOnCooldown(MNK.RiddleOfFire))
-                                {
-                                    return MNK.RiddleOfFire;
-                                }
-                            }
-
-                            if (canWeave)
-                            {
-                                if (IsOnCooldown(MNK.RiddleOfFire) && GetCooldownRemainingTime(MNK.RiddleOfFire) <= 59)
-                                {
-                                    if (level >= MNK.Levels.Brotherhood && !IsOnCooldown(MNK.Brotherhood) && IsOnCooldown(MNK.RiddleOfFire) &&
-                                       (lastComboMove == MNK.Bootshine || lastComboMove == MNK.DragonKick))
-                                    {
-                                        return MNK.Brotherhood;
-                                    }
-                                    if (GetRemainingCharges(MNK.PerfectBalance) > 0 && !HasEffect(MNK.Buffs.PerfectBalance) && !HasEffect(MNK.Buffs.FormlessFist) &&
-                                       (lastComboMove == MNK.Bootshine || lastComboMove == MNK.DragonKick) && OriginalHook(MNK.MasterfulBlitz) == MNK.MasterfulBlitz)
-                                    {
-                                        return MNK.PerfectBalance;
-                                    }
-                                    if (level >= MNK.Levels.RiddleOfWind && HasEffect(MNK.Buffs.PerfectBalance) && !IsOnCooldown(MNK.RiddleOfWind))
-                                    {
-                                        return MNK.RiddleOfWind;
-                                    }
-                                    if (level >= MNK.Levels.Meditation && gauge.Chakra == 5)
-                                    {
-                                        return OriginalHook(MNK.Meditation);
-                                    }
-                                }
-                            }
-                        }
-                        else
-                        {
-                            // Automatically exit opener if we don't have Riddle of Fire
-                            inOpener = false;
-                            openerFinished = true;
-                        }
-                    }
-                }
-
-                // Out of combat preparation
-                if (!inCombat)
-                {
-                    if (!inOpener && gauge.Chakra < 5)
-                    {
-                        return MNK.Meditation;
-                    }
-                    if (!inOpener && level >= MNK.Levels.FormShift && !HasEffect(MNK.Buffs.FormlessFist) && comboTime <= 0)
-                    {
-                        return MNK.FormShift;
-                    }
-                    if (IsEnabled(CustomComboPreset.MnkThunderclapOnMainComboFeature) && !InMeleeRange() && gauge.Chakra == 5 && HasEffect(MNK.Buffs.FormlessFist))
-                    {
-                        return MNK.Thunderclap;
-                    }
-                }
-
-                // Buffs
-                if (inCombat && !inOpener)
-                {
-                    if (IsEnabled(CustomComboPreset.MnkCDsOnMainComboFeature))
-                    {
-                        if (canWeave)
-                        {
-                            if (IsEnabled(CustomComboPreset.MnkPerfectBalanceOnMainComboFeature) && !HasEffect(MNK.Buffs.FormlessFist) &&
-                                level >= MNK.Levels.PerfectBalance && !HasEffect(MNK.Buffs.PerfectBalance) && HasEffect(MNK.Buffs.DisciplinedFist) &&
-                                OriginalHook(MNK.MasterfulBlitz) == MNK.MasterfulBlitz)
+                            if (IsEnabled(CustomComboPreset.MnkPerfectBalanceOnAoEComboFeature) &&
+                                level >= Levels.PerfectBalance && !HasEffect(Buffs.PerfectBalance) && OriginalHook(MasterfulBlitz) == MasterfulBlitz)
                             {
                                 // Use Perfect Balance if:
                                 // 1. It's after Bootshine/Dragon Kick.
                                 // 2. At max stacks / before overcap.
                                 // 3. During Brotherhood.
-                                // 4. During Riddle of Fire after Demolish has been applied.
+                                // 4. During Riddle of Fire.
                                 // 5. Prepare Masterful Blitz for the Riddle of Fire & Brotherhood window.
-                                if ((lastComboMove == MNK.Bootshine || lastComboMove == MNK.DragonKick) &&
-                                    ((GetRemainingCharges(MNK.PerfectBalance) == 2) ||
-                                    (GetRemainingCharges(MNK.PerfectBalance) == 1 && GetCooldownChargeRemainingTime(MNK.PerfectBalance) < 4) ||
-                                    (GetRemainingCharges(MNK.PerfectBalance) >= 1 && HasEffect(MNK.Buffs.Brotherhood)) ||
-                                    (GetRemainingCharges(MNK.PerfectBalance) >= 1 && GetCooldownRemainingTime(MNK.RiddleOfFire) < 3 && GetCooldownRemainingTime(MNK.Brotherhood) > 40) ||
-                                    (GetRemainingCharges(MNK.PerfectBalance) >= 1 && HasEffect(MNK.Buffs.RiddleOfFire) && FindEffect(MNK.Buffs.RiddleOfFire).RemainingTime > 6) ||
-                                    (GetRemainingCharges(MNK.PerfectBalance) >= 1 && GetCooldownRemainingTime(MNK.RiddleOfFire) < 3 && GetCooldownRemainingTime(MNK.Brotherhood) < 10)))
+                                if (((GetRemainingCharges(PerfectBalance) == 2) ||
+                                    (GetRemainingCharges(PerfectBalance) == 1 && GetCooldownChargeRemainingTime(PerfectBalance) < 4) ||
+                                    (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.Brotherhood)) ||
+                                    (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.RiddleOfFire) && FindEffect(Buffs.RiddleOfFire).RemainingTime < 10) ||
+                                    (GetRemainingCharges(PerfectBalance) >= 1 && GetCooldownRemainingTime(RiddleOfFire) < 4 && GetCooldownRemainingTime(Brotherhood) < 8)))
                                 {
-                                    return MNK.PerfectBalance;
+                                    return PerfectBalance;
                                 }
+                            }
+                            if (IsEnabled(CustomComboPreset.MnkBrotherhoodOnAoEComboFeature) && level >= Levels.Brotherhood && !IsOnCooldown(Brotherhood))
+                            {
+                                return Brotherhood;
+                            }
+                            if (IsEnabled(CustomComboPreset.MnkRiddleOfWindOnAoEComboFeature) && level >= Levels.RiddleOfWind && !IsOnCooldown(RiddleOfWind))
+                            {
+                                return RiddleOfWind;
+                            }
+                        }
+                        if (IsEnabled(CustomComboPreset.MnkMeditationOnAoEComboFeature) && level >= Levels.Meditation && gauge.Chakra == 5 && HasEffect(Buffs.DisciplinedFist) && canWeaveChakra)
+                        {
+                            return level >= Levels.Enlightenment ? OriginalHook(Enlightenment) : OriginalHook(Meditation);
+                        }
+                    }
+
+                    // Masterful Blitz
+                    if (IsEnabled(CustomComboPreset.MonkMasterfulBlitzOnAoECombo) &&
+                        level >= Levels.MasterfulBlitz && !HasEffect(Buffs.PerfectBalance) && OriginalHook(MasterfulBlitz) != MasterfulBlitz)
+                    {
+                        return OriginalHook(MasterfulBlitz);
+                    }
+
+                    // Perfect Balance
+                    if (HasEffect(Buffs.PerfectBalance))
+                    {
+                        if (nadiNONE || !lunarNadi)
+                        {
+                            if (pbStacks.StackCount > 0)
+                            {
+                                return level >= Levels.ShadowOfTheDestroyer ? ShadowOfTheDestroyer : Rockbreaker;
+                            }
+                        }
+                        if (lunarNadi)
+                        {
+                            switch (pbStacks.StackCount)
+                            {
+                                case 3:
+                                    return OriginalHook(ArmOfTheDestroyer);
+                                case 2:
+                                    return FourPointFury;
+                                case 1:
+                                    return Rockbreaker;
+                            }
+                        }
+                    }
+
+                    // Monk Rotation
+                    if (HasEffect(Buffs.OpoOpoForm))
+                    {
+                        return OriginalHook(ArmOfTheDestroyer);
+                    }
+
+                    if (HasEffect(Buffs.RaptorForm) && level >= Levels.FourPointFury)
+                    {
+                        return FourPointFury;
+                    }
+
+                    if (HasEffect(Buffs.CoerlForm) && level >= Levels.Rockbreaker)
+                    {
+                        return Rockbreaker;
+                    }
+                }
+                return actionID;
+            }
+        }
+
+        internal class MnkBootshineFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkBootshineFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == DragonKick)
+                {
+                    if (IsEnabled(CustomComboPreset.MnkBootshineBalanceFeature) && OriginalHook(MasterfulBlitz) != MasterfulBlitz)
+                        return OriginalHook(MasterfulBlitz);
+
+                    if (HasEffect(Buffs.LeadenFist) && (
+                        HasEffect(Buffs.FormlessFist) || HasEffect(Buffs.PerfectBalance) ||
+                        HasEffect(Buffs.OpoOpoForm) || HasEffect(Buffs.RaptorForm) || HasEffect(Buffs.CoerlForm)))
+                        return Bootshine;
+
+                    if (level < Levels.DragonKick)
+                        return Bootshine;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class MnkTwinSnakesFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkTwinSnakesFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == TrueStrike)
+                {
+                    var disciplinedFistBuff = HasEffect(Buffs.DisciplinedFist);
+                    var disciplinedFistDuration = FindEffect(Buffs.DisciplinedFist);
+
+                    if (level >= Levels.TrueStrike)
+                    {
+                        if ((!disciplinedFistBuff && level >= Levels.TwinSnakes) || (disciplinedFistDuration.RemainingTime < 6 && level >= Levels.TwinSnakes))
+                            return TwinSnakes;
+                        return TrueStrike;
+                    }
+
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class MnkBasicCombo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkBasicCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Bootshine)
+                {
+                    var gauge = GetJobGauge<MNKGauge>();
+                    if (HasEffect(Buffs.RaptorForm) && level >= Levels.TrueStrike)
+                    {
+                        if (!HasEffect(Buffs.DisciplinedFist) && level >= Levels.TwinSnakes)
+                            return TwinSnakes;
+                        return TrueStrike;
+                    }
+
+                    if (HasEffect(Buffs.CoerlForm) && level >= Levels.SnapPunch)
+                    {
+                        if (!TargetHasEffect(Debuffs.Demolish) && level >= Levels.Demolish)
+                            return Demolish;
+                        return SnapPunch;
+                    }
+
+                    if (!HasEffect(Buffs.LeadenFist) && HasEffect(Buffs.OpoOpoForm) && level >= Levels.DragonKick)
+                        return DragonKick;
+                    return Bootshine;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class MonkPerfectBalanceFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MonkPerfectBalanceFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == PerfectBalance)
+                {
+                    if (OriginalHook(MasterfulBlitz) != MasterfulBlitz && level >= 60)
+                        return OriginalHook(MasterfulBlitz);
+                }
+
+                return actionID;
+            }
+        }
+        internal class MnkBootshineCombo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkBootshineCombo;
+
+            internal static bool inOpener = false;
+            internal static bool openerFinished = false;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Bootshine)
+                {
+                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var gauge = GetJobGauge<MNKGauge>();
+                    var canWeave = CanWeave(actionID, 0.5);
+                    var canDelayedWeave = CanWeave(actionID, 0.0) && GetCooldown(actionID).CooldownRemaining < 0.7;
+
+                    var twinsnakeDuration = FindEffect(Buffs.DisciplinedFist);
+                    var demolishDuration = FindTargetEffect(Debuffs.Demolish);
+
+                    var pbStacks = FindEffectAny(Buffs.PerfectBalance);
+                    var lunarNadi = gauge.Nadi == Nadi.LUNAR;
+                    var solarNadi = gauge.Nadi == Nadi.SOLAR;
+
+                    // Opener for MNK
+                    if (IsEnabled(CustomComboPreset.MnkLunarSolarOpenerOnMainComboFeature))
+                    {
+                        // Re-enter opener when Brotherhood is used
+                        if (lastComboMove == Brotherhood)
+                        {
+                            inOpener = true;
+                            openerFinished = false;
+                        }
+
+                        if (!inCombat)
+                        {
+                            if (inOpener || openerFinished)
+                            {
+                                inOpener = false;
+                                openerFinished = false;
+                            }
+                        }
+                        else
+                        {
+                            if (!inOpener && !openerFinished)
+                            {
+                                inOpener = true;
                             }
                         }
 
-                        if (canDelayedWeave)
+                        if (inCombat && inOpener && !openerFinished)
                         {
-                            if (level >= MNK.Levels.RiddleOfFire && !IsOnCooldown(MNK.RiddleOfFire) && HasEffect(MNK.Buffs.DisciplinedFist))
+                            if (level >= Levels.RiddleOfFire)
                             {
-                                return MNK.RiddleOfFire;
+                                // Early exit out of opener
+                                if (IsOnCooldown(RiddleOfFire) && GetCooldownRemainingTime(RiddleOfFire) <= 40)
+                                {
+                                    inOpener = false;
+                                    openerFinished = true;
+                                }
+
+                                // Delayed weave for Riddle of Fire specifically
+                                if (canDelayedWeave)
+                                {
+                                    if ((HasEffect(Buffs.CoerlForm) || lastComboMove == TwinSnakes) && !IsOnCooldown(RiddleOfFire))
+                                    {
+                                        return RiddleOfFire;
+                                    }
+                                }
+
+                                if (canWeave)
+                                {
+                                    if (IsOnCooldown(RiddleOfFire) && GetCooldownRemainingTime(RiddleOfFire) <= 59)
+                                    {
+                                        if (level >= Levels.Brotherhood && !IsOnCooldown(Brotherhood) && IsOnCooldown(RiddleOfFire) &&
+                                           (lastComboMove == Bootshine || lastComboMove == DragonKick))
+                                        {
+                                            return Brotherhood;
+                                        }
+                                        if (GetRemainingCharges(PerfectBalance) > 0 && !HasEffect(Buffs.PerfectBalance) && !HasEffect(Buffs.FormlessFist) &&
+                                           (lastComboMove == Bootshine || lastComboMove == DragonKick) && OriginalHook(MasterfulBlitz) == MasterfulBlitz)
+                                        {
+                                            return PerfectBalance;
+                                        }
+                                        if (level >= Levels.RiddleOfWind && HasEffect(Buffs.PerfectBalance) && !IsOnCooldown(RiddleOfWind))
+                                        {
+                                            return RiddleOfWind;
+                                        }
+                                        if (level >= Levels.Meditation && gauge.Chakra == 5)
+                                        {
+                                            return OriginalHook(Meditation);
+                                        }
+                                    }
+                                }
+                            }
+                            else
+                            {
+                                // Automatically exit opener if we don't have Riddle of Fire
+                                inOpener = false;
+                                openerFinished = true;
+                            }
+                        }
+                    }
+
+                    // Out of combat preparation
+                    if (!inCombat)
+                    {
+                        if (!inOpener && gauge.Chakra < 5)
+                        {
+                            return Meditation;
+                        }
+                        if (!inOpener && level >= Levels.FormShift && !HasEffect(Buffs.FormlessFist) && comboTime <= 0)
+                        {
+                            return FormShift;
+                        }
+                        if (IsEnabled(CustomComboPreset.MnkThunderclapOnMainComboFeature) && !InMeleeRange() && gauge.Chakra == 5 && HasEffect(Buffs.FormlessFist))
+                        {
+                            return Thunderclap;
+                        }
+                    }
+
+                    // Buffs
+                    if (inCombat && !inOpener)
+                    {
+                        if (IsEnabled(CustomComboPreset.MnkCDsOnMainComboFeature))
+                        {
+                            if (canWeave)
+                            {
+                                if (IsEnabled(CustomComboPreset.MnkPerfectBalanceOnMainComboFeature) && !HasEffect(Buffs.FormlessFist) &&
+                                    level >= Levels.PerfectBalance && !HasEffect(Buffs.PerfectBalance) && HasEffect(Buffs.DisciplinedFist) &&
+                                    OriginalHook(MasterfulBlitz) == MasterfulBlitz)
+                                {
+                                    // Use Perfect Balance if:
+                                    // 1. It's after Bootshine/Dragon Kick.
+                                    // 2. At max stacks / before overcap.
+                                    // 3. During Brotherhood.
+                                    // 4. During Riddle of Fire after Demolish has been applied.
+                                    // 5. Prepare Masterful Blitz for the Riddle of Fire & Brotherhood window.
+                                    if ((lastComboMove == Bootshine || lastComboMove == DragonKick) &&
+                                        ((GetRemainingCharges(PerfectBalance) == 2) ||
+                                        (GetRemainingCharges(PerfectBalance) == 1 && GetCooldownChargeRemainingTime(PerfectBalance) < 4) ||
+                                        (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.Brotherhood)) ||
+                                        (GetRemainingCharges(PerfectBalance) >= 1 && GetCooldownRemainingTime(RiddleOfFire) < 3 && GetCooldownRemainingTime(Brotherhood) > 40) ||
+                                        (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.RiddleOfFire) && FindEffect(Buffs.RiddleOfFire).RemainingTime > 6) ||
+                                        (GetRemainingCharges(PerfectBalance) >= 1 && GetCooldownRemainingTime(RiddleOfFire) < 3 && GetCooldownRemainingTime(Brotherhood) < 10)))
+                                    {
+                                        return PerfectBalance;
+                                    }
+                                }
+                            }
+
+                            if (canDelayedWeave)
+                            {
+                                if (level >= Levels.RiddleOfFire && !IsOnCooldown(RiddleOfFire) && HasEffect(Buffs.DisciplinedFist))
+                                {
+                                    return RiddleOfFire;
+                                }
+                            }
+
+                            if (canWeave)
+                            {
+                                if (IsEnabled(CustomComboPreset.MnkBrotherhoodOnMainComboFeature) && level >= Levels.Brotherhood &&
+                                   !IsOnCooldown(Brotherhood) && IsOnCooldown(RiddleOfFire))
+                                {
+                                    return Brotherhood;
+                                }
+
+                                if (IsEnabled(CustomComboPreset.MnkRiddleOfWindOnMainComboFeature) && level >= Levels.RiddleOfWind &&
+                                   !IsOnCooldown(RiddleOfWind) && IsOnCooldown(RiddleOfFire) && IsOnCooldown(Brotherhood))
+                                {
+                                    return RiddleOfWind;
+                                }
                             }
                         }
 
                         if (canWeave)
                         {
-                            if (IsEnabled(CustomComboPreset.MnkBrotherhoodOnMainComboFeature) && level >= MNK.Levels.Brotherhood &&
-                               !IsOnCooldown(MNK.Brotherhood) && IsOnCooldown(MNK.RiddleOfFire))
+                            if (IsEnabled(CustomComboPreset.MnkMeditationOnMainComboFeature) && level >= Levels.Meditation && gauge.Chakra == 5 &&
+                                HasEffect(Buffs.DisciplinedFist) && IsOnCooldown(RiddleOfFire) && lastComboMove != RiddleOfFire)
                             {
-                                return MNK.Brotherhood;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.MnkRiddleOfWindOnMainComboFeature) && level >= MNK.Levels.RiddleOfWind &&
-                               !IsOnCooldown(MNK.RiddleOfWind) && IsOnCooldown(MNK.RiddleOfFire) && IsOnCooldown(MNK.Brotherhood))
-                            {
-                                return MNK.RiddleOfWind;
+                                return OriginalHook(Meditation);
                             }
                         }
                     }
 
-                    if (canWeave)
+                    // Masterful Blitz
+                    if (IsEnabled(CustomComboPreset.MonkMasterfulBlitzOnMainCombo) &&
+                        level >= Levels.MasterfulBlitz && !HasEffect(Buffs.PerfectBalance) && OriginalHook(MasterfulBlitz) != MasterfulBlitz)
                     {
-                        if (IsEnabled(CustomComboPreset.MnkMeditationOnMainComboFeature) && level >= MNK.Levels.Meditation && gauge.Chakra == 5 &&
-                            HasEffect(MNK.Buffs.DisciplinedFist) && IsOnCooldown(MNK.RiddleOfFire) && lastComboMove != MNK.RiddleOfFire)
-                        {
-                            return OriginalHook(MNK.Meditation);
-                        }
+                        return OriginalHook(MasterfulBlitz);
                     }
-                }
 
-                // Masterful Blitz
-                if (IsEnabled(CustomComboPreset.MonkMasterfulBlitzOnMainCombo) &&
-                    level >= MNK.Levels.MasterfulBlitz && !HasEffect(MNK.Buffs.PerfectBalance) && OriginalHook(MNK.MasterfulBlitz) != MNK.MasterfulBlitz)
-                {
-                    return OriginalHook(MNK.MasterfulBlitz);
-                }
-
-                // Perfect Balance
-                if (HasEffect(MNK.Buffs.PerfectBalance))
-                {
-                    bool opoopoChakra = Array.Exists(gauge.BeastChakra, e => e == BeastChakra.OPOOPO);
-                    bool coeurlChakra = Array.Exists(gauge.BeastChakra, e => e == BeastChakra.COEURL);
-                    bool raptorChakra = Array.Exists(gauge.BeastChakra, e => e == BeastChakra.RAPTOR);
-                    bool canSolar = gauge.BeastChakra.Where(e => e == BeastChakra.OPOOPO).Count() != 2;
-                    if (opoopoChakra)
+                    // Perfect Balance
+                    if (HasEffect(Buffs.PerfectBalance))
                     {
-                        if (coeurlChakra)
+                        bool opoopoChakra = Array.Exists(gauge.BeastChakra, e => e == BeastChakra.OPOOPO);
+                        bool coeurlChakra = Array.Exists(gauge.BeastChakra, e => e == BeastChakra.COEURL);
+                        bool raptorChakra = Array.Exists(gauge.BeastChakra, e => e == BeastChakra.RAPTOR);
+                        bool canSolar = gauge.BeastChakra.Where(e => e == BeastChakra.OPOOPO).Count() != 2;
+                        if (opoopoChakra)
                         {
-                            return MNK.TwinSnakes;
-                        }
-                        if (raptorChakra)
-                        {
-                            return MNK.Demolish;
-                        }
-                        if (lunarNadi && !solarNadi)
-                        {
-                            bool demolishFirst = !TargetHasEffect(MNK.Debuffs.Demolish);
-                            if (!demolishFirst && HasEffect(MNK.Buffs.DisciplinedFist))
+                            if (coeurlChakra)
                             {
-                                demolishFirst = twinsnakeDuration.RemainingTime >= demolishDuration.RemainingTime;
+                                return TwinSnakes;
                             }
-                            return demolishFirst ? MNK.Demolish : MNK.TwinSnakes;
+                            if (raptorChakra)
+                            {
+                                return Demolish;
+                            }
+                            if (lunarNadi && !solarNadi)
+                            {
+                                bool demolishFirst = !TargetHasEffect(Debuffs.Demolish);
+                                if (!demolishFirst && HasEffect(Buffs.DisciplinedFist))
+                                {
+                                    demolishFirst = twinsnakeDuration.RemainingTime >= demolishDuration.RemainingTime;
+                                }
+                                return demolishFirst ? Demolish : TwinSnakes;
+                            }
                         }
-                    }
-                    if (canSolar && (lunarNadi || !solarNadi))
-                    {
-                        if (!raptorChakra && (!HasEffect(MNK.Buffs.DisciplinedFist) || twinsnakeDuration.RemainingTime <= 2.5))
+                        if (canSolar && (lunarNadi || !solarNadi))
                         {
-                            return MNK.TwinSnakes;
+                            if (!raptorChakra && (!HasEffect(Buffs.DisciplinedFist) || twinsnakeDuration.RemainingTime <= 2.5))
+                            {
+                                return TwinSnakes;
+                            }
+                            if (!coeurlChakra && (demolishDuration.RemainingTime <= 2.5 || !TargetHasEffect(Debuffs.Demolish)))
+                            {
+                                return Demolish;
+                            }
                         }
-                        if (!coeurlChakra && (demolishDuration.RemainingTime <= 2.5 || !TargetHasEffect(MNK.Debuffs.Demolish)))
+                        return HasEffect(Buffs.LeadenFist) ? Bootshine : DragonKick;
+                    }
+
+                    // Monk Rotation
+                    if ((level >= Levels.DragonKick && HasEffect(Buffs.OpoOpoForm)) ||
+                        (HasEffect(Buffs.FormlessFist)) && !HasEffect(Buffs.LeadenFist))
+                    {
+                        return HasEffect(Buffs.LeadenFist) ? Bootshine : DragonKick;
+                    }
+                    if (level >= Levels.TrueStrike && HasEffect(Buffs.RaptorForm))
+                    {
+                        if (level >= Levels.TwinSnakes && (!HasEffect(Buffs.DisciplinedFist) || twinsnakeDuration.RemainingTime <= Service.Configuration.GetCustomIntValue(Config.MnkDisciplinedFistApply)))
                         {
-                            return MNK.Demolish;
+                            return TwinSnakes;
                         }
+                        return TrueStrike;
                     }
-                    return HasEffect(MNK.Buffs.LeadenFist) ? MNK.Bootshine : MNK.DragonKick;
-                }
-
-                // Monk Rotation
-                if ((level >= MNK.Levels.DragonKick && HasEffect(MNK.Buffs.OpoOpoForm)) || 
-                    (HasEffect(MNK.Buffs.FormlessFist)) && !HasEffect(MNK.Buffs.LeadenFist))
-                {
-                    return HasEffect(MNK.Buffs.LeadenFist) ? MNK.Bootshine : MNK.DragonKick;
-                }
-                if (level >= MNK.Levels.TrueStrike && HasEffect(MNK.Buffs.RaptorForm))
-                {
-                    if (level >= MNK.Levels.TwinSnakes && (!HasEffect(MNK.Buffs.DisciplinedFist) || twinsnakeDuration.RemainingTime <= Service.Configuration.GetCustomIntValue(MNK.Config.MnkDisciplinedFistApply)))
+                    if (level >= Levels.SnapPunch && HasEffect(Buffs.CoerlForm))
                     {
-                        return MNK.TwinSnakes;
+                        if (level >= Levels.Demolish && HasEffect(Buffs.DisciplinedFist) && (!TargetHasEffect(Debuffs.Demolish) || demolishDuration.RemainingTime <= Service.Configuration.GetCustomIntValue(Config.MnkDemolishApply)))
+                        {
+                            return Demolish;
+                        }
+                        return SnapPunch;
                     }
-                    return MNK.TrueStrike;
                 }
-                if (level >= MNK.Levels.SnapPunch && HasEffect(MNK.Buffs.CoerlForm))
+                return actionID;
+            }
+        }
+        internal class MnkPerfectBalancePlus : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkPerfectBalancePlus;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == MasterfulBlitz)
                 {
-                    if (level >= MNK.Levels.Demolish && HasEffect(MNK.Buffs.DisciplinedFist) && (!TargetHasEffect(MNK.Debuffs.Demolish) || demolishDuration.RemainingTime <= Service.Configuration.GetCustomIntValue(MNK.Config.MnkDemolishApply)))
+                    var gauge = GetJobGauge<MNKGauge>();
+                    var pbStacks = FindEffectAny(Buffs.PerfectBalance);
+                    var lunarNadi = gauge.Nadi == Nadi.LUNAR;
+                    var nadiNONE = gauge.Nadi == Nadi.NONE;
+                    if (!nadiNONE && !lunarNadi)
                     {
-                        return MNK.Demolish;
+                        if (pbStacks.StackCount == 3)
+                            return DragonKick;
+                        if (pbStacks.StackCount == 2)
+                            return Bootshine;
+                        if (pbStacks.StackCount == 1)
+                            return DragonKick;
                     }
-                    return MNK.SnapPunch;
+                    if (nadiNONE)
+                    {
+                        if (pbStacks.StackCount == 3)
+                            return DragonKick;
+                        if (pbStacks.StackCount == 2)
+                            return Bootshine;
+                        if (pbStacks.StackCount == 1)
+                            return DragonKick;
+                    }
+                    if (lunarNadi)
+                    {
+                        if (pbStacks.StackCount == 3)
+                            return TwinSnakes;
+                        if (pbStacks.StackCount == 2)
+                            return DragonKick;
+                        if (pbStacks.StackCount == 1)
+                            return Demolish;
+                    }
+
                 }
+                return actionID;
             }
-            return actionID;
         }
-    }
-    internal class MnkPerfectBalancePlus : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkPerfectBalancePlus;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class MnkRiddleOfFireBrotherhoodFeature : CustomCombo
         {
-            if (actionID == MNK.MasterfulBlitz)
-            {
-                var gauge = GetJobGauge<MNKGauge>();
-                var pbStacks = FindEffectAny(MNK.Buffs.PerfectBalance);
-                var lunarNadi = gauge.Nadi == Nadi.LUNAR;
-                var nadiNONE = gauge.Nadi == Nadi.NONE;
-                if (!nadiNONE && !lunarNadi)
-                {
-                    if (pbStacks.StackCount == 3)
-                        return MNK.DragonKick;
-                    if (pbStacks.StackCount == 2)
-                        return MNK.Bootshine;
-                    if (pbStacks.StackCount == 1)
-                        return MNK.DragonKick;
-                }
-                if (nadiNONE)
-                {
-                    if (pbStacks.StackCount == 3)
-                        return MNK.DragonKick;
-                    if (pbStacks.StackCount == 2)
-                        return MNK.Bootshine;
-                    if (pbStacks.StackCount == 1)
-                        return MNK.DragonKick;
-                }
-                if (lunarNadi)
-                {
-                    if (pbStacks.StackCount == 3)
-                        return MNK.TwinSnakes;
-                    if (pbStacks.StackCount == 2)
-                        return MNK.DragonKick;
-                    if (pbStacks.StackCount == 1)
-                        return MNK.Demolish;
-                }
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkRiddleOfFireBrotherhoodFeature;
 
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var RoFCD = GetCooldown(RiddleOfFire);
+                var BrotherhoodCD = GetCooldown(Brotherhood);
+
+                if (actionID == RiddleOfFire)
+                {
+                    if (level >= 68 && level < 70)
+                        return RiddleOfFire;
+                    if (RoFCD.IsCooldown && BrotherhoodCD.IsCooldown && level >= 70)
+                        return RiddleOfFire;
+                    if (RoFCD.IsCooldown && !BrotherhoodCD.IsCooldown && level >= 70)
+                        return Brotherhood;
+
+                    return RiddleOfFire;
+                }
+                return actionID;
             }
-            return actionID;
         }
-    }
-    internal class MnkRiddleOfFireBrotherhoodFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MnkRiddleOfFireBrotherhoodFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class MonkHowlingFistMeditationFeature : CustomCombo
         {
-            var RoFCD = GetCooldown(MNK.RiddleOfFire);
-            var BrotherhoodCD = GetCooldown(MNK.Brotherhood);
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MonkHowlingFistMeditationFeature;
 
-            if (actionID == MNK.RiddleOfFire)
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (level >= 68 && level < 70)
-                    return MNK.RiddleOfFire;
-                if (RoFCD.IsCooldown && BrotherhoodCD.IsCooldown && level >= 70)
-                    return MNK.RiddleOfFire;
-                if (RoFCD.IsCooldown && !BrotherhoodCD.IsCooldown && level >= 70)
-                    return MNK.Brotherhood;
-
-                return MNK.RiddleOfFire;
-            }
-            return actionID;
-        }
-    }
-    internal class MonkHowlingFistMeditationFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MonkHowlingFistMeditationFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == MNK.HowlingFist || actionID == MNK.Enlightenment)
-            {
-                var gauge = GetJobGauge<MNKGauge>();
-
-                if (gauge.Chakra < 5)
+                if (actionID == HowlingFist || actionID == Enlightenment)
                 {
-                    return MNK.Meditation;
+                    var gauge = GetJobGauge<MNKGauge>();
+
+                    if (gauge.Chakra < 5)
+                    {
+                        return Meditation;
+                    }
                 }
+                return actionID;
             }
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -115,663 +115,664 @@ namespace XIVSlothComboPlugin.Combos
                 NinkiBhavaPooling = "NinkiBhavaPooling",
                 NinkiBunshinPooling = "NinkiBunshinPooling";
         }
-    }
 
-    internal class NinjaAeolianEdgeCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaAeolianEdgeCombo;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class NinjaAeolianEdgeCombo : CustomCombo
         {
-            if (actionID == NIN.AeolianEdge)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaAeolianEdgeCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (OriginalHook(NIN.Ninjutsu) is NIN.Rabbit) return OriginalHook(NIN.Ninjutsu);
+                if (actionID == AeolianEdge)
+                {
+                    if (OriginalHook(Ninjutsu) is NIN.Rabbit) return OriginalHook(Ninjutsu);
 
-                if (IsEnabled(CustomComboPreset.NinjaRangedUptimeFeature) && !HasEffect(NIN.Buffs.Mudra))
-                {
-                    if (!InMeleeRange())
-                        return NIN.ThrowingDaggers;
-                }
-                if (IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && (HasEffect(NIN.Buffs.Mudra) || HasEffect(NIN.Buffs.Kassatsu)))
-                {
-                    return OriginalHook(NIN.Ninjutsu);
-                }
-                if (IsEnabled(CustomComboPreset.NinjaFleetingRaijuFeature))
-                {
-                    if (HasEffect(NIN.Buffs.RaijuReady))
-                        return NIN.FleetingRaiju;
-                }
-                if (IsEnabled(CustomComboPreset.NinjaHuraijinFeature) && level >= NIN.Levels.Huraijin)
-                {
-                    var gauge = GetJobGauge<NINGauge>();
-                    if (gauge.HutonTimer <= 0)
-                        return NIN.Huraijin;
-                }
-
-                if (IsEnabled(CustomComboPreset.NinjaBunshinFeature) && level >= NIN.Levels.Bunshin)
-                {
-                    var canWeave = CanWeave(actionID);
-                    var gauge = GetJobGauge<NINGauge>();
-                    var bunshinCD = GetCooldown(NIN.Bunshin);
-                    if (gauge.Ninki >= 50 && !bunshinCD.IsCooldown && canWeave)
-                        return NIN.Bunshin;
-                    if (HasEffect(NIN.Buffs.PhantomReady) && canWeave && level >= NIN.Levels.PhantomKamaitachi)
-                        return NIN.PhantomKamaitachi;
-                }
-                if (IsEnabled(CustomComboPreset.NinjaBhavacakraFeature) && level >= NIN.Levels.Bhavacakra)
-                {
-                    var actionIDCD = GetCooldown(actionID);
-                    var gauge = GetJobGauge<NINGauge>();
-                    var bunshinCD = GetCooldown(NIN.Bunshin);
-                    if (gauge.Ninki >= 50 && actionIDCD.IsCooldown)
-                        return NIN.Bhavacakra;
-                }
-
-                if (IsEnabled(CustomComboPreset.NinAeolianAssassinateFeature) && level >= NIN.Levels.Assassinate)
-                {
-                    var actionIDCD = GetCooldown(actionID);
-                    var gauge = GetJobGauge<NINGauge>();
-                    var assasinateCD = GetCooldown(NIN.Assassinate);
-                    if (actionIDCD.IsCooldown && !assasinateCD.IsCooldown)
-                        return OriginalHook(NIN.Assassinate);
-                }
-                if (IsEnabled(CustomComboPreset.NinAeolianMugFeature) && level >= NIN.Levels.Mug)
-                {
-                    var canWeave = CanWeave(actionID);
-                    var gauge = GetJobGauge<NINGauge>();
-                    var mugCD = GetCooldown(NIN.Mug);
-                    var mugNinkiValue = Service.Configuration.GetCustomIntValue(NIN.Config.MugNinkiGauge);
-                    if (!mugCD.IsCooldown && gauge.Ninki <= mugNinkiValue && canWeave && level >= NIN.TraitLevels.Shukiho)
-                        return OriginalHook(NIN.Mug);
-                    if (!mugCD.IsCooldown && canWeave && level < NIN.TraitLevels.Shukiho)
-                        return OriginalHook(NIN.Mug);
-                }
-
-                if (comboTime > 0f)
-                {
-                    if (lastComboMove == NIN.SpinningEdge && level >= NIN.Levels.GustSlash)
+                    if (IsEnabled(CustomComboPreset.NinjaRangedUptimeFeature) && !HasEffect(Buffs.Mudra))
                     {
-                        return NIN.GustSlash;
+                        if (!InMeleeRange())
+                            return ThrowingDaggers;
+                    }
+                    if (IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && (HasEffect(Buffs.Mudra) || HasEffect(Buffs.Kassatsu)))
+                    {
+                        return OriginalHook(Ninjutsu);
+                    }
+                    if (IsEnabled(CustomComboPreset.NinjaFleetingRaijuFeature))
+                    {
+                        if (HasEffect(Buffs.RaijuReady))
+                            return FleetingRaiju;
+                    }
+                    if (IsEnabled(CustomComboPreset.NinjaHuraijinFeature) && level >= Levels.Huraijin)
+                    {
+                        var gauge = GetJobGauge<NINGauge>();
+                        if (gauge.HutonTimer <= 0)
+                            return Huraijin;
                     }
 
-                    var huton = GetJobGauge<NINGauge>();
-                    var armorcrushTimer = Service.Configuration.GetCustomIntValue(NIN.Config.HutonRemainingArmorCrush);
-
-                    if (lastComboMove == NIN.GustSlash && level >= NIN.Levels.ArmorCrush && huton.HutonTimer < armorcrushTimer * 1000 && IsEnabled(CustomComboPreset.NinjaArmorCrushOnMainCombo))
+                    if (IsEnabled(CustomComboPreset.NinjaBunshinFeature) && level >= Levels.Bunshin)
                     {
-                        return NIN.ArmorCrush;
+                        var canWeave = CanWeave(actionID);
+                        var gauge = GetJobGauge<NINGauge>();
+                        var bunshinCD = GetCooldown(Bunshin);
+                        if (gauge.Ninki >= 50 && !bunshinCD.IsCooldown && canWeave)
+                            return Bunshin;
+                        if (HasEffect(Buffs.PhantomReady) && canWeave && level >= Levels.PhantomKamaitachi)
+                            return PhantomKamaitachi;
+                    }
+                    if (IsEnabled(CustomComboPreset.NinjaBhavacakraFeature) && level >= Levels.Bhavacakra)
+                    {
+                        var actionIDCD = GetCooldown(actionID);
+                        var gauge = GetJobGauge<NINGauge>();
+                        var bunshinCD = GetCooldown(Bunshin);
+                        if (gauge.Ninki >= 50 && actionIDCD.IsCooldown)
+                            return Bhavacakra;
                     }
 
-                    if (lastComboMove == NIN.GustSlash && level >= NIN.Levels.AeolianEdge)
+                    if (IsEnabled(CustomComboPreset.NinAeolianAssassinateFeature) && level >= Levels.Assassinate)
                     {
-                        return NIN.AeolianEdge;
+                        var actionIDCD = GetCooldown(actionID);
+                        var gauge = GetJobGauge<NINGauge>();
+                        var assasinateCD = GetCooldown(Assassinate);
+                        if (actionIDCD.IsCooldown && !assasinateCD.IsCooldown)
+                            return OriginalHook(Assassinate);
                     }
+                    if (IsEnabled(CustomComboPreset.NinAeolianMugFeature) && level >= Levels.Mug)
+                    {
+                        var canWeave = CanWeave(actionID);
+                        var gauge = GetJobGauge<NINGauge>();
+                        var mugCD = GetCooldown(Mug);
+                        var mugNinkiValue = Service.Configuration.GetCustomIntValue(Config.MugNinkiGauge);
+                        if (!mugCD.IsCooldown && gauge.Ninki <= mugNinkiValue && canWeave && level >= TraitLevels.Shukiho)
+                            return OriginalHook(Mug);
+                        if (!mugCD.IsCooldown && canWeave && level < TraitLevels.Shukiho)
+                            return OriginalHook(Mug);
+                    }
+
+                    if (comboTime > 0f)
+                    {
+                        if (lastComboMove == SpinningEdge && level >= Levels.GustSlash)
+                        {
+                            return GustSlash;
+                        }
+
+                        var huton = GetJobGauge<NINGauge>();
+                        var armorcrushTimer = Service.Configuration.GetCustomIntValue(Config.HutonRemainingArmorCrush);
+
+                        if (lastComboMove == GustSlash && level >= Levels.ArmorCrush && huton.HutonTimer < armorcrushTimer * 1000 && IsEnabled(CustomComboPreset.NinjaArmorCrushOnMainCombo))
+                        {
+                            return ArmorCrush;
+                        }
+
+                        if (lastComboMove == GustSlash && level >= Levels.AeolianEdge)
+                        {
+                            return AeolianEdge;
+                        }
+                    }
+
+                    return SpinningEdge;
                 }
 
-                return NIN.SpinningEdge;
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class SimpleNinjaSingleTarget : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinSimpleSingleTarget;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class SimpleNinjaSingleTarget : CustomCombo
         {
-            if (actionID == NIN.SpinningEdge)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinSimpleSingleTarget;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var canWeave = CanWeave(actionID);
-                var gauge = GetJobGauge<NINGauge>();
-                var bunshinCD = GetCooldown(NIN.Bunshin);
-                var trickCDThreshold = Service.Configuration.GetCustomIntValue(NIN.Config.TrickCooldownRemaining);
-                var ninkiBhavaPooling = Service.Configuration.GetCustomIntValue(NIN.Config.NinkiBhavaPooling);
-                var ninkiBunshinPooling = Service.Configuration.GetCustomIntValue(NIN.Config.NinkiBunshinPooling);
-
-                if (OriginalHook(NIN.Ninjutsu) is NIN.Rabbit) return OriginalHook(NIN.Ninjutsu);
-
-
-                if (HasEffect(NIN.Buffs.RaijuReady) && !HasEffect(NIN.Buffs.Mudra))
-                    return NIN.FleetingRaiju;
-
-                if (level >= 60 && gauge.HutonTimer == 0 && !HasEffect(NIN.Buffs.Mudra))
-                    return NIN.Huraijin;
-
-                if (level >= NIN.Levels.Mug && IsEnabled(CustomComboPreset.NinSimpleMug))
+                if (actionID == SpinningEdge)
                 {
-                    var mugCD = GetCooldown(NIN.Mug);
-                    if (canWeave && !mugCD.IsCooldown && gauge.Ninki <= 60 && !HasEffect(NIN.Buffs.Mudra))
-                        return OriginalHook(NIN.Mug);
-                }
+                    var canWeave = CanWeave(actionID);
+                    var gauge = GetJobGauge<NINGauge>();
+                    var bunshinCD = GetCooldown(Bunshin);
+                    var trickCDThreshold = Service.Configuration.GetCustomIntValue(Config.TrickCooldownRemaining);
+                    var ninkiBhavaPooling = Service.Configuration.GetCustomIntValue(Config.NinkiBhavaPooling);
+                    var ninkiBunshinPooling = Service.Configuration.GetCustomIntValue(Config.NinkiBunshinPooling);
 
-                if ((!GetCooldown(NIN.TrickAttack).IsCooldown || GetCooldown(NIN.TrickAttack).CooldownRemaining <= trickCDThreshold) && (!HasEffect(NIN.Buffs.Kassatsu) || (HasEffect(NIN.Buffs.Kassatsu) && IsEnabled(CustomComboPreset.NinSimpleTrickKassatsuFeature))) && level >= 45 && IsEnabled(CustomComboPreset.NinSimpleTrickFeature))
-                {
-                    if (HasEffect(NIN.Buffs.Suiton) && !GetCooldown(NIN.TrickAttack).IsCooldown)
-                        return NIN.TrickAttack;
-
-                    if (!HasEffect(NIN.Buffs.Mudra) && !HasEffect(NIN.Buffs.Suiton) && (GetCooldown(NIN.Chi).RemainingCharges > 0 || (HasEffect(NIN.Buffs.Kassatsu) && IsEnabled(CustomComboPreset.NinSimpleTrickKassatsuFeature))))
-                        return OriginalHook(NIN.Chi);
-
-                    if (level >= NIN.Levels.Ten && !HasEffect(NIN.Buffs.Suiton) &&  OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                        return OriginalHook(NIN.TenCombo);
-
-                    if (level >= NIN.Levels.Jin && !HasEffect(NIN.Buffs.Suiton) && (OriginalHook(NIN.Ninjutsu) is NIN.Katon or NIN.GokaMekkyaku))
-                        return OriginalHook(NIN.JinCombo);
-
-                    if (OriginalHook(NIN.Ninjutsu) is NIN.Suiton && !HasEffect(NIN.Buffs.Suiton))
-                        return OriginalHook(NIN.Ninjutsu);
-                }
+                    if (OriginalHook(Ninjutsu) is NIN.Rabbit) return OriginalHook(Ninjutsu);
 
 
-                if (!GetCooldown(NIN.Kassatsu).IsCooldown && CanWeave(actionID) && !HasEffect(NIN.Buffs.Mudra) && level >= 50)
-                    return NIN.Kassatsu;
+                    if (HasEffect(Buffs.RaijuReady) && !HasEffect(Buffs.Mudra))
+                        return FleetingRaiju;
 
+                    if (level >= 60 && gauge.HutonTimer == 0 && !HasEffect(Buffs.Mudra))
+                        return Huraijin;
 
-                if (level >= 76)
-                {
-                    if (!HasEffect(NIN.Buffs.Kassatsu))
+                    if (level >= Levels.Mug && IsEnabled(CustomComboPreset.NinSimpleMug))
                     {
-                        if (OriginalHook(NIN.Ninjutsu) == NIN.Raiton)
-                            return OriginalHook(NIN.Ninjutsu);
-                        if (OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            return OriginalHook(NIN.ChiCombo);
-                        if (HasEffect(NIN.Buffs.Kassatsu))
-                            return NIN.JinCombo;
-                        if (GetCooldown(NIN.Jin).RemainingCharges > 0)
-                            return NIN.Jin;
+                        var mugCD = GetCooldown(Mug);
+                        if (canWeave && !mugCD.IsCooldown && gauge.Ninki <= 60 && !HasEffect(Buffs.Mudra))
+                            return OriginalHook(Mug);
+                    }
+
+                    if ((!GetCooldown(TrickAttack).IsCooldown || GetCooldown(TrickAttack).CooldownRemaining <= trickCDThreshold) && (!HasEffect(Buffs.Kassatsu) || (HasEffect(Buffs.Kassatsu) && IsEnabled(CustomComboPreset.NinSimpleTrickKassatsuFeature))) && level >= 45 && IsEnabled(CustomComboPreset.NinSimpleTrickFeature))
+                    {
+                        if (HasEffect(Buffs.Suiton) && !GetCooldown(TrickAttack).IsCooldown)
+                            return TrickAttack;
+
+                        if (!HasEffect(Buffs.Mudra) && !HasEffect(Buffs.Suiton) && (GetCooldown(Chi).RemainingCharges > 0 || (HasEffect(Buffs.Kassatsu) && IsEnabled(CustomComboPreset.NinSimpleTrickKassatsuFeature))))
+                            return OriginalHook(Chi);
+
+                        if (level >= Levels.Ten && !HasEffect(Buffs.Suiton) && OriginalHook(Ninjutsu) == FumaShuriken)
+                            return OriginalHook(TenCombo);
+
+                        if (level >= Levels.Jin && !HasEffect(Buffs.Suiton) && (OriginalHook(Ninjutsu) is Katon or GokaMekkyaku))
+                            return OriginalHook(JinCombo);
+
+                        if (OriginalHook(Ninjutsu) is NIN.Suiton && !HasEffect(Buffs.Suiton))
+                            return OriginalHook(Ninjutsu);
+                    }
+
+
+                    if (!GetCooldown(Kassatsu).IsCooldown && CanWeave(actionID) && !HasEffect(Buffs.Mudra) && level >= 50)
+                        return Kassatsu;
+
+
+                    if (level >= 76)
+                    {
+                        if (!HasEffect(Buffs.Kassatsu))
+                        {
+                            if (OriginalHook(Ninjutsu) == Raiton)
+                                return OriginalHook(Ninjutsu);
+                            if (OriginalHook(Ninjutsu) == FumaShuriken)
+                                return OriginalHook(ChiCombo);
+                            if (HasEffect(Buffs.Kassatsu))
+                                return JinCombo;
+                            if (GetCooldown(Jin).RemainingCharges > 0)
+                                return Jin;
+                        }
+                        else
+                        {
+                            if (OriginalHook(Ninjutsu) is HyoshoRanryu or Raiton)
+                                return OriginalHook(Ninjutsu);
+                            if (OriginalHook(Ninjutsu) == FumaShuriken)
+                                return OriginalHook(JinCombo);
+
+                            return OriginalHook(Ten);
+                        }
                     }
                     else
                     {
-                        if (OriginalHook(NIN.Ninjutsu) is NIN.HyoshoRanryu or NIN.Raiton)
-                            return OriginalHook(NIN.Ninjutsu);
-                        if (OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            return OriginalHook(NIN.JinCombo);
-
-                        return OriginalHook(NIN.Ten);
-                    }
-                }
-                else
-                {
-                    if (OriginalHook(NIN.Ninjutsu) == NIN.Raiton)
-                        return OriginalHook(NIN.Ninjutsu);
-                    if (OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                    {
-                        if (level < NIN.Levels.Chi)
-                            return OriginalHook(NIN.Ninjutsu);
-
-                        return OriginalHook(NIN.ChiCombo);
-                    }
-                    if (HasEffect(NIN.Buffs.Kassatsu))
-                        return NIN.JinCombo;
-                    if (GetCooldown(NIN.Jin).RemainingCharges > 0 && level >= NIN.Levels.Jin)
-                        return NIN.Jin;
-                }
-
-                if (!IsEnabled(CustomComboPreset.NinNinkiBunshinPooling))
-                {
-                    if (gauge.Ninki >= 50 && !bunshinCD.IsCooldown && canWeave && level >= NIN.Levels.Bunshin)
-                        return NIN.Bunshin;
-                }
-                else
-                {
-                    if (gauge.Ninki >= ninkiBunshinPooling && !bunshinCD.IsCooldown && canWeave && level >= NIN.Levels.Bunshin)
-                        return NIN.Bunshin;
-                }
-
-                if (HasEffect(NIN.Buffs.PhantomReady) && level >= NIN.Levels.PhantomKamaitachi)
-                    return NIN.PhantomKamaitachi;
-
-                if (!IsEnabled(CustomComboPreset.NinNinkiBhavacakraPooling))
-                {
-                    if (gauge.Ninki >= 50 && canWeave && level >= NIN.Levels.Bhavacakra)
-                        return NIN.Bhavacakra;
-                }
-                else
-                {
-                    if (gauge.Ninki >= ninkiBhavaPooling && canWeave && level >= NIN.Levels.Bhavacakra)
-                        return NIN.Bhavacakra;
-                }
-
-
-                if (level >= NIN.Levels.Assassinate)
-                {
-                    var assasinateCD = GetCooldown(OriginalHook(NIN.Assassinate));
-                    if (canWeave && !assasinateCD.IsCooldown)
-                        return OriginalHook(NIN.Assassinate);
-                }
-
-
-                if (comboTime > 0f)
-                {
-                    if (lastComboMove == NIN.SpinningEdge && level >= NIN.Levels.GustSlash)
-                        return NIN.GustSlash;
-
-
-                    if (lastComboMove == NIN.GustSlash && gauge.HutonTimer < 15000 && level >= NIN.Levels.ArmorCrush)
-                        return NIN.ArmorCrush;
-
-
-                    if (lastComboMove == NIN.GustSlash && level >= NIN.Levels.AeolianEdge)
-                        return NIN.AeolianEdge;
-
-                }
-
-                return NIN.SpinningEdge;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class SimpleNinjaAoE : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinSimpleAoE;
-
-        private static uint lastUsedJutsu { get; set; }
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == NIN.DeathBlossom)
-            {
-
-                var dotonBuff = FindEffect(NIN.Buffs.Doton);
-                var jutsuCooldown = GetCooldown(NIN.Ten);
-                var jutsuCharges = jutsuCooldown.RemainingCharges;
-                var jutsuFullCooldown = jutsuCooldown.CooldownRemaining;
-                lastUsedJutsu = OriginalHook(NIN.Ninjutsu) != NIN.Ninjutsu ? OriginalHook(NIN.Ninjutsu) : lastUsedJutsu;
-
-
-                var gauge = GetJobGauge<NINGauge>();
-                if (gauge.HutonTimer == 0 && !HasEffect(NIN.Buffs.Mudra) && !HasEffect(NIN.Buffs.Kassatsu) && level >= 60)
-                    return NIN.Huraijin;
-
-                //Doton is really annoying. It takes a hot moment for the buff to apply. This is just logic to try and deal with it so it doesn't clip with the rest of the feature.
-                if (OriginalHook(NIN.Ninjutsu) == NIN.Doton)
-                {
-                    return OriginalHook(NIN.Ninjutsu);
-                }
-
-                if ((!HasEffect(NIN.Buffs.Doton) || (dotonBuff != null && dotonBuff?.RemainingTime <= 5)) && (jutsuCharges > 0 || HasEffect(NIN.Buffs.Mudra)) && level >= NIN.Levels.Doton && lastUsedJutsu != NIN.Doton && IsEnabled(CustomComboPreset.NinSimpleAoeMudras))
-                {
-                    if (OriginalHook(NIN.Ninjutsu) == NIN.Doton)
-                    {
-                        return NIN.Doton;
-                    }
-                    if (OriginalHook(NIN.Ninjutsu) is NIN.Katon or NIN.GokaMekkyaku)
-                    {
-                        return NIN.ChiCombo;
-                    }
-                    if (OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                    {
-                        return NIN.TenCombo;
-                    }
-
-                    if (HasEffect(NIN.Buffs.Kassatsu)) return NIN.JinCombo;
-
-                    if (!HasEffect(NIN.Buffs.Mudra))
-                        return NIN.Jin;
-
-                }
-
-
-
-                if ((jutsuCharges > 0 || HasEffect(NIN.Buffs.Mudra) || HasEffect(NIN.Buffs.Kassatsu) || (!GetCooldown(NIN.Kassatsu).IsCooldown) && level >= NIN.Levels.Kassatsu) && IsEnabled(CustomComboPreset.NinSimpleAoeMudras))
-                {
-                    if (!GetCooldown(NIN.Kassatsu).IsCooldown && !HasEffect(NIN.Buffs.Mudra) && level >= NIN.Levels.Kassatsu)
-                    {
-                        return NIN.Kassatsu;
-                    }
-
-                    if (OriginalHook(NIN.Ninjutsu) is NIN.Katon or NIN.GokaMekkyaku) return OriginalHook(NIN.Ninjutsu);
-                    if (OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken) return NIN.TenCombo;
-
-                    if (HasEffect(NIN.Buffs.Kassatsu)) return NIN.JinCombo;
-
-                    return NIN.Jin;
-
-                }
-
-                if (!HasEffect(NIN.Buffs.Mudra))
-                {
-                    var actionIDCD = GetCooldown(actionID);
-                    var bunshinCD = GetCooldown(NIN.Bunshin);
-
-                    if (gauge.Ninki >= 50 && !bunshinCD.IsCooldown && actionIDCD.IsCooldown && level >= NIN.Levels.Bunshin && IsEnabled(CustomComboPreset.NinSimpleAoeBunshin))
-                        return NIN.Bunshin;
-                    if (HasEffect(NIN.Buffs.PhantomReady) && level >= NIN.Levels.PhantomKamaitachi && IsEnabled(CustomComboPreset.NinSimpleAoeBunshin))
-                        return NIN.PhantomKamaitachi;
-                    if (gauge.Ninki >= 50 && actionIDCD.IsCooldown && IsEnabled(CustomComboPreset.NinSimpleHellfrogFeature))
-                        return NIN.Hellfrog;
-
-                    if (comboTime > 0f && lastComboMove == NIN.DeathBlossom && level >= 52)
-                    {
-                        return NIN.HakkeMujinsatsu;
-                    }
-
-
-                    return NIN.DeathBlossom;
-                }
-
-
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class NinjaArmorCrushCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaArmorCrushCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == NIN.ArmorCrush)
-            {
-                if (CustomCombo.IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && CustomCombo.OriginalHook(NIN.Jin) == CustomCombo.OriginalHook(NIN.JinCombo))
-                {
-                    return CustomCombo.OriginalHook(NIN.Ninjutsu);
-                }
-
-                if (comboTime > 0f)
-                {
-                    if (lastComboMove == NIN.SpinningEdge && level >= 4)
-                    {
-                        return NIN.GustSlash;
-                    }
-
-                    if (lastComboMove == NIN.GustSlash && level >= 54)
-                    {
-                        return NIN.ArmorCrush;
-                    }
-                }
-
-                return NIN.SpinningEdge;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class NinHuraijinArmorCrush : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinHuraijinArmorCrush;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == NIN.Huraijin)
-            {
-                if (lastComboMove == NIN.GustSlash)
-                    return NIN.ArmorCrush;
-            }
-
-            return actionID;
-        }
-    }
-
-
-    internal class NinjaHideMugFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaHideMugFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == NIN.Hide)
-            {
-                if (CustomCombo.HasEffect(NIN.Buffs.Suiton) || CustomCombo.HasEffect(NIN.Buffs.Hidden))
-                {
-                    return NIN.TrickAttack;
-                }
-
-                if (CustomCombo.HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
-                {
-                    return NIN.Mug;
-                }
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class NinjaKassatsuChiJinFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaKassatsuChiJinFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == NIN.Chi && level >= 76 && CustomCombo.HasEffect(NIN.Buffs.Kassatsu))
-            {
-                return NIN.Jin;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class NinjaKassatsuTrickFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaKassatsuTrickFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == NIN.Kassatsu)
-            {
-                if (CustomCombo.HasEffect(NIN.Buffs.Suiton) || CustomCombo.HasEffect(NIN.Buffs.Hidden))
-                {
-                    return NIN.TrickAttack;
-                }
-
-                return NIN.Kassatsu;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class NinjaTCJMeisuiFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.NinjaTCJMeisuiFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == NIN.TenChiJin)
-            {
-
-                if (HasEffect(NIN.Buffs.Suiton))
-                    return NIN.Meisui;
-
-                if (HasEffect(NIN.Buffs.TenChiJin) && IsEnabled(CustomComboPreset.NinTCJFeature))
-                {
-                    var tcjTimer = FindEffectAny(NIN.Buffs.TenChiJin).RemainingTime;
-
-                    if (tcjTimer > 5)
-                        return OriginalHook(NIN.Ten);
-                    if (tcjTimer > 4)
-                        return OriginalHook(NIN.Chi);
-                    if (tcjTimer > 3)
-                        return OriginalHook(NIN.Jin);
-                }
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class NinjaHuraijinRaijuFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaHuraijinRaijuFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == NIN.Huraijin)
-            {
-                if (IsEnabled(CustomComboPreset.NinjaHuraijinRaijuFeature1) && level >= NIN.Levels.ForkedRaiju && HasEffect(NIN.Buffs.RaijuReady))
-                    return NIN.FleetingRaiju;
-
-                if (IsEnabled(CustomComboPreset.NinjaHuraijinRaijuFeature2) && level >= NIN.Levels.ForkedRaiju && HasEffect(NIN.Buffs.RaijuReady))
-                    return NIN.ForkedRaiju;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class NinjaSimpleMudras : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaSimpleMudras;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is NIN.Ten or NIN.Chi or NIN.Jin)
-            {
-                var mudrapath = Service.Configuration.MudraPathSelection;
-
-                if (HasEffect(NIN.Buffs.Mudra))
-                {
-                    if (mudrapath == 0)
-                    {
-                        if (level >= NIN.Levels.Ten && actionID == NIN.Ten)
+                        if (OriginalHook(Ninjutsu) == Raiton)
+                            return OriginalHook(Ninjutsu);
+                        if (OriginalHook(Ninjutsu) == FumaShuriken)
                         {
-                            if (level >= NIN.Levels.Chi && (OriginalHook(NIN.Ninjutsu) is NIN.Hyoton or NIN.HyoshoRanryu))
-                            {
-                                return OriginalHook(NIN.ChiCombo);
-                            }
-                            if (OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            {
-                                if (level >= NIN.Levels.Jin) return OriginalHook(NIN.JinCombo);
-                                else if (level >= NIN.Levels.Chi) return OriginalHook(NIN.ChiCombo);
-                            }
+                            if (level < Levels.Chi)
+                                return OriginalHook(Ninjutsu);
+
+                            return OriginalHook(ChiCombo);
+                        }
+                        if (HasEffect(Buffs.Kassatsu))
+                            return JinCombo;
+                        if (GetCooldown(Jin).RemainingCharges > 0 && level >= Levels.Jin)
+                            return Jin;
+                    }
+
+                    if (!IsEnabled(CustomComboPreset.NinNinkiBunshinPooling))
+                    {
+                        if (gauge.Ninki >= 50 && !bunshinCD.IsCooldown && canWeave && level >= Levels.Bunshin)
+                            return Bunshin;
+                    }
+                    else
+                    {
+                        if (gauge.Ninki >= ninkiBunshinPooling && !bunshinCD.IsCooldown && canWeave && level >= Levels.Bunshin)
+                            return Bunshin;
+                    }
+
+                    if (HasEffect(Buffs.PhantomReady) && level >= Levels.PhantomKamaitachi)
+                        return PhantomKamaitachi;
+
+                    if (!IsEnabled(CustomComboPreset.NinNinkiBhavacakraPooling))
+                    {
+                        if (gauge.Ninki >= 50 && canWeave && level >= Levels.Bhavacakra)
+                            return Bhavacakra;
+                    }
+                    else
+                    {
+                        if (gauge.Ninki >= ninkiBhavaPooling && canWeave && level >= Levels.Bhavacakra)
+                            return Bhavacakra;
+                    }
+
+
+                    if (level >= Levels.Assassinate)
+                    {
+                        var assasinateCD = GetCooldown(OriginalHook(Assassinate));
+                        if (canWeave && !assasinateCD.IsCooldown)
+                            return OriginalHook(Assassinate);
+                    }
+
+
+                    if (comboTime > 0f)
+                    {
+                        if (lastComboMove == SpinningEdge && level >= Levels.GustSlash)
+                            return GustSlash;
+
+
+                        if (lastComboMove == GustSlash && gauge.HutonTimer < 15000 && level >= Levels.ArmorCrush)
+                            return ArmorCrush;
+
+
+                        if (lastComboMove == GustSlash && level >= Levels.AeolianEdge)
+                            return AeolianEdge;
+
+                    }
+
+                    return SpinningEdge;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class SimpleNinjaAoE : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinSimpleAoE;
+
+            private static uint lastUsedJutsu { get; set; }
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == DeathBlossom)
+                {
+
+                    var dotonBuff = FindEffect(Buffs.Doton);
+                    var jutsuCooldown = GetCooldown(Ten);
+                    var jutsuCharges = jutsuCooldown.RemainingCharges;
+                    var jutsuFullCooldown = jutsuCooldown.CooldownRemaining;
+                    lastUsedJutsu = OriginalHook(Ninjutsu) != Ninjutsu ? OriginalHook(Ninjutsu) : lastUsedJutsu;
+
+
+                    var gauge = GetJobGauge<NINGauge>();
+                    if (gauge.HutonTimer == 0 && !HasEffect(Buffs.Mudra) && !HasEffect(Buffs.Kassatsu) && level >= 60)
+                        return Huraijin;
+
+                    //Doton is really annoying. It takes a hot moment for the buff to apply. This is just logic to try and deal with it so it doesn't clip with the rest of the feature.
+                    if (OriginalHook(Ninjutsu) == Doton)
+                    {
+                        return OriginalHook(Ninjutsu);
+                    }
+
+                    if ((!HasEffect(Buffs.Doton) || (dotonBuff != null && dotonBuff?.RemainingTime <= 5)) && (jutsuCharges > 0 || HasEffect(Buffs.Mudra)) && level >= Levels.Doton && lastUsedJutsu != Doton && IsEnabled(CustomComboPreset.NinSimpleAoeMudras))
+                    {
+                        if (OriginalHook(Ninjutsu) == Doton)
+                        {
+                            return Doton;
+                        }
+                        if (OriginalHook(Ninjutsu) is Katon or GokaMekkyaku)
+                        {
+                            return ChiCombo;
+                        }
+                        if (OriginalHook(Ninjutsu) == FumaShuriken)
+                        {
+                            return TenCombo;
                         }
 
-                        if (level >= NIN.Levels.Chi && actionID == NIN.Chi)
-                        {
-                            if (level >= NIN.Levels.Jin && (OriginalHook(NIN.Ninjutsu) is NIN.Katon or NIN.GokaMekkyaku))
-                            {
-                                return OriginalHook(NIN.JinCombo);
-                            }
-                            if (level >= NIN.Levels.Ten && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            {
-                                return OriginalHook(NIN.TenCombo);
-                            }
-                        }
+                        if (HasEffect(Buffs.Kassatsu)) return JinCombo;
 
-                        if (level >= NIN.Levels.Jin && actionID == NIN.Jin)
-                        {
-                            if (level >= NIN.Levels.Ten && OriginalHook(NIN.Ninjutsu) == NIN.Raiton)
-                            {
-                                return OriginalHook(NIN.TenCombo);
-                            }
-                            if (level >= NIN.Levels.Chi && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            {
-                                return OriginalHook(NIN.ChiCombo);
-                            }
-                        }
+                        if (!HasEffect(Buffs.Mudra))
+                            return Jin;
 
-                        return OriginalHook(NIN.Ninjutsu);
                     }
 
 
-                    if (mudrapath == 1)
+
+                    if ((jutsuCharges > 0 || HasEffect(Buffs.Mudra) || HasEffect(Buffs.Kassatsu) || (!GetCooldown(Kassatsu).IsCooldown) && level >= Levels.Kassatsu) && IsEnabled(CustomComboPreset.NinSimpleAoeMudras))
                     {
-                        if (level >= NIN.Levels.Ten && actionID == NIN.Ten)
+                        if (!GetCooldown(Kassatsu).IsCooldown && !HasEffect(Buffs.Mudra) && level >= Levels.Kassatsu)
                         {
-                            if (level >= NIN.Levels.Jin && (OriginalHook(NIN.Ninjutsu) is NIN.Raiton))
-                            {
-                                return OriginalHook(NIN.JinCombo);
-                            }
-                            if (level >= NIN.Levels.Chi && (OriginalHook(NIN.Ninjutsu) is NIN.HyoshoRanryu))
-                            {
-                                return OriginalHook(NIN.ChiCombo);
-                            }
-                            if (OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            {
-                                if (HasEffect(NIN.Buffs.Kassatsu) && level >= NIN.Levels.EnhancedKassatsu) return NIN.JinCombo;
-                                if (level >= NIN.Levels.Chi) return OriginalHook(NIN.ChiCombo);
-                                else if (level >= NIN.Levels.Jin) return OriginalHook(NIN.JinCombo);
-                            }
+                            return Kassatsu;
                         }
 
-                        if (level >= NIN.Levels.Chi && actionID == NIN.Chi)
-                        {
-                            if (level >= NIN.Levels.Ten && (OriginalHook(NIN.Ninjutsu) is NIN.Hyoton))
-                            {
-                                return OriginalHook(NIN.TenCombo);
-                            }
-                            if (level >= NIN.Levels.Jin && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            {
-                                return OriginalHook(NIN.JinCombo);
-                            }
-                        }
+                        if (OriginalHook(Ninjutsu) is Katon or GokaMekkyaku) return OriginalHook(Ninjutsu);
+                        if (OriginalHook(Ninjutsu) == FumaShuriken) return TenCombo;
 
-                        if (level >= NIN.Levels.Jin && actionID == NIN.Jin)
-                        {
-                            if (level >= NIN.Levels.Chi && OriginalHook(NIN.Ninjutsu) is NIN.GokaMekkyaku or NIN.Katon)
-                            {
-                                return OriginalHook(NIN.ChiCombo);
-                            }
-                            if (level >= NIN.Levels.Ten && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            {
-                                return OriginalHook(NIN.TenCombo);
-                            }
-                        }
+                        if (HasEffect(Buffs.Kassatsu)) return JinCombo;
 
-                        return OriginalHook(NIN.Ninjutsu);
+                        return Jin;
+
                     }
 
-                    if (mudrapath == 2)
+                    if (!HasEffect(Buffs.Mudra))
                     {
-                        if (level >= NIN.Levels.Ten && actionID == NIN.Ten)
-                        {
-                            if (level >= NIN.Levels.Chi && (OriginalHook(NIN.Ninjutsu) is NIN.Hyoton or NIN.HyoshoRanryu))
-                            {
-                                return OriginalHook(NIN.Chi);
-                            }
+                        var actionIDCD = GetCooldown(actionID);
+                        var bunshinCD = GetCooldown(Bunshin);
 
-                            if (OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            {
-                                if (level >= NIN.Levels.Jin) return OriginalHook(NIN.JinCombo);
-                                else if (level >= NIN.Levels.Chi) return OriginalHook(NIN.ChiCombo);
-                            }
+                        if (gauge.Ninki >= 50 && !bunshinCD.IsCooldown && actionIDCD.IsCooldown && level >= Levels.Bunshin && IsEnabled(CustomComboPreset.NinSimpleAoeBunshin))
+                            return Bunshin;
+                        if (HasEffect(Buffs.PhantomReady) && level >= Levels.PhantomKamaitachi && IsEnabled(CustomComboPreset.NinSimpleAoeBunshin))
+                            return PhantomKamaitachi;
+                        if (gauge.Ninki >= 50 && actionIDCD.IsCooldown && IsEnabled(CustomComboPreset.NinSimpleHellfrogFeature))
+                            return Hellfrog;
+
+                        if (comboTime > 0f && lastComboMove == DeathBlossom && level >= 52)
+                        {
+                            return HakkeMujinsatsu;
                         }
 
-                        if (level >= NIN.Levels.Chi && actionID == NIN.Chi)
-                        {
-                            if (level >= NIN.Levels.Jin && (OriginalHook(NIN.Ninjutsu) is NIN.Katon or NIN.GokaMekkyaku))
-                            {
-                                return OriginalHook(NIN.Jin);
-                            }
-                            if (level >= NIN.Levels.Ten && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            {
-                                return OriginalHook(NIN.Ten);
-                            }
-                        }
 
-                        if (level >= NIN.Levels.Jin && actionID == NIN.Jin)
-                        {
-                            if (level >= NIN.Levels.Ten && OriginalHook(NIN.Ninjutsu) is NIN.Raiton)
-                            {
-                                return OriginalHook(NIN.Ten);
-                            }
-                            if (level >= NIN.Levels.Chi && OriginalHook(NIN.Ninjutsu) == NIN.GokaMekkyaku)
-                            {
-                                return OriginalHook(NIN.Chi);
-                            }
-                            if (level >= NIN.Levels.Chi && OriginalHook(NIN.Ninjutsu) == NIN.FumaShuriken)
-                            {
-                                if (HasEffect(NIN.Buffs.Kassatsu) && level >= NIN.Levels.EnhancedKassatsu) return OriginalHook(NIN.Ten);
-                                return OriginalHook(NIN.Chi);
-                            }
-                        }
-
-                        return OriginalHook(NIN.Ninjutsu);
+                        return DeathBlossom;
                     }
 
 
                 }
-            }
 
-            return actionID;
+                return actionID;
+            }
+        }
+
+        internal class NinjaArmorCrushCombo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaArmorCrushCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == ArmorCrush)
+                {
+                    if (IsEnabled(CustomComboPreset.NinjaGCDNinjutsuFeature) && OriginalHook(Jin) == OriginalHook(JinCombo))
+                    {
+                        return OriginalHook(Ninjutsu);
+                    }
+
+                    if (comboTime > 0f)
+                    {
+                        if (lastComboMove == SpinningEdge && level >= 4)
+                        {
+                            return GustSlash;
+                        }
+
+                        if (lastComboMove == GustSlash && level >= 54)
+                        {
+                            return ArmorCrush;
+                        }
+                    }
+
+                    return SpinningEdge;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class NinHuraijinArmorCrush : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinHuraijinArmorCrush;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Huraijin)
+                {
+                    if (lastComboMove == GustSlash)
+                        return ArmorCrush;
+                }
+
+                return actionID;
+            }
+        }
+
+
+        internal class NinjaHideMugFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaHideMugFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Hide)
+                {
+                    if (HasEffect(Buffs.Suiton) || HasEffect(Buffs.Hidden))
+                    {
+                        return TrickAttack;
+                    }
+
+                    if (HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
+                    {
+                        return Mug;
+                    }
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class NinjaKassatsuChiJinFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaKassatsuChiJinFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Chi && level >= 76 && HasEffect(Buffs.Kassatsu))
+                {
+                    return Jin;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class NinjaKassatsuTrickFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaKassatsuTrickFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Kassatsu)
+                {
+                    if (HasEffect(Buffs.Suiton) || HasEffect(Buffs.Hidden))
+                    {
+                        return TrickAttack;
+                    }
+
+                    return Kassatsu;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class NinjaTCJMeisuiFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset => CustomComboPreset.NinjaTCJMeisuiFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == TenChiJin)
+                {
+
+                    if (HasEffect(Buffs.Suiton))
+                        return Meisui;
+
+                    if (HasEffect(Buffs.TenChiJin) && IsEnabled(CustomComboPreset.NinTCJFeature))
+                    {
+                        var tcjTimer = FindEffectAny(Buffs.TenChiJin).RemainingTime;
+
+                        if (tcjTimer > 5)
+                            return OriginalHook(Ten);
+                        if (tcjTimer > 4)
+                            return OriginalHook(Chi);
+                        if (tcjTimer > 3)
+                            return OriginalHook(Jin);
+                    }
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class NinjaHuraijinRaijuFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaHuraijinRaijuFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Huraijin)
+                {
+                    if (IsEnabled(CustomComboPreset.NinjaHuraijinRaijuFeature1) && level >= Levels.ForkedRaiju && HasEffect(Buffs.RaijuReady))
+                        return FleetingRaiju;
+
+                    if (IsEnabled(CustomComboPreset.NinjaHuraijinRaijuFeature2) && level >= Levels.ForkedRaiju && HasEffect(Buffs.RaijuReady))
+                        return ForkedRaiju;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class NinjaSimpleMudras : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NinjaSimpleMudras;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Ten or Chi or Jin)
+                {
+                    var mudrapath = Service.Configuration.MudraPathSelection;
+
+                    if (HasEffect(Buffs.Mudra))
+                    {
+                        if (mudrapath == 0)
+                        {
+                            if (level >= Levels.Ten && actionID == Ten)
+                            {
+                                if (level >= Levels.Chi && (OriginalHook(Ninjutsu) is Hyoton or HyoshoRanryu))
+                                {
+                                    return OriginalHook(ChiCombo);
+                                }
+                                if (OriginalHook(Ninjutsu) == FumaShuriken)
+                                {
+                                    if (level >= Levels.Jin) return OriginalHook(JinCombo);
+                                    else if (level >= Levels.Chi) return OriginalHook(ChiCombo);
+                                }
+                            }
+
+                            if (level >= Levels.Chi && actionID == Chi)
+                            {
+                                if (level >= Levels.Jin && (OriginalHook(Ninjutsu) is Katon or GokaMekkyaku))
+                                {
+                                    return OriginalHook(JinCombo);
+                                }
+                                if (level >= Levels.Ten && OriginalHook(Ninjutsu) == FumaShuriken)
+                                {
+                                    return OriginalHook(TenCombo);
+                                }
+                            }
+
+                            if (level >= Levels.Jin && actionID == Jin)
+                            {
+                                if (level >= Levels.Ten && OriginalHook(Ninjutsu) == Raiton)
+                                {
+                                    return OriginalHook(TenCombo);
+                                }
+                                if (level >= Levels.Chi && OriginalHook(Ninjutsu) == FumaShuriken)
+                                {
+                                    return OriginalHook(ChiCombo);
+                                }
+                            }
+
+                            return OriginalHook(Ninjutsu);
+                        }
+
+
+                        if (mudrapath == 1)
+                        {
+                            if (level >= Levels.Ten && actionID == Ten)
+                            {
+                                if (level >= Levels.Jin && (OriginalHook(Ninjutsu) is NIN.Raiton))
+                                {
+                                    return OriginalHook(JinCombo);
+                                }
+                                if (level >= Levels.Chi && (OriginalHook(Ninjutsu) is NIN.HyoshoRanryu))
+                                {
+                                    return OriginalHook(ChiCombo);
+                                }
+                                if (OriginalHook(Ninjutsu) == FumaShuriken)
+                                {
+                                    if (HasEffect(Buffs.Kassatsu) && level >= Levels.EnhancedKassatsu) return JinCombo;
+                                    if (level >= Levels.Chi) return OriginalHook(ChiCombo);
+                                    else if (level >= Levels.Jin) return OriginalHook(JinCombo);
+                                }
+                            }
+
+                            if (level >= Levels.Chi && actionID == Chi)
+                            {
+                                if (level >= Levels.Ten && (OriginalHook(Ninjutsu) is NIN.Hyoton))
+                                {
+                                    return OriginalHook(TenCombo);
+                                }
+                                if (level >= Levels.Jin && OriginalHook(Ninjutsu) == FumaShuriken)
+                                {
+                                    return OriginalHook(JinCombo);
+                                }
+                            }
+
+                            if (level >= Levels.Jin && actionID == Jin)
+                            {
+                                if (level >= Levels.Chi && OriginalHook(Ninjutsu) is GokaMekkyaku or Katon)
+                                {
+                                    return OriginalHook(ChiCombo);
+                                }
+                                if (level >= Levels.Ten && OriginalHook(Ninjutsu) == FumaShuriken)
+                                {
+                                    return OriginalHook(TenCombo);
+                                }
+                            }
+
+                            return OriginalHook(Ninjutsu);
+                        }
+
+                        if (mudrapath == 2)
+                        {
+                            if (level >= Levels.Ten && actionID == Ten)
+                            {
+                                if (level >= Levels.Chi && (OriginalHook(Ninjutsu) is Hyoton or HyoshoRanryu))
+                                {
+                                    return OriginalHook(Chi);
+                                }
+
+                                if (OriginalHook(Ninjutsu) == FumaShuriken)
+                                {
+                                    if (level >= Levels.Jin) return OriginalHook(JinCombo);
+                                    else if (level >= Levels.Chi) return OriginalHook(ChiCombo);
+                                }
+                            }
+
+                            if (level >= Levels.Chi && actionID == Chi)
+                            {
+                                if (level >= Levels.Jin && (OriginalHook(Ninjutsu) is Katon or GokaMekkyaku))
+                                {
+                                    return OriginalHook(Jin);
+                                }
+                                if (level >= Levels.Ten && OriginalHook(Ninjutsu) == FumaShuriken)
+                                {
+                                    return OriginalHook(Ten);
+                                }
+                            }
+
+                            if (level >= Levels.Jin && actionID == Jin)
+                            {
+                                if (level >= Levels.Ten && OriginalHook(Ninjutsu) is NIN.Raiton)
+                                {
+                                    return OriginalHook(Ten);
+                                }
+                                if (level >= Levels.Chi && OriginalHook(Ninjutsu) == GokaMekkyaku)
+                                {
+                                    return OriginalHook(Chi);
+                                }
+                                if (level >= Levels.Chi && OriginalHook(Ninjutsu) == FumaShuriken)
+                                {
+                                    if (HasEffect(Buffs.Kassatsu) && level >= Levels.EnhancedKassatsu) return OriginalHook(Ten);
+                                    return OriginalHook(Chi);
+                                }
+                            }
+
+                            return OriginalHook(Ninjutsu);
+                        }
+
+
+                    }
+                }
+
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/Combos/PLD.cs
+++ b/XIVSlothCombo/Combos/PLD.cs
@@ -89,260 +89,261 @@
             public const string
                 PLDKeepInterveneCharges = "PLDKeepInterveneCharges";
         }
-    }
 
-    internal class PaladinGoringBladeCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinGoringBladeCombo;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class PaladinGoringBladeCombo : CustomCombo
         {
-            if (actionID is PLD.GoringBlade)
-            {
-                if (comboTime > 0)
-                {
-                    if (lastComboMove is PLD.FastBlade && level >= PLD.Levels.RiotBlade)
-                        return PLD.RiotBlade;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinGoringBladeCombo;
 
-                    if (lastComboMove is PLD.RiotBlade && level >= PLD.Levels.GoringBlade)
-                        return PLD.GoringBlade;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is PLD.GoringBlade)
+                {
+                    if (comboTime > 0)
+                    {
+                        if (lastComboMove is PLD.FastBlade && level >= Levels.RiotBlade)
+                            return RiotBlade;
+
+                        if (lastComboMove is PLD.RiotBlade && level >= Levels.GoringBlade)
+                            return GoringBlade;
+                    }
+
+                    return FastBlade;
                 }
 
-                return PLD.FastBlade;
+                return actionID;
+            }
+        }
+
+        internal class PaladinRoyalAuthorityCombo : CustomCombo
+        {
+
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinRoyalAuthorityCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is RageOfHalone or RoyalAuthority)
+                {
+                    var interveneChargesRemaining = Service.Configuration.GetCustomIntValue(Config.PLDKeepInterveneCharges);
+                    var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+
+                    // Uptime Features
+                    if (!InMeleeRange() && !(HasEffect(Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth))
+                    {
+                        if (IsEnabled(CustomComboPreset.PaladinRangedUptimeFeature) && level >= Levels.ShieldLob && !HasEffect(Buffs.Requiescat))
+                            return ShieldLob;
+                        if (IsEnabled(CustomComboPreset.PaladinRangedUptimeFeature2) && level >= Levels.HolySpirit)
+                            return HolySpirit;
+                    }
+
+                    // Buffs
+                    if (GetCooldown(actionID).CooldownRemaining < 0.9 && GetCooldown(actionID).CooldownRemaining > 0.2)
+                    {
+                        if (IsEnabled(CustomComboPreset.PaladinFightOrFlightFeature) && level >= Levels.FightOrFlight && lastComboMove is PLD.FastBlade && IsOffCooldown(FightOrFlight))
+                            return FightOrFlight;
+                        if (IsEnabled(CustomComboPreset.PaladinReqMainComboFeature) && level >= Levels.Requiescat && HasEffect(Buffs.FightOrFlight) && GetBuffRemainingTime(Buffs.FightOrFlight) < 17 && IsOffCooldown(Requiescat))
+                            return Requiescat;
+                    }
+
+                    // oGCD features
+                    if (CanWeave(actionID))
+                    {
+                        if (IsEnabled(CustomComboPreset.PaladinExpiacionScornFeature) && incombat && lastComboMove != FastBlade && lastComboMove != RiotBlade)
+                        {
+                            if (level >= Levels.SpiritsWithin && IsOffCooldown(SpiritsWithin))
+                                return OriginalHook(SpiritsWithin);
+
+                            if (level >= Levels.CircleOfScorn && IsOffCooldown(CircleOfScorn))
+                                return CircleOfScorn;
+                        }
+
+                        if (IsEnabled(CustomComboPreset.PaladinInterveneFeature) && level >= Levels.Intervene && GetRemainingCharges(Intervene) > interveneChargesRemaining)
+                        {
+                            if (IsNotEnabled(CustomComboPreset.PaladinMeleeInterveneOption) ||
+                                (IsEnabled(CustomComboPreset.PaladinMeleeInterveneOption) && HasEffect(Buffs.FightOrFlight) && GetTargetDistance() <= 1))
+                                return Intervene;
+                        }
+                    }
+
+                    // GCDs
+                    if (IsEnabled(CustomComboPreset.PaladinRequiescatFeature))
+                    {
+                        if (HasEffect(Buffs.Requiescat) && level >= Levels.HolySpirit && !HasEffect(Buffs.FightOrFlight) && LocalPlayer.CurrentMp >= 1000)
+                        {
+                            if (IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && level >= Levels.Confiteor &&
+                                ((GetBuffRemainingTime(Buffs.Requiescat) <= 3 && GetBuffRemainingTime(Buffs.Requiescat) >= 0) || GetBuffStacks(Buffs.Requiescat) is 1 || LocalPlayer.CurrentMp <= 2000)) //Confiteor Conditions
+                                return Confiteor;
+
+                            return HolySpirit;
+                        }
+
+                        if (HasEffect(Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth)
+                            return OriginalHook(Confiteor);
+                    }
+
+                    if (level >= Levels.Atonement && HasEffect(Buffs.SwordOath) && IsEnabled(CustomComboPreset.PaladinAtonementFeature))
+                    {
+                        if (IsNotEnabled(CustomComboPreset.PaladinAtonementDropFeature))
+                            return Atonement;
+
+                        if ((IsEnabled(CustomComboPreset.PaladinAtonementDropFeature) &&
+                             GetCooldownRemainingTime(FightOrFlight) <= 15 && GetBuffStacks(Buffs.SwordOath) > 1) ||
+                            (HasEffect(Buffs.Requiescat) && GetCooldownRemainingTime(FightOrFlight) <= 49))
+                            return Atonement;
+                    }
+
+                    // 1-2-3 Combo
+                    if (comboTime > 0)
+                    {
+                        if (lastComboMove is PLD.FastBlade && level >= Levels.RiotBlade)
+                            return RiotBlade;
+
+                        if (lastComboMove is PLD.RiotBlade && level >= Levels.RageOfHalone)
+                        {
+                            if (IsEnabled(CustomComboPreset.PaladinRoyalGoringOption) && level > Levels.GoringBlade &&
+                                ((GetDebuffRemainingTime(Debuffs.BladeOfValor) > 0 && GetDebuffRemainingTime(Debuffs.BladeOfValor) < 5) ||
+                                (FindTargetEffect(Debuffs.BladeOfValor) is null && GetDebuffRemainingTime(Debuffs.GoringBlade) < 5)))
+                                return GoringBlade;
+
+                            return OriginalHook(RageOfHalone);
+                        }
+                    }
+
+                    return FastBlade;
+                }
+
+                return actionID;
             }
 
-            return actionID;
         }
-    }
 
-    internal class PaladinRoyalAuthorityCombo : CustomCombo
-    {
-
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinRoyalAuthorityCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class PaladinProminenceCombo : CustomCombo
         {
-            if (actionID is PLD.RageOfHalone or PLD.RoyalAuthority)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinProminenceCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var interveneChargesRemaining = Service.Configuration.GetCustomIntValue(PLD.Config.PLDKeepInterveneCharges);
                 var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
 
-                // Uptime Features
-                if (!InMeleeRange() && !(HasEffect(PLD.Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth))
+                if (actionID is PLD.Prominence)
                 {
-                    if (IsEnabled(CustomComboPreset.PaladinRangedUptimeFeature) && level >= PLD.Levels.ShieldLob && !HasEffect(PLD.Buffs.Requiescat))
-                        return PLD.ShieldLob;
-                    if (IsEnabled(CustomComboPreset.PaladinRangedUptimeFeature2) && level >= PLD.Levels.HolySpirit)
-                        return PLD.HolySpirit;
-                }
-
-                // Buffs
-                if (GetCooldown(actionID).CooldownRemaining < 0.9 && GetCooldown(actionID).CooldownRemaining > 0.2)
-                {
-                    if (IsEnabled(CustomComboPreset.PaladinFightOrFlightFeature) && level >= PLD.Levels.FightOrFlight && lastComboMove is PLD.FastBlade && IsOffCooldown(PLD.FightOrFlight))
-                        return PLD.FightOrFlight;
-                    if (IsEnabled(CustomComboPreset.PaladinReqMainComboFeature) && level >= PLD.Levels.Requiescat && HasEffect(PLD.Buffs.FightOrFlight) && GetBuffRemainingTime(PLD.Buffs.FightOrFlight) < 17 && IsOffCooldown(PLD.Requiescat))
-                        return PLD.Requiescat;
-                }
-
-                // oGCD features
-                if (CanWeave(actionID))
-                {
-                    if (IsEnabled(CustomComboPreset.PaladinExpiacionScornFeature) && incombat && lastComboMove != PLD.FastBlade && lastComboMove != PLD.RiotBlade)
+                    if (CanWeave(actionID))
                     {
-                        if (level >= PLD.Levels.SpiritsWithin && IsOffCooldown(PLD.SpiritsWithin))
-                            return OriginalHook(PLD.SpiritsWithin);
+                        if (IsEnabled(CustomComboPreset.PaladinReqAoEComboFeature) && level >= Levels.Requiescat && IsOffCooldown(Requiescat))
+                            return Requiescat;
 
-                        if (level >= PLD.Levels.CircleOfScorn && IsOffCooldown(PLD.CircleOfScorn))
-                            return PLD.CircleOfScorn;
+                        if (IsEnabled(CustomComboPreset.PaladinAoEExpiacionScornFeature) && incombat)
+                        {
+                            if (level >= Levels.SpiritsWithin && IsOffCooldown(SpiritsWithin))
+                                return OriginalHook(SpiritsWithin);
+
+                            if (level >= Levels.CircleOfScorn && IsOffCooldown(CircleOfScorn))
+                                return CircleOfScorn;
+                        }
                     }
 
-                    if (IsEnabled(CustomComboPreset.PaladinInterveneFeature) && level >= PLD.Levels.Intervene && GetRemainingCharges(PLD.Intervene) > interveneChargesRemaining)
+                    if (IsEnabled(CustomComboPreset.PaladinHolyCircleFeature) && HasEffect(Buffs.Requiescat) && level >= Levels.HolyCircle && LocalPlayer.CurrentMp >= 1000)
                     {
-                        if (IsNotEnabled(CustomComboPreset.PaladinMeleeInterveneOption) ||
-                            (IsEnabled(CustomComboPreset.PaladinMeleeInterveneOption) && HasEffect(PLD.Buffs.FightOrFlight) && GetTargetDistance() <= 1))
-                            return PLD.Intervene;
-                    }
-                }
+                        if (IsEnabled(CustomComboPreset.PaladinAoEConfiteorFeature) && level >= Levels.Confiteor &&
+                            ((GetBuffRemainingTime(Buffs.Requiescat) <= 3 && GetBuffRemainingTime(Buffs.Requiescat) >= 0) || GetBuffStacks(Buffs.Requiescat) is 1 || LocalPlayer.CurrentMp <= 2000))
+                            return Confiteor;
 
-                // GCDs
-                if (IsEnabled(CustomComboPreset.PaladinRequiescatFeature))
-                {
-                    if (HasEffect(PLD.Buffs.Requiescat) && level >= PLD.Levels.HolySpirit && !HasEffect(PLD.Buffs.FightOrFlight) && LocalPlayer.CurrentMp >= 1000)
-                    {
-                        if (IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && level >= PLD.Levels.Confiteor &&
-                            ((GetBuffRemainingTime(PLD.Buffs.Requiescat) <= 3 && GetBuffRemainingTime(PLD.Buffs.Requiescat) >= 0) || GetBuffStacks(PLD.Buffs.Requiescat) is 1 || LocalPlayer.CurrentMp <= 2000)) //Confiteor Conditions
-                                return PLD.Confiteor;
+                        return HolyCircle;
 
-                            return PLD.HolySpirit;
                     }
 
-                    if (HasEffect(PLD.Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth)
-                        return OriginalHook(PLD.Confiteor);
-                }
+                    if (IsEnabled(CustomComboPreset.PaladinAoEConfiteorFeature) &&
+                        (HasEffect(Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth))
+                        return OriginalHook(Confiteor);
 
-                if (level >= PLD.Levels.Atonement && HasEffect(PLD.Buffs.SwordOath) && IsEnabled(CustomComboPreset.PaladinAtonementFeature))
-                {
-                    if (IsNotEnabled(CustomComboPreset.PaladinAtonementDropFeature))
-                        return PLD.Atonement;
-
-                    if ((IsEnabled(CustomComboPreset.PaladinAtonementDropFeature) &&
-                         GetCooldownRemainingTime(PLD.FightOrFlight) <= 15 && GetBuffStacks(PLD.Buffs.SwordOath) > 1) ||
-                        (HasEffect(PLD.Buffs.Requiescat) && GetCooldownRemainingTime(PLD.FightOrFlight) <= 49))
-                        return PLD.Atonement;
-                }
-
-                // 1-2-3 Combo
                     if (comboTime > 0)
-                {
-                    if (lastComboMove is PLD.FastBlade && level >= PLD.Levels.RiotBlade)
-                        return PLD.RiotBlade;
-
-                    if (lastComboMove is PLD.RiotBlade && level >= PLD.Levels.RageOfHalone)
                     {
-                        if (IsEnabled(CustomComboPreset.PaladinRoyalGoringOption) && level > PLD.Levels.GoringBlade &&
-                            ((GetDebuffRemainingTime(PLD.Debuffs.BladeOfValor) > 0 && GetDebuffRemainingTime(PLD.Debuffs.BladeOfValor) < 5) ||
-                            (FindTargetEffect(PLD.Debuffs.BladeOfValor) is null && GetDebuffRemainingTime(PLD.Debuffs.GoringBlade) < 5)))
-                                return PLD.GoringBlade;
-
-                            return OriginalHook(PLD.RageOfHalone);
+                        if (lastComboMove is PLD.TotalEclipse && level >= Levels.Prominence)
+                            return Prominence;
                     }
-                }                
 
-                return PLD.FastBlade;
+                    return TotalEclipse;
+                }
+
+                return actionID;
             }
-
-            return actionID;
         }
 
-    }
-
-    internal class PaladinProminenceCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinProminenceCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class PaladinScornfulSpiritsFeature : CustomCombo
         {
-            var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinScornfulSpiritsFeature;
 
-            if (actionID is PLD.Prominence)
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (CanWeave(actionID))
+                if (actionID is SpiritsWithin or CircleOfScorn)
                 {
-                    if (IsEnabled(CustomComboPreset.PaladinReqAoEComboFeature) && level >= PLD.Levels.Requiescat && IsOffCooldown(PLD.Requiescat))
-                            return PLD.Requiescat;
+                    if (level >= Levels.SpiritsWithin && level <= Levels.Expiacion)
+                        return CalcBestAction(actionID, SpiritsWithin, CircleOfScorn);
 
-                    if (IsEnabled(CustomComboPreset.PaladinAoEExpiacionScornFeature) && incombat)
+                    if (level >= Levels.Expiacion)
+                        return CalcBestAction(actionID, Expiacion, CircleOfScorn);
+
+                    if (level >= Levels.CircleOfScorn)
+                        return CalcBestAction(actionID, SpiritsWithin, CircleOfScorn);
+
+                    return SpiritsWithin;
+                }
+
+                return actionID;
+            }
+        }
+        internal class PaladinStandaloneHolySpiritFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinStandaloneHolySpiritFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is PLD.HolySpirit)
+                {
+                    if (HasEffect(Buffs.Requiescat) && level >= Levels.HolySpirit)
                     {
-                        if (level >= PLD.Levels.SpiritsWithin && IsOffCooldown(PLD.SpiritsWithin))
-                            return OriginalHook(PLD.SpiritsWithin);
+                        var requiescat = FindEffect(Buffs.Requiescat);
 
-                        if (level >= PLD.Levels.CircleOfScorn && IsOffCooldown(PLD.CircleOfScorn))
-                            return PLD.CircleOfScorn;
+                        if (level >= Levels.Confiteor &&
+                                ((IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && requiescat.RemainingTime <= 3 && requiescat.RemainingTime > 0) ||
+                                requiescat.StackCount is 1 || LocalPlayer.CurrentMp <= 2000))
+                            return Confiteor;
+
+                        return HolySpirit;
                     }
+
+                    if (HasEffect(Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth)
+                        return OriginalHook(Confiteor);
                 }
 
-                if (IsEnabled(CustomComboPreset.PaladinHolyCircleFeature) && HasEffect(PLD.Buffs.Requiescat) && level >= PLD.Levels.HolyCircle && LocalPlayer.CurrentMp >= 1000)
-                {
-                    if (IsEnabled(CustomComboPreset.PaladinAoEConfiteorFeature) && level >= PLD.Levels.Confiteor &&
-                        ((GetBuffRemainingTime(PLD.Buffs.Requiescat) <= 3 && GetBuffRemainingTime(PLD.Buffs.Requiescat) >= 0) || GetBuffStacks(PLD.Buffs.Requiescat) is 1 || LocalPlayer.CurrentMp <= 2000))
-                            return PLD.Confiteor;
-
-                    return PLD.HolyCircle;
-
-                }
-
-                if (IsEnabled(CustomComboPreset.PaladinAoEConfiteorFeature) &&
-                    (HasEffect(PLD.Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth))
-                        return OriginalHook(PLD.Confiteor);
-
-                if (comboTime > 0)
-                {
-                    if (lastComboMove is PLD.TotalEclipse && level >= PLD.Levels.Prominence)
-                        return PLD.Prominence;
-                }
-
-                return PLD.TotalEclipse;
+                return actionID;
             }
-
-            return actionID;
         }
-    }
-
-    internal class PaladinScornfulSpiritsFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinScornfulSpiritsFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class PaladinStandaloneHolyCircleFeature : CustomCombo
         {
-            if (actionID is PLD.SpiritsWithin or PLD.CircleOfScorn)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinStandaloneHolyCircleFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (level >= PLD.Levels.SpiritsWithin && level <= PLD.Levels.Expiacion)
-                    return CalcBestAction(actionID, PLD.SpiritsWithin, PLD.CircleOfScorn);
-
-                if (level >= PLD.Levels.Expiacion)
-                    return CalcBestAction(actionID, PLD.Expiacion, PLD.CircleOfScorn);
-
-                if (level >= PLD.Levels.CircleOfScorn)
-                    return CalcBestAction(actionID, PLD.SpiritsWithin, PLD.CircleOfScorn);
-
-                return PLD.SpiritsWithin;
-            }
-
-            return actionID;
-        }
-    }
-    internal class PaladinStandaloneHolySpiritFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinStandaloneHolySpiritFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is PLD.HolySpirit)
-            {
-                if (HasEffect(PLD.Buffs.Requiescat) && level >= PLD.Levels.HolySpirit)
+                if (actionID is PLD.HolyCircle)
                 {
-                    var requiescat = FindEffect(PLD.Buffs.Requiescat);
+                    if (HasEffect(Buffs.Requiescat) && level >= Levels.HolyCircle)
+                    {
+                        var requiescat = FindEffect(Buffs.Requiescat);
 
-                    if (level >= PLD.Levels.Confiteor &&
-                            ((IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && requiescat.RemainingTime <= 3 && requiescat.RemainingTime > 0) ||
-                            requiescat.StackCount is 1 || LocalPlayer.CurrentMp <= 2000))
-                            return PLD.Confiteor;
+                        if (level >= Levels.Confiteor && ((IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && requiescat.RemainingTime <= 3 && requiescat.RemainingTime > 0) ||
+                                requiescat.StackCount is 1 || LocalPlayer.CurrentMp <= 2000))
+                            return Confiteor;
 
-                        return PLD.HolySpirit;
+                        return HolyCircle;
+                    }
+
+                    if (HasEffect(Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth)
+                        return OriginalHook(Confiteor);
                 }
 
-                if (HasEffect(PLD.Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth)
-                    return OriginalHook(PLD.Confiteor);
+                return actionID;
             }
-
-            return actionID;
-        }
-    }
-    internal class PaladinStandaloneHolyCircleFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PaladinStandaloneHolyCircleFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is PLD.HolyCircle)
-            {
-                if (HasEffect(PLD.Buffs.Requiescat) && level >= PLD.Levels.HolyCircle)
-                {
-                    var requiescat = FindEffect(PLD.Buffs.Requiescat);
-
-                    if (level >= PLD.Levels.Confiteor &&((IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && requiescat.RemainingTime <= 3 && requiescat.RemainingTime > 0) ||
-                            requiescat.StackCount is 1 || LocalPlayer.CurrentMp <= 2000))
-                            return PLD.Confiteor;
-
-                        return PLD.HolyCircle;
-                }
-
-                if (HasEffect(PLD.Buffs.BladeOfFaithReady) || lastComboMove is PLD.BladeOfFaith || lastComboMove is PLD.BladeOfTruth)
-                        return OriginalHook(PLD.Confiteor);
-            }
-
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -102,7 +102,7 @@ namespace XIVSlothComboPlugin.Combos
             public const string RDM_MeleeFinisher_OnAction = "RDM_MeleeFinisher_OnAction";
             public const string RDM_LucidDreaming_Threshold = "RDM_LucidDreaming_Threshold";
         }
-    }
+    
 
     internal class RDM_Main_Combos : CustomCombo
     {
@@ -123,31 +123,31 @@ namespace XIVSlothComboPlugin.Combos
             //END_MAIN_COMBO_VARIABLES
 
             //RDM_BALANCE_OPENER
-            if (IsEnabled(CustomComboPreset.RDM_Balance_Opener) && level >= 90 && actionID is RDM.Jolt or RDM.Jolt2)
+            if (IsEnabled(CustomComboPreset.RDM_Balance_Opener) && level >= 90 && actionID is Jolt or Jolt2)
             {
                 bool inCombat = HasCondition(ConditionFlag.InCombat);
 
                 // Check to start opener
-                if (openerStarted && lastComboMove is RDM.Verthunder3 && HasEffect(RDM.Buffs.Dualcast)) { inOpener = true; openerStarted = false; readyOpener = false; }
-                if ((readyOpener || openerStarted) && !inOpener && LocalPlayer.CastActionId == RDM.Verthunder3) { openerStarted = true; return RDM.Veraero3; } else { openerStarted = false; }
+                if (openerStarted && lastComboMove is RDM.Verthunder3 && HasEffect(Buffs.Dualcast)) { inOpener = true; openerStarted = false; readyOpener = false; }
+                if ((readyOpener || openerStarted) && !inOpener && LocalPlayer.CastActionId == Verthunder3) { openerStarted = true; return Veraero3; } else { openerStarted = false; }
 
                 // Reset check for opener
                 if ((IsEnabled(CustomComboPreset.RDM_Opener_Any_Mana) || (gauge.BlackMana == 0 && gauge.WhiteMana == 0)) 
-                    && IsOffCooldown(RDM.Embolden) && IsOffCooldown(RDM.Manafication) && IsOffCooldown(All.Swiftcast)
-                    && GetCooldown(RDM.Acceleration).RemainingCharges == 2 && GetCooldown(RDM.Corpsacorps).RemainingCharges == 2 && GetCooldown(RDM.Engagement).RemainingCharges == 2
-                    && IsOffCooldown(RDM.Fleche) && IsOffCooldown(RDM.ContreSixte)
+                    && IsOffCooldown(Embolden) && IsOffCooldown(Manafication) && IsOffCooldown(All.Swiftcast)
+                    && GetCooldown(Acceleration).RemainingCharges == 2 && GetCooldown(Corpsacorps).RemainingCharges == 2 && GetCooldown(Engagement).RemainingCharges == 2
+                    && IsOffCooldown(Fleche) && IsOffCooldown(ContreSixte)
                     && EnemyHealthPercentage() == 100 && !inOpener && !openerStarted)
                 {
                     readyOpener = true;
                     inOpener = false;
                     step = 0;
-                    return RDM.Verthunder3;
+                    return Verthunder3;
                 }
                 else
                 { readyOpener = false; }
 
                 // Reset if opener is interrupted, requires step 0 and 1 to be explicit since the inCombat check can be slow
-                if ((step == 0 && lastComboMove is RDM.Verthunder3 && !HasEffect(RDM.Buffs.Dualcast))
+                if ((step == 0 && lastComboMove is RDM.Verthunder3 && !HasEffect(Buffs.Dualcast))
                     || (inOpener && step >= 1 && IsOffCooldown(actionID) && !inCombat)) inOpener = false;
 
                 // Start Opener
@@ -176,8 +176,8 @@ namespace XIVSlothComboPlugin.Combos
                     //we do it in steps to be able to control it
                     if (step == 0)
                     {
-                        if (lastComboMove == RDM.Veraero3) step++;
-                        else return RDM.Veraero3;
+                        if (lastComboMove == Veraero3) step++;
+                        else return Veraero3;
                     }
 
                     if (step == 1)
@@ -188,104 +188,104 @@ namespace XIVSlothComboPlugin.Combos
 
                     if (step == 2)
                     {
-                        if (GetRemainingCharges(RDM.Acceleration) < 2) step++;
-                        else return RDM.Acceleration;
+                        if (GetRemainingCharges(Acceleration) < 2) step++;
+                        else return Acceleration;
                     }
 
                     if (step == 3)
                     {
-                        if (lastComboMove == RDM.Verthunder3 && !HasEffect(RDM.Buffs.Acceleration)) step++;
-                        else return RDM.Verthunder3;
+                        if (lastComboMove == Verthunder3 && !HasEffect(Buffs.Acceleration)) step++;
+                        else return Verthunder3;
                     }
 
                     if (step == 4)
                     {
-                        if (lastComboMove == RDM.Verthunder3 && !HasEffect(All.Buffs.Swiftcast)) step++;
-                        else return RDM.Verthunder3;
+                        if (lastComboMove == Verthunder3 && !HasEffect(All.Buffs.Swiftcast)) step++;
+                        else return Verthunder3;
                     }
 
                     if (step == 5)
                     {
-                        if (IsOnCooldown(RDM.Embolden)) step++;
-                        else return RDM.Embolden;
+                        if (IsOnCooldown(Embolden)) step++;
+                        else return Embolden;
                     }
 
                     if (step == 6)
                     {
-                        if (IsOnCooldown(RDM.Manafication)) step++;
-                        else return RDM.Manafication;
+                        if (IsOnCooldown(Manafication)) step++;
+                        else return Manafication;
                     }
 
                     if (step == 7)
                     {
-                        if (lastComboMove == RDM.Riposte) step++;
-                        else return RDM.EnchantedRiposte;
+                        if (lastComboMove == Riposte) step++;
+                        else return EnchantedRiposte;
                     }
 
                     if (step == 8)
                     {
-                        if (IsOnCooldown(RDM.Fleche)) step++;
-                        else return RDM.Fleche;
+                        if (IsOnCooldown(Fleche)) step++;
+                        else return Fleche;
                     }
 
                     if (step == 9)
                     {
-                        if (lastComboMove == RDM.Zwerchhau) step++;
-                        else return RDM.EnchantedZwerchhau;
+                        if (lastComboMove == Zwerchhau) step++;
+                        else return EnchantedZwerchhau;
                     }
 
                     if (step == 10)
                     {
-                        if (IsOnCooldown(RDM.ContreSixte)) step++;
-                        else return RDM.ContreSixte;
+                        if (IsOnCooldown(ContreSixte)) step++;
+                        else return ContreSixte;
                     }
 
                     if (step == 11)
                     {
-                        if (lastComboMove == RDM.Redoublement || gauge.ManaStacks == 3) step++;
-                        else return RDM.EnchantedRedoublement;
+                        if (lastComboMove == Redoublement || gauge.ManaStacks == 3) step++;
+                        else return EnchantedRedoublement;
                     }
 
                     if (step == 12)
                     {
-                        if (GetRemainingCharges(RDM.Corpsacorps) < 2) step++;
-                        else return RDM.Corpsacorps;
+                        if (GetRemainingCharges(Corpsacorps) < 2) step++;
+                        else return Corpsacorps;
                     }
 
                     if (step == 13)
                     {
-                        if (GetRemainingCharges(RDM.Engagement) < 2) step++;
-                        else return RDM.Engagement;
+                        if (GetRemainingCharges(Engagement) < 2) step++;
+                        else return Engagement;
                     }
 
                     if (step == 14)
                     {
-                        if (lastComboMove == RDM.Verholy) step++;
-                        else return RDM.Verholy;
+                        if (lastComboMove == Verholy) step++;
+                        else return Verholy;
                     }
 
                     if (step == 15)
                     {
-                        if (GetRemainingCharges(RDM.Corpsacorps) < 1) step++;
-                        else return RDM.Corpsacorps;
+                        if (GetRemainingCharges(Corpsacorps) < 1) step++;
+                        else return Corpsacorps;
                     }
 
                     if (step == 16)
                     {
-                        if (GetRemainingCharges(RDM.Engagement) < 1) step++;
-                        else return RDM.Engagement;
+                        if (GetRemainingCharges(Engagement) < 1) step++;
+                        else return Engagement;
                     }
 
                     if (step == 17)
                     {
-                        if (lastComboMove == RDM.Scorch) step++;
-                        else return RDM.Scorch;
+                        if (lastComboMove == Scorch) step++;
+                        else return Scorch;
                     }
 
                     if (step == 18)
                     {
-                        if (lastComboMove == RDM.Resolution) step++;
-                        else return RDM.Resolution;
+                        if (lastComboMove == Resolution) step++;
+                        else return Resolution;
                     }
 
                     inOpener = false;
@@ -294,106 +294,106 @@ namespace XIVSlothComboPlugin.Combos
             //END_RDM_BALANCE_OPENER
 
             //RDM_ST_MANAFICATIONEMBOLDEN
-            if (IsEnabled(CustomComboPreset.RDM_ST_ManaficationEmbolden) && level >= RDM.Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
-                && !HasEffect(RDM.Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(RDM.Buffs.Acceleration) 
-                && (GetTargetDistance() <= 3 || (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && GetCooldown(RDM.Corpsacorps).RemainingCharges >= 1)))
+            if (IsEnabled(CustomComboPreset.RDM_ST_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
+                && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration) 
+                && (GetTargetDistance() <= 3 || (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && GetCooldown(Corpsacorps).RemainingCharges >= 1)))
             {
-                var radioButton = Service.Configuration.GetCustomIntValue(RDM.Config.RDM_ST_MeleeCombo_OnAction);
+                var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_ST_MeleeCombo_OnAction);
 
-                if ((radioButton == 1 && actionID is RDM.Riposte or RDM.EnchantedRiposte)
-                    || (radioButton == 2 && actionID is RDM.Jolt or RDM.Jolt2)
-                    || (radioButton == 3 && actionID is RDM.Riposte or RDM.EnchantedRiposte or RDM.Jolt or RDM.Jolt2))
+                if ((radioButton == 1 && actionID is Riposte or EnchantedRiposte)
+                    || (radioButton == 2 && actionID is Jolt or Jolt2)
+                    || (radioButton == 3 && actionID is Riposte or EnchantedRiposte or Jolt or Jolt2))
                 {
                     //Situation 1: Manafication first
                     if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
                     && System.Math.Max(black, white) <= 50 && System.Math.Max(black, white) >= 42 && System.Math.Min(black, white) >= 31
-                    && IsOffCooldown(RDM.Manafication) && gauge.ManaStacks == 0
-                    && (IsOffCooldown(RDM.Embolden) || GetCooldown(RDM.Embolden).CooldownRemaining <= 3))
+                    && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
+                    && (IsOffCooldown(Embolden) || GetCooldown(Embolden).CooldownRemaining <= 3))
                     {
-                        return RDM.Manafication;
+                        return Manafication;
                     }
                     if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                        && lastComboMove is RDM.Zwerchhau && level >= RDM.Levels.Redoublement
+                        && lastComboMove is RDM.Zwerchhau && level >= Levels.Redoublement
                         && System.Math.Max(black, white) >= 55 && System.Math.Min(black, white) >= 46
-                        && GetCooldown(RDM.Manafication).CooldownRemaining >= 100
-                        && IsOffCooldown(RDM.Embolden))
+                        && GetCooldown(Manafication).CooldownRemaining >= 100
+                        && IsOffCooldown(Embolden))
                     {
-                        return RDM.Embolden;
+                        return Embolden;
                     }
 
                     //Situation 2: Embolden first
                     if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                        && lastComboMove is RDM.Zwerchhau && level >= RDM.Levels.Redoublement
+                        && lastComboMove is RDM.Zwerchhau && level >= Levels.Redoublement
                         && System.Math.Max(black, white) <= 57 && System.Math.Min(black, white) <= 46
-                        && (GetCooldown(RDM.Manafication).CooldownRemaining <= 7 || IsOffCooldown(RDM.Manafication))
-                        && IsOffCooldown(RDM.Embolden))
+                        && (GetCooldown(Manafication).CooldownRemaining <= 7 || IsOffCooldown(Manafication))
+                        && IsOffCooldown(Embolden))
                     {
-                        return RDM.Embolden;
+                        return Embolden;
                     }
                     if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
                         && System.Math.Max(black, white) <= 50
-                        && IsOffCooldown(RDM.Manafication)
+                        && IsOffCooldown(Manafication)
                         && (gauge.ManaStacks == 3 || lastComboMove is RDM.Resolution)
-                        && GetCooldown(RDM.Embolden).CooldownRemaining >= 105)
+                        && GetCooldown(Embolden).CooldownRemaining >= 105)
                     {
-                        return RDM.Manafication;
+                        return Manafication;
                     }
 
                     //Situation 3: Just use them together
-                    if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= RDM.Levels.Embolden
+                    if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Embolden
                         && System.Math.Max(black, white) <= 50
-                        && (IsOffCooldown(RDM.Manafication) || level < RDM.Levels.Manafication) && IsOffCooldown(RDM.Embolden))
+                        && (IsOffCooldown(Manafication) || level < Levels.Manafication) && IsOffCooldown(Embolden))
                     {
-                        return RDM.Embolden;
+                        return Embolden;
                     }
-                    if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= RDM.Levels.Manafication
+                    if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Manafication
                         && System.Math.Max(black, white) <= 50
-                        && IsOffCooldown(RDM.Manafication) && gauge.ManaStacks == 0
-                        && GetCooldown(RDM.Embolden).CooldownRemaining >= 110)
+                        && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
+                        && GetCooldown(Embolden).CooldownRemaining >= 110)
                     {
-                        return RDM.Manafication;
+                        return Manafication;
                     }
 
                     //Situation 4: Level 58 or 59
-                    if (level < RDM.Levels.Manafication && level >= RDM.Levels.Embolden
-                        && System.Math.Min(black, white) >= 50 && IsOffCooldown(RDM.Embolden))
+                    if (level < Levels.Manafication && level >= Levels.Embolden
+                        && System.Math.Min(black, white) >= 50 && IsOffCooldown(Embolden))
                     {
-                        return RDM.Embolden;
+                        return Embolden;
                     }
                 }
             }
             //END_RDM_ST_MANAFICATIONEMBOLDEN
 
             //RDM_AOE_MANAFICATIONEMBOLDEN
-            if (IsEnabled(CustomComboPreset.RDM_AoE_ManaficationEmbolden) && level >= RDM.Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
-                && !HasEffect(RDM.Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(RDM.Buffs.Acceleration)
-                && GetTargetDistance() < 8 && actionID is RDM.Scatter or RDM.Impact)
+            if (IsEnabled(CustomComboPreset.RDM_AoE_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
+                && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
+                && GetTargetDistance() < 8 && actionID is Scatter or Impact)
             {
-                if (level >= RDM.Levels.Manafication
+                if (level >= Levels.Manafication
                 && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
-                && (IsOffCooldown(RDM.Manafication) || level < RDM.Levels.Manafication) && IsOffCooldown(RDM.Embolden))
+                && (IsOffCooldown(Manafication) || level < Levels.Manafication) && IsOffCooldown(Embolden))
                 {
-                    return RDM.Embolden;
+                    return Embolden;
                 }
-                if (level >= RDM.Levels.Manafication
+                if (level >= Levels.Manafication
                     && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
-                    && IsOffCooldown(RDM.Manafication) && gauge.ManaStacks == 0
-                    && GetCooldown(RDM.Embolden).CooldownRemaining >= 110)
+                    && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
+                    && GetCooldown(Embolden).CooldownRemaining >= 110)
                 {
-                    return RDM.Manafication;
+                    return Manafication;
                 }
-                if (level < RDM.Levels.Manafication && level >= RDM.Levels.Embolden
-                    && System.Math.Min(black, white) >= 20 && IsOffCooldown(RDM.Embolden))
+                if (level < Levels.Manafication && level >= Levels.Embolden
+                    && System.Math.Min(black, white) >= 20 && IsOffCooldown(Embolden))
                 {
-                    return RDM.Embolden;
+                    return Embolden;
                 }
             }
             //END_RDM_AOE_MANAFICATIONEMBOLDEN
 
             //RDM_OGCD
-            if (IsEnabled(CustomComboPreset.RDM_OGCD) && level >= RDM.Levels.Corpsacorps)
+            if (IsEnabled(CustomComboPreset.RDM_OGCD) && level >= Levels.Corpsacorps)
             {
-                var radioButton = Service.Configuration.GetCustomIntValue(RDM.Config.RDM_OGCD_OnAction);
+                var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_OGCD_OnAction);
                 //Radio Button Settings:
                 //1: Fleche
                 //2: Jolt
@@ -409,35 +409,35 @@ namespace XIVSlothComboPlugin.Combos
                 if (IsEnabled(CustomComboPreset.RDM_Corpsacorps_MeleeRange)) corpacorpsRange = 3;
                 if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && IsEnabled(CustomComboPreset.RDM_ST_PoolCorps)) corpsacorpsPool = 1;
 
-                if (actionID is RDM.Jolt or RDM.Jolt2 or RDM.Scatter or RDM.Impact or RDM.Fleche)
+                if (actionID is Jolt or Jolt2 or Scatter or Impact or Fleche)
                 {
-                    if (IsEnabled(CustomComboPreset.RDM_Engagement) && GetCooldown(RDM.Engagement).RemainingCharges > 0
-                        && level >= RDM.Levels.Engagement && distance <= 3) placeOGCD = RDM.Engagement;
-                    if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && GetCooldown(RDM.Corpsacorps).RemainingCharges > corpsacorpsPool
-                        && ((GetCooldown(RDM.Corpsacorps).RemainingCharges >= GetCooldown(RDM.Engagement).RemainingCharges) || level < RDM.Levels.Engagement) // Try to alternate between Corps-a-corps and Engagement
-                        && level >= RDM.Levels.Corpsacorps && distance <= corpacorpsRange) placeOGCD = RDM.Corpsacorps;
-                    if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && IsOffCooldown(RDM.ContreSixte) && level >= RDM.Levels.ContreSixte) placeOGCD = RDM.ContreSixte;
-                    if ((radioButton == 1 || IsEnabled(CustomComboPreset.RDM_Fleche)) && IsOffCooldown(RDM.Fleche) && level >= RDM.Levels.Fleche) placeOGCD = RDM.Fleche;
+                    if (IsEnabled(CustomComboPreset.RDM_Engagement) && GetCooldown(Engagement).RemainingCharges > 0
+                        && level >= Levels.Engagement && distance <= 3) placeOGCD = Engagement;
+                    if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && GetCooldown(Corpsacorps).RemainingCharges > corpsacorpsPool
+                        && ((GetCooldown(Corpsacorps).RemainingCharges >= GetCooldown(Engagement).RemainingCharges) || level < Levels.Engagement) // Try to alternate between Corps-a-corps and Engagement
+                        && level >= Levels.Corpsacorps && distance <= corpacorpsRange) placeOGCD = Corpsacorps;
+                    if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && IsOffCooldown(ContreSixte) && level >= Levels.ContreSixte) placeOGCD = ContreSixte;
+                    if ((radioButton == 1 || IsEnabled(CustomComboPreset.RDM_Fleche)) && IsOffCooldown(Fleche) && level >= Levels.Fleche) placeOGCD = Fleche;
 
-                    if ((actionID is RDM.Jolt or RDM.Jolt2) && (radioButton is 2 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
-                    if ((actionID is RDM.Scatter or RDM.Impact) && (radioButton is 3 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
+                    if ((actionID is Jolt or Jolt2) && (radioButton is 2 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
+                    if ((actionID is Scatter or Impact) && (radioButton is 3 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
                     if (actionID is RDM.Fleche && radioButton == 1 && placeOGCD == 0) // All actions are on cooldown, determine the lowest CD to display on Fleche.
                     {
-                        placeOGCD = RDM.Fleche;
-                        if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && level >= RDM.Levels.ContreSixte
-                            && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(RDM.ContreSixte).CooldownRemaining) placeOGCD = RDM.ContreSixte;
-                        if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && level >= RDM.Levels.Corpsacorps
-                            && ((IsNotEnabled(CustomComboPreset.RDM_ST_PoolCorps) && GetCooldown(RDM.Corpsacorps).RemainingCharges >= 0) || GetCooldown(RDM.Corpsacorps).RemainingCharges >= 2)
-                            && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(RDM.Corpsacorps).ChargeCooldownRemaining
-                            && distance <= corpacorpsRange) placeOGCD = RDM.Corpsacorps;
-                        if (placeOGCD == RDM.Corpsacorps)
+                        placeOGCD = Fleche;
+                        if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && level >= Levels.ContreSixte
+                            && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(ContreSixte).CooldownRemaining) placeOGCD = ContreSixte;
+                        if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && level >= Levels.Corpsacorps
+                            && ((IsNotEnabled(CustomComboPreset.RDM_ST_PoolCorps) && GetCooldown(Corpsacorps).RemainingCharges >= 0) || GetCooldown(Corpsacorps).RemainingCharges >= 2)
+                            && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Corpsacorps).ChargeCooldownRemaining
+                            && distance <= corpacorpsRange) placeOGCD = Corpsacorps;
+                        if (placeOGCD == Corpsacorps)
                         {
-                            if (IsEnabled(CustomComboPreset.RDM_Engagement) && level >= RDM.Levels.Engagement
-                                && GetCooldown(placeOGCD).ChargeCooldownRemaining > GetCooldown(RDM.Engagement).ChargeCooldownRemaining
-                                && distance <= 3) placeOGCD = RDM.Engagement;
+                            if (IsEnabled(CustomComboPreset.RDM_Engagement) && level >= Levels.Engagement
+                                && GetCooldown(placeOGCD).ChargeCooldownRemaining > GetCooldown(Engagement).ChargeCooldownRemaining
+                                && distance <= 3) placeOGCD = Engagement;
                         } else if (IsEnabled(CustomComboPreset.RDM_Engagement)
-                            && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(RDM.Engagement).ChargeCooldownRemaining
-                            && distance <= 3) placeOGCD = RDM.Engagement;
+                            && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Engagement).ChargeCooldownRemaining
+                            && distance <= 3) placeOGCD = Engagement;
                     }
                     if (actionID is RDM.Fleche && radioButton == 1) return placeOGCD;
                 }
@@ -465,22 +465,22 @@ namespace XIVSlothComboPlugin.Combos
             bool useThunder2 = false;
             bool useAero2 = false;
 
-            if (level >= RDM.Levels.Verthunder && (HasEffect(RDM.Buffs.Dualcast) || HasEffect(All.Buffs.Swiftcast) || HasEffect(RDM.Buffs.Acceleration)))
+            if (level >= Levels.Verthunder && (HasEffect(Buffs.Dualcast) || HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Acceleration)))
             {
-                if (black <= white || HasEffect(RDM.Buffs.VerstoneReady)) useThunder = true;
-                if (white <= black || HasEffect(RDM.Buffs.VerfireReady)) useAero = true;
-                if (level < RDM.Levels.Veraero) useThunder = true;
+                if (black <= white || HasEffect(Buffs.VerstoneReady)) useThunder = true;
+                if (white <= black || HasEffect(Buffs.VerfireReady)) useAero = true;
+                if (level < Levels.Veraero) useThunder = true;
             }
-            if (!HasEffect(RDM.Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(RDM.Buffs.Acceleration))
+            if (!HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))
             {
-                if (black <= white && HasEffect(RDM.Buffs.VerfireReady)) useFire = true;
-                if (white <= black && HasEffect(RDM.Buffs.VerstoneReady)) useStone = true;
-                if (!useFire && !useStone && HasEffect(RDM.Buffs.VerfireReady)) useFire = true;
-                if (!useFire && !useStone && HasEffect(RDM.Buffs.VerstoneReady)) useStone = true;
+                if (black <= white && HasEffect(Buffs.VerfireReady)) useFire = true;
+                if (white <= black && HasEffect(Buffs.VerstoneReady)) useStone = true;
+                if (!useFire && !useStone && HasEffect(Buffs.VerfireReady)) useFire = true;
+                if (!useFire && !useStone && HasEffect(Buffs.VerstoneReady)) useStone = true;
             }
-            if (level >= RDM.Levels.Verthunder2 && !HasEffect(RDM.Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(RDM.Buffs.Acceleration))
+            if (level >= Levels.Verthunder2 && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))
             {
-                if (black <= white || level < RDM.Levels.Veraero2) useThunder2 = true;
+                if (black <= white || level < Levels.Veraero2) useThunder2 = true;
                 else useAero2 = true;
             }
             //END_SYSTEM_MANA_BALANCING_MACHINE
@@ -488,34 +488,34 @@ namespace XIVSlothComboPlugin.Combos
             //RDM_MELEEFINISHER
             if (IsEnabled(CustomComboPreset.RDM_MeleeFinisher))
             {
-                var radioButton = Service.Configuration.GetCustomIntValue(RDM.Config.RDM_MeleeFinisher_OnAction);
+                var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_MeleeFinisher_OnAction);
 
-                if ((radioButton == 1 && actionID is RDM.Riposte or RDM.EnchantedRiposte or RDM.Moulinet or RDM.EnchantedMoulinet)
-                    || (radioButton == 2 && actionID is RDM.Jolt or RDM.Jolt2 or RDM.Scatter or RDM.Impact)
-                    || (radioButton == 3 && actionID is RDM.Riposte or RDM.EnchantedRiposte or RDM.Moulinet or RDM.EnchantedMoulinet or RDM.Jolt or RDM.Jolt2 or RDM.Scatter or RDM.Impact))
+                if ((radioButton == 1 && actionID is Riposte or EnchantedRiposte or Moulinet or EnchantedMoulinet)
+                    || (radioButton == 2 && actionID is Jolt or Jolt2 or Scatter or Impact)
+                    || (radioButton == 3 && actionID is Riposte or EnchantedRiposte or Moulinet or EnchantedMoulinet or Jolt or Jolt2 or Scatter or Impact))
                 {
                     if (gauge.ManaStacks >= 3)
                     {
-                        if (black >= white && level >= RDM.Levels.Verholy)
+                        if (black >= white && level >= Levels.Verholy)
                         {
-                            if (HasEffect(RDM.Buffs.VerstoneReady) && (!HasEffect(RDM.Buffs.VerfireReady) || HasEffect(RDM.Buffs.Embolden)) && (black - white <= 9))
-                                return RDM.Verflare;
+                            if (HasEffect(Buffs.VerstoneReady) && (!HasEffect(Buffs.VerfireReady) || HasEffect(Buffs.Embolden)) && (black - white <= 9))
+                                return Verflare;
 
-                            return RDM.Verholy;
+                            return Verholy;
                         }
-                        else if (level >= RDM.Levels.Verflare)
+                        else if (level >= Levels.Verflare)
                         {
-                            if (!HasEffect(RDM.Buffs.VerstoneReady) && (HasEffect(RDM.Buffs.VerfireReady) || HasEffect(RDM.Buffs.Embolden)) && level >= RDM.Levels.Verholy && (white - black <= 9))
-                                return RDM.Verholy;
+                            if (!HasEffect(Buffs.VerstoneReady) && (HasEffect(Buffs.VerfireReady) || HasEffect(Buffs.Embolden)) && level >= Levels.Verholy && (white - black <= 9))
+                                return Verholy;
 
-                            return RDM.Verflare;
+                            return Verflare;
                         }
                     }
-                    if ((lastComboMove is RDM.Verflare or RDM.Verholy) && level >= RDM.Levels.Scorch)
-                        return RDM.Scorch;
+                    if ((lastComboMove is Verflare or Verholy) && level >= Levels.Scorch)
+                        return Scorch;
 
-                    if (lastComboMove is RDM.Scorch && level >= RDM.Levels.Resolution)
-                        return RDM.Resolution;
+                    if (lastComboMove is RDM.Scorch && level >= Levels.Resolution)
+                        return Resolution;
                 }
             }
             //END_RDM_MELEEFINISHER
@@ -523,88 +523,88 @@ namespace XIVSlothComboPlugin.Combos
             //RDM_ST_MELEECOMBO
             if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo) && LocalPlayer.IsCasting == false)
             {
-                var radioButton = Service.Configuration.GetCustomIntValue(RDM.Config.RDM_ST_MeleeCombo_OnAction);
+                var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_ST_MeleeCombo_OnAction);
                 var distance = GetTargetDistance();
 
-                if ((radioButton == 1 && actionID is RDM.Riposte or RDM.EnchantedRiposte)
-                    || (radioButton == 2 && actionID is RDM.Jolt or RDM.Jolt2)
-                    || (radioButton == 3 && actionID is RDM.Riposte or RDM.EnchantedRiposte or RDM.Jolt or RDM.Jolt2))
+                if ((radioButton == 1 && actionID is Riposte or EnchantedRiposte)
+                    || (radioButton == 2 && actionID is Jolt or Jolt2)
+                    || (radioButton == 3 && actionID is Riposte or EnchantedRiposte or Jolt or Jolt2))
                 {
-                    if ((lastComboMove is RDM.Riposte or RDM.EnchantedRiposte) && level >= RDM.Levels.Zwerchhau)
-                        return OriginalHook(RDM.Zwerchhau);
+                    if ((lastComboMove is Riposte or EnchantedRiposte) && level >= Levels.Zwerchhau)
+                        return OriginalHook(Zwerchhau);
 
-                    if (lastComboMove is RDM.Zwerchhau && level >= RDM.Levels.Redoublement)
-                        return OriginalHook(RDM.Redoublement);
+                    if (lastComboMove is RDM.Zwerchhau && level >= Levels.Redoublement)
+                        return OriginalHook(Redoublement);
 
-                    if (((System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 50 && level >= RDM.Levels.Redoublement) 
-                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 35 && level < RDM.Levels.Redoublement)
-                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 20 && level < RDM.Levels.Zwerchhau))
-                        && (!HasEffect(RDM.Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(RDM.Buffs.Acceleration))) //Not sure if Swift and Accel are necessary, but better to clear I think.
+                    if (((System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 50 && level >= Levels.Redoublement) 
+                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 35 && level < Levels.Redoublement)
+                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 20 && level < Levels.Zwerchhau))
+                        && (!HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))) //Not sure if Swift and Accel are necessary, but better to clear I think.
                     {
-                        if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && level >= RDM.Levels.Corpsacorps && GetCooldown(RDM.Corpsacorps).RemainingCharges >= 1 && distance > 3) return RDM.Corpsacorps;
-                        if (distance <= 3) return OriginalHook(RDM.Riposte);
+                        if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && level >= Levels.Corpsacorps && GetCooldown(Corpsacorps).RemainingCharges >= 1 && distance > 3) return Corpsacorps;
+                        if (distance <= 3) return OriginalHook(Riposte);
                     }
                 }
             }
             //END_RDM_ST_MELEECOMBO
 
             //RDM_AOE_MELEECOMBO
-            if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo) && level >= RDM.Levels.Moulinet && actionID is RDM.Scatter or RDM.Impact && LocalPlayer.IsCasting == false
-                && !HasEffect(RDM.Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(RDM.Buffs.Acceleration)
-                && (System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60 || (level < RDM.Levels.Manafication && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
+            if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo) && level >= Levels.Moulinet && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
+                && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
+                && (System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60 || (level < Levels.Manafication && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
                 && ((GetTargetDistance() <= 7 && gauge.ManaStacks == 0) || gauge.ManaStacks > 0))
-                return OriginalHook(RDM.EnchantedMoulinet);
+                return OriginalHook(EnchantedMoulinet);
             //END_RDM_AOE_MELEECOMBO
 
             //RDM_ST_ACCELERATION
-            if (IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && actionID is RDM.Jolt or RDM.Jolt2 && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
-                && !HasEffect(RDM.Buffs.VerfireReady) && !HasEffect(RDM.Buffs.VerstoneReady) && !HasEffect(RDM.Buffs.Acceleration) && !HasEffect(RDM.Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
+            if (IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && actionID is Jolt or Jolt2 && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
+                && !HasEffect(Buffs.VerfireReady) && !HasEffect(Buffs.VerstoneReady) && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
             {
-                if (level >= RDM.Levels.Acceleration && GetCooldown(RDM.Acceleration).RemainingCharges > 0 && GetCooldown(RDM.Acceleration).ChargeCooldownRemaining < 54)
-                    return RDM.Acceleration;
-                if (IsEnabled(CustomComboPreset.RDM_ST_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(RDM.Acceleration).RemainingCharges == 0)
+                if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54)
+                    return Acceleration;
+                if (IsEnabled(CustomComboPreset.RDM_ST_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(Acceleration).RemainingCharges == 0)
                     return All.Swiftcast;
             }
             //END_RDM_ST_ACCELERATION
 
             //RDM_AoE_ACCELERATION
-            if (IsEnabled(CustomComboPreset.RDM_AoE_Acceleration) && actionID is RDM.Scatter or RDM.Impact && LocalPlayer.IsCasting == false
-                && !HasEffect(RDM.Buffs.Acceleration) && !HasEffect(RDM.Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
+            if (IsEnabled(CustomComboPreset.RDM_AoE_Acceleration) && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
+                && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
             {
-                if (level >= RDM.Levels.Acceleration && GetCooldown(RDM.Acceleration).RemainingCharges > 0 && GetCooldown(RDM.Acceleration).ChargeCooldownRemaining < 54)
-                    return RDM.Acceleration;
-                if (IsEnabled(CustomComboPreset.RDM_AoE_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(RDM.Acceleration).RemainingCharges == 0)
+                if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54)
+                    return Acceleration;
+                if (IsEnabled(CustomComboPreset.RDM_AoE_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(Acceleration).RemainingCharges == 0)
                     return All.Swiftcast;
             }
             //END_RDM_AoE_ACCELERATION
 
             //RDM_VERFIREVERSTONE
-            if (IsEnabled(CustomComboPreset.RDM_VerfireVerstone) && actionID is RDM.Jolt or RDM.Jolt2
-                && !HasEffect(RDM.Buffs.Acceleration) && !HasEffect(RDM.Buffs.Dualcast))
+            if (IsEnabled(CustomComboPreset.RDM_VerfireVerstone) && actionID is Jolt or Jolt2
+                && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast))
             {
-                if (useFire) return RDM.Verfire;
-                if (useStone) return RDM.Verstone;
+                if (useFire) return Verfire;
+                if (useStone) return Verstone;
             }
             //END_RDM_VERFIREVERSTONE
 
             //RDM_VERTHUNDERVERAERO
-            if (IsEnabled(CustomComboPreset.RDM_VerthunderVeraero) && actionID is RDM.Jolt or RDM.Jolt2)
+            if (IsEnabled(CustomComboPreset.RDM_VerthunderVeraero) && actionID is Jolt or Jolt2)
             {
-                if (useThunder) return OriginalHook(RDM.Verthunder);
-                if (useAero) return OriginalHook(RDM.Veraero);
+                if (useThunder) return OriginalHook(Verthunder);
+                if (useAero) return OriginalHook(Veraero);
             }
             //END_RDM_VERTHUNDERVERAERO
 
             //RDM_VERTHUNDERIIVVERAEROII
-            if (IsEnabled(CustomComboPreset.RDM_VerthunderIIVeraeroII) && actionID is RDM.Scatter or RDM.Impact)
+            if (IsEnabled(CustomComboPreset.RDM_VerthunderIIVeraeroII) && actionID is Scatter or Impact)
             {
-                if (useThunder2) return RDM.Verthunder2;
-                if (useAero2) return RDM.Veraero2;
+                if (useThunder2) return Verthunder2;
+                if (useAero2) return Veraero2;
             }
             //END_RDM_VERTHUNDERIIVVERAEROII
 
             //NO_CONDITIONS_MET
-            if (level < RDM.Levels.Jolt && actionID is RDM.Jolt or RDM.Jolt2) { return RDM.Riposte; }
+            if (level < Levels.Jolt && actionID is Jolt or Jolt2) { return Riposte; }
             return actionID;
         }
     }
@@ -617,19 +617,19 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is RDM.Verthunder or RDM.Veraero or RDM.Scatter or RDM.Verthunder3 or RDM.Veraero3 or RDM.Verthunder2 or RDM.Veraero2 or RDM.Impact or RDM.Jolt or RDM.Jolt2)
+            if (actionID is Verthunder or Veraero or Scatter or Verthunder3 or Veraero3 or Verthunder2 or Veraero2 or Impact or Jolt or Jolt2)
             {
-                var lucidThreshold = Service.Configuration.GetCustomIntValue(RDM.Config.RDM_LucidDreaming_Threshold);
+                var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.RDM_LucidDreaming_Threshold);
 
                 if (level >= All.Levels.LucidDreaming && LocalPlayer.CurrentMp <= lucidThreshold) // Check to show Lucid Dreaming
                 {
                     showLucid = true;
                 }
 
-                if (showLucid && CanSpellWeave(actionID) && HasCondition(ConditionFlag.InCombat) && IsOffCooldown(All.LucidDreaming) && !HasEffect(RDM.Buffs.Dualcast)
-                    && lastComboMove != RDM.EnchantedRiposte && lastComboMove != RDM.EnchantedZwerchhau
-                    && lastComboMove != RDM.EnchantedRedoublement && lastComboMove != RDM.Verflare
-                    && lastComboMove != RDM.Verholy && lastComboMove != RDM.Scorch) // Change abilities to Lucid Dreaming for entire weave window
+                if (showLucid && CanSpellWeave(actionID) && HasCondition(ConditionFlag.InCombat) && IsOffCooldown(All.LucidDreaming) && !HasEffect(Buffs.Dualcast)
+                    && lastComboMove != EnchantedRiposte && lastComboMove != EnchantedZwerchhau
+                    && lastComboMove != EnchantedRedoublement && lastComboMove != Verflare
+                    && lastComboMove != Verholy && lastComboMove != Scorch) // Change abilities to Lucid Dreaming for entire weave window
                 {
                     return All.LucidDreaming;
                 }
@@ -639,26 +639,27 @@ namespace XIVSlothComboPlugin.Combos
         }
     }
 
-    // RDM_Verraise
-    // Swiftcast combos to Verraise when:
-    //  -Swiftcast is on cooldown.
-    //  -Swiftcast is available, but we we have Dualcast (Dualcasting verraise)
-    // Using this variation other than the alternatefeature style, as verrise is level 63
-    // and swiftcast is unlocked way earlier and in theory, on a hotbar somewhere
-    internal class RDM_Verraise : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Verraise;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        // RDM_Verraise
+        // Swiftcast combos to Verraise when:
+        //  -Swiftcast is on cooldown.
+        //  -Swiftcast is available, but we we have Dualcast (Dualcasting verraise)
+        // Using this variation other than the alternatefeature style, as verrise is level 63
+        // and swiftcast is unlocked way earlier and in theory, on a hotbar somewhere
+        internal class RDM_Verraise : CustomCombo
         {
-            if (actionID is All.Swiftcast && level >= RDM.Levels.Verraise)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Verraise;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (GetCooldown(All.Swiftcast).CooldownRemaining > 0 ||   // Condition 1: Swiftcast is on cooldown
-                    HasEffect(RDM.Buffs.Dualcast))                        // Condition 2: Swiftcast is available, but we have DualCast)
-                    return RDM.Verraise;
-            }
+                if (actionID is All.Swiftcast && level >= Levels.Verraise)
+                {
+                    if (GetCooldown(All.Swiftcast).CooldownRemaining > 0 ||   // Condition 1: Swiftcast is on cooldown
+                        HasEffect(Buffs.Dualcast))                        // Condition 2: Swiftcast is available, but we have DualCast)
+                        return Verraise;
+                }
 
-            // Else we just exit normally and return SwiftCast
-            return actionID;
+                // Else we just exit normally and return SwiftCast
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/Combos/RPR.cs
+++ b/XIVSlothCombo/Combos/RPR.cs
@@ -44,7 +44,7 @@ namespace XIVSlothComboPlugin.Combos
             Harpe = 24386,
             Soulsow = 24387,
             HarvestMoon = 24388;
-        
+
 
         public static class Buffs
         {
@@ -89,467 +89,468 @@ namespace XIVSlothComboPlugin.Combos
                 HarvestMoon = 82,
                 PlentifulHarvest = 88,
                 Communio = 90;
-                
+
         }
-    }
 
-    internal class ReaperComboCommunioFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperComboCommunioFeature;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class ReaperComboCommunioFeature : CustomCombo
         {
-            if (actionID is RPR.Gibbet or RPR.Gallows or RPR.Guillotine)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperComboCommunioFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<RPRGauge>();
-
-                if (HasEffect(RPR.Buffs.Enshrouded) && gauge.LemureShroud is 1 && (gauge.VoidShroud is 0 || !IsEnabled(CustomComboPreset.ReaperLemureFeature)) && level >= RPR.Levels.Communio)
-                    return RPR.Communio;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class ReaperLemureFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperLemureFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is RPR.Gibbet or RPR.Gallows or RPR.Guillotine)
-            {
-                var gauge = GetJobGauge<RPRGauge>();
-
-                if (HasEffect(RPR.Buffs.Enshrouded) && gauge.VoidShroud >= 2)
+                if (actionID is Gibbet or Gallows or Guillotine)
                 {
-                    if (actionID is RPR.Guillotine)
-                        return OriginalHook(RPR.GrimSwathe);
-                    return OriginalHook(RPR.BloodStalk);
+                    var gauge = GetJobGauge<RPRGauge>();
+
+                    if (HasEffect(Buffs.Enshrouded) && gauge.LemureShroud is 1 && (gauge.VoidShroud is 0 || !IsEnabled(CustomComboPreset.ReaperLemureFeature)) && level >= Levels.Communio)
+                        return Communio;
                 }
+
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class ReaperSliceCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperSliceCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class ReaperLemureFeature : CustomCombo
         {
-            if (actionID is RPR.Slice)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperLemureFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<RPRGauge>();
-                var enhancedHarpe = HasEffect(RPR.Buffs.EnhancedHarpe);
-                var enshrouded = HasEffect(RPR.Buffs.Enshrouded);
-                var enshroudedTimer = FindEffect(RPR.Buffs.Enshrouded);
-                var soulScytheReady = IsOffCooldown(RPR.SoulScythe);
-                var soulReaver = HasEffect(RPR.Buffs.SoulReaver);
-                var deathsDesign = TargetHasEffect(RPR.Debuffs.DeathsDesign);
-                var deathsDesignTimer = FindTargetEffect(RPR.Debuffs.DeathsDesign);
-                var soulsow = HasEffect(RPR.Buffs.Soulsow);
-                var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                var playerHP = PlayerHealthPercentageHp();
-                var enemyHP = EnemyHealthPercentage();
-                var distance = GetTargetDistance();
-
-                if (IsEnabled(CustomComboPreset.ReaperRangedFillerOption) && !InMeleeRange())
+                if (actionID is Gibbet or Gallows or Guillotine)
                 {
-                    if (HasEffect(RPR.Buffs.Enshrouded) && gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= RPR.Levels.Communio)
-                        return RPR.Communio;
+                    var gauge = GetJobGauge<RPRGauge>();
 
-                    if (level >= RPR.Levels.HarvestMoon && soulsow)
+                    if (HasEffect(Buffs.Enshrouded) && gauge.VoidShroud >= 2)
                     {
-                        if ((IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonEnhancedOption) && enhancedHarpe) || (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonCombatOption) && !inCombat))
-                            return RPR.Harpe;
-
-                        return RPR.HarvestMoon;
+                        if (actionID is RPR.Guillotine)
+                            return OriginalHook(GrimSwathe);
+                        return OriginalHook(BloodStalk);
                     }
-
-                    return RPR.Harpe;
                 }
 
-                if (IsEnabled(CustomComboPreset.ReaperStunOption) && level >= All.Levels.LegSweep && CanInterruptEnemy() && IsOffCooldown(All.LegSweep))
-                    return All.LegSweep;
-
-                if (IsEnabled(CustomComboPreset.ReaperSoulSliceFeature) && !enshrouded && !soulReaver && level >= RPR.Levels.SoulSlice && gauge.Soul <= 50 && !GetCooldown(RPR.SoulSlice).IsCooldown && deathsDesign)
-                    return RPR.SoulSlice;
-
-                if (IsEnabled(CustomComboPreset.ReaperShadowOfDeathFeature) && level >= RPR.Levels.ShadowOfDeath && !(deathsDesignTimer?.RemainingTime > 3) && !soulReaver && !(enshroudedTimer?.RemainingTime <= 10) && enemyHP > 5)
-                    return RPR.ShadowOfDeath;
-
-                if (IsEnabled(CustomComboPreset.ReaperComboHealsOption))
-                {
-                    if (level >= All.Levels.Bloodbath && playerHP < 65 && IsOffCooldown(All.Bloodbath))
-                        return All.Bloodbath;
-
-                    if (level >= All.Levels.SecondWind && playerHP < 40 && IsOffCooldown(All.SecondWind))
-                        return All.SecondWind;
-                }
-
-                if (IsEnabled(CustomComboPreset.ReaperLemureFeature) && enshrouded && gauge.VoidShroud >= 2)
-                        return OriginalHook(RPR.BloodStalk);
-
-                if (IsEnabled(CustomComboPreset.ReaperComboCommunioFeature) && enshrouded && gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= RPR.Levels.Communio)
-                        return RPR.Communio;
-
-                if (IsEnabled(CustomComboPreset.ReaperGibbetGallowsFeature) && (soulReaver || enshrouded))
-                {
-                    if ((HasEffect(RPR.Buffs.EnhancedGallows) && !enshrouded && IsEnabled(CustomComboPreset.ReaperGibbetGallowsOption)) || (HasEffect(RPR.Buffs.EnhancedCrossReaping) && enshrouded))
-                        return OriginalHook(RPR.Gallows);
-
-                    return OriginalHook(RPR.Gibbet);
-                }
-
-                if (IsEnabled(CustomComboPreset.ReaperGibbetGallowsInverseFeature) && (soulReaver || enshrouded))
-                {
-                    if ((HasEffect(RPR.Buffs.EnhancedGibbet) && !enshrouded) || (HasEffect(RPR.Buffs.EnhancedVoidReaping) && enshrouded))
-                        return OriginalHook(RPR.Gibbet);
-
-                    return OriginalHook(RPR.Gallows);
-                }
-
-                if (level >= RPR.Levels.WaxingSlice && lastComboMove is RPR.Slice)
-                    return RPR.WaxingSlice;
-
-                else if (level >= RPR.Levels.InfernalSlice && lastComboMove is RPR.WaxingSlice)
-                    return RPR.InfernalSlice;
-
+                return actionID;
             }
-            return actionID;
         }
-    }
 
-    internal class ReaperScytheCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperScytheCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class ReaperSliceCombo : CustomCombo
         {
-            if (actionID is RPR.SpinningScythe)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperSliceCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var aoecombo = 0;
-                var gauge = GetJobGauge<RPRGauge>();
-                var enshrouded = HasEffect(RPR.Buffs.Enshrouded);
-                var enshroudedTimer = FindEffect(RPR.Buffs.Enshrouded);
-                var soulScytheReady = IsOffCooldown(RPR.SoulScythe);
-                var soulReaver = HasEffect(RPR.Buffs.SoulReaver);
-                var deathsDesign = TargetHasEffect(RPR.Debuffs.DeathsDesign);
-                var deathsDesignTimer = FindTargetEffect(RPR.Debuffs.DeathsDesign);
-                var enemyHP = EnemyHealthPercentage();
-
-                if (IsEnabled(CustomComboPreset.ReaperSoulScytheFeature) && !enshrouded && !soulReaver
-                    && level >= RPR.Levels.SoulScythe && gauge.Soul <= 50 && soulScytheReady && deathsDesign)
-                    return RPR.SoulScythe;
-
-                if (comboTime > 0 && IsEnabled(CustomComboPreset.ReaperWhorlOfDeathFeature) && !(deathsDesignTimer?.RemainingTime > 3) && !soulReaver && !(enshroudedTimer?.RemainingTime <= 10) && enemyHP > 5)
+                if (actionID is RPR.Slice)
                 {
-                    if ((lastComboMove is RPR.SpinningScythe) && (!deathsDesign || deathsDesignTimer.RemainingTime <= 3 && level >= RPR.Levels.WhorlOfDeath))
+                    var gauge = GetJobGauge<RPRGauge>();
+                    var enhancedHarpe = HasEffect(Buffs.EnhancedHarpe);
+                    var enshrouded = HasEffect(Buffs.Enshrouded);
+                    var enshroudedTimer = FindEffect(Buffs.Enshrouded);
+                    var soulScytheReady = IsOffCooldown(SoulScythe);
+                    var soulReaver = HasEffect(Buffs.SoulReaver);
+                    var deathsDesign = TargetHasEffect(Debuffs.DeathsDesign);
+                    var deathsDesignTimer = FindTargetEffect(Debuffs.DeathsDesign);
+                    var soulsow = HasEffect(Buffs.Soulsow);
+                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    var playerHP = PlayerHealthPercentageHp();
+                    var enemyHP = EnemyHealthPercentage();
+                    var distance = GetTargetDistance();
+
+                    if (IsEnabled(CustomComboPreset.ReaperRangedFillerOption) && !InMeleeRange())
                     {
-                        if (level >= RPR.Levels.NightmareScythe)
+                        if (HasEffect(Buffs.Enshrouded) && gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= Levels.Communio)
+                            return Communio;
+
+                        if (level >= Levels.HarvestMoon && soulsow)
                         {
-                            aoecombo = 1;
+                            if ((IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonEnhancedOption) && enhancedHarpe) || (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonCombatOption) && !inCombat))
+                                return Harpe;
+
+                            return HarvestMoon;
                         }
 
-                        return RPR.WhorlOfDeath;
+                        return Harpe;
                     }
 
-                    if ((aoecombo is 1) || (lastComboMove is RPR.SpinningScythe && deathsDesignTimer.RemainingTime >= 4 && level >= RPR.Levels.NightmareScythe))
+                    if (IsEnabled(CustomComboPreset.ReaperStunOption) && level >= All.Levels.LegSweep && CanInterruptEnemy() && IsOffCooldown(All.LegSweep))
+                        return All.LegSweep;
+
+                    if (IsEnabled(CustomComboPreset.ReaperSoulSliceFeature) && !enshrouded && !soulReaver && level >= Levels.SoulSlice && gauge.Soul <= 50 && !GetCooldown(SoulSlice).IsCooldown && deathsDesign)
+                        return SoulSlice;
+
+                    if (IsEnabled(CustomComboPreset.ReaperShadowOfDeathFeature) && level >= Levels.ShadowOfDeath && !(deathsDesignTimer?.RemainingTime > 3) && !soulReaver && !(enshroudedTimer?.RemainingTime <= 10) && enemyHP > 5)
+                        return ShadowOfDeath;
+
+                    if (IsEnabled(CustomComboPreset.ReaperComboHealsOption))
                     {
-                        if (aoecombo is 1)
+                        if (level >= All.Levels.Bloodbath && playerHP < 65 && IsOffCooldown(All.Bloodbath))
+                            return All.Bloodbath;
+
+                        if (level >= All.Levels.SecondWind && playerHP < 40 && IsOffCooldown(All.SecondWind))
+                            return All.SecondWind;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperLemureFeature) && enshrouded && gauge.VoidShroud >= 2)
+                        return OriginalHook(BloodStalk);
+
+                    if (IsEnabled(CustomComboPreset.ReaperComboCommunioFeature) && enshrouded && gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= Levels.Communio)
+                        return Communio;
+
+                    if (IsEnabled(CustomComboPreset.ReaperGibbetGallowsFeature) && (soulReaver || enshrouded))
+                    {
+                        if ((HasEffect(Buffs.EnhancedGallows) && !enshrouded && IsEnabled(CustomComboPreset.ReaperGibbetGallowsOption)) || (HasEffect(Buffs.EnhancedCrossReaping) && enshrouded))
+                            return OriginalHook(Gallows);
+
+                        return OriginalHook(Gibbet);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperGibbetGallowsInverseFeature) && (soulReaver || enshrouded))
+                    {
+                        if ((HasEffect(Buffs.EnhancedGibbet) && !enshrouded) || (HasEffect(Buffs.EnhancedVoidReaping) && enshrouded))
+                            return OriginalHook(Gibbet);
+
+                        return OriginalHook(Gallows);
+                    }
+
+                    if (level >= Levels.WaxingSlice && lastComboMove is RPR.Slice)
+                        return WaxingSlice;
+
+                    else if (level >= Levels.InfernalSlice && lastComboMove is RPR.WaxingSlice)
+                        return InfernalSlice;
+
+                }
+                return actionID;
+            }
+        }
+
+        internal class ReaperScytheCombo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperScytheCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is RPR.SpinningScythe)
+                {
+                    var aoecombo = 0;
+                    var gauge = GetJobGauge<RPRGauge>();
+                    var enshrouded = HasEffect(Buffs.Enshrouded);
+                    var enshroudedTimer = FindEffect(Buffs.Enshrouded);
+                    var soulScytheReady = IsOffCooldown(SoulScythe);
+                    var soulReaver = HasEffect(Buffs.SoulReaver);
+                    var deathsDesign = TargetHasEffect(Debuffs.DeathsDesign);
+                    var deathsDesignTimer = FindTargetEffect(Debuffs.DeathsDesign);
+                    var enemyHP = EnemyHealthPercentage();
+
+                    if (IsEnabled(CustomComboPreset.ReaperSoulScytheFeature) && !enshrouded && !soulReaver
+                        && level >= Levels.SoulScythe && gauge.Soul <= 50 && soulScytheReady && deathsDesign)
+                        return SoulScythe;
+
+                    if (comboTime > 0 && IsEnabled(CustomComboPreset.ReaperWhorlOfDeathFeature) && !(deathsDesignTimer?.RemainingTime > 3) && !soulReaver && !(enshroudedTimer?.RemainingTime <= 10) && enemyHP > 5)
+                    {
+                        if ((lastComboMove is RPR.SpinningScythe) && (!deathsDesign || deathsDesignTimer.RemainingTime <= 3 && level >= Levels.WhorlOfDeath))
                         {
-                            aoecombo = 0; 
+                            if (level >= Levels.NightmareScythe)
+                            {
+                                aoecombo = 1;
+                            }
+
+                            return WhorlOfDeath;
                         }
 
-                        return RPR.NightmareScythe;
+                        if ((aoecombo is 1) || (lastComboMove is RPR.SpinningScythe && deathsDesignTimer.RemainingTime >= 4 && level >= Levels.NightmareScythe))
+                        {
+                            if (aoecombo is 1)
+                            {
+                                aoecombo = 0;
+                            }
+
+                            return NightmareScythe;
+                        }
                     }
-                }
 
-                if (IsEnabled(CustomComboPreset.ReaperWhorlOfDeathFeature) && !(deathsDesignTimer?.RemainingTime > 4) && !soulReaver && !(enshroudedTimer?.RemainingTime <= 10) && enemyHP > 5)
-                    return RPR.WhorlOfDeath;
+                    if (IsEnabled(CustomComboPreset.ReaperWhorlOfDeathFeature) && !(deathsDesignTimer?.RemainingTime > 4) && !soulReaver && !(enshroudedTimer?.RemainingTime <= 10) && enemyHP > 5)
+                        return WhorlOfDeath;
 
-                if (comboTime > 0 && !IsEnabled(CustomComboPreset.ReaperWhorlOfDeathFeature) && enemyHP > 5 && !enshrouded && !soulReaver)
-                {
-                    if (lastComboMove is RPR.SpinningScythe && level >= RPR.Levels.NightmareScythe)
-                        return RPR.NightmareScythe;
-                }
-
-                if (IsEnabled(CustomComboPreset.ReaperLemureFeature))
-                {
-                    if (enshrouded && gauge.VoidShroud >= 2)
-                        return OriginalHook(RPR.GrimSwathe);
-                }
-
-                if (IsEnabled(CustomComboPreset.ReaperComboCommunioFeature))
-                {
-                    if (enshrouded && gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= RPR.Levels.Communio)
-                        return RPR.Communio;
-                }
-
-                if (IsEnabled(CustomComboPreset.ReaperGuillotineFeature) && (soulReaver || enshrouded))
-                    return OriginalHook(RPR.Guillotine);
-
-                if (lastComboMove is RPR.SpinningScythe)
-                    return OriginalHook(RPR.NightmareScythe);
-
-                return RPR.SpinningScythe;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class ReaperEnshroudCommunioFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperEnshroudCommunioFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var enshroudCD = GetCooldown(RPR.Enshroud);
-            if (actionID is RPR.Enshroud)
-            {
-                if (level >= RPR.Levels.Communio && HasEffect(RPR.Buffs.Enshrouded) && enshroudCD.CooldownRemaining < 12)
-                    return RPR.Communio;
-
-                return RPR.Enshroud;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class ReaperGibbetGallowsFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperGibbetGallowsFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is RPR.ShadowOfDeath)
-            {
-                if (HasEffect(RPR.Buffs.SoulReaver) && !HasEffect(RPR.Buffs.Enshrouded) && (!IsEnabled(CustomComboPreset.ReaperGibbetGallowsOption) || (!HasEffect(RPR.Buffs.EnhancedGallows) && !HasEffect(RPR.Buffs.EnhancedGibbet))))
-                    return OriginalHook(RPR.Gallows);
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class ReaperHarvestFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperHarvestFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is RPR.ArcaneCircle)
-            {
-                if (HasEffect(RPR.Buffs.ImmortalSacrifice) && level >= RPR.Levels.PlentifulHarvest)
-                    return RPR.PlentifulHarvest;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class ReaperRegressFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperRegressFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if ((actionID is RPR.HellsEgress or RPR.HellsIngress) && HasEffect(RPR.Buffs.Threshold))
-                return RPR.Regress;
-
-            return actionID;
-        }
-    }
-
-    internal class ReaperBloodSwatheFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperBloodSwatheFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gluttonyCD = GetCooldown(RPR.Gluttony);
-            if ((actionID is RPR.GrimSwathe or RPR.BloodStalk) && !gluttonyCD.IsCooldown && level >= RPR.Levels.Gluttony)
-                return RPR.Gluttony;
-
-            return actionID;
-        }
-    }
-
-    internal class ReaperBloodStalkComboFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperBloodStalkComboFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gluttonyCD = GetCooldown(RPR.Gluttony);
-            var gauge = GetJobGauge<RPRGauge>();
-
-            if (actionID is RPR.BloodStalk)
-            {
-                if (HasEffect(RPR.Buffs.Enshrouded) && level >= RPR.Levels.Enshroud)
-                {
-                    if (gauge.VoidShroud >= 2)
-                        return OriginalHook(RPR.BloodStalk);
-
-                    if (gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= RPR.Levels.Communio)
-                        return OriginalHook(RPR.Communio);
-
-                    if (HasEffect(RPR.Buffs.EnhancedCrossReaping))
-                        return OriginalHook(RPR.Gallows);
-
-                    if (HasEffect(RPR.Buffs.EnhancedVoidReaping))
-                        return OriginalHook(RPR.Gibbet);
-
-                    return OriginalHook(RPR.Gibbet);
-                }
-
-                if (!HasEffect(RPR.Buffs.SoulReaver) && !HasEffect(RPR.Buffs.Enshrouded))
-                {
-                    if ((actionID is RPR.BloodStalk) && !gluttonyCD.IsCooldown && level >= RPR.Levels.Gluttony)
-                        return RPR.Gluttony;
-                    return RPR.BloodStalk;
-                }
-
-                if (!HasEffect(RPR.Buffs.Enshrouded) && HasEffect(RPR.Buffs.SoulReaver) && (actionID is RPR.BloodStalk or RPR.Gluttony))
-                {
-                    if (HasEffect(RPR.Buffs.EnhancedGallows) && !HasEffect(RPR.Buffs.Enshrouded))
-                        return RPR.Gallows;
-
-                    return RPR.Gibbet;
-                }
-            }
-            return actionID;
-        }
-    }
-
-    internal class ReaperBloodStalkAlternateComboOption : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperBloodStalkAlternateComboOption;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gluttonyCD = GetCooldown(RPR.Gluttony);
-            var gauge = GetJobGauge<RPRGauge>();
-
-            if (actionID is RPR.BloodStalk)
-            {
-                if (HasEffect(RPR.Buffs.Enshrouded) && level >= (RPR.Levels.Enshroud))
-                {
-                    if (gauge.VoidShroud >= 2)
-                        return OriginalHook(RPR.BloodStalk);
-
-                    if (gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= RPR.Levels.Communio)
-                        return OriginalHook(RPR.Communio);
-
-                    if (HasEffect(RPR.Buffs.EnhancedCrossReaping))
-                        return OriginalHook(RPR.Gallows);
-
-                    if (HasEffect(RPR.Buffs.EnhancedVoidReaping))
-                        return OriginalHook(RPR.Gibbet);
-
-                    return OriginalHook(RPR.Gallows);
-                }
-
-                if (!HasEffect(RPR.Buffs.SoulReaver) && !HasEffect(RPR.Buffs.Enshrouded))
-                {
-                    if ((actionID is RPR.BloodStalk) && !gluttonyCD.IsCooldown && level >= RPR.Levels.Gluttony)
-                        return RPR.Gluttony;
-                    return RPR.BloodStalk;
-                }
-
-                if (!HasEffect(RPR.Buffs.Enshrouded) && HasEffect(RPR.Buffs.SoulReaver) && (actionID is RPR.BloodStalk or RPR.Gluttony))
-                {
-                    if (HasEffect(RPR.Buffs.EnhancedGallows))
-                        return RPR.Gallows;
-
-                    if (HasEffect(RPR.Buffs.EnhancedGibbet))
-                        return RPR.Gibbet;
-
-                    return RPR.Gallows;
-                }
-            }
-            return actionID;
-        }
-    }
-
-    internal class ReaperGrimSwatheComboFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperGrimSwatheComboFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gluttonyCD = GetCooldown(RPR.Gluttony);
-            var gauge = GetJobGauge<RPRGauge>();
-            if (actionID is RPR.GrimSwathe)
-            {
-                if (HasEffect(RPR.Buffs.Enshrouded) && level >= RPR.Levels.Enshroud)
-                {
-                    if (gauge.VoidShroud >= 2)
-                        return OriginalHook(RPR.GrimSwathe);
-
-                    if (gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= RPR.Levels.Communio)
-                        return OriginalHook(RPR.Communio);
-
-                    return OriginalHook(RPR.Guillotine);
-                }
-
-                if (!HasEffect(RPR.Buffs.SoulReaver) && !HasEffect(RPR.Buffs.Enshrouded))
-                {
-                    if ((actionID is RPR.GrimSwathe) && !gluttonyCD.IsCooldown && level >= RPR.Levels.Gluttony)
-                        return RPR.Gluttony;
-                    return RPR.GrimSwathe;
-                }
-
-                if (!HasEffect(RPR.Buffs.Enshrouded) && HasEffect(RPR.Buffs.SoulReaver) && (actionID is RPR.GrimSwathe or RPR.Gluttony))
-                    return RPR.Guillotine;
-
-            }
-            return actionID;
-        }
-    }
-
-    internal class ReaperHarpeSoulsowFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperHarpeSoulsowFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is RPR.Harpe)
-            {
-                if (level >= RPR.Levels.Soulsow && !HasEffect(RPR.Buffs.Soulsow) && (!HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat) || !HasTarget()))
-                    return RPR.Soulsow;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class ReaperHarvestMoonFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperHarpeHarvestMoonFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is RPR.Harpe)
-
-                if (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonFeature))
-                {
-                    if (level >= RPR.Levels.HarvestMoon && HasEffect(RPR.Buffs.Soulsow))
+                    if (comboTime > 0 && !IsEnabled(CustomComboPreset.ReaperWhorlOfDeathFeature) && enemyHP > 5 && !enshrouded && !soulReaver)
                     {
-
-                        if (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonEnhancedOption) && HasEffect(RPR.Buffs.EnhancedHarpe))
-                                return RPR.Harpe;
-
-                        if (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonCombatOption) && !HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
-                                return RPR.Harpe;
-
-                        return RPR.HarvestMoon;
+                        if (lastComboMove is RPR.SpinningScythe && level >= Levels.NightmareScythe)
+                            return NightmareScythe;
                     }
+
+                    if (IsEnabled(CustomComboPreset.ReaperLemureFeature))
+                    {
+                        if (enshrouded && gauge.VoidShroud >= 2)
+                            return OriginalHook(GrimSwathe);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperComboCommunioFeature))
+                    {
+                        if (enshrouded && gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= Levels.Communio)
+                            return Communio;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.ReaperGuillotineFeature) && (soulReaver || enshrouded))
+                        return OriginalHook(Guillotine);
+
+                    if (lastComboMove is RPR.SpinningScythe)
+                        return OriginalHook(NightmareScythe);
+
+                    return SpinningScythe;
                 }
 
-            return actionID;
+                return actionID;
+            }
+        }
+
+        internal class ReaperEnshroudCommunioFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperEnshroudCommunioFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var enshroudCD = GetCooldown(Enshroud);
+                if (actionID is RPR.Enshroud)
+                {
+                    if (level >= Levels.Communio && HasEffect(Buffs.Enshrouded) && enshroudCD.CooldownRemaining < 12)
+                        return Communio;
+
+                    return Enshroud;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class ReaperGibbetGallowsFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperGibbetGallowsFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is RPR.ShadowOfDeath)
+                {
+                    if (HasEffect(Buffs.SoulReaver) && !HasEffect(Buffs.Enshrouded) && (!IsEnabled(CustomComboPreset.ReaperGibbetGallowsOption) || (!HasEffect(Buffs.EnhancedGallows) && !HasEffect(Buffs.EnhancedGibbet))))
+                        return OriginalHook(Gallows);
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class ReaperHarvestFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperHarvestFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is RPR.ArcaneCircle)
+                {
+                    if (HasEffect(Buffs.ImmortalSacrifice) && level >= Levels.PlentifulHarvest)
+                        return PlentifulHarvest;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class ReaperRegressFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperRegressFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if ((actionID is HellsEgress or HellsIngress) && HasEffect(Buffs.Threshold))
+                    return Regress;
+
+                return actionID;
+            }
+        }
+
+        internal class ReaperBloodSwatheFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperBloodSwatheFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var gluttonyCD = GetCooldown(Gluttony);
+                if ((actionID is GrimSwathe or BloodStalk) && !gluttonyCD.IsCooldown && level >= Levels.Gluttony)
+                    return Gluttony;
+
+                return actionID;
+            }
+        }
+
+        internal class ReaperBloodStalkComboFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperBloodStalkComboFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var gluttonyCD = GetCooldown(Gluttony);
+                var gauge = GetJobGauge<RPRGauge>();
+
+                if (actionID is RPR.BloodStalk)
+                {
+                    if (HasEffect(Buffs.Enshrouded) && level >= Levels.Enshroud)
+                    {
+                        if (gauge.VoidShroud >= 2)
+                            return OriginalHook(BloodStalk);
+
+                        if (gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= Levels.Communio)
+                            return OriginalHook(Communio);
+
+                        if (HasEffect(Buffs.EnhancedCrossReaping))
+                            return OriginalHook(Gallows);
+
+                        if (HasEffect(Buffs.EnhancedVoidReaping))
+                            return OriginalHook(Gibbet);
+
+                        return OriginalHook(Gibbet);
+                    }
+
+                    if (!HasEffect(Buffs.SoulReaver) && !HasEffect(Buffs.Enshrouded))
+                    {
+                        if ((actionID is RPR.BloodStalk) && !gluttonyCD.IsCooldown && level >= Levels.Gluttony)
+                            return Gluttony;
+                        return BloodStalk;
+                    }
+
+                    if (!HasEffect(Buffs.Enshrouded) && HasEffect(Buffs.SoulReaver) && (actionID is BloodStalk or Gluttony))
+                    {
+                        if (HasEffect(Buffs.EnhancedGallows) && !HasEffect(Buffs.Enshrouded))
+                            return Gallows;
+
+                        return Gibbet;
+                    }
+                }
+                return actionID;
+            }
+        }
+
+        internal class ReaperBloodStalkAlternateComboOption : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperBloodStalkAlternateComboOption;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var gluttonyCD = GetCooldown(Gluttony);
+                var gauge = GetJobGauge<RPRGauge>();
+
+                if (actionID is RPR.BloodStalk)
+                {
+                    if (HasEffect(Buffs.Enshrouded) && level >= (Levels.Enshroud))
+                    {
+                        if (gauge.VoidShroud >= 2)
+                            return OriginalHook(BloodStalk);
+
+                        if (gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= Levels.Communio)
+                            return OriginalHook(Communio);
+
+                        if (HasEffect(Buffs.EnhancedCrossReaping))
+                            return OriginalHook(Gallows);
+
+                        if (HasEffect(Buffs.EnhancedVoidReaping))
+                            return OriginalHook(Gibbet);
+
+                        return OriginalHook(Gallows);
+                    }
+
+                    if (!HasEffect(Buffs.SoulReaver) && !HasEffect(Buffs.Enshrouded))
+                    {
+                        if ((actionID is RPR.BloodStalk) && !gluttonyCD.IsCooldown && level >= Levels.Gluttony)
+                            return Gluttony;
+                        return BloodStalk;
+                    }
+
+                    if (!HasEffect(Buffs.Enshrouded) && HasEffect(Buffs.SoulReaver) && (actionID is BloodStalk or Gluttony))
+                    {
+                        if (HasEffect(Buffs.EnhancedGallows))
+                            return Gallows;
+
+                        if (HasEffect(Buffs.EnhancedGibbet))
+                            return Gibbet;
+
+                        return Gallows;
+                    }
+                }
+                return actionID;
+            }
+        }
+
+        internal class ReaperGrimSwatheComboFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperGrimSwatheComboFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var gluttonyCD = GetCooldown(Gluttony);
+                var gauge = GetJobGauge<RPRGauge>();
+                if (actionID is RPR.GrimSwathe)
+                {
+                    if (HasEffect(Buffs.Enshrouded) && level >= Levels.Enshroud)
+                    {
+                        if (gauge.VoidShroud >= 2)
+                            return OriginalHook(GrimSwathe);
+
+                        if (gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= Levels.Communio)
+                            return OriginalHook(Communio);
+
+                        return OriginalHook(Guillotine);
+                    }
+
+                    if (!HasEffect(Buffs.SoulReaver) && !HasEffect(Buffs.Enshrouded))
+                    {
+                        if ((actionID is RPR.GrimSwathe) && !gluttonyCD.IsCooldown && level >= Levels.Gluttony)
+                            return Gluttony;
+                        return GrimSwathe;
+                    }
+
+                    if (!HasEffect(Buffs.Enshrouded) && HasEffect(Buffs.SoulReaver) && (actionID is GrimSwathe or Gluttony))
+                        return Guillotine;
+
+                }
+                return actionID;
+            }
+        }
+
+        internal class ReaperHarpeSoulsowFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperHarpeSoulsowFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is RPR.Harpe)
+                {
+                    if (level >= Levels.Soulsow && !HasEffect(Buffs.Soulsow) && (!HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat) || !HasTarget()))
+                        return Soulsow;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class ReaperHarvestMoonFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.ReaperHarpeHarvestMoonFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is RPR.Harpe)
+
+                    if (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonFeature))
+                    {
+                        if (level >= Levels.HarvestMoon && HasEffect(Buffs.Soulsow))
+                        {
+
+                            if (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonEnhancedOption) && HasEffect(Buffs.EnhancedHarpe))
+                                return Harpe;
+
+                            if (IsEnabled(CustomComboPreset.ReaperHarpeHarvestMoonCombatOption) && !HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
+                                return Harpe;
+
+                            return HarvestMoon;
+                        }
+                    }
+
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/Combos/SAM.cs
+++ b/XIVSlothCombo/Combos/SAM.cs
@@ -103,7 +103,7 @@ namespace XIVSlothComboPlugin.Combos
             public const string
                 SamFillerCombo = "SamFillerCombo";
         }
-    }
+    
 
     internal class SamuraiYukikazeCombo : CustomCombo
     {
@@ -111,29 +111,29 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SAM.Yukikaze)
+            if (actionID == Yukikaze)
             {
                 var gauge = GetJobGauge<SAMGauge>();
-                var SamKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamKenkiOvercapAmount);
+                var SamKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(Config.SamKenkiOvercapAmount);
 
                 if (CanWeave(actionID))
                 {
-                    if (IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) && GetBuffStacks(SAM.Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
+                    if (IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) && GetBuffStacks(Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
                         return All.TrueNorth;
-                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount && level >= SAM.Levels.Shinten)
-                        return SAM.Shinten;
+                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount && level >= Levels.Shinten)
+                        return Shinten;
                 }
 
-                if (HasEffect(SAM.Buffs.MeikyoShisui))
-                    return SAM.Yukikaze;
+                if (HasEffect(Buffs.MeikyoShisui))
+                    return Yukikaze;
 
                 if (comboTime > 0)
                 {
-                    if (lastComboMove == SAM.Hakaze && level >= SAM.Levels.Yukikaze)
-                        return SAM.Yukikaze;
+                    if (lastComboMove == Hakaze && level >= Levels.Yukikaze)
+                        return Yukikaze;
                 }
 
-                return SAM.Hakaze;
+                return Hakaze;
             }
 
             return actionID;
@@ -151,25 +151,25 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SAM.Gekko)
+            if (actionID == Gekko)
             {
                 var gauge = GetJobGauge<SAMGauge>();
-                var SamKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamKenkiOvercapAmount);
-                var meikyoBuff = HasEffect(SAM.Buffs.MeikyoShisui);
-                var oneSeal = OriginalHook(SAM.Iaijutsu) == SAM.Higanbana;
-                var twoSeal = OriginalHook(SAM.Iaijutsu) == SAM.TenkaGoken;
-                var threeSeal = OriginalHook(SAM.Iaijutsu) == SAM.Setsugekka;
-                var meikyostacks = GetBuffStacks(SAM.Buffs.MeikyoShisui);
-                var SamFillerCombo = Service.Configuration.GetCustomIntValue(SAM.Config.SamFillerCombo);
-                bool openerReady = GetRemainingCharges(SAM.MeikyoShisui) == 1 && IsOffCooldown(SAM.Senei) && IsOffCooldown(SAM.Ikishoten) && GetRemainingCharges(SAM.TsubameGaeshi) == 2;
+                var SamKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(Config.SamKenkiOvercapAmount);
+                var meikyoBuff = HasEffect(Buffs.MeikyoShisui);
+                var oneSeal = OriginalHook(Iaijutsu) == Higanbana;
+                var twoSeal = OriginalHook(Iaijutsu) == TenkaGoken;
+                var threeSeal = OriginalHook(Iaijutsu) == Setsugekka;
+                var meikyostacks = GetBuffStacks(Buffs.MeikyoShisui);
+                var SamFillerCombo = Service.Configuration.GetCustomIntValue(Config.SamFillerCombo);
+                bool openerReady = GetRemainingCharges(MeikyoShisui) == 1 && IsOffCooldown(Senei) && IsOffCooldown(Ikishoten) && GetRemainingCharges(TsubameGaeshi) == 2;
 
-                if (IsEnabled(CustomComboPreset.SamuraiRangedUptimeFeature) && level >= SAM.Levels.Enpi && !inEvenFiller && !inOddFiller)
+                if (IsEnabled(CustomComboPreset.SamuraiRangedUptimeFeature) && level >= Levels.Enpi && !inEvenFiller && !inOddFiller)
                 {
                     if (!InMeleeRange())
-                        return SAM.Enpi;
+                        return Enpi;
                 }
 
-                if (CanSpellWeave(actionID) && IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) && GetBuffStacks(SAM.Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
+                if (CanSpellWeave(actionID) && IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) && GetBuffStacks(Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
                     return All.TrueNorth;
 
                 if (!InCombat())
@@ -189,21 +189,21 @@ namespace XIVSlothComboPlugin.Combos
 
                         if (inOpener)
                         {
-                            if (GetBuffStacks(SAM.Buffs.MeikyoShisui) == 3 && (oneSeal || twoSeal || threeSeal))
-                                return SAM.Hagakure;
+                            if (GetBuffStacks(Buffs.MeikyoShisui) == 3 && (oneSeal || twoSeal || threeSeal))
+                                return Hagakure;
                         }
                     }
                     //Prep for Opener
-                    if (meikyoBuff && IsOnCooldown(SAM.MeikyoShisui) && gauge.Sen == Sen.NONE)
-                        return SAM.Gekko;
+                    if (meikyoBuff && IsOnCooldown(MeikyoShisui) && gauge.Sen == Sen.NONE)
+                        return Gekko;
 
                     //Stops waste if you use Iaijutsu or Ogi and you've got a Kaeshi ready
                     if (!inOpener)
                     {
                         if (IsEnabled(CustomComboPreset.SamuraiOgiNamikiriSTFeature) && (gauge.Kaeshi == Kaeshi.NAMIKIRI))
-                            return OriginalHook(SAM.OgiNamikiri);
+                            return OriginalHook(OgiNamikiri);
                         if (IsEnabled(CustomComboPreset.IaijutsuSTFeature) && (gauge.Kaeshi == Kaeshi.GOKEN || gauge.Kaeshi == Kaeshi.SETSUGEKKA))
-                            return OriginalHook(SAM.TsubameGaeshi);
+                            return OriginalHook(TsubameGaeshi);
                     }
                 }
 
@@ -215,62 +215,62 @@ namespace XIVSlothComboPlugin.Combos
                         if (CanSpellWeave(actionID))
                         {
                             if (gauge.Kaeshi == Kaeshi.NAMIKIRI && gauge.MeditationStacks == 3)
-                                return SAM.Shoha;
-                            if (twoSeal && gauge.MeditationStacks == 0 && GetCooldownRemainingTime(SAM.Ikishoten) < 110 && IsOnCooldown(SAM.Ikishoten))
+                                return Shoha;
+                            if (twoSeal && gauge.MeditationStacks == 0 && GetCooldownRemainingTime(Ikishoten) < 110 && IsOnCooldown(Ikishoten))
                             {
-                                if (gauge.Kenki >= 10 && IsOffCooldown(SAM.Gyoten))
-                                    return SAM.Gyoten;
+                                if (gauge.Kenki >= 10 && IsOffCooldown(Gyoten))
+                                    return Gyoten;
                                 if (gauge.Kenki >= 25)
-                                    return SAM.Shinten;
+                                    return Shinten;
                             }
 
-                            if (twoSeal && IsOffCooldown(SAM.Ikishoten))
-                                return SAM.Ikishoten;
+                            if (twoSeal && IsOffCooldown(Ikishoten))
+                                return Ikishoten;
                             if (gauge.Kenki >= 25)
                             {
-                                if (oneSeal && GetRemainingCharges(SAM.MeikyoShisui) == 0 && oneSeal)
-                                    return SAM.Shinten;
-                                if (GetRemainingCharges(SAM.MeikyoShisui) == 1 && IsOffCooldown(SAM.Senei) && (gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Sen == Sen.NONE))
-                                    return SAM.Senei;
+                                if (oneSeal && GetRemainingCharges(MeikyoShisui) == 0 && oneSeal)
+                                    return Shinten;
+                                if (GetRemainingCharges(MeikyoShisui) == 1 && IsOffCooldown(Senei) && (gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Sen == Sen.NONE))
+                                    return Senei;
                             }
 
-                            if (gauge.Sen == Sen.NONE && GetRemainingCharges(SAM.MeikyoShisui) == 1)
-                                return SAM.MeikyoShisui;
-                            if (gauge.Kenki >= 25 && IsOnCooldown(SAM.Shoha))
-                                return SAM.Shinten;
+                            if (gauge.Sen == Sen.NONE && GetRemainingCharges(MeikyoShisui) == 1)
+                                return MeikyoShisui;
+                            if (gauge.Kenki >= 25 && IsOnCooldown(Shoha))
+                                return Shinten;
                         }
 
                         //GCDs
-                        if ((twoSeal && lastComboMove == SAM.Yukikaze) ||
-                            (threeSeal && (GetRemainingCharges(SAM.MeikyoShisui) == 1 || !HasEffect(SAM.Buffs.OgiNamikiriReady))) ||
-                            (oneSeal && !TargetHasEffect(SAM.Debuffs.Higanbana) && GetRemainingCharges(SAM.TsubameGaeshi) == 1))
-                            return OriginalHook(SAM.Iaijutsu);
+                        if ((twoSeal && lastComboMove == Yukikaze) ||
+                            (threeSeal && (GetRemainingCharges(MeikyoShisui) == 1 || !HasEffect(Buffs.OgiNamikiriReady))) ||
+                            (oneSeal && !TargetHasEffect(Debuffs.Higanbana) && GetRemainingCharges(TsubameGaeshi) == 1))
+                            return OriginalHook(Iaijutsu);
                         if ((gauge.Kaeshi == Kaeshi.NAMIKIRI) ||
-                            (oneSeal && TargetHasEffect(SAM.Debuffs.Higanbana) && HasEffect(SAM.Buffs.OgiNamikiriReady)))
-                            return OriginalHook(SAM.OgiNamikiri);
+                            (oneSeal && TargetHasEffect(Debuffs.Higanbana) && HasEffect(Buffs.OgiNamikiriReady)))
+                            return OriginalHook(OgiNamikiri);
                         if (gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Kaeshi == Kaeshi.GOKEN)
-                            return OriginalHook(SAM.TsubameGaeshi);
+                            return OriginalHook(TsubameGaeshi);
 
                         //1-2-3 Logic
-                        if (lastComboMove == SAM.Hakaze)
-                            return SAM.Yukikaze;
-                        if (twoSeal && gauge.MeditationStacks == 0 && TargetHasEffect(SAM.Debuffs.Higanbana))
-                            return SAM.Hakaze;
+                        if (lastComboMove == Hakaze)
+                            return Yukikaze;
+                        if (twoSeal && gauge.MeditationStacks == 0 && TargetHasEffect(Debuffs.Higanbana))
+                            return Hakaze;
                         if (meikyostacks == 3)
-                            return SAM.Gekko;
+                            return Gekko;
                         if (meikyostacks == 2)
-                            return SAM.Kasha;
+                            return Kasha;
                         if (meikyostacks == 1)
                         {
-                            if (GetCooldownRemainingTime(SAM.Ikishoten) > 110)
-                                return SAM.Yukikaze;
-                            if (gauge.MeditationStacks == 0 || !HasEffect(SAM.Buffs.OgiNamikiriReady))
-                                return SAM.Gekko;
+                            if (GetCooldownRemainingTime(Ikishoten) > 110)
+                                return Yukikaze;
+                            if (gauge.MeditationStacks == 0 || !HasEffect(Buffs.OgiNamikiriReady))
+                                return Gekko;
                         }
                    
-                        if (GetRemainingCharges(SAM.TsubameGaeshi) == 0)
+                        if (GetRemainingCharges(TsubameGaeshi) == 0)
                             inOpener = false;
-                        if (lastComboMove == SAM.Yukikaze && oneSeal)
+                        if (lastComboMove == Yukikaze && oneSeal)
                         {
                             inOpener = false;
                             nonOpener = true;
@@ -286,10 +286,10 @@ namespace XIVSlothComboPlugin.Combos
                         //Filler Features
                         if (IsEnabled(CustomComboPreset.SamuraiFillersonMainCombo) && !hasDied && !nonOpener && level == 90)
                         {
-                            bool oddMinute = GetCooldownRemainingTime(SAM.Ikishoten) < 60 && gauge.Sen == Sen.NONE && !meikyoBuff && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) > 45;
-                            bool evenMinute = !meikyoBuff && GetCooldownRemainingTime(SAM.Ikishoten) > 60 && gauge.Sen == Sen.NONE && GetRemainingCharges(SAM.TsubameGaeshi) == 0 && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) > 42 && gauge.Kenki > 15;
+                            bool oddMinute = GetCooldownRemainingTime(Ikishoten) < 60 && gauge.Sen == Sen.NONE && !meikyoBuff && GetDebuffRemainingTime(Debuffs.Higanbana) > 45;
+                            bool evenMinute = !meikyoBuff && GetCooldownRemainingTime(Ikishoten) > 60 && gauge.Sen == Sen.NONE && GetRemainingCharges(TsubameGaeshi) == 0 && GetDebuffRemainingTime(Debuffs.Higanbana) > 42 && gauge.Kenki > 15;
 
-                            if (GetDebuffRemainingTime(SAM.Debuffs.Higanbana) < 40)
+                            if (GetDebuffRemainingTime(Debuffs.Higanbana) < 40)
                             {
                                 if (inOddFiller || inEvenFiller)
                                 {
@@ -303,29 +303,29 @@ namespace XIVSlothComboPlugin.Combos
 
                             if (inEvenFiller)
                             {
-                                if (hasDied || IsOnCooldown(SAM.Hagakure) || (InMeleeRange() && !HasEffect(SAM.Buffs.EnhancedEnpi)))
+                                if (hasDied || IsOnCooldown(Hagakure) || (InMeleeRange() && !HasEffect(Buffs.EnhancedEnpi)))
                                     inEvenFiller = false;
 
                                 if (SamFillerCombo == 2)
                                 {
-                                    if (!InMeleeRange() && !HasEffect(SAM.Buffs.EnhancedEnpi) && gauge.Kenki >= 10)
-                                        return SAM.Gyoten;
-                                    if (HasEffect(SAM.Buffs.EnhancedEnpi))
-                                        return SAM.Enpi;
+                                    if (!InMeleeRange() && !HasEffect(Buffs.EnhancedEnpi) && gauge.Kenki >= 10)
+                                        return Gyoten;
+                                    if (HasEffect(Buffs.EnhancedEnpi))
+                                        return Enpi;
                                     if (gauge.Sen == 0 && gauge.Kenki >= 10)
-                                        return SAM.Yaten;
+                                        return Yaten;
                                 }
 
                                 if (SamFillerCombo == 3)
                                 {
                                     if (gauge.Kenki >= 75 && CanWeave(actionID))
-                                        return SAM.Shinten;
+                                        return Shinten;
                                     if (gauge.Sen == Sen.SETSU)
-                                        return SAM.Hagakure;
-                                    if (lastComboMove == SAM.Hakaze)
-                                        return SAM.Yukikaze;
+                                        return Hagakure;
+                                    if (lastComboMove == Hakaze)
+                                        return Yukikaze;
                                     if (gauge.Sen == 0)
-                                        return SAM.Hakaze;
+                                        return Hakaze;
                                 }
 
                             }
@@ -335,66 +335,66 @@ namespace XIVSlothComboPlugin.Combos
 
                             if (inOddFiller)
                             {
-                                if (hasDied || IsOnCooldown(SAM.Hagakure))
+                                if (hasDied || IsOnCooldown(Hagakure))
                                     inOddFiller = false;
 
                                 if (SamFillerCombo == 1)
                                 {
                                     if (gauge.Kenki >= 75 && CanWeave(actionID))
-                                        return SAM.Shinten;
+                                        return Shinten;
                                     if (gauge.Sen == Sen.SETSU)
-                                        return SAM.Hagakure;
-                                    if (lastComboMove == SAM.Hakaze)
-                                        return SAM.Yukikaze;
+                                        return Hagakure;
+                                    if (lastComboMove == Hakaze)
+                                        return Yukikaze;
                                     if (gauge.Sen == 0)
-                                        return SAM.Hakaze;
+                                        return Hakaze;
                                 }
 
                                 if (SamFillerCombo == 2)
                                 {
                                     if (gauge.Kenki >= 75 && CanWeave(actionID))
-                                        return SAM.Shinten;
+                                        return Shinten;
                                     if (gauge.Sen == Sen.GETSU)
-                                        return SAM.Hagakure;
-                                    if (lastComboMove == SAM.Jinpu)
-                                        return SAM.Gekko;
-                                    if (lastComboMove == SAM.Hakaze)
-                                        return SAM.Jinpu;
+                                        return Hagakure;
+                                    if (lastComboMove == Jinpu)
+                                        return Gekko;
+                                    if (lastComboMove == Hakaze)
+                                        return Jinpu;
                                     if (gauge.Sen == 0)
-                                        return SAM.Hakaze;
+                                        return Hakaze;
                                 }
 
                                 if (SamFillerCombo == 3)
                                 {
-                                    if (!InMeleeRange() && !HasEffect(SAM.Buffs.EnhancedEnpi) && gauge.Kenki >= 10)
-                                        return SAM.Gyoten;
+                                    if (!InMeleeRange() && !HasEffect(Buffs.EnhancedEnpi) && gauge.Kenki >= 10)
+                                        return Gyoten;
                                     if (gauge.Kenki >= 75 && CanWeave(actionID))
-                                        return SAM.Shinten;
+                                        return Shinten;
                                     if (gauge.Sen == Sen.GETSU)
-                                        return SAM.Hagakure;
-                                    if (lastComboMove == SAM.Jinpu)
-                                        return SAM.Gekko;
-                                    if (lastComboMove == SAM.Hakaze)
-                                        return SAM.Jinpu;
-                                    if (InMeleeRange() && !HasEffect(SAM.Buffs.EnhancedEnpi) && IsOnCooldown(SAM.Gyoten))
-                                        return SAM.Hakaze;
-                                    if (HasEffect(SAM.Buffs.EnhancedEnpi))
-                                        return SAM.Enpi;
+                                        return Hagakure;
+                                    if (lastComboMove == Jinpu)
+                                        return Gekko;
+                                    if (lastComboMove == Hakaze)
+                                        return Jinpu;
+                                    if (InMeleeRange() && !HasEffect(Buffs.EnhancedEnpi) && IsOnCooldown(Gyoten))
+                                        return Hakaze;
+                                    if (HasEffect(Buffs.EnhancedEnpi))
+                                        return Enpi;
                                     if (gauge.Sen == 0 && gauge.Kenki >= 10)
-                                        return SAM.Yaten;
+                                        return Yaten;
                                 }
                             }
                         }
 
                         //Meikyo Waste Protection (Stops waste during even minute windows)
-                        if (meikyoBuff && GetBuffRemainingTime(SAM.Buffs.MeikyoShisui) < 6 && HasEffect(SAM.Buffs.OgiNamikiriReady))
+                        if (meikyoBuff && GetBuffRemainingTime(Buffs.MeikyoShisui) < 6 && HasEffect(Buffs.OgiNamikiriReady))
                         {
                             if (gauge.Sen.HasFlag(Sen.GETSU) == false)
-                                return SAM.Gekko;
+                                return Gekko;
                             if (IsEnabled(CustomComboPreset.KashaonST) && gauge.Sen.HasFlag(Sen.KA) == false)
-                                return SAM.Kasha;
+                                return Kasha;
                             if (IsEnabled(CustomComboPreset.YukionST) && gauge.Sen.HasFlag(Sen.SETSU) == false)
-                                return SAM.Yukikaze;
+                                return Yukikaze;
                         }
 
                         if (IsEnabled(CustomComboPreset.SamuraiGekkoCDs))
@@ -403,110 +403,110 @@ namespace XIVSlothComboPlugin.Combos
                             if (CanSpellWeave(actionID))
                             {
                                 //Senei Features
-                                if (IsEnabled(CustomComboPreset.SeneionST) && gauge.Kenki >= 25 && IsOffCooldown(SAM.Senei) && level >= SAM.Levels.Senei)
+                                if (IsEnabled(CustomComboPreset.SeneionST) && gauge.Kenki >= 25 && IsOffCooldown(Senei) && level >= Levels.Senei)
                                 {
                                     if (IsNotEnabled(CustomComboPreset.SeneiBurstFeature))
-                                        return SAM.Senei;
+                                        return Senei;
                                     if (IsEnabled(CustomComboPreset.SeneiBurstFeature))
                                     {
-                                        if (hasDied || nonOpener || GetCooldownRemainingTime(SAM.Ikishoten) <= 100 || ((gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Sen == Sen.NONE) && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) <= 10))
-                                            return SAM.Senei;
+                                        if (hasDied || nonOpener || GetCooldownRemainingTime(Ikishoten) <= 100 || ((gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Sen == Sen.NONE) && GetDebuffRemainingTime(Debuffs.Higanbana) <= 10))
+                                            return Senei;
                                     }
                                 }
 
-                                if (level >= SAM.Levels.Shinten && gauge.Kenki >= 25)
+                                if (level >= Levels.Shinten && gauge.Kenki >= 25)
                                 {
-                                    if (GetCooldownRemainingTime(SAM.Senei) > 110 || (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount))
-                                        return SAM.Shinten;
+                                    if (GetCooldownRemainingTime(Senei) > 110 || (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount))
+                                        return Shinten;
                                 }
 
                                 //Ikishoten Features
-                                if (IsEnabled(CustomComboPreset.SamuraiIkishotenonmaincombo) && level >= SAM.Levels.Ikishoten)
+                                if (IsEnabled(CustomComboPreset.SamuraiIkishotenonmaincombo) && level >= Levels.Ikishoten)
                                 {
                                     //Dumps Kenki in preparation for Ikishoten
-                                    if (gauge.Kenki > 50 && GetCooldownRemainingTime(SAM.Ikishoten) < 10)
-                                        return SAM.Shinten;
-                                    if (gauge.Kenki <= 50 && IsOffCooldown(SAM.Ikishoten))
-                                        return SAM.Ikishoten;
+                                    if (gauge.Kenki > 50 && GetCooldownRemainingTime(Ikishoten) < 10)
+                                        return Shinten;
+                                    if (gauge.Kenki <= 50 && IsOffCooldown(Ikishoten))
+                                        return Ikishoten;
                                 }
 
                                 //Meikyo Features
-                                if (IsEnabled(CustomComboPreset.MeikyoShisuionST) && level >= SAM.Levels.MeikyoShisui && !meikyoBuff && GetRemainingCharges(SAM.MeikyoShisui) > 0)
+                                if (IsEnabled(CustomComboPreset.MeikyoShisuionST) && level >= Levels.MeikyoShisui && !meikyoBuff && GetRemainingCharges(MeikyoShisui) > 0)
                                 {
                                     if (IsNotEnabled(CustomComboPreset.MeikyoShisuiBurstFeature))
-                                        return SAM.MeikyoShisui;
+                                        return MeikyoShisui;
                                     if (IsEnabled(CustomComboPreset.MeikyoShisuiBurstFeature))
                                     {
-                                        if (hasDied || nonOpener || GetRemainingCharges(SAM.MeikyoShisui) == 2 || (gauge.Kaeshi == Kaeshi.NONE && gauge.Sen == Sen.NONE && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) <= 15))
-                                            return SAM.MeikyoShisui;
+                                        if (hasDied || nonOpener || GetRemainingCharges(MeikyoShisui) == 2 || (gauge.Kaeshi == Kaeshi.NONE && gauge.Sen == Sen.NONE && GetDebuffRemainingTime(Debuffs.Higanbana) <= 15))
+                                            return MeikyoShisui;
                                     }
                                 }
 
-                                if (IsEnabled(CustomComboPreset.SamuraiShohaSTFeature) && level >= SAM.Levels.Shoha && gauge.MeditationStacks == 3)
-                                    return SAM.Shoha;
+                                if (IsEnabled(CustomComboPreset.SamuraiShohaSTFeature) && level >= Levels.Shoha && gauge.MeditationStacks == 3)
+                                    return Shoha;
                             }
 
                             // Iaijutsu Features
-                            if (IsEnabled(CustomComboPreset.IaijutsuSTFeature) && level >= SAM.Levels.Higanbana)
+                            if (IsEnabled(CustomComboPreset.IaijutsuSTFeature) && level >= Levels.Higanbana)
                             {
-                                if (gauge.Kaeshi == Kaeshi.SETSUGEKKA && level >= SAM.Levels.TsubameGaeshi && GetRemainingCharges(SAM.TsubameGaeshi) > 0)
-                                    return OriginalHook(SAM.TsubameGaeshi);
+                                if (gauge.Kaeshi == Kaeshi.SETSUGEKKA && level >= Levels.TsubameGaeshi && GetRemainingCharges(TsubameGaeshi) > 0)
+                                    return OriginalHook(TsubameGaeshi);
                                 if (!this.IsMoving)
                                 {
-                                    if (((oneSeal || (oneSeal && meikyostacks == 2)) && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) <= 10) ||
-                                        (twoSeal && level < SAM.Levels.Setsugekka) ||
-                                        (threeSeal && level >= SAM.Levels.Setsugekka))
-                                        return OriginalHook(SAM.Iaijutsu);
+                                    if (((oneSeal || (oneSeal && meikyostacks == 2)) && GetDebuffRemainingTime(Debuffs.Higanbana) <= 10) ||
+                                        (twoSeal && level < Levels.Setsugekka) ||
+                                        (threeSeal && level >= Levels.Setsugekka))
+                                        return OriginalHook(Iaijutsu);
                                 }
                             }
 
                             //Ogi Namikiri Features
-                            if (IsEnabled(CustomComboPreset.SamuraiOgiNamikiriSTFeature) && level >= SAM.Levels.OgiNamikiri)
+                            if (IsEnabled(CustomComboPreset.SamuraiOgiNamikiriSTFeature) && level >= Levels.OgiNamikiri)
                             {
-                                if ((!this.IsMoving && HasEffect(SAM.Buffs.OgiNamikiriReady)) || gauge.Kaeshi == Kaeshi.NAMIKIRI)
+                                if ((!this.IsMoving && HasEffect(Buffs.OgiNamikiriReady)) || gauge.Kaeshi == Kaeshi.NAMIKIRI)
                                 {
                                     if (IsNotEnabled(CustomComboPreset.OgiNamikiriinBurstFeature))
-                                        return OriginalHook(SAM.OgiNamikiri);
+                                        return OriginalHook(OgiNamikiri);
                                     if (IsEnabled(CustomComboPreset.OgiNamikiriinBurstFeature))
                                     {
-                                        if (hasDied || nonOpener || (meikyostacks == 1 && GetDebuffRemainingTime(SAM.Debuffs.Higanbana) >= 45 && HasEffect(SAM.Buffs.MeikyoShisui)) || GetCooldownRemainingTime(SAM.Ikishoten) <= 105)
-                                            return OriginalHook(SAM.OgiNamikiri);
+                                        if (hasDied || nonOpener || (meikyostacks == 1 && GetDebuffRemainingTime(Debuffs.Higanbana) >= 45 && HasEffect(Buffs.MeikyoShisui)) || GetCooldownRemainingTime(Ikishoten) <= 105)
+                                            return OriginalHook(OgiNamikiri);
                                     }
                                 }
                             }
                         }
 
-                        if (HasEffect(SAM.Buffs.MeikyoShisui))
+                        if (HasEffect(Buffs.MeikyoShisui))
                         {
                             if (gauge.Sen.HasFlag(Sen.GETSU) == false)
-                                return SAM.Gekko;
+                                return Gekko;
                             if (IsEnabled(CustomComboPreset.KashaonST) && gauge.Sen.HasFlag(Sen.KA) == false)
-                                return SAM.Kasha;
+                                return Kasha;
                             if (IsEnabled(CustomComboPreset.YukionST) && gauge.Sen.HasFlag(Sen.SETSU) == false)
-                                return SAM.Yukikaze;
+                                return Yukikaze;
                         }
 
                         if (comboTime > 0)
                         {
-                            if (lastComboMove == SAM.Hakaze && level >= SAM.Levels.Jinpu)
+                            if (lastComboMove == Hakaze && level >= Levels.Jinpu)
                             {
-                                if (IsEnabled(CustomComboPreset.YukionST) && gauge.Sen.HasFlag(Sen.SETSU) == false && level >= SAM.Levels.Yukikaze && HasEffect(SAM.Buffs.Fugetsu) && HasEffect(SAM.Buffs.Fuka))
-                                    return SAM.Yukikaze;
+                                if (IsEnabled(CustomComboPreset.YukionST) && gauge.Sen.HasFlag(Sen.SETSU) == false && level >= Levels.Yukikaze && HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
+                                    return Yukikaze;
                                 if (gauge.Sen.HasFlag(Sen.GETSU) == false)
-                                    return SAM.Jinpu;
+                                    return Jinpu;
                                 if (IsEnabled(CustomComboPreset.KashaonST) && gauge.Sen.HasFlag(Sen.KA) == false)
-                                    return SAM.Shifu;
-                                return SAM.Jinpu;
+                                    return Shifu;
+                                return Jinpu;
                             }
 
-                            if (lastComboMove == SAM.Jinpu && level >= SAM.Levels.Gekko)
-                                return SAM.Gekko;
-                            if (IsEnabled(CustomComboPreset.KashaonST) && lastComboMove == SAM.Shifu && level >= SAM.Levels.Kasha)
-                                return SAM.Kasha;
+                            if (lastComboMove == Jinpu && level >= Levels.Gekko)
+                                return Gekko;
+                            if (IsEnabled(CustomComboPreset.KashaonST) && lastComboMove == Shifu && level >= Levels.Kasha)
+                                return Kasha;
                         }
                     }
                 }
-                return SAM.Hakaze;
+                return Hakaze;
             }
 
             return actionID;
@@ -520,30 +520,30 @@ namespace XIVSlothComboPlugin.Combos
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             var gauge = GetJobGauge<SAMGauge>();
-            var SamKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamKenkiOvercapAmount);
+            var SamKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(Config.SamKenkiOvercapAmount);
 
-            if (actionID == SAM.Kasha)
+            if (actionID == Kasha)
             {
                 if (CanWeave(actionID))
                 {
-                    if (IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) && GetBuffStacks(SAM.Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
+                    if (IsEnabled(CustomComboPreset.SamuraiTrueNorthFeature) && GetBuffStacks(Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0)
                         return All.TrueNorth;
-                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount && level >= SAM.Levels.Shinten)
-                        return SAM.Shinten;
+                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeature) && gauge.Kenki >= SamKenkiOvercapAmount && level >= Levels.Shinten)
+                        return Shinten;
                 }
-                if (HasEffect(SAM.Buffs.MeikyoShisui))
-                    return SAM.Kasha;
+                if (HasEffect(Buffs.MeikyoShisui))
+                    return Kasha;
 
                 if (comboTime > 0)
                 {
-                    if (lastComboMove == SAM.Hakaze && level >= SAM.Levels.Shifu)
-                        return SAM.Shifu;
+                    if (lastComboMove == Hakaze && level >= Levels.Shifu)
+                        return Shifu;
 
-                    if (lastComboMove == SAM.Shifu && level >= SAM.Levels.Kasha)
-                        return SAM.Kasha;
+                    if (lastComboMove == Shifu && level >= Levels.Kasha)
+                        return Kasha;
                 }
 
-                return SAM.Hakaze;
+                return Hakaze;
             }
 
             return actionID;
@@ -556,70 +556,70 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SAM.Mangetsu)
+            if (actionID == Mangetsu)
             {
                 var gauge = GetJobGauge<SAMGauge>();
-                var SamAOEKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamAOEKenkiOvercapAmount);
+                var SamAOEKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(Config.SamAOEKenkiOvercapAmount);
 
                 //oGCD Features
                 if (CanSpellWeave(actionID))
                 {
-                    if (IsEnabled(CustomComboPreset.SamuraiGurenAOEFeature) && IsOffCooldown(SAM.Guren) && level >= SAM.Levels.Guren && gauge.Kenki >= 25)
-                        return SAM.Guren;
-                    if (IsEnabled(CustomComboPreset.SamuraiIkishotenonmaincombo) && gauge.Kenki <= 50 && IsOffCooldown(SAM.Ikishoten) && level >= SAM.Levels.Ikishoten)
-                        return SAM.Ikishoten;
-                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeatureAoe) && gauge.Kenki >= SamAOEKenkiOvercapAmount && level >= SAM.Levels.Kyuten)
-                            return SAM.Kyuten;
-                    if (IsEnabled(CustomComboPreset.SamuraiShoha2AOEFeature) && level >= SAM.Levels.Shoha2 && gauge.MeditationStacks == 3)
-                        return SAM.Shoha2;
+                    if (IsEnabled(CustomComboPreset.SamuraiGurenAOEFeature) && IsOffCooldown(Guren) && level >= Levels.Guren && gauge.Kenki >= 25)
+                        return Guren;
+                    if (IsEnabled(CustomComboPreset.SamuraiIkishotenonmaincombo) && gauge.Kenki <= 50 && IsOffCooldown(Ikishoten) && level >= Levels.Ikishoten)
+                        return Ikishoten;
+                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeatureAoe) && gauge.Kenki >= SamAOEKenkiOvercapAmount && level >= Levels.Kyuten)
+                            return Kyuten;
+                    if (IsEnabled(CustomComboPreset.SamuraiShoha2AOEFeature) && level >= Levels.Shoha2 && gauge.MeditationStacks == 3)
+                        return Shoha2;
                 }
 
-                if (IsEnabled(CustomComboPreset.SamuraiOgiNamikiriAOEFeature) && level >= SAM.Levels.OgiNamikiri)
+                if (IsEnabled(CustomComboPreset.SamuraiOgiNamikiriAOEFeature) && level >= Levels.OgiNamikiri)
                 {
-                    if ((!this.IsMoving && HasEffect(SAM.Buffs.OgiNamikiriReady)) || gauge.Kaeshi == Kaeshi.NAMIKIRI)
-                        return OriginalHook(SAM.OgiNamikiri);
+                    if ((!this.IsMoving && HasEffect(Buffs.OgiNamikiriReady)) || gauge.Kaeshi == Kaeshi.NAMIKIRI)
+                        return OriginalHook(OgiNamikiri);
                 }
 
-                if (IsEnabled(CustomComboPreset.TenkaGokenAOEFeature) && level >= SAM.Levels.TenkaGoken)
+                if (IsEnabled(CustomComboPreset.TenkaGokenAOEFeature) && level >= Levels.TenkaGoken)
                 {
-                    if (!this.IsMoving && (OriginalHook(SAM.Iaijutsu) == SAM.TenkaGoken || (OriginalHook(SAM.Iaijutsu) == SAM.Setsugekka && level >= SAM.Levels.Setsugekka)))
-                        return OriginalHook(SAM.Iaijutsu);
-                    if ((gauge.Kaeshi == Kaeshi.GOKEN || gauge.Kaeshi == Kaeshi.SETSUGEKKA) && level >= SAM.Levels.TsubameGaeshi && GetRemainingCharges(SAM.TsubameGaeshi) > 0)
-                        return OriginalHook(SAM.TsubameGaeshi);
+                    if (!this.IsMoving && (OriginalHook(Iaijutsu) == TenkaGoken || (OriginalHook(Iaijutsu) == Setsugekka && level >= Levels.Setsugekka)))
+                        return OriginalHook(Iaijutsu);
+                    if ((gauge.Kaeshi == Kaeshi.GOKEN || gauge.Kaeshi == Kaeshi.SETSUGEKKA) && level >= Levels.TsubameGaeshi && GetRemainingCharges(TsubameGaeshi) > 0)
+                        return OriginalHook(TsubameGaeshi);
                 }
 
-                if (HasEffect(SAM.Buffs.MeikyoShisui))
+                if (HasEffect(Buffs.MeikyoShisui))
                 {
                     if (gauge.Sen.HasFlag(Sen.GETSU) == false)
-                        return SAM.Mangetsu;
+                        return Mangetsu;
                     if (IsEnabled(CustomComboPreset.SamuraiOkaFeature) && gauge.Sen.HasFlag(Sen.KA) == false)
-                        return SAM.Oka;
+                        return Oka;
                 }
 
                 if (comboTime > 0)
                 {
-                    if (level >= SAM.Levels.Mangetsu && (lastComboMove == SAM.Fuko || lastComboMove == SAM.Fuga))
+                    if (level >= Levels.Mangetsu && (lastComboMove == Fuko || lastComboMove == Fuga))
                     {
                         if (IsNotEnabled(CustomComboPreset.SamuraiOkaFeature) ||
-                            gauge.Sen.HasFlag(Sen.GETSU) == false || GetBuffRemainingTime(SAM.Buffs.Fugetsu) < GetBuffRemainingTime(SAM.Buffs.Fuka) || !HasEffect(SAM.Buffs.Fugetsu))
-                            return SAM.Mangetsu;
-                        if (IsEnabled(CustomComboPreset.SamuraiOkaFeature) && level >= SAM.Levels.Oka &&
-                            (gauge.Sen.HasFlag(Sen.KA) == false || GetBuffRemainingTime(SAM.Buffs.Fuka) < GetBuffRemainingTime(SAM.Buffs.Fugetsu) || !HasEffect(SAM.Buffs.Fuka)))
-                            return SAM.Oka;
+                            gauge.Sen.HasFlag(Sen.GETSU) == false || GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka) || !HasEffect(Buffs.Fugetsu))
+                            return Mangetsu;
+                        if (IsEnabled(CustomComboPreset.SamuraiOkaFeature) && level >= Levels.Oka &&
+                            (gauge.Sen.HasFlag(Sen.KA) == false || GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu) || !HasEffect(Buffs.Fuka)))
+                            return Oka;
                     }
                 }
 
-                if (level < SAM.Levels.Oka && level >= SAM.Levels.Kasha)
+                if (level < Levels.Oka && level >= Levels.Kasha)
                 {
-                    if (lastComboMove == SAM.Shifu)
-                        return SAM.Kasha;
-                    if (lastComboMove == SAM.Hakaze)
-                        return SAM.Shifu;
-                    if (gauge.Sen.HasFlag(Sen.KA) == false || GetBuffRemainingTime(SAM.Buffs.Fuka) < GetBuffRemainingTime(SAM.Buffs.Fugetsu) || !HasEffect(SAM.Buffs.Fuka))
-                        return SAM.Hakaze;
+                    if (lastComboMove == Shifu)
+                        return Kasha;
+                    if (lastComboMove == Hakaze)
+                        return Shifu;
+                    if (gauge.Sen.HasFlag(Sen.KA) == false || GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu) || !HasEffect(Buffs.Fuka))
+                        return Hakaze;
                 }
 
-                return OriginalHook(SAM.Fuko);
+                return OriginalHook(Fuko);
             }
 
             return actionID;
@@ -632,67 +632,67 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SAM.Oka)
+            if (actionID == Oka)
             {
                 var gauge = GetJobGauge<SAMGauge>();
-                var SamAOEKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(SAM.Config.SamAOEKenkiOvercapAmount);
+                var SamAOEKenkiOvercapAmount = Service.Configuration.GetCustomIntValue(Config.SamAOEKenkiOvercapAmount);
 
                 if (CanWeave(actionID))
                 {
-                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeatureAoe) && IsNotEnabled(CustomComboPreset.SamTwoTargetFeature) && gauge.Kenki >= SamAOEKenkiOvercapAmount && level >= SAM.Levels.Kyuten)
-                            return SAM.Kyuten;
+                    if (IsEnabled(CustomComboPreset.SamuraiOvercapFeatureAoe) && IsNotEnabled(CustomComboPreset.SamTwoTargetFeature) && gauge.Kenki >= SamAOEKenkiOvercapAmount && level >= Levels.Kyuten)
+                            return Kyuten;
                 }
 
-                if (HasEffect(SAM.Buffs.MeikyoShisui) && IsNotEnabled(CustomComboPreset.SamTwoTargetFeature))
-                    return SAM.Oka;
+                if (HasEffect(Buffs.MeikyoShisui) && IsNotEnabled(CustomComboPreset.SamTwoTargetFeature))
+                    return Oka;
 
                 //Two Target Rotation
                 if (IsEnabled(CustomComboPreset.SamTwoTargetFeature))
                 {
                     if (CanSpellWeave(actionID))
                     {
-                        if (level >= SAM.Levels.Senei && gauge.Kenki >= 25 && IsOffCooldown(SAM.Senei))
-                            return SAM.Senei;
-                        if (level >= SAM.Levels.Shinten && gauge.Kenki >= 25)
-                            return SAM.Shinten;
-                        if (level >= SAM.Levels.Shoha && gauge.MeditationStacks == 3)
-                            return SAM.Shoha;
+                        if (level >= Levels.Senei && gauge.Kenki >= 25 && IsOffCooldown(Senei))
+                            return Senei;
+                        if (level >= Levels.Shinten && gauge.Kenki >= 25)
+                            return Shinten;
+                        if (level >= Levels.Shoha && gauge.MeditationStacks == 3)
+                            return Shoha;
                     }
 
-                    if (HasEffect(SAM.Buffs.MeikyoShisui))
+                    if (HasEffect(Buffs.MeikyoShisui))
                     {
-                        if (gauge.Sen.HasFlag(Sen.SETSU) == false && level >= SAM.Levels.Yukikaze)
-                            return SAM.Yukikaze;
-                        if (gauge.Sen.HasFlag(Sen.GETSU) == false && level >= SAM.Levels.Gekko)
-                            return SAM.Gekko;
-                        if (gauge.Sen.HasFlag(Sen.KA) == false && level >= SAM.Levels.Kasha)
-                            return SAM.Kasha;
+                        if (gauge.Sen.HasFlag(Sen.SETSU) == false && level >= Levels.Yukikaze)
+                            return Yukikaze;
+                        if (gauge.Sen.HasFlag(Sen.GETSU) == false && level >= Levels.Gekko)
+                            return Gekko;
+                        if (gauge.Sen.HasFlag(Sen.KA) == false && level >= Levels.Kasha)
+                            return Kasha;
                     }
 
-                    if (level >= SAM.Levels.TsubameGaeshi && gauge.Kaeshi == Kaeshi.SETSUGEKKA && GetRemainingCharges(SAM.TsubameGaeshi) > 0)
-                        return OriginalHook(SAM.TsubameGaeshi);
-                    if (level >= SAM.Levels.Setsugekka && OriginalHook(SAM.Iaijutsu) == SAM.Setsugekka)
-                        return OriginalHook(SAM.Iaijutsu);
+                    if (level >= Levels.TsubameGaeshi && gauge.Kaeshi == Kaeshi.SETSUGEKKA && GetRemainingCharges(TsubameGaeshi) > 0)
+                        return OriginalHook(TsubameGaeshi);
+                    if (level >= Levels.Setsugekka && OriginalHook(Iaijutsu) == Setsugekka)
+                        return OriginalHook(Iaijutsu);
 
                     if (comboTime > 0)
                     {
-                        if (lastComboMove == SAM.Hakaze && level >= SAM.Levels.Yukikaze)
-                            return SAM.Yukikaze;
-                        if (lastComboMove is SAM.Fuko or SAM.Fuga && gauge.Sen.HasFlag(Sen.GETSU) == false && level >= SAM.Levels.Mangetsu)
-                            return SAM.Mangetsu;
+                        if (lastComboMove == Hakaze && level >= Levels.Yukikaze)
+                            return Yukikaze;
+                        if (lastComboMove is Fuko or Fuga && gauge.Sen.HasFlag(Sen.GETSU) == false && level >= Levels.Mangetsu)
+                            return Mangetsu;
                     }
 
                     if (gauge.Sen.HasFlag(Sen.SETSU) == false)
-                        return SAM.Hakaze;
+                        return Hakaze;
                 }
 
-                if (comboTime > 0 && level >= SAM.Levels.Oka)
+                if (comboTime > 0 && level >= Levels.Oka)
                 {
-                    if (lastComboMove == SAM.Fuko || lastComboMove == SAM.Fuga)
-                        return SAM.Oka;
+                    if (lastComboMove == Fuko || lastComboMove == Fuga)
+                        return Oka;
                 }
 
-                return OriginalHook(SAM.Fuko);
+                return OriginalHook(Fuko);
             }
 
             return actionID;
@@ -707,19 +707,19 @@ namespace XIVSlothComboPlugin.Combos
         {
             var gauge = GetJobGauge<SAMGauge>();
 
-            if (actionID == SAM.MeikyoShisui)
+            if (actionID == MeikyoShisui)
             {
-                if (HasEffect(SAM.Buffs.MeikyoShisui))
+                if (HasEffect(Buffs.MeikyoShisui))
                 {
-                    if (!HasEffect(SAM.Buffs.Fugetsu) || gauge.Sen.HasFlag(Sen.GETSU) == false)
-                        return SAM.Gekko;
-                    if (!HasEffect(SAM.Buffs.Fuka) || gauge.Sen.HasFlag(Sen.KA) == false)
-                        return SAM.Kasha;
+                    if (!HasEffect(Buffs.Fugetsu) || gauge.Sen.HasFlag(Sen.GETSU) == false)
+                        return Gekko;
+                    if (!HasEffect(Buffs.Fuka) || gauge.Sen.HasFlag(Sen.KA) == false)
+                        return Kasha;
                     if (gauge.Sen.HasFlag(Sen.SETSU) == false)
-                        return SAM.Yukikaze;
+                        return Yukikaze;
                 }
 
-                return SAM.MeikyoShisui;
+                return MeikyoShisui;
             }
 
             return actionID;
@@ -733,14 +733,14 @@ namespace XIVSlothComboPlugin.Combos
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             var gauge = GetJobGauge<SAMGauge>();
-            if (actionID == SAM.Iaijutsu)
+            if (actionID == Iaijutsu)
             {
-                if (IsEnabled(CustomComboPreset.SamuraiIaijutsuShohaFeature) && level >= SAM.Levels.Shoha && gauge.MeditationStacks >= 3 && CanSpellWeave(actionID))
-                    return SAM.Shoha;
-                if (IsEnabled(CustomComboPreset.SamuraiIaijutsuTsubameGaeshiFeature) && level >= SAM.Levels.TsubameGaeshi && gauge.Kaeshi != Kaeshi.NONE)
-                        return OriginalHook(SAM.TsubameGaeshi);
-                if (IsEnabled(CustomComboPreset.SamuraiIaijutsuOgiFeature) && level >= SAM.Levels.OgiNamikiri && (gauge.Kaeshi == Kaeshi.NAMIKIRI || HasEffect(SAM.Buffs.OgiNamikiriReady)))
-                    return OriginalHook(SAM.OgiNamikiri);
+                if (IsEnabled(CustomComboPreset.SamuraiIaijutsuShohaFeature) && level >= Levels.Shoha && gauge.MeditationStacks >= 3 && CanSpellWeave(actionID))
+                    return Shoha;
+                if (IsEnabled(CustomComboPreset.SamuraiIaijutsuTsubameGaeshiFeature) && level >= Levels.TsubameGaeshi && gauge.Kaeshi != Kaeshi.NONE)
+                        return OriginalHook(TsubameGaeshi);
+                if (IsEnabled(CustomComboPreset.SamuraiIaijutsuOgiFeature) && level >= Levels.OgiNamikiri && (gauge.Kaeshi == Kaeshi.NAMIKIRI || HasEffect(Buffs.OgiNamikiriReady)))
+                    return OriginalHook(OgiNamikiri);
             }
 
             return actionID;
@@ -754,12 +754,12 @@ namespace XIVSlothComboPlugin.Combos
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             var gauge = GetJobGauge<SAMGauge>();
-            if (actionID == SAM.Shinten)
+            if (actionID == Shinten)
             {
-                if (IsEnabled(CustomComboPreset.SamuraiSeneiFeature) && IsOffCooldown(SAM.Senei) && level >= SAM.Levels.Senei)
-                    return SAM.Senei;
-                if (gauge.MeditationStacks >= 3 && level >= SAM.Levels.Shoha)
-                    return SAM.Shoha;
+                if (IsEnabled(CustomComboPreset.SamuraiSeneiFeature) && IsOffCooldown(Senei) && level >= Levels.Senei)
+                    return Senei;
+                if (gauge.MeditationStacks >= 3 && level >= Levels.Shoha)
+                    return Shoha;
             }
 
             return actionID;
@@ -773,12 +773,12 @@ namespace XIVSlothComboPlugin.Combos
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
             var gauge = GetJobGauge<SAMGauge>();
-            if (actionID == SAM.Kyuten)
+            if (actionID == Kyuten)
             {
-                if (IsOffCooldown(SAM.Guren) && level >= SAM.Levels.Guren)
-                    return SAM.Guren;
-                if (IsEnabled(CustomComboPreset.SamuraiShoha2Feature) && gauge.MeditationStacks == 3 && level >= SAM.Levels.Shoha2)
-                    return SAM.Shoha2;
+                if (IsOffCooldown(Guren) && level >= Levels.Guren)
+                    return Guren;
+                if (IsEnabled(CustomComboPreset.SamuraiShoha2Feature) && gauge.MeditationStacks == 3 && level >= Levels.Shoha2)
+                    return Shoha2;
             }
 
             return actionID;
@@ -791,46 +791,47 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID == SAM.Ikishoten)
+            if (actionID == Ikishoten)
             {
-                if (level >= SAM.Levels.OgiNamikiri)
+                if (level >= Levels.OgiNamikiri)
                 {
-                    if (HasEffect(SAM.Buffs.OgiNamikiriReady))
+                    if (HasEffect(Buffs.OgiNamikiriReady))
                     {
-                        if (HasEffect(SAM.Buffs.OgiNamikiriReady))
-                            return SAM.OgiNamikiri;
+                        if (HasEffect(Buffs.OgiNamikiriReady))
+                            return OgiNamikiri;
                     }
 
-                    if (OriginalHook(SAM.OgiNamikiri) == SAM.KaeshiNamikiri)
-                        return SAM.KaeshiNamikiri;
+                    if (OriginalHook(OgiNamikiri) == KaeshiNamikiri)
+                        return KaeshiNamikiri;
                 }
 
-                return SAM.Ikishoten;
+                return Ikishoten;
             }
 
             return actionID;
         }
     }
 
-    internal class SamuraiYatenFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SamuraiYatenFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class SamuraiYatenFeature : CustomCombo
         {
-            if (actionID == SAM.Gyoten)
-            {
-                var gauge = GetJobGauge<SAMGauge>();
-                if (gauge.Kenki >= 10)
-                {
-                    if (InMeleeRange())
-                        return SAM.Yaten;
-                    if (!InMeleeRange())
-                        return SAM.Gyoten;
-                }
-            }
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SamuraiYatenFeature;
 
-            return actionID;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Gyoten)
+                {
+                    var gauge = GetJobGauge<SAMGauge>();
+                    if (gauge.Kenki >= 10)
+                    {
+                        if (InMeleeRange())
+                            return Yaten;
+                        if (!InMeleeRange())
+                            return Gyoten;
+                    }
+                }
+
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/Combos/SCH.cs
+++ b/XIVSlothCombo/Combos/SCH.cs
@@ -51,7 +51,7 @@ namespace XIVSlothComboPlugin.Combos
 
             // Role
             Resurrection = 173;
-            //Esuna = 5768,
+        //Esuna = 5768,
 
         public static class Buffs
         {
@@ -115,180 +115,181 @@ namespace XIVSlothComboPlugin.Combos
                 SCH_Aetherflow_Recite_Indom = "SCH_Aetherflow_Recite_Indom",
                 SCH_FairyFeature = "SCH_FairyFeature";
         }
-    }
 
-    //Even though Summon Seraph becomes Consolation, this Feature puts the temporary fairy aoe heal+barrier ontop of the existing fairy AoE skill Fey Blessing
-    internal class ScholarSeraphConsolationFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ConsolationFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is SCH.FeyBlessing &&
-                level >= SCH.Levels.SummonSeraph &&
-                GetJobGauge<SCHGauge>().SeraphTimer > 0
-               ) return SCH.Consolation; else return actionID;
-        }
-    }
 
-    //Replaces all EnergyDrain actions with Aetherflow when depleted
-    //Revised to a similar flow as Sage Rhizomata, but with Dissipation / Recitation as a backup
-    internal class ScholarAetherflowFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AetherflowFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        //Even though Summon Seraph becomes Consolation, this Feature puts the temporary fairy aoe heal+barrier ontop of the existing fairy AoE skill Fey Blessing
+        internal class ScholarSeraphConsolationFeature : CustomCombo
         {
-            if (actionID is SCH.EnergyDrain or SCH.Lustrate or SCH.SacredSoil or SCH.Indomitability or SCH.Excogitation &&
-                level >= SCH.Levels.Aetherflow)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ConsolationFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<SCHGauge>().Aetherflow;
-                if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite) && 
-                    level >= SCH.Levels.Recitation && 
-                    (IsOffCooldown(SCH.Recitation) || HasEffect(SCH.Buffs.Recitation)) )
-                {
-                    //Request here. Recitation Indominability and Excogitation, with optional check against AF zero stack count
-                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite_Excog) &&
-                        (GetOptionValue(SCH.Config.SCH_Aetherflow_Recite_Excog) == 1 || (GetOptionValue(SCH.Config.SCH_Aetherflow_Recite_Excog) == 2 && gauge == 0)) &&
-                        actionID is SCH.Excogitation )
-                    {   //Do not merge this nested if with above. Won't procede with next set
-                        if (HasEffect(SCH.Buffs.Recitation) && IsOffCooldown(SCH.Excogitation)) return SCH.Excogitation; else return SCH.Recitation;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite_Indom) &&
-                        (GetOptionValue(SCH.Config.SCH_Aetherflow_Recite_Indom) == 1 || (GetOptionValue(SCH.Config.SCH_Aetherflow_Recite_Indom) == 2 && gauge == 0)) &&
-                        actionID is SCH.Indomitability )
-                    {
-                        if (HasEffect(SCH.Buffs.Recitation) && IsOffCooldown(SCH.Excogitation)) return SCH.Indomitability; else return SCH.Recitation;
-                    }
-                }
-                if (gauge == 0)
-                {
-                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Dissipation) &&
-                        level >= SCH.Levels.Dissipation &&
-                        IsOffCooldown(SCH.Dissipation) &&
-                        IsOnCooldown(SCH.Aetherflow) &&
-                        HasPetPresent() //Dissipation requires fairy, can't seem to make it replace dissipation with fairy summon feature *shrug*
-                       ) return SCH.Dissipation;
-                    else return SCH.Aetherflow;
-
-                }
+                if (actionID is SCH.FeyBlessing &&
+                    level >= Levels.SummonSeraph &&
+                    GetJobGauge<SCHGauge>().SeraphTimer > 0
+                   ) return Consolation;
+                else return actionID;
             }
-            return actionID;
         }
-    }
 
-    //Swiftcast changes to Raise when activated / on cooldown
-    internal class ScholarRaiseFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_RaiseFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        //Replaces all EnergyDrain actions with Aetherflow when depleted
+        //Revised to a similar flow as Sage Rhizomata, but with Dissipation / Recitation as a backup
+        internal class ScholarAetherflowFeature : CustomCombo
         {
-            if (actionID is All.Swiftcast && IsOnCooldown(All.Swiftcast)) return SCH.Resurrection;
-            else return actionID;
-        }
-    }
-
-    //Replaces Fairy abilitys with fairy summoning with Eos (default) or Selene
-    internal class ScholarFairyFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_FairyFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is SCH.WhisperingDawn or SCH.FeyBlessing or SCH.FeyBlessing or SCH.FeyIllumination or SCH.Dissipation or SCH.Aetherpact or SCH.Dissipation &&
-                !HasPetPresent() && 
-                GetJobGauge<SCHGauge>().SeraphTimer == 0)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AetherflowFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if ((GetOptionValue(SCH.Config.SCH_FairyFeature)) == 2) return SCH.SummonSelene; //it's a 1 or 2 option atm.
-                else return SCH.SummonEos;
-            }
-            return actionID;
-        }
-    }
-
-    //Overwrides main DPS ability family, The Broils (and ruin 1)
-    //Implements new Sage features as ToT, and Ruin 2 as the movement option
-    //ChainStratagem has overlap protection
-    internal class ScholarBroilFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_BroilFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is SCH.Ruin1 or SCH.Broil1 or SCH.Broil2 or SCH.Broil3 or SCH.Broil4 && InCombat())
-            {
-                //Lucid Dreaming
-                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Lucid) &&
-                    level >= All.Levels.LucidDreaming &&
-                    IsOffCooldown(All.LucidDreaming) &&
-                    LocalPlayer.CurrentMp <= GetOptionValue(SCH.Config.SCH_ST_Broil_Lucid) &&
-                    CanSpellWeave(actionID)
-                   ) return All.LucidDreaming;
-
-                //Chain Stratagem
-                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_ChainStratagem) &&
-                    level >= SCH.Levels.ChainStratagem &&
-                    IsOffCooldown(SCH.ChainStratagem) &&
-                    !TargetHasEffectAny(SCH.Debuffs.ChainStratagem) && //Overwrite protection
-                    EnemyHealthPercentage() > GetOptionValue(SCH.Config.SCH_ST_Broil_ChainStratagem) &&
-                    CanSpellWeave(actionID)
-                   ) return SCH.ChainStratagem;
-
-                //Bio/Biolysis
-                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Bio) && level >= SCH.Levels.Bio1 && CurrentTarget is not null)
+                if (actionID is EnergyDrain or Lustrate or SacredSoil or Indomitability or Excogitation &&
+                    level >= Levels.Aetherflow)
                 {
-                    var OurTarget = CurrentTarget;
-                    //Check if our Target is there and not an enemy
-                    if ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy)
+                    var gauge = GetJobGauge<SCHGauge>().Aetherflow;
+                    if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite) &&
+                        level >= Levels.Recitation &&
+                        (IsOffCooldown(Recitation) || HasEffect(Buffs.Recitation)))
                     {
-                        //If ToT is enabled, Check if ToT is not null
-                        if ((IsEnabled(CustomComboPreset.SCH_ST_Broil_BioToT)) &&
-                            (CurrentTarget.TargetObject is not null) &&
-                            ((CurrentTarget.TargetObject as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy))
-                            //Set Ourtarget as the Target of Target
-                            OurTarget = CurrentTarget.TargetObject;
-                        //Our Target of Target wasn't hostile, our target isn't hostile, time to exit, nothing to check debuff on, fuck this shit we're out
-                        else return actionID;
-                    }
-
-                    //Determine which Bio debuff to check
-                    var BioDebuffID = level switch
-                    {
-                        //Using FindEffect b/c we have a custom Target variable
-                        >= SCH.Levels.Biolysis => FindEffect(SCH.Debuffs.Biolysis, OurTarget, LocalPlayer?.ObjectId),
-                        >= SCH.Levels.Bio2 => FindEffect(SCH.Debuffs.Bio2, OurTarget, LocalPlayer?.ObjectId),
-                        //Bio 1 checked at the start, fine for default
-                        _ => FindEffect(SCH.Debuffs.Bio1, OurTarget, LocalPlayer?.ObjectId),
-                    };
-                    if ((BioDebuffID is null) || (BioDebuffID.RemainingTime <= 3))
-                    {
-                        //Advanced Options Enabled to procede with auto-bio
-                        //Incompatible with ToT due to Enemy checks that are using CurrentTarget.
-                        if (IsEnabled(CustomComboPreset.SCH_ST_Broil_BioHPPer))
-                        {
-                            if (EnemyHealthPercentage() > GetOptionValue(SCH.Config.SCH_ST_Broil_BioHPPer))
-                                return OriginalHook(SCH.Bio1);
+                        //Request here. Recitation Indominability and Excogitation, with optional check against AF zero stack count
+                        if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite_Excog) &&
+                            (GetOptionValue(Config.SCH_Aetherflow_Recite_Excog) == 1 || (GetOptionValue(Config.SCH_Aetherflow_Recite_Excog) == 2 && gauge == 0)) &&
+                            actionID is SCH.Excogitation)
+                        {   //Do not merge this nested if with above. Won't procede with next set
+                            if (HasEffect(Buffs.Recitation) && IsOffCooldown(Excogitation)) return Excogitation; else return Recitation;
                         }
-                        else return OriginalHook(SCH.Bio1); ;
+
+                        if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite_Indom) &&
+                            (GetOptionValue(Config.SCH_Aetherflow_Recite_Indom) == 1 || (GetOptionValue(Config.SCH_Aetherflow_Recite_Indom) == 2 && gauge == 0)) &&
+                            actionID is SCH.Indomitability)
+                        {
+                            if (HasEffect(Buffs.Recitation) && IsOffCooldown(Excogitation)) return Indomitability; else return Recitation;
+                        }
+                    }
+                    if (gauge == 0)
+                    {
+                        if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Dissipation) &&
+                            level >= Levels.Dissipation &&
+                            IsOffCooldown(Dissipation) &&
+                            IsOnCooldown(Aetherflow) &&
+                            HasPetPresent() //Dissipation requires fairy, can't seem to make it replace dissipation with fairy summon feature *shrug*
+                           ) return Dissipation;
+                        else return Aetherflow;
+
                     }
                 }
-
-                //Aetherflow
-                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Aetherflow) &&
-                    level >= SCH.Levels.Aetherflow &&
-                    GetJobGauge<SCHGauge>().Aetherflow == 0 &&
-                    IsOffCooldown(SCH.Aetherflow)
-                   ) return SCH.Aetherflow;
-
-                //Ruin 2 Movement 
-                if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Ruin2Movement) &&
-                    level >= SCH.Levels.Ruin2 &&
-                    HasBattleTarget() &&
-                    this.IsMoving
-                   ) return OriginalHook(SCH.Ruin2); //Who knows in the future
-
-                //End
+                return actionID;
             }
-            return actionID;
+        }
+
+        //Swiftcast changes to Raise when activated / on cooldown
+        internal class ScholarRaiseFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_RaiseFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is All.Swiftcast && IsOnCooldown(All.Swiftcast)) return Resurrection;
+                else return actionID;
+            }
+        }
+
+        //Replaces Fairy abilitys with fairy summoning with Eos (default) or Selene
+        internal class ScholarFairyFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_FairyFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is WhisperingDawn or FeyBlessing or FeyBlessing or FeyIllumination or Dissipation or Aetherpact or Dissipation &&
+                    !HasPetPresent() &&
+                    GetJobGauge<SCHGauge>().SeraphTimer == 0)
+                {
+                    if ((GetOptionValue(Config.SCH_FairyFeature)) == 2) return SummonSelene; //it's a 1 or 2 option atm.
+                    else return SummonEos;
+                }
+                return actionID;
+            }
+        }
+
+        //Overwrides main DPS ability family, The Broils (and ruin 1)
+        //Implements new Sage features as ToT, and Ruin 2 as the movement option
+        //ChainStratagem has overlap protection
+        internal class ScholarBroilFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_BroilFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Ruin1 or Broil1 or Broil2 or Broil3 or Broil4 && InCombat())
+                {
+                    //Lucid Dreaming
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Lucid) &&
+                        level >= All.Levels.LucidDreaming &&
+                        IsOffCooldown(All.LucidDreaming) &&
+                        LocalPlayer.CurrentMp <= GetOptionValue(Config.SCH_ST_Broil_Lucid) &&
+                        CanSpellWeave(actionID)
+                       ) return All.LucidDreaming;
+
+                    //Chain Stratagem
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_ChainStratagem) &&
+                        level >= Levels.ChainStratagem &&
+                        IsOffCooldown(ChainStratagem) &&
+                        !TargetHasEffectAny(Debuffs.ChainStratagem) && //Overwrite protection
+                        EnemyHealthPercentage() > GetOptionValue(Config.SCH_ST_Broil_ChainStratagem) &&
+                        CanSpellWeave(actionID)
+                       ) return ChainStratagem;
+
+                    //Bio/Biolysis
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Bio) && level >= Levels.Bio1 && CurrentTarget is not null)
+                    {
+                        var OurTarget = CurrentTarget;
+                        //Check if our Target is there and not an enemy
+                        if ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy)
+                        {
+                            //If ToT is enabled, Check if ToT is not null
+                            if ((IsEnabled(CustomComboPreset.SCH_ST_Broil_BioToT)) &&
+                                (CurrentTarget.TargetObject is not null) &&
+                                ((CurrentTarget.TargetObject as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy))
+                                //Set Ourtarget as the Target of Target
+                                OurTarget = CurrentTarget.TargetObject;
+                            //Our Target of Target wasn't hostile, our target isn't hostile, time to exit, nothing to check debuff on, fuck this shit we're out
+                            else return actionID;
+                        }
+
+                        //Determine which Bio debuff to check
+                        var BioDebuffID = level switch
+                        {
+                            //Using FindEffect b/c we have a custom Target variable
+                            >= Levels.Biolysis => FindEffect(Debuffs.Biolysis, OurTarget, LocalPlayer?.ObjectId),
+                            >= Levels.Bio2 => FindEffect(Debuffs.Bio2, OurTarget, LocalPlayer?.ObjectId),
+                            //Bio 1 checked at the start, fine for default
+                            _ => FindEffect(Debuffs.Bio1, OurTarget, LocalPlayer?.ObjectId),
+                        };
+                        if ((BioDebuffID is null) || (BioDebuffID.RemainingTime <= 3))
+                        {
+                            //Advanced Options Enabled to procede with auto-bio
+                            //Incompatible with ToT due to Enemy checks that are using CurrentTarget.
+                            if (IsEnabled(CustomComboPreset.SCH_ST_Broil_BioHPPer))
+                            {
+                                if (EnemyHealthPercentage() > GetOptionValue(Config.SCH_ST_Broil_BioHPPer))
+                                    return OriginalHook(Bio1);
+                            }
+                            else return OriginalHook(Bio1); ;
+                        }
+                    }
+
+                    //Aetherflow
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Aetherflow) &&
+                        level >= Levels.Aetherflow &&
+                        GetJobGauge<SCHGauge>().Aetherflow == 0 &&
+                        IsOffCooldown(Aetherflow)
+                       ) return Aetherflow;
+
+                    //Ruin 2 Movement 
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Ruin2Movement) &&
+                        level >= Levels.Ruin2 &&
+                        HasBattleTarget() &&
+                        this.IsMoving
+                       ) return OriginalHook(Ruin2); //Who knows in the future
+
+                    //End
+                }
+                return actionID;
+            }
         }
     }
-
 }

--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -126,312 +126,313 @@ namespace XIVSlothComboPlugin.Combos
                 SGE_ST_Heal_Druochole = "SGE_ST_Heal_Druochole",
                 SGE_ST_Heal_Taurochole = "SGE_ST_Heal_Taurochole";
         }
-    }
 
 
-    //SageSoteriaKardia
-    //Soteria becomes Kardia when Kardia's Buff is not active or Soteria is on cooldown.
-    internal class SageSoteriaKardiaFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_KardiaFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+
+        //SageSoteriaKardia
+        //Soteria becomes Kardia when Kardia's Buff is not active or Soteria is on cooldown.
+        internal class SageSoteriaKardiaFeature : CustomCombo
         {
-            if (actionID is SGE.Soteria && 
-                (!HasEffect(SGE.Buffs.Kardia) || IsOnCooldown(SGE.Soteria)) 
-               ) return SGE.Kardia;
-            else return actionID;
-        }
-    }
-
-    //SageRhizomata
-    //Replaces all Addersgal using Abilities (Taurochole/Druochole/Ixochole/Kerachole) with Rhizomata if out of Addersgall stacks
-    //(Scholar speak: Replaces all Aetherflow abilities with Aetherflow when out)
-    internal class SageRhizomataFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_RhizoFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is SGE.Taurochole or SGE.Druochole or SGE.Ixochole or SGE.Kerachole &&
-                level >= SGE.Levels.Rhizomata &&
-                GetJobGauge<SGEGauge>().Addersgall == 0
-               ) return SGE.Rhizomata;
-            else return actionID;
-        }
-    }
-
-    //SageDruoTauro
-    //Druochole Upgrade to Taurochole (like a trait upgrade)
-    //Replaces Druocole with Taurochole when Taurochole is available
-    //(As of 6.0) Taurochole (single target massive insta heal w/ cooldown), Druochole (Single target insta heal)
-    internal class SageDruoTauroFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauroFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is SGE.Druochole && level >= SGE.Levels.Taurochole && IsOffCooldown(SGE.Taurochole)) return SGE.Taurochole;
-            else return actionID;
-        }
-    }
-
-    //Sage AoE / Phlegma Replacement
-    //Replaces Zero Charges/Stacks of Phlegma with Toxikon (if you can use it) or Dyskrasia 
-    internal class SageAoEPhlegmaFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_PhlegmaFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is SGE.Phlegma or SGE.Phlegma2 or SGE.Phlegma3)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_KardiaFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                //Check for "out of Phlegma stacks" 
-                if (GetCooldown(OriginalHook(SGE.Phlegma)).RemainingCharges == 0)
-                {
-                    //Toxikon Checks
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Toxikon) &&
-                        level >= SGE.Levels.Toxikon &&
-                        HasBattleTarget() &&
-                        GetJobGauge<SGEGauge>().Addersting > 0
-                       ) return OriginalHook(SGE.Toxikon);
-
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Dyskrasia) && level >= SGE.Levels.Dyskrasia)
-                        return OriginalHook(SGE.Dyskrasia);
-                }
-                //Sub-Sub Feature. Allows running around in a dungeon/field with nothing targetted, saving charges.
-                //Will switch back to Phlegma/Toxikon when targetting something, as those two are target only skills
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Dyskrasia) && //Check for parent until GUI fixes for an active child feature with a disabled parent
-                    IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Dyskrasia_NoTarget) &&
-                    level >= SGE.Levels.Dyskrasia &&
-                    CurrentTarget == null
-                   ) return OriginalHook(SGE.Dyskrasia);
+                if (actionID is SGE.Soteria &&
+                    (!HasEffect(Buffs.Kardia) || IsOnCooldown(Soteria))
+                   ) return Kardia;
+                else return actionID;
             }
-            return actionID;
         }
-    }
 
-    //SageSTDosis
-    //Single Target Dosis Combo
-    //Currently Replaces Dosis with Eukrasia when the debuff on the target is < 3 seconds or not existing
-    //Lucid Dreaming, Target of Target optional
-    internal class SageSTDosisFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_DosisFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        //SageRhizomata
+        //Replaces all Addersgal using Abilities (Taurochole/Druochole/Ixochole/Kerachole) with Rhizomata if out of Addersgall stacks
+        //(Scholar speak: Replaces all Aetherflow abilities with Aetherflow when out)
+        internal class SageRhizomataFeature : CustomCombo
         {
-            if (actionID is SGE.Dosis1 or SGE.Dosis2 or SGE.Dosis3 && InCombat())
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_RhizoFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                //Lucid Dreaming
-                if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) &&
-                    level >= All.Levels.LucidDreaming &&
-                    IsOffCooldown(All.LucidDreaming) &&
-                    LocalPlayer.CurrentMp <= GetOptionValue(SGE.Config.SGE_ST_Dosis_Lucid) &&
-                    CanSpellWeave(actionID)
-                   ) return All.LucidDreaming;
+                if (actionID is Taurochole or Druochole or Ixochole or Kerachole &&
+                    level >= Levels.Rhizomata &&
+                    GetJobGauge<SGEGauge>().Addersgall == 0
+                   ) return Rhizomata;
+                else return actionID;
+            }
+        }
 
-                //Eukrasian Dosis.
-                //If we're too low level to use Eukrasia, we can stop here.
-                if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && (level >= SGE.Levels.Eukrasia) && CurrentTarget is not null)
+        //SageDruoTauro
+        //Druochole Upgrade to Taurochole (like a trait upgrade)
+        //Replaces Druocole with Taurochole when Taurochole is available
+        //(As of 6.0) Taurochole (single target massive insta heal w/ cooldown), Druochole (Single target insta heal)
+        internal class SageDruoTauroFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauroFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is SGE.Druochole && level >= Levels.Taurochole && IsOffCooldown(Taurochole)) return Taurochole;
+                else return actionID;
+            }
+        }
+
+        //Sage AoE / Phlegma Replacement
+        //Replaces Zero Charges/Stacks of Phlegma with Toxikon (if you can use it) or Dyskrasia 
+        internal class SageAoEPhlegmaFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_PhlegmaFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Phlegma or Phlegma2 or Phlegma3)
                 {
-                    var OurTarget = CurrentTarget;
-                    //Check if our Target is there and not an enemy
-                    if ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy)
+                    //Check for "out of Phlegma stacks" 
+                    if (GetCooldown(OriginalHook(Phlegma)).RemainingCharges == 0)
                     {
-                        //If ToT is enabled, Check if ToT is not null
-                        if ((IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosisToT)) &&
-                            (CurrentTarget.TargetObject is not null) &&
-                            ((CurrentTarget.TargetObject as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy))
-                            //Set Ourtarget as the Target of Target
-                            OurTarget = CurrentTarget.TargetObject;
-                        //Our Target of Target wasn't hostile, our target isn't hostile, time to exit, nothing to check debuff on, fuck this shit we're out
-                        else return actionID;
+                        //Toxikon Checks
+                        if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Toxikon) &&
+                            level >= Levels.Toxikon &&
+                            HasBattleTarget() &&
+                            GetJobGauge<SGEGauge>().Addersting > 0
+                           ) return OriginalHook(Toxikon);
+
+                        if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Dyskrasia) && level >= Levels.Dyskrasia)
+                            return OriginalHook(Dyskrasia);
                     }
+                    //Sub-Sub Feature. Allows running around in a dungeon/field with nothing targetted, saving charges.
+                    //Will switch back to Phlegma/Toxikon when targetting something, as those two are target only skills
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Dyskrasia) && //Check for parent until GUI fixes for an active child feature with a disabled parent
+                        IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Dyskrasia_NoTarget) &&
+                        level >= Levels.Dyskrasia &&
+                        CurrentTarget == null
+                       ) return OriginalHook(Dyskrasia);
+                }
+                return actionID;
+            }
+        }
 
-                    //Determine which Dosis debuff to check
-                    var DosisDebuffID = level switch
+        //SageSTDosis
+        //Single Target Dosis Combo
+        //Currently Replaces Dosis with Eukrasia when the debuff on the target is < 3 seconds or not existing
+        //Lucid Dreaming, Target of Target optional
+        internal class SageSTDosisFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_DosisFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Dosis1 or Dosis2 or Dosis3 && InCombat())
+                {
+                    //Lucid Dreaming
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) &&
+                        level >= All.Levels.LucidDreaming &&
+                        IsOffCooldown(All.LucidDreaming) &&
+                        LocalPlayer.CurrentMp <= GetOptionValue(Config.SGE_ST_Dosis_Lucid) &&
+                        CanSpellWeave(actionID)
+                       ) return All.LucidDreaming;
+
+                    //Eukrasian Dosis.
+                    //If we're too low level to use Eukrasia, we can stop here.
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && (level >= Levels.Eukrasia) && CurrentTarget is not null)
                     {
-                        //Using FindEffect b/c we have a custom Target variable
-                        >= SGE.Levels.Dosis3 => FindEffect(SGE.Debuffs.EukrasianDosis3, OurTarget, LocalPlayer?.ObjectId),
-                        >= SGE.Levels.Dosis2 => FindEffect(SGE.Debuffs.EukrasianDosis2, OurTarget, LocalPlayer?.ObjectId),
-                        //Ekrasia Dosis unlocks with Eukrasia, checked at the start
-                        _ => FindEffect(SGE.Debuffs.EukrasianDosis1, OurTarget, LocalPlayer?.ObjectId),
-                    };
-
-                    if (HasEffect(SGE.Buffs.Eukrasia))
-                        return OriginalHook(SGE.Dosis1); //OriginalHook will autoselect the correct Dosis for us
-
-                    //Got our Debuff for our level, check for it and procede 
-                    if ((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3))
-                    {
-                        //Advanced Options Enabled to procede with auto-Eukrasia
-                        //Incompatible with ToT due to Enemy checks that are using CurrentTarget.
-                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosisHPPer))
+                        var OurTarget = CurrentTarget;
+                        //Check if our Target is there and not an enemy
+                        if ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy)
                         {
-                            if (EnemyHealthPercentage() > GetOptionValue(SGE.Config.SGE_ST_Dosis_EDosisHPPer)) return SGE.Eukrasia;
+                            //If ToT is enabled, Check if ToT is not null
+                            if ((IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosisToT)) &&
+                                (CurrentTarget.TargetObject is not null) &&
+                                ((CurrentTarget.TargetObject as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy))
+                                //Set Ourtarget as the Target of Target
+                                OurTarget = CurrentTarget.TargetObject;
+                            //Our Target of Target wasn't hostile, our target isn't hostile, time to exit, nothing to check debuff on, fuck this shit we're out
+                            else return actionID;
                         }
-                        else return SGE.Eukrasia;
+
+                        //Determine which Dosis debuff to check
+                        var DosisDebuffID = level switch
+                        {
+                            //Using FindEffect b/c we have a custom Target variable
+                            >= Levels.Dosis3 => FindEffect(Debuffs.EukrasianDosis3, OurTarget, LocalPlayer?.ObjectId),
+                            >= Levels.Dosis2 => FindEffect(Debuffs.EukrasianDosis2, OurTarget, LocalPlayer?.ObjectId),
+                            //Ekrasia Dosis unlocks with Eukrasia, checked at the start
+                            _ => FindEffect(Debuffs.EukrasianDosis1, OurTarget, LocalPlayer?.ObjectId),
+                        };
+
+                        if (HasEffect(Buffs.Eukrasia))
+                            return OriginalHook(Dosis1); //OriginalHook will autoselect the correct Dosis for us
+
+                        //Got our Debuff for our level, check for it and procede 
+                        if ((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3))
+                        {
+                            //Advanced Options Enabled to procede with auto-Eukrasia
+                            //Incompatible with ToT due to Enemy checks that are using CurrentTarget.
+                            if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosisHPPer))
+                            {
+                                if (EnemyHealthPercentage() > GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer)) return Eukrasia;
+                            }
+                            else return Eukrasia;
+                        }
+                    }
+
+                    //Toxikon
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
+                        level >= Levels.Toxikon &&
+                        HasBattleTarget() &&
+                        ((GetOptionValue(Config.SGE_ST_Dosis_Toxikon) == 1 && this.IsMoving) || (GetOptionValue(Config.SGE_ST_Dosis_Toxikon) == 2)) &&
+                        GetJobGauge<SGEGauge>().Addersting > 0
+                       ) return OriginalHook(Toxikon);
+                }
+                return actionID;
+            }
+        }
+
+        //SageRaise
+        //Swiftcast combos to Egeiro (Raise) while Swiftcast is on cooldown
+        internal class SageRaiseFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_RaiseFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is All.Swiftcast && IsOnCooldown(All.Swiftcast)) return Egeiro;
+                else return actionID;
+            }
+        }
+
+        internal class SageSingleTargetHealFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_HealFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is SGE.Diagnosis)
+                {
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) &&
+                        level >= Levels.Druochole &&
+                        IsOffCooldown(Druochole) &&
+                        GetJobGauge<SGEGauge>().Addersgall >= 1 &&
+                        EnemyHealthPercentage() <= GetOptionValue(Config.SGE_ST_Heal_Druochole)
+                       ) return Druochole;
+
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) &&
+                        level >= Levels.Taurochole &&
+                        IsOffCooldown(Taurochole) &&
+                        GetJobGauge<SGEGauge>().Addersgall >= 1 &&
+                        EnemyHealthPercentage() <= GetOptionValue(Config.SGE_ST_Heal_Taurochole)
+                       ) return Taurochole;
+
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) &&
+                        level >= Levels.Rhizomata &&
+                        IsOffCooldown(Rhizomata) &&
+                        GetJobGauge<SGEGauge>().Addersgall is 0
+                       ) return Rhizomata;
+
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Kardia) &&
+                        level >= Levels.Kardia &&
+                        FindEffect(Buffs.Kardia) is null &&
+                        FindTargetEffect(Buffs.Kardion) is null
+                       ) return Kardia;
+
+                    if (CurrentTarget?.ObjectKind is ObjectKind.Player)
+                    {
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) &&
+                            level >= Levels.Soteria &&
+                            IsOffCooldown(Soteria) &&
+                            EnemyHealthPercentage() <= GetOptionValue(Config.SGE_ST_Heal_Soteria)
+                           ) return Soteria;
+
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) &&
+                            level >= Levels.Zoe &&
+                            IsOffCooldown(Zoe) &&
+                            EnemyHealthPercentage() <= GetOptionValue(Config.SGE_ST_Heal_Zoe)
+                           ) return Zoe;
+
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) &&
+                            level >= Levels.Krasis &&
+                            IsOffCooldown(Krasis) && EnemyHealthPercentage() <= GetOptionValue(Config.SGE_ST_Heal_Krasis)
+                           ) return Krasis;
+
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) &&
+                            level >= Levels.Pepsis &&
+                            IsOffCooldown(Pepsis) && EnemyHealthPercentage() <= GetOptionValue(Config.SGE_ST_Heal_Pepsis) &&
+                            FindTargetEffect(Buffs.EukrasianDiagnosis) is not null
+                           ) return Pepsis;
+
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) &&
+                            level >= Levels.Haima &&
+                            IsOffCooldown(Haima) && EnemyHealthPercentage() <= GetOptionValue(Config.SGE_ST_Heal_Haima)
+                           ) return Haima;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Diagnosis) &&
+                        level >= Levels.Eukrasia &&
+                        FindTargetEffect(Buffs.EukrasianDiagnosis) is null &&
+                        EnemyHealthPercentage() <= GetOptionValue(Config.SGE_ST_Heal_Diagnosis))
+                    {
+                        if (!HasEffect(Buffs.Eukrasia))
+                            return Eukrasia;
+                        else return EukrasianDiagnosis;
                     }
                 }
-
-                //Toxikon
-                if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
-                    level >= SGE.Levels.Toxikon &&
-                    HasBattleTarget() &&
-                    ((GetOptionValue(SGE.Config.SGE_ST_Dosis_Toxikon) == 1 && this.IsMoving) || (GetOptionValue(SGE.Config.SGE_ST_Dosis_Toxikon) == 2)) &&
-                    GetJobGauge<SGEGauge>().Addersting > 0
-                   ) return OriginalHook(SGE.Toxikon);
+                return actionID;
             }
-            return actionID;
         }
-    }
 
-    //SageRaise
-    //Swiftcast combos to Egeiro (Raise) while Swiftcast is on cooldown
-    internal class SageRaiseFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_RaiseFeature;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class SageAoEHealFeature : CustomCombo
         {
-            if (actionID is All.Swiftcast && IsOnCooldown(All.Swiftcast)) return SGE.Egeiro;
-            else return actionID;
-        }
-    }
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_HealFeature;
 
-    internal class SageSingleTargetHealFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_HealFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is SGE.Diagnosis )
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && 
-                    level >= SGE.Levels.Druochole &&
-                    IsOffCooldown(SGE.Druochole) &&
-                    GetJobGauge<SGEGauge>().Addersgall >= 1 && 
-                    EnemyHealthPercentage() <= GetOptionValue(SGE.Config.SGE_ST_Heal_Druochole)
-                   ) return SGE.Druochole;
-
-                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) &&
-                    level >= SGE.Levels.Taurochole && 
-                    IsOffCooldown(SGE.Taurochole) && 
-                    GetJobGauge<SGEGauge>().Addersgall >= 1 &&
-                    EnemyHealthPercentage() <= GetOptionValue(SGE.Config.SGE_ST_Heal_Taurochole)
-                   ) return SGE.Taurochole;
-
-                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) &&
-                    level >= SGE.Levels.Rhizomata &&
-                    IsOffCooldown(SGE.Rhizomata) &&
-                    GetJobGauge<SGEGauge>().Addersgall is 0
-                   ) return SGE.Rhizomata;
-
-                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Kardia) && 
-                    level >= SGE.Levels.Kardia &&
-                    FindEffect(SGE.Buffs.Kardia) is null &&
-                    FindTargetEffect(SGE.Buffs.Kardion) is null
-                   ) return SGE.Kardia;
-
-                if (CurrentTarget?.ObjectKind is ObjectKind.Player)
+                if (actionID is SGE.Prognosis)
                 {
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) &&
-                        level >= SGE.Levels.Soteria &&
-                        IsOffCooldown(SGE.Soteria) && 
-                        EnemyHealthPercentage() <= GetOptionValue(SGE.Config.SGE_ST_Heal_Soteria)
-                       ) return SGE.Soteria;
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) &&
+                        level >= Levels.Rhizomata &&
+                        IsOffCooldown(Rhizomata) &&
+                        GetJobGauge<SGEGauge>().Addersgall is 0
+                       ) return Rhizomata;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) &&
-                        level >= SGE.Levels.Zoe &&
-                        IsOffCooldown(SGE.Zoe) && 
-                        EnemyHealthPercentage() <= GetOptionValue(SGE.Config.SGE_ST_Heal_Zoe)
-                       ) return SGE.Zoe;
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) &&
+                        level >= Levels.Kerachole &&
+                        IsOffCooldown(Kerachole) &&
+                        GetJobGauge<SGEGauge>().Addersgall >= 1
+                       ) return Kerachole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) &&
-                        level >= SGE.Levels.Krasis &&
-                        IsOffCooldown(SGE.Krasis) && EnemyHealthPercentage() <= GetOptionValue(SGE.Config.SGE_ST_Heal_Krasis)
-                       ) return SGE.Krasis;
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) &&
+                        level >= Levels.Ixochole &&
+                        IsOffCooldown(Ixochole) &&
+                        GetJobGauge<SGEGauge>().Addersgall >= 1
+                       ) return Ixochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) &&
-                        level >= SGE.Levels.Pepsis && 
-                        IsOffCooldown(SGE.Pepsis) && EnemyHealthPercentage() <= GetOptionValue(SGE.Config.SGE_ST_Heal_Pepsis) &&
-                        FindTargetEffect(SGE.Buffs.EukrasianDiagnosis) is not null
-                       ) return SGE.Pepsis;
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) &&
+                        level >= Levels.Physis &&
+                        IsOffCooldown(OriginalHook(Physis))
+                       ) return OriginalHook(Physis);
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) &&
-                        level >= SGE.Levels.Haima &&
-                        IsOffCooldown(SGE.Haima) && EnemyHealthPercentage() <= GetOptionValue(SGE.Config.SGE_ST_Heal_Haima)
-                       ) return SGE.Haima;
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EkPrognosis) &&
+                        level >= Levels.Eukrasia &&
+                        FindEffect(Buffs.EukrasianPrognosis) is null)
+                    {
+                        if (!HasEffect(Buffs.Eukrasia))
+                            return Eukrasia;
+                        if (HasEffect(Buffs.Eukrasia))
+                            return EukrasianPrognosis;
+                    }
+
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) &&
+                        level >= Levels.Holos &&
+                        IsOffCooldown(Holos)
+                       ) return Holos;
+
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) &&
+                        level >= Levels.Panhaima &&
+                        IsOffCooldown(Panhaima)
+                       ) return Panhaima;
+
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) &&
+                        level >= Levels.Pepsis &&
+                        IsOffCooldown(Pepsis) &&
+                        FindEffect(Buffs.EukrasianPrognosis) is not null
+                       ) return Pepsis;
                 }
-                
-                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Diagnosis) &&
-                    level >= SGE.Levels.Eukrasia &&
-                    FindTargetEffect(SGE.Buffs.EukrasianDiagnosis) is null && 
-                    EnemyHealthPercentage() <= GetOptionValue(SGE.Config.SGE_ST_Heal_Diagnosis))
-                {
-                    if (!HasEffect(SGE.Buffs.Eukrasia))
-                        return SGE.Eukrasia;
-                    else return SGE.EukrasianDiagnosis;
-                }
+                return actionID;
             }
-            return actionID;
-        }
-    }
-
-    internal class SageAoEHealFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_HealFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID is SGE.Prognosis)
-            {
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) &&
-                    level >= SGE.Levels.Rhizomata &&
-                    IsOffCooldown(SGE.Rhizomata) &&
-                    GetJobGauge<SGEGauge>().Addersgall is 0 
-                   ) return SGE.Rhizomata;
-
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) &&
-                    level >= SGE.Levels.Kerachole &&
-                    IsOffCooldown(SGE.Kerachole) && 
-                    GetJobGauge<SGEGauge>().Addersgall >= 1
-                   ) return SGE.Kerachole;
-
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) &&
-                    level >= SGE.Levels.Ixochole &&
-                    IsOffCooldown(SGE.Ixochole) &&
-                    GetJobGauge<SGEGauge>().Addersgall >= 1                     
-                   ) return SGE.Ixochole;
-
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) &&
-                    level >= SGE.Levels.Physis &&
-                    IsOffCooldown(OriginalHook(SGE.Physis))
-                   ) return OriginalHook(SGE.Physis);
-
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EkPrognosis) &&
-                    level >= SGE.Levels.Eukrasia &&
-                    FindEffect(SGE.Buffs.EukrasianPrognosis) is null)
-                {
-                    if (!HasEffect(SGE.Buffs.Eukrasia))
-                        return SGE.Eukrasia;
-                    if (HasEffect(SGE.Buffs.Eukrasia))
-                        return SGE.EukrasianPrognosis;
-                }
-
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) &&
-                    level >= SGE.Levels.Holos &&
-                    IsOffCooldown(SGE.Holos)
-                   ) return SGE.Holos;
-
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) &&
-                    level >= SGE.Levels.Panhaima &&
-                    IsOffCooldown(SGE.Panhaima)
-                   ) return SGE.Panhaima;
-
-                if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) &&
-                    level >= SGE.Levels.Pepsis &&
-                    IsOffCooldown(SGE.Pepsis) &&
-                    FindEffect(SGE.Buffs.EukrasianPrognosis) is not null
-                   ) return SGE.Pepsis;
-            }
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -161,371 +161,372 @@ namespace XIVSlothComboPlugin.Combos
                 SummonerBurstPhase = "SummonerBurstPhase",
                 SummonerPrimalChoice = "SummonerPrimalChoice";
         }
-    }
-    internal class SummonerRaiseFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerRaiseFeature;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class SummonerRaiseFeature : CustomCombo
         {
-            if (actionID == All.Swiftcast)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerRaiseFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (IsOnCooldown(All.Swiftcast))
-                    return SMN.Resurrection;
+                if (actionID == All.Swiftcast)
+                {
+                    if (IsOnCooldown(All.Swiftcast))
+                        return Resurrection;
+                }
+                return actionID;
             }
-            return actionID;
         }
-    }
 
-    internal class SummonerSpecialRuinFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerSpecialRuinFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class SummonerSpecialRuinFeature : CustomCombo
         {
-            if (actionID == SMN.Ruin4)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerSpecialRuinFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var furtherRuin = HasEffect(SMN.Buffs.FurtherRuin);
-                if (!furtherRuin)
-                    return SMN.Ruin3;
+                if (actionID == Ruin4)
+                {
+                    var furtherRuin = HasEffect(Buffs.FurtherRuin);
+                    if (!furtherRuin)
+                        return Ruin3;
+                }
+                return actionID;
             }
-            return actionID;
         }
-    }
 
-    internal class SummonerEDFesterCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerEDFesterCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class SummonerEDFesterCombo : CustomCombo
         {
-            if (actionID == SMN.Fester)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerEDFesterCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Fester)
+                {
+                    var gauge = GetJobGauge<SMNGauge>();
+                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SummonerFesterPainflareRuinFeature))
+                        return Ruin4;
+                    if (level >= Levels.EnergyDrain && !gauge.HasAetherflowStacks)
+                        return EnergyDrain;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class SummonerESPainflareCombo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerESPainflareCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Painflare)
+                {
+                    var gauge = GetJobGauge<SMNGauge>();
+                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SummonerFesterPainflareRuinFeature))
+                        return Ruin4;
+                    if (level >= Levels.EnergySiphon && !gauge.HasAetherflowStacks)
+                        return EnergySiphon;
+
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class SummonerMainComboFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerMainComboFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 var gauge = GetJobGauge<SMNGauge>();
-                if (HasEffect(SMN.Buffs.FurtherRuin) && IsOnCooldown(SMN.EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SummonerFesterPainflareRuinFeature))
-                    return SMN.Ruin4;
-                if (level >= SMN.Levels.EnergyDrain && !gauge.HasAetherflowStacks)
-                    return SMN.EnergyDrain;
-            }
+                var summonerPrimalChoice = Service.Configuration.GetCustomIntValue(Config.SummonerPrimalChoice);
+                var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
+                var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.SMNLucidDreamingFeature);
 
-            return actionID;
-        }
-    }
-
-    internal class SummonerESPainflareCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerESPainflareCombo;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == SMN.Painflare)
-            {
-                var gauge = GetJobGauge<SMNGauge>();
-                if (HasEffect(SMN.Buffs.FurtherRuin) && IsOnCooldown(SMN.EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SummonerFesterPainflareRuinFeature))
-                    return SMN.Ruin4;
-                if (level >= SMN.Levels.EnergySiphon && !gauge.HasAetherflowStacks)
-                    return SMN.EnergySiphon;
-
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class SummonerMainComboFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerMainComboFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gauge = GetJobGauge<SMNGauge>();
-            var summonerPrimalChoice = Service.Configuration.GetCustomIntValue(SMN.Config.SummonerPrimalChoice);
-            var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(SMN.Config.SummonerBurstPhase);
-            var lucidThreshold = Service.Configuration.GetCustomIntValue(SMN.Config.SMNLucidDreamingFeature);
-
-            if (actionID is SMN.Ruin or SMN.Ruin2 && InCombat())
-            {
-                if (CanSpellWeave(actionID))
-                {
-                    // Searing Light
-                    if (IsEnabled(CustomComboPreset.SearingLightonRuinFeature) && IsOffCooldown(SMN.SearingLight) && level >= SMN.Levels.SearingLight)
-                    {
-                        if (IsEnabled(CustomComboPreset.SummonerSearingLightBurstOption))
-                        {
-                            if ((SummonerBurstPhase == 1 && OriginalHook(SMN.Ruin) == SMN.AstralImpulse) ||
-                                (SummonerBurstPhase == 2 && OriginalHook(SMN.Ruin) == SMN.FountainOfFire))
-                                return SMN.SearingLight;
-                        }
-
-                        else return SMN.SearingLight;
-                    }
-
-                    // ED & Fester
-                    if (IsEnabled(CustomComboPreset.SummonerEDMainComboFeature))
-                    {
-                        if (gauge.HasAetherflowStacks)
-                        {
-                            if (IsNotEnabled(CustomComboPreset.SummonerEDPoolonMainFeature))
-                                return SMN.Fester;
-                            if (IsEnabled(CustomComboPreset.SummonerEDPoolonMainFeature))
-                            {
-                                if (level < SMN.Levels.SearingLight)
-                                    return SMN.Fester;
-                                if (HasEffect(SMN.Buffs.SearingLight) && 
-                                    ((SummonerBurstPhase == 1 && OriginalHook(SMN.Ruin) == SMN.AstralImpulse) ||
-                                    (SummonerBurstPhase == 2 && OriginalHook(SMN.Ruin) == SMN.FountainOfFire)))
-                                    return SMN.Fester;
-                            }
-                        }
-
-                        if (level >= SMN.Levels.EnergyDrain && !gauge.HasAetherflowStacks && IsOffCooldown(SMN.EnergyDrain))
-                            return SMN.EnergyDrain;
-                    }
-
-                    // Lucid
-                    if (IsEnabled(CustomComboPreset.SMNLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
-                        return All.LucidDreaming;
-                }
-
-                // Egi Features
-                if (IsEnabled(CustomComboPreset.EgisOnRuinFeature))
-                {
-                    //Swiftcast Garuda Feature                                 
-                    if (IsEnabled(CustomComboPreset.SummonerSwiftcastFeatureGaruda) && level >= SMN.Levels.Slipstream)
-                    {
-                        if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && HasEffect(SMN.Buffs.GarudasFavor) && gauge.IsGarudaAttuned)
-                            return All.Swiftcast;
-                        if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && gauge.IsGarudaAttuned && HasEffect(SMN.Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast))
-                            return OriginalHook(SMN.AstralFlow);
-                    }
-
-                    //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                    if (IsEnabled(CustomComboPreset.SummonerSwiftcastFeatureIfrit) && level >= SMN.Levels.RubyRuin1 && CanSpellWeave(actionID))
-                    {
-                        if (IsOffCooldown(All.Swiftcast) && level >= All.Levels.Swiftcast && gauge.IsIfritAttuned)
-                        {
-                            if (IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
-                                (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && lastComboMove is SMN.CrimsonStrike or SMN.RubyRuin1 or SMN.RubyRuin2 or SMN.RubyRuin3 or SMN.RubyRite))
-                                return All.Swiftcast;
-                        }
-                    }
-
-                    if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && IsNotEnabled(CustomComboPreset.SummonerSwiftcastFeatureGaruda) && gauge.IsGarudaAttuned && HasEffect(SMN.Buffs.GarudasFavor) || //Garuda
-                        IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(SMN.Buffs.TitansFavor) && lastComboMove == SMN.TopazRite && CanSpellWeave(actionID) || //Titan
-                        IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(SMN.Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == SMN.CrimsonCyclone)) //Ifrit
-                        return OriginalHook(SMN.AstralFlow);
-
-                    if (IsEnabled(CustomComboPreset.SummonerEgiAttacksFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
-                        return OriginalHook(SMN.Gemshine);
-
-                    if (IsEnabled(CustomComboPreset.SummonerEgiSummonsonMainFeature) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SMN.SummonPhoenix) && IsOnCooldown(SMN.SummonBahamut))
-                    {
-                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && level >= SMN.Levels.SummonRuby)
-                            return OriginalHook(SMN.SummonRuby);
-
-                        if (summonerPrimalChoice == 1)
-                        {
-                            if (gauge.IsTitanReady && level >= SMN.Levels.SummonTopaz)
-                                return OriginalHook(SMN.SummonTopaz);
-
-                            if (gauge.IsGarudaReady && level >= SMN.Levels.SummonEmerald)
-                                return OriginalHook(SMN.SummonEmerald);
-                        }
-
-                        if (summonerPrimalChoice == 2)
-                        {
-                            if (gauge.IsGarudaReady && level >= SMN.Levels.SummonEmerald)
-                                return OriginalHook(SMN.SummonEmerald);
-
-                            if (gauge.IsTitanReady && level >= SMN.Levels.SummonTopaz)
-                                return OriginalHook(SMN.SummonTopaz);
-                        }
-                    }
-                }
-
-                //Demi Features
-                if (IsEnabled(CustomComboPreset.SummonerDemiSummonsFeature))
-                {
-                    if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(SMN.Aethercharge)) &&
-                        (level >= SMN.Levels.Aethercharge && level < SMN.Levels.Bahamut || //Pre Bahamut Phase
-                        gauge.IsBahamutReady && level >= SMN.Levels.Bahamut || //Bahamut Phase
-                        gauge.IsPhoenixReady && level >= SMN.Levels.Phoenix)) //Phoenix Phase
-                        return OriginalHook(SMN.Aethercharge);
-
-                    if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID))
-                    {
-                        if (IsOffCooldown(OriginalHook(SMN.AstralFlow)) && level >= SMN.Levels.AstralFlow && (level < SMN.Levels.Bahamut || lastComboMove is SMN.AstralImpulse))
-                            return OriginalHook(SMN.AstralFlow);
-
-                        if (IsOffCooldown(OriginalHook(SMN.EnkindleBahamut)) && level >= SMN.Levels.Bahamut && lastComboMove is SMN.AstralImpulse or SMN.FountainOfFire)
-                            return OriginalHook(SMN.EnkindleBahamut);
-                    }
-
-                    if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption))
-                    {
-                        if (IsOffCooldown(OriginalHook(SMN.AstralFlow)) && lastComboMove is SMN.FountainOfFire)
-                            return OriginalHook(SMN.AstralFlow);
-                    }
-                }
-
-                if (IsEnabled(CustomComboPreset.SummonerRuin4ToRuin3Feature) && level >= SMN.Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(SMN.Buffs.FurtherRuin))
-                    return SMN.Ruin4;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class SummonerAOEComboFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerAOEComboFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gauge = GetJobGauge<SMNGauge>();
-            var lucidThreshold = Service.Configuration.GetCustomIntValue(SMN.Config.SMNLucidDreamingFeature);
-
-            if (actionID is SMN.Tridisaster or SMN.Outburst)
-            {
-                if (InCombat())
+                if (actionID is Ruin or Ruin2 && InCombat())
                 {
                     if (CanSpellWeave(actionID))
                     {
-                        var searingChoice = Service.Configuration.GetCustomIntValue(SMN.Config.SMNSearingLightChoice);
+                        // Searing Light
+                        if (IsEnabled(CustomComboPreset.SearingLightonRuinFeature) && IsOffCooldown(SearingLight) && level >= Levels.SearingLight)
+                        {
+                            if (IsEnabled(CustomComboPreset.SummonerSearingLightBurstOption))
+                            {
+                                if ((SummonerBurstPhase == 1 && OriginalHook(Ruin) == AstralImpulse) ||
+                                    (SummonerBurstPhase == 2 && OriginalHook(Ruin) == FountainOfFire))
+                                    return SearingLight;
+                            }
 
-                        // Searing
-                        if (IsEnabled(CustomComboPreset.BuffOnSimpleAoESummoner) &&
-                            IsOffCooldown(SMN.SearingLight) &&
-                            level >= SMN.Levels.SearingLight &&
-                            (searingChoice == 0 ||
-                            (OriginalHook(SMN.Tridisaster) is SMN.AstralFlare && gauge.SummonTimerRemaining > 0 && searingChoice == 1) ||
-                            (OriginalHook(SMN.Tridisaster) is SMN.BrandOfPurgatory && gauge.SummonTimerRemaining > 0 && searingChoice == 2) ||
-                            (OriginalHook(SMN.PreciousBrilliance) is (SMN.RubyCata or SMN.RubyOutburst) && gauge.SummonTimerRemaining > 0 && searingChoice == 3) ||
-                            (OriginalHook(SMN.PreciousBrilliance) is (SMN.EmeraldCata or SMN.EmeraldOutburst) && gauge.SummonTimerRemaining > 0 && searingChoice == 4) ||
-                            (OriginalHook(SMN.PreciousBrilliance) is (SMN.TopazCata or SMN.TopazOutburst) && gauge.SummonTimerRemaining > 0 && searingChoice == 5)))
-                            return SMN.SearingLight;
-
+                            else return SearingLight;
+                        }
 
                         // ED & Fester
-                        if (IsEnabled(CustomComboPreset.SummonerESAOEFeature))
+                        if (IsEnabled(CustomComboPreset.SummonerEDMainComboFeature))
                         {
-                            if (gauge.HasAetherflowStacks && HasEffect(SMN.Buffs.SearingLight))
-                                return SMN.Painflare;
-                            if (level >= SMN.Levels.EnergySiphon && !gauge.HasAetherflowStacks && IsOffCooldown(SMN.EnergySiphon))
-                                return SMN.EnergySiphon;
+                            if (gauge.HasAetherflowStacks)
+                            {
+                                if (IsNotEnabled(CustomComboPreset.SummonerEDPoolonMainFeature))
+                                    return Fester;
+                                if (IsEnabled(CustomComboPreset.SummonerEDPoolonMainFeature))
+                                {
+                                    if (level < Levels.SearingLight)
+                                        return Fester;
+                                    if (HasEffect(Buffs.SearingLight) &&
+                                        ((SummonerBurstPhase == 1 && OriginalHook(Ruin) == AstralImpulse) ||
+                                        (SummonerBurstPhase == 2 && OriginalHook(Ruin) == FountainOfFire)))
+                                        return Fester;
+                                }
+                            }
+
+                            if (level >= Levels.EnergyDrain && !gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain))
+                                return EnergyDrain;
                         }
 
                         // Lucid
                         if (IsEnabled(CustomComboPreset.SMNLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
                             return All.LucidDreaming;
-
-                        //Demi Nuke
-                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID))
-                        {
-                            if (IsOffCooldown(OriginalHook(SMN.AstralFlow)) &&
-                                level >= SMN.Levels.AstralFlow &&
-                                (level < SMN.Levels.Bahamut || lastComboMove is SMN.AstralFlare) &&
-                                gauge.AttunmentTimerRemaining > 0)
-                                return OriginalHook(SMN.AstralFlow);
-
-                            if (IsOffCooldown(OriginalHook(SMN.EnkindleBahamut)) &&
-                                level >= SMN.Levels.Bahamut &&
-                                OriginalHook(SMN.Tridisaster) is SMN.AstralFlare or SMN.BrandOfPurgatory &&
-                                gauge.SummonTimerRemaining > 0)
-                                return OriginalHook(SMN.EnkindleBahamut);
-                        }
-
-                        //Demi Nuke 2: Electric Boogaloo
-                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption))
-                        {
-                            if (IsOffCooldown(OriginalHook(SMN.AstralFlow)) &&
-                                OriginalHook(SMN.Tridisaster) is SMN.BrandOfPurgatory)
-                                return OriginalHook(SMN.AstralFlow);
-                        }
                     }
 
-                   
-
-                    //Demi
-                    if (IsEnabled(CustomComboPreset.SummonerDemiAoESummonsFeature))
+                    // Egi Features
+                    if (IsEnabled(CustomComboPreset.EgisOnRuinFeature))
                     {
-                        if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(SMN.Aethercharge)) &&
-                            (level >= SMN.Levels.Aethercharge && level < SMN.Levels.Bahamut || //Pre Bahamut Phase
-                            gauge.IsBahamutReady && level >= SMN.Levels.Bahamut || //Bahamut Phase
-                            gauge.IsPhoenixReady && level >= SMN.Levels.Phoenix) && //Phoenix Phase
-                            !gauge.IsIfritReady && 
-                            !gauge.IsTitanReady && 
-                            !gauge.IsGarudaReady) 
-                            return OriginalHook(SMN.Aethercharge);
-
-                    }
-
-
-                    // Egis
-                    if (IsEnabled(CustomComboPreset.EgisOnAOEFeature))
-                    {
-                        if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && gauge.IsGarudaAttuned && HasEffect(SMN.Buffs.GarudasFavor) || //Garuda
-                            IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(SMN.Buffs.TitansFavor) && lastComboMove == SMN.TopazCata && CanSpellWeave(actionID) || //Titan
-                            IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(SMN.Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == SMN.CrimsonCyclone)) //Ifrit
-                            return OriginalHook(SMN.AstralFlow);
-
-                        if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0)
+                        //Swiftcast Garuda Feature                                 
+                        if (IsEnabled(CustomComboPreset.SummonerSwiftcastFeatureGaruda) && level >= Levels.Slipstream)
                         {
-                            if (gauge.IsTitanReady && level >= SMN.Levels.SummonTopaz)
-                                return OriginalHook(SMN.SummonTopaz);
-                            if (gauge.IsGarudaReady && level >= SMN.Levels.SummonEmerald)
-                                return OriginalHook(SMN.SummonEmerald);
-                            if (gauge.IsIfritReady && level >= SMN.Levels.SummonRuby)
-                                return OriginalHook(SMN.SummonRuby);
+                            if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && HasEffect(Buffs.GarudasFavor) && gauge.IsGarudaAttuned)
+                                return All.Swiftcast;
+                            if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast))
+                                return OriginalHook(AstralFlow);
+                        }
+
+                        //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
+                        if (IsEnabled(CustomComboPreset.SummonerSwiftcastFeatureIfrit) && level >= Levels.RubyRuin1 && CanSpellWeave(actionID))
+                        {
+                            if (IsOffCooldown(All.Swiftcast) && level >= All.Levels.Swiftcast && gauge.IsIfritAttuned)
+                            {
+                                if (IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
+                                    (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && lastComboMove is CrimsonStrike or RubyRuin1 or RubyRuin2 or RubyRuin3 or RubyRite))
+                                    return All.Swiftcast;
+                            }
+                        }
+
+                        if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && IsNotEnabled(CustomComboPreset.SummonerSwiftcastFeatureGaruda) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
+                            IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazRite && CanSpellWeave(actionID) || //Titan
+                            IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
+                            return OriginalHook(AstralFlow);
+
+                        if (IsEnabled(CustomComboPreset.SummonerEgiAttacksFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
+                            return OriginalHook(Gemshine);
+
+                        if (IsEnabled(CustomComboPreset.SummonerEgiSummonsonMainFeature) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                        {
+                            if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && level >= Levels.SummonRuby)
+                                return OriginalHook(SummonRuby);
+
+                            if (summonerPrimalChoice == 1)
+                            {
+                                if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
+                                    return OriginalHook(SummonTopaz);
+
+                                if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
+                                    return OriginalHook(SummonEmerald);
+                            }
+
+                            if (summonerPrimalChoice == 2)
+                            {
+                                if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
+                                    return OriginalHook(SummonEmerald);
+
+                                if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
+                                    return OriginalHook(SummonTopaz);
+                            }
                         }
                     }
 
-                    //Precious Brilliance
-                    if (IsEnabled(CustomComboPreset.SummonerEgiAttacksAOEFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
-                        return OriginalHook(SMN.PreciousBrilliance);
+                    //Demi Features
+                    if (IsEnabled(CustomComboPreset.SummonerDemiSummonsFeature))
+                    {
+                        if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
+                            (level >= Levels.Aethercharge && level < Levels.Bahamut || //Pre Bahamut Phase
+                            gauge.IsBahamutReady && level >= Levels.Bahamut || //Bahamut Phase
+                            gauge.IsPhoenixReady && level >= Levels.Phoenix)) //Phoenix Phase
+                            return OriginalHook(Aethercharge);
 
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID))
+                        {
+                            if (IsOffCooldown(OriginalHook(AstralFlow)) && level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is SMN.AstralImpulse))
+                                return OriginalHook(AstralFlow);
 
+                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && level >= Levels.Bahamut && lastComboMove is AstralImpulse or FountainOfFire)
+                                return OriginalHook(EnkindleBahamut);
+                        }
 
-                    if (IsEnabled(CustomComboPreset.SummonerRuin4ToTridisasterFeature) && level >= SMN.Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(SMN.Buffs.FurtherRuin))
-                        return SMN.Ruin4;
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption))
+                        {
+                            if (IsOffCooldown(OriginalHook(AstralFlow)) && lastComboMove is SMN.FountainOfFire)
+                                return OriginalHook(AstralFlow);
+                        }
+                    }
+
+                    if (IsEnabled(CustomComboPreset.SummonerRuin4ToRuin3Feature) && level >= Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                        return Ruin4;
                 }
-            }
 
-            return actionID;
+                return actionID;
+            }
         }
-    }
 
-    internal class SummonerCarbuncleSummonFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.SummonerCarbuncleSummonFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class SummonerAOEComboFeature : CustomCombo
         {
-            var gauge = GetJobGauge<SMNGauge>();
-            if (actionID is SMN.Ruin or SMN.Ruin2 or SMN.Ruin3 or SMN.DreadwyrmTrance or SMN.AstralFlow or SMN.EnkindleBahamut or SMN.SearingLight or SMN.RadiantAegis or SMN.Outburst or SMN.Tridisaster or SMN.PreciousBrilliance or SMN.Gemshine)
-            {
-                if (!HasPetPresent() && gauge.SummonTimerRemaining == 0 && gauge.Attunement == 0)
-                    return SMN.SummonCarbuncle;
-            }
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerAOEComboFeature;
 
-            return actionID;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var gauge = GetJobGauge<SMNGauge>();
+                var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.SMNLucidDreamingFeature);
+
+                if (actionID is Tridisaster or Outburst)
+                {
+                    if (InCombat())
+                    {
+                        if (CanSpellWeave(actionID))
+                        {
+                            var searingChoice = Service.Configuration.GetCustomIntValue(Config.SMNSearingLightChoice);
+
+                            // Searing
+                            if (IsEnabled(CustomComboPreset.BuffOnSimpleAoESummoner) &&
+                                IsOffCooldown(SearingLight) &&
+                                level >= Levels.SearingLight &&
+                                (searingChoice == 0 ||
+                                (OriginalHook(Tridisaster) is SMN.AstralFlare && gauge.SummonTimerRemaining > 0 && searingChoice == 1) ||
+                                (OriginalHook(Tridisaster) is SMN.BrandOfPurgatory && gauge.SummonTimerRemaining > 0 && searingChoice == 2) ||
+                                (OriginalHook(PreciousBrilliance) is (RubyCata or RubyOutburst) && gauge.SummonTimerRemaining > 0 && searingChoice == 3) ||
+                                (OriginalHook(PreciousBrilliance) is (EmeraldCata or EmeraldOutburst) && gauge.SummonTimerRemaining > 0 && searingChoice == 4) ||
+                                (OriginalHook(PreciousBrilliance) is (TopazCata or TopazOutburst) && gauge.SummonTimerRemaining > 0 && searingChoice == 5)))
+                                return SearingLight;
+
+
+                            // ED & Fester
+                            if (IsEnabled(CustomComboPreset.SummonerESAOEFeature))
+                            {
+                                if (gauge.HasAetherflowStacks && HasEffect(Buffs.SearingLight))
+                                    return Painflare;
+                                if (level >= Levels.EnergySiphon && !gauge.HasAetherflowStacks && IsOffCooldown(EnergySiphon))
+                                    return EnergySiphon;
+                            }
+
+                            // Lucid
+                            if (IsEnabled(CustomComboPreset.SMNLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
+                                return All.LucidDreaming;
+
+                            //Demi Nuke
+                            if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID))
+                            {
+                                if (IsOffCooldown(OriginalHook(AstralFlow)) &&
+                                    level >= Levels.AstralFlow &&
+                                    (level < Levels.Bahamut || lastComboMove is SMN.AstralFlare) &&
+                                    gauge.AttunmentTimerRemaining > 0)
+                                    return OriginalHook(AstralFlow);
+
+                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) &&
+                                    level >= Levels.Bahamut &&
+                                    OriginalHook(Tridisaster) is AstralFlare or BrandOfPurgatory &&
+                                    gauge.SummonTimerRemaining > 0)
+                                    return OriginalHook(EnkindleBahamut);
+                            }
+
+                            //Demi Nuke 2: Electric Boogaloo
+                            if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption))
+                            {
+                                if (IsOffCooldown(OriginalHook(AstralFlow)) &&
+                                    OriginalHook(Tridisaster) is SMN.BrandOfPurgatory)
+                                    return OriginalHook(AstralFlow);
+                            }
+                        }
+
+
+
+                        //Demi
+                        if (IsEnabled(CustomComboPreset.SummonerDemiAoESummonsFeature))
+                        {
+                            if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
+                                (level >= Levels.Aethercharge && level < Levels.Bahamut || //Pre Bahamut Phase
+                                gauge.IsBahamutReady && level >= Levels.Bahamut || //Bahamut Phase
+                                gauge.IsPhoenixReady && level >= Levels.Phoenix) && //Phoenix Phase
+                                !gauge.IsIfritReady &&
+                                !gauge.IsTitanReady &&
+                                !gauge.IsGarudaReady)
+                                return OriginalHook(Aethercharge);
+
+                        }
+
+
+                        // Egis
+                        if (IsEnabled(CustomComboPreset.EgisOnAOEFeature))
+                        {
+                            if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
+                                IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazCata && CanSpellWeave(actionID) || //Titan
+                                IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
+                                return OriginalHook(AstralFlow);
+
+                            if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0)
+                            {
+                                if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
+                                    return OriginalHook(SummonTopaz);
+                                if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
+                                    return OriginalHook(SummonEmerald);
+                                if (gauge.IsIfritReady && level >= Levels.SummonRuby)
+                                    return OriginalHook(SummonRuby);
+                            }
+                        }
+
+                        //Precious Brilliance
+                        if (IsEnabled(CustomComboPreset.SummonerEgiAttacksAOEFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
+                            return OriginalHook(PreciousBrilliance);
+
+
+
+                        if (IsEnabled(CustomComboPreset.SummonerRuin4ToTridisasterFeature) && level >= Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                            return Ruin4;
+                    }
+                }
+
+                return actionID;
+            }
         }
-    }
 
-    internal class SummonerAstralFlowonSummonsFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset => CustomComboPreset.SummonerAstralFlowonSummonsFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class SummonerCarbuncleSummonFeature : CustomCombo
         {
-            var gauge = GetJobGauge<SMNGauge>();
-            if (actionID is SMN.SummonEmerald or SMN.SummonRuby or SMN.SummonTopaz or SMN.SummonIfrit or SMN.SummonTitan or SMN.SummonGaruda or SMN.SummonIfrit2 or SMN.SummonTitan2 or SMN.SummonGaruda2)
-            {
-                if (HasEffect(SMN.Buffs.TitansFavor) || HasEffect(SMN.Buffs.GarudasFavor) || HasEffect(SMN.Buffs.IfritsFavor) || lastComboMove == SMN.CrimsonCyclone)
-                    return OriginalHook(SMN.AstralFlow);
-            }
+            protected internal override CustomComboPreset Preset => CustomComboPreset.SummonerCarbuncleSummonFeature;
 
-            return actionID;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var gauge = GetJobGauge<SMNGauge>();
+                if (actionID is Ruin or Ruin2 or Ruin3 or DreadwyrmTrance or AstralFlow or EnkindleBahamut or SearingLight or RadiantAegis or Outburst or Tridisaster or PreciousBrilliance or Gemshine)
+                {
+                    if (!HasPetPresent() && gauge.SummonTimerRemaining == 0 && gauge.Attunement == 0)
+                        return SummonCarbuncle;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class SummonerAstralFlowonSummonsFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset => CustomComboPreset.SummonerAstralFlowonSummonsFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var gauge = GetJobGauge<SMNGauge>();
+                if (actionID is SummonEmerald or SummonRuby or SummonTopaz or SummonIfrit or SummonTitan or SummonGaruda or SummonIfrit2 or SummonTitan2 or SummonGaruda2)
+                {
+                    if (HasEffect(Buffs.TitansFavor) || HasEffect(Buffs.GarudasFavor) || HasEffect(Buffs.IfritsFavor) || lastComboMove == CrimsonCyclone)
+                        return OriginalHook(AstralFlow);
+                }
+
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -77,247 +77,248 @@ namespace XIVSlothComboPlugin.Combos
                 WarSurgingRefreshRange = "WarSurgingRefreshRange",
                 WarKeepOnslaughtCharges = "WarKeepOnslaughtCharges";
         }
-    }
 
-    // Replace Storm's Path with Storm's Path combo and overcap feature on main combo to fellcleave
-    internal class WarriorStormsPathCombo : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorStormsPathCombo;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        // Replace Storm's Path with Storm's Path combo and overcap feature on main combo to fellcleave
+        internal class WarriorStormsPathCombo : CustomCombo
         {
-            if (IsEnabled(CustomComboPreset.WarriorStormsPathCombo) && actionID == WAR.StormsPath)
-            {
-                var gauge = GetJobGauge<WARGauge>().BeastGauge;
-                var surgingThreshold = Service.Configuration.GetCustomIntValue(WAR.Config.WarSurgingRefreshRange);
-                var onslaughtChargesRemaining = Service.Configuration.GetCustomIntValue(WAR.Config.WarKeepOnslaughtCharges);
-
-                if (IsEnabled(CustomComboPreset.WARRangedUptimeFeature) && level >= WAR.Levels.Tomahawk)
-                {
-                    if (!InMeleeRange())
-                        return WAR.Tomahawk;
-                }
-
-                if (IsEnabled(CustomComboPreset.WarriorInfuriateonST) && level >= WAR.Levels.Infuriate && GetRemainingCharges(WAR.Infuriate) >= 1 && !HasEffect(WAR.Buffs.NascentChaos) && gauge <= 40 && CanWeave(actionID))
-                    return WAR.Infuriate;
-
-                //Sub Storm's Eye level check
-                if (IsEnabled(CustomComboPreset.WarriorIRonST) && CanDelayedWeave(actionID) && IsOffCooldown(OriginalHook(WAR.Berserk)) && level >= WAR.Levels.Berserk && level < WAR.Levels.StormsEye && InCombat())
-                    return OriginalHook(WAR.Berserk);
-
-                if (HasEffect(WAR.Buffs.SurgingTempest) && InCombat())
-                {
-                    if (CanWeave(actionID))
-                    {
-                        if (IsEnabled(CustomComboPreset.WarriorIRonST) && CanDelayedWeave(actionID) && IsOffCooldown(OriginalHook(WAR.Berserk)) && level >= WAR.Levels.Berserk)
-                            return OriginalHook(WAR.Berserk);
-                        if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(WAR.Upheaval) && level >= WAR.Levels.Upheaval)
-                            return WAR.Upheaval;
-                        if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && level >= WAR.Levels.Onslaught && GetRemainingCharges(WAR.Onslaught) > onslaughtChargesRemaining)
-                        {
-                            if (IsNotEnabled(CustomComboPreset.WarriorMeleeOnslaughtOption) ||
-                                (IsEnabled(CustomComboPreset.WarriorMeleeOnslaughtOption) && GetTargetDistance() <= 1))
-                                return WAR.Onslaught;
-                        }
-                    }
-
-                    if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady) && level >= WAR.Levels.PrimalRend)
-                    {
-                        if (IsEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature) && (GetTargetDistance() <= 1 || GetBuffRemainingTime(WAR.Buffs.PrimalRendReady) <= 10))
-                            return WAR.PrimalRend;
-                        if (IsNotEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature))
-                        return WAR.PrimalRend;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && level >= WAR.Levels.InnerBeast)
-                    {
-                        if (gauge >= 50 && (IsOffCooldown(WAR.InnerRelease) || GetCooldownRemainingTime(WAR.InnerRelease) > 35 || HasEffect(WAR.Buffs.NascentChaos)))
-                            return OriginalHook(WAR.InnerBeast);
-                        if (HasEffect(WAR.Buffs.InnerRelease))
-                            return OriginalHook(WAR.InnerBeast);
-                    }
-
-                }
-
-                if (comboTime > 0)
-                {
-                    if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim)
-                    {
-                        if (gauge == 100 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= WAR.Levels.InnerBeast)
-                            return OriginalHook(WAR.InnerBeast);
-                        return WAR.Maim;
-                    }
-
-                    if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsPath)
-                    {
-                        if (IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= WAR.Levels.InnerBeast && (level < WAR.Levels.StormsEye || HasEffectAny(WAR.Buffs.SurgingTempest)) && gauge >= 90)
-                            return OriginalHook(WAR.InnerBeast);
-                        if ((GetBuffRemainingTime(WAR.Buffs.SurgingTempest) <= surgingThreshold) && level >= WAR.Levels.StormsEye)
-                            return WAR.StormsEye;
-                        return WAR.StormsPath;
-                    }
-                }
-
-                return WAR.HeavySwing;
-            }
-
-            return actionID;
-        }
-
-        internal class WarriorStormsEyeCombo : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorStormsEyeCombo;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorStormsPathCombo;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID == WAR.StormsEye)
-                {
-                    if (comboTime > 0)
-                    {
-                        if (lastComboMove == WAR.HeavySwing && level >= WAR.Levels.Maim)
-                            return WAR.Maim;
-
-                        if (lastComboMove == WAR.Maim && level >= WAR.Levels.StormsEye)
-                            return WAR.StormsEye;
-                    }
-
-                    return WAR.HeavySwing;
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class WarriorMythrilTempestCombo : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorMythrilTempestCombo;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID == WAR.Overpower)
+                if (IsEnabled(CustomComboPreset.WarriorStormsPathCombo) && actionID == StormsPath)
                 {
                     var gauge = GetJobGauge<WARGauge>().BeastGauge;
+                    var surgingThreshold = Service.Configuration.GetCustomIntValue(Config.WarSurgingRefreshRange);
+                    var onslaughtChargesRemaining = Service.Configuration.GetCustomIntValue(Config.WarKeepOnslaughtCharges);
 
-                    if (IsEnabled(CustomComboPreset.WarriorInfuriateOnAOE) && level >= WAR.Levels.Infuriate && GetRemainingCharges(WAR.Infuriate) >= 1 && !HasEffect(WAR.Buffs.NascentChaos) && gauge <= 50 && CanWeave(actionID))
-                        return WAR.Infuriate;
+                    if (IsEnabled(CustomComboPreset.WARRangedUptimeFeature) && level >= Levels.Tomahawk)
+                    {
+                        if (!InMeleeRange())
+                            return Tomahawk;
+                    }
 
-                    //Sub Mythril Tempest level check
-                    if (IsEnabled(CustomComboPreset.WarriorIRonAOE) && CanDelayedWeave(actionID) && IsOffCooldown(OriginalHook(WAR.Berserk)) && level >= WAR.Levels.Berserk && level < WAR.Levels.MythrilTempest && InCombat())
-                        return OriginalHook(WAR.Berserk);
+                    if (IsEnabled(CustomComboPreset.WarriorInfuriateonST) && level >= Levels.Infuriate && GetRemainingCharges(Infuriate) >= 1 && !HasEffect(Buffs.NascentChaos) && gauge <= 40 && CanWeave(actionID))
+                        return Infuriate;
 
-                    if (HasEffect(WAR.Buffs.SurgingTempest) && InCombat())
+                    //Sub Storm's Eye level check
+                    if (IsEnabled(CustomComboPreset.WarriorIRonST) && CanDelayedWeave(actionID) && IsOffCooldown(OriginalHook(Berserk)) && level >= Levels.Berserk && level < Levels.StormsEye && InCombat())
+                        return OriginalHook(Berserk);
+
+                    if (HasEffect(Buffs.SurgingTempest) && InCombat())
                     {
                         if (CanWeave(actionID))
                         {
-                            if (IsEnabled(CustomComboPreset.WarriorIRonAOE) && CanDelayedWeave(actionID) && IsOffCooldown(OriginalHook(WAR.Berserk)) && level >= WAR.Levels.Berserk)
-                                return OriginalHook(WAR.Berserk);
-                            if (IsEnabled(CustomComboPreset.WarriorOrogenyFeature) && IsOffCooldown(WAR.Orogeny) && level >= WAR.Levels.Orogeny && HasEffect(WAR.Buffs.SurgingTempest))
-                                return WAR.Orogeny;
+                            if (IsEnabled(CustomComboPreset.WarriorIRonST) && CanDelayedWeave(actionID) && IsOffCooldown(OriginalHook(Berserk)) && level >= Levels.Berserk)
+                                return OriginalHook(Berserk);
+                            if (IsEnabled(CustomComboPreset.WarriorUpheavalMainComboFeature) && IsOffCooldown(Upheaval) && level >= Levels.Upheaval)
+                                return Upheaval;
+                            if (IsEnabled(CustomComboPreset.WarriorOnslaughtFeature) && level >= Levels.Onslaught && GetRemainingCharges(Onslaught) > onslaughtChargesRemaining)
+                            {
+                                if (IsNotEnabled(CustomComboPreset.WarriorMeleeOnslaughtOption) ||
+                                    (IsEnabled(CustomComboPreset.WarriorMeleeOnslaughtOption) && GetTargetDistance() <= 1))
+                                    return Onslaught;
+                            }
                         }
 
-                        if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(WAR.Buffs.PrimalRendReady) && level >= WAR.Levels.PrimalRend)
+                        if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(Buffs.PrimalRendReady) && level >= Levels.PrimalRend)
                         {
-                            if (IsEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature) && (GetTargetDistance() <= 3 || GetBuffRemainingTime(WAR.Buffs.PrimalRendReady) <= 10))
-                                return WAR.PrimalRend;
+                            if (IsEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature) && (GetTargetDistance() <= 1 || GetBuffRemainingTime(Buffs.PrimalRendReady) <= 10))
+                                return PrimalRend;
                             if (IsNotEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature))
-                                return WAR.PrimalRend;
+                                return PrimalRend;
                         }
 
-                        if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && level >= WAR.Levels.SteelCyclone && (gauge >= 50 || HasEffect(WAR.Buffs.InnerRelease)))
-                            return OriginalHook(WAR.SteelCyclone);
+                        if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && level >= Levels.InnerBeast)
+                        {
+                            if (gauge >= 50 && (IsOffCooldown(InnerRelease) || GetCooldownRemainingTime(InnerRelease) > 35 || HasEffect(Buffs.NascentChaos)))
+                                return OriginalHook(InnerBeast);
+                            if (HasEffect(Buffs.InnerRelease))
+                                return OriginalHook(InnerBeast);
+                        }
+
                     }
 
                     if (comboTime > 0)
                     {
-                        if (lastComboMove == WAR.Overpower && level >= WAR.Levels.MythrilTempest)
+                        if (lastComboMove == HeavySwing && level >= Levels.Maim)
                         {
-                            if (IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && gauge >= 90 && level >= WAR.Levels.SteelCyclone)
-                                return OriginalHook(WAR.SteelCyclone);
-                            return WAR.MythrilTempest;
+                            if (gauge == 100 && IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= Levels.InnerBeast)
+                                return OriginalHook(InnerBeast);
+                            return Maim;
+                        }
+
+                        if (lastComboMove == Maim && level >= Levels.StormsPath)
+                        {
+                            if (IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && level >= Levels.InnerBeast && (level < Levels.StormsEye || HasEffectAny(Buffs.SurgingTempest)) && gauge >= 90)
+                                return OriginalHook(InnerBeast);
+                            if ((GetBuffRemainingTime(Buffs.SurgingTempest) <= surgingThreshold) && level >= Levels.StormsEye)
+                                return StormsEye;
+                            return StormsPath;
                         }
                     }
 
-                    return WAR.Overpower;
+                    return HeavySwing;
                 }
 
                 return actionID;
             }
+
+            internal class WarriorStormsEyeCombo : CustomCombo
+            {
+                protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorStormsEyeCombo;
+
+                protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+                {
+                    if (actionID == StormsEye)
+                    {
+                        if (comboTime > 0)
+                        {
+                            if (lastComboMove == HeavySwing && level >= Levels.Maim)
+                                return Maim;
+
+                            if (lastComboMove == Maim && level >= Levels.StormsEye)
+                                return StormsEye;
+                        }
+
+                        return HeavySwing;
+                    }
+
+                    return actionID;
+                }
+            }
+
+            internal class WarriorMythrilTempestCombo : CustomCombo
+            {
+                protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorMythrilTempestCombo;
+
+                protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+                {
+                    if (actionID == Overpower)
+                    {
+                        var gauge = GetJobGauge<WARGauge>().BeastGauge;
+
+                        if (IsEnabled(CustomComboPreset.WarriorInfuriateOnAOE) && level >= Levels.Infuriate && GetRemainingCharges(Infuriate) >= 1 && !HasEffect(Buffs.NascentChaos) && gauge <= 50 && CanWeave(actionID))
+                            return Infuriate;
+
+                        //Sub Mythril Tempest level check
+                        if (IsEnabled(CustomComboPreset.WarriorIRonAOE) && CanDelayedWeave(actionID) && IsOffCooldown(OriginalHook(Berserk)) && level >= Levels.Berserk && level < Levels.MythrilTempest && InCombat())
+                            return OriginalHook(Berserk);
+
+                        if (HasEffect(Buffs.SurgingTempest) && InCombat())
+                        {
+                            if (CanWeave(actionID))
+                            {
+                                if (IsEnabled(CustomComboPreset.WarriorIRonAOE) && CanDelayedWeave(actionID) && IsOffCooldown(OriginalHook(Berserk)) && level >= Levels.Berserk)
+                                    return OriginalHook(Berserk);
+                                if (IsEnabled(CustomComboPreset.WarriorOrogenyFeature) && IsOffCooldown(Orogeny) && level >= Levels.Orogeny && HasEffect(Buffs.SurgingTempest))
+                                    return Orogeny;
+                            }
+
+                            if (IsEnabled(CustomComboPreset.WarriorPrimalRendFeature) && HasEffect(Buffs.PrimalRendReady) && level >= Levels.PrimalRend)
+                            {
+                                if (IsEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature) && (GetTargetDistance() <= 3 || GetBuffRemainingTime(Buffs.PrimalRendReady) <= 10))
+                                    return PrimalRend;
+                                if (IsNotEnabled(CustomComboPreset.WarriorPrimalRendCloseRangeFeature))
+                                    return PrimalRend;
+                            }
+
+                            if (IsEnabled(CustomComboPreset.WarriorSpenderOption) && level >= Levels.SteelCyclone && (gauge >= 50 || HasEffect(Buffs.InnerRelease)))
+                                return OriginalHook(SteelCyclone);
+                        }
+
+                        if (comboTime > 0)
+                        {
+                            if (lastComboMove == Overpower && level >= Levels.MythrilTempest)
+                            {
+                                if (IsEnabled(CustomComboPreset.WarriorGaugeOvercapFeature) && gauge >= 90 && level >= Levels.SteelCyclone)
+                                    return OriginalHook(SteelCyclone);
+                                return MythrilTempest;
+                            }
+                        }
+
+                        return Overpower;
+                    }
+
+                    return actionID;
+                }
+            }
+
+            internal class WarriorNascentFlashFeature : CustomCombo
+            {
+                protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorNascentFlashFeature;
+
+                protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+                {
+                    if (actionID == NascentFlash)
+                    {
+                        if (level >= Levels.NascentFlash)
+                            return NascentFlash;
+                        return RawIntuition;
+                    }
+
+                    return actionID;
+                }
+            }
         }
 
-        internal class WarriorNascentFlashFeature : CustomCombo
+        internal class WarriorPrimalRendFeature : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorNascentFlashFeature;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorPrimalRendFeature;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID == WAR.NascentFlash)
+                if (actionID == InnerBeast || actionID == SteelCyclone)
                 {
-                    if (level >= WAR.Levels.NascentFlash)
-                        return WAR.NascentFlash;
-                    return WAR.RawIntuition;
+
+                    if (level >= Levels.PrimalRend && HasEffect(Buffs.PrimalRendReady))
+                        return PrimalRend;
+
+                    // Fell Cleave or Decimate
+                    return OriginalHook(actionID);
+
+
                 }
 
                 return actionID;
             }
         }
-    }
 
-    internal class WarriorPrimalRendFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorPrimalRendFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class WarriorInfuriateFellCleave : CustomCombo
         {
-            if (actionID == WAR.InnerBeast || actionID == WAR.SteelCyclone)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorInfuriateFellCleave;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
+                if (actionID is InnerBeast or FellCleave or SteelCyclone or Decimate)
+                {
+                    var rageGauge = GetJobGauge<WARGauge>();
+                    var rageThreshold = Service.Configuration.GetCustomIntValue(Config.WarInfuriateRange);
+                    var hasNascent = HasEffect(Buffs.NascentChaos);
+                    var hasInnerRelease = HasEffect(Buffs.InnerRelease);
 
-                if (level >= WAR.Levels.PrimalRend && HasEffect(WAR.Buffs.PrimalRendReady))
-                    return WAR.PrimalRend;
-
-                // Fell Cleave or Decimate
-                return OriginalHook(actionID);
-
-
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class WarriorInfuriateFellCleave : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorInfuriateFellCleave;
-
-        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
-        {
-            if (actionID is WAR.InnerBeast or WAR.FellCleave or WAR.SteelCyclone or WAR.Decimate)
-            {
-                var rageGauge = GetJobGauge<WARGauge>();
-                var rageThreshold = Service.Configuration.GetCustomIntValue(WAR.Config.WarInfuriateRange);
-                var hasNascent = HasEffect(WAR.Buffs.NascentChaos);
-                var hasInnerRelease = HasEffect(WAR.Buffs.InnerRelease);
-
-                    if (InCombat() && rageGauge.BeastGauge <= rageThreshold && GetCooldown(WAR.Infuriate).RemainingCharges > 0 && !hasNascent && level >= WAR.Levels.Infuriate
+                    if (InCombat() && rageGauge.BeastGauge <= rageThreshold && GetCooldown(Infuriate).RemainingCharges > 0 && !hasNascent && level >= Levels.Infuriate
                     && ((!hasInnerRelease) || IsNotEnabled(CustomComboPreset.WarriorUseInnerReleaseFirst)))
-                        return OriginalHook(WAR.Infuriate);
-            }
+                        return OriginalHook(Infuriate);
+                }
 
-            return actionID;
+                return actionID;
+            }
         }
-    }
-    internal class WarriorPrimalRendOnInnerRelease : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorPrimalRendOnInnerRelease;
-
-        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        internal class WarriorPrimalRendOnInnerRelease : CustomCombo
         {
-            if (actionID is WAR.Berserk or WAR.InnerRelease)
-            {
-                if (level >= WAR.Levels.PrimalRend && HasEffect(WAR.Buffs.PrimalRendReady))
-                    return WAR.PrimalRend;
-            }
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WarriorPrimalRendOnInnerRelease;
 
-            return actionID;
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+            {
+                if (actionID is Berserk or InnerRelease)
+                {
+                    if (level >= Levels.PrimalRend && HasEffect(Buffs.PrimalRendReady))
+                        return PrimalRend;
+                }
+
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/Combos/WHM.cs
+++ b/XIVSlothCombo/Combos/WHM.cs
@@ -83,242 +83,243 @@ namespace XIVSlothComboPlugin.Combos
                 WHMLucidDreamingFeature = "WHMLucidDreamingFeature",
                 WHMogcdHealsShieldsFeature = "WHMogcdHealsShieldsFeature";
         }
-    }
 
-    internal class WhiteMageSolaceMiseryFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WhiteMageSolaceMiseryFeature;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class WhiteMageSolaceMiseryFeature : CustomCombo
         {
-            if (actionID == WHM.AfflatusSolace)
-            {
-                var gauge = GetJobGauge<WHMGauge>();
-
-                if (gauge.BloodLily == 3)
-                    return WHM.AfflatusMisery;
-
-            }
-            return actionID;
-        }
-    }
-
-    internal class WhiteMageRaptureMiseryFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WhiteMageRaptureMiseryFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == WHM.AfflatusRapture)
-            {
-                var gauge = GetJobGauge<WHMGauge>();
-
-                if (gauge.BloodLily == 3)
-                    return WHM.AfflatusMisery;
-
-            }
-            return actionID;
-        }
-    }
-
-    internal class WhiteMageCureFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WhiteMageCureFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            if (actionID == WHM.Cure2)
-            {
-                if (level < WHM.Levels.Cure2)
-                    return WHM.Cure;
-            }
-
-            return actionID;
-        }
-    }
-
-    internal class WhiteMageAfflatusFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WhiteMageAfflatusFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-        {
-            var gauge = GetJobGauge<WHMGauge>();
-            var tetraHP = Service.Configuration.GetCustomIntValue(WHM.Config.WHMogcdHealsShieldsFeature);
-
-
-            if (actionID == WHM.Cure2)
-            {
-                if (IsEnabled(CustomComboPreset.WHMPrioritizeoGCDHealsShields) && IsEnabled(CustomComboPreset.WHMBenisonGCDOption) //Is the priority option enabled
-                    && level >= WHM.Levels.DivineBenison && !TargetHasEffectAny(WHM.Buffs.DivineBenison) && HasCharges(WHM.DivineBenison) //Can I use Divine Benison
-                     && (GetCooldown(WHM.DivineBenison).RemainingCharges == 2 || GetCooldown(WHM.DivineBenison).ChargeCooldownRemaining <= 29)) //Did I just use Divine Benison
-                    return actionID;
-                if (IsEnabled(CustomComboPreset.WHMPrioritizeoGCDHealsShields) && IsEnabled(CustomComboPreset.WHMTetraOnGCDOption)
-                    && IsOffCooldown(WHM.Tetragrammaton) && level >= WHM.Levels.Tetragrammaton && EnemyHealthPercentage() <= tetraHP)
-                    return actionID;
-                else if (IsEnabled(CustomComboPreset.WhiteMageAfflatusMiseryCure2Feature) && gauge.BloodLily == 3)
-                    return WHM.AfflatusMisery;
-                if (level >= WHM.Levels.AfflatusSolace && gauge.Lily > 0)
-                    return WHM.AfflatusSolace;
-
-                return actionID;
-            }
-
-            if (actionID == WHM.Medica)
-            {
-                if (level >= WHM.Levels.AfflatusRapture && gauge.Lily > 0)
-                    return WHM.AfflatusRapture;
-
-                return actionID;
-            }
-
-            return actionID;
-        }
-
-        internal class WHMRaiseFeature : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHMRaiseFeature;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WhiteMageSolaceMiseryFeature;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID == All.Swiftcast)
+                if (actionID == AfflatusSolace)
                 {
-                    var thinairCD = GetCooldown(WHM.ThinAir);
-                    var hasThinAirBuff = HasEffect(WHM.Buffs.ThinAir);
-
-                    if (IsEnabled(CustomComboPreset.WHMThinAirFeature) && thinairCD.RemainingCharges > 0 && HasEffect(All.Buffs.Swiftcast) && !hasThinAirBuff && level >= WHM.Levels.ThinAir)
-                        return WHM.ThinAir;
-                    if (HasEffect(All.Buffs.Swiftcast))
-                        return WHM.Raise;
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class WHMCDsonMainComboGroup : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHMCDsonMainComboGroup;
-            internal static uint glare3Count = 0;
-            internal static bool usedGlare3 = false;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID == WHM.Glare3 || actionID == WHM.Glare1 || actionID == WHM.Stone1 || actionID == WHM.Stone2 || actionID == WHM.Stone3 || actionID == WHM.Stone4)
-                {
-                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                    var diaDebuff = FindTargetEffect(WHM.Debuffs.Dia);
-                    var aero1Debuff = FindTargetEffect(WHM.Debuffs.Aero);
-                    var aero2Debuff = FindTargetEffect(WHM.Debuffs.Aero2);
-                    var lucidThreshold = Service.Configuration.GetCustomIntValue(WHM.Config.WHMLucidDreamingFeature);
                     var gauge = GetJobGauge<WHMGauge>();
 
-                    //WHM_NO_SWIFT_OPENER_MACHINE
-                    //COUNTER_RESET
-                    if (!inCombat) glare3Count = 0; // Resets counter
-                    //CHECK_GLARE3_USE
-                    if (inCombat && usedGlare3 == false && lastComboMove == WHM.Glare3 && GetCooldownRemainingTime(WHM.Glare3) > 1)
-                    {
-                        usedGlare3 = true; // Registers that Glare3 was used and blocks further incrementation of glare3Count
-                        glare3Count++; // Increments Glare3 counter
-                    }
-                    //CHECK_GLARE3_USE_RESET
-                    if (usedGlare3 == true && GetCooldownRemainingTime(WHM.Glare3) < 1) usedGlare3 = false; // Resets block to allow CHECK_GLARE3_USE
-                    //BYPASS_COUNTER_WHEN_DISABLED
-                    if (IsNotEnabled(CustomComboPreset.WHMNoSwiftOpenerOption) || level < WHM.Levels.Glare3) glare3Count = 3;
+                    if (gauge.BloodLily == 3)
+                        return AfflatusMisery;
 
-                    if (CanSpellWeave(actionID) && glare3Count >= 3)
-                    {
-                        if (IsEnabled(CustomComboPreset.WHMPresenceOfMindFeature) && level >= WHM.Levels.PresenceOfMind && IsOffCooldown(WHM.PresenceOfMind))
-                            return WHM.PresenceOfMind;
-                        if (IsEnabled(CustomComboPreset.WHMAssizeFeature) && level >= WHM.Levels.Assize && IsOffCooldown(WHM.Assize))
-                            return WHM.Assize;
-                        if (IsEnabled(CustomComboPreset.WHMLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
-                            return All.LucidDreaming;
-                    }
-
-                    if (IsEnabled(CustomComboPreset.WHMDotMainComboFeature) && inCombat)
-                    {
-                        if (level >= WHM.Levels.Aero1 && level < WHM.Levels.Aero2)
-                        {
-                            if ((aero1Debuff is null) || (aero1Debuff.RemainingTime <= 3))
-                                return WHM.Aero1;
-                        }
-
-                        if (level >= WHM.Levels.Aero2 && level < WHM.Levels.Dia)
-                        {
-                            if ((aero2Debuff is null) || (aero2Debuff.RemainingTime <= 3))
-                                return WHM.Aero2;
-                        }
-
-                        if (level >= WHM.Levels.Dia)
-                        {
-                            if ((diaDebuff is null) || (diaDebuff.RemainingTime <= 3))
-                                return WHM.Dia;
-                        }
-                    }
-
-                    if (IsEnabled(CustomComboPreset.WHMLilyOvercapFeature) && level >= WHM.Levels.AfflatusRapture && ((gauge.Lily == 3) || (gauge.Lily == 2 && gauge.LilyTimer >= 17000)))
-                                return WHM.AfflatusRapture;
-
-                    if (IsEnabled(CustomComboPreset.WHMAfflatusMiseryOGCDFeature) && level >= WHM.Levels.AfflatusMisery && gauge.BloodLily >= 3 && glare3Count >= 3)
-                                return WHM.AfflatusMisery;
                 }
-
                 return actionID;
             }
         }
 
-        internal class WHMMedicaFeature : CustomCombo
+        internal class WhiteMageRaptureMiseryFeature : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHMMedicaFeature;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WhiteMageRaptureMiseryFeature;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID == WHM.Medica2)
+                if (actionID == AfflatusRapture)
                 {
                     var gauge = GetJobGauge<WHMGauge>();
-                    var medica2Buff = FindEffect(WHM.Buffs.Medica2);
-                    if (level < WHM.Levels.Medica2)
-                        return WHM.Medica1;
-                    if (IsEnabled(CustomComboPreset.WhiteMageAfflatusMiseryMedicaFeature) && gauge.BloodLily == 3)
-                        return WHM.AfflatusMisery;
-                    if (IsEnabled(CustomComboPreset.WhiteMageAfflatusRaptureMedicaFeature) && level >= WHM.Levels.AfflatusRapture && gauge.Lily > 0 && medica2Buff.RemainingTime > 2)
-                        return WHM.AfflatusRapture;
-                    if (HasEffect(WHM.Buffs.Medica2) && medica2Buff.RemainingTime > 2)
-                        return WHM.Medica1;
+
+                    if (gauge.BloodLily == 3)
+                        return AfflatusMisery;
+
+                }
+                return actionID;
+            }
+        }
+
+        internal class WhiteMageCureFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WhiteMageCureFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID == Cure2)
+                {
+                    if (level < Levels.Cure2)
+                        return Cure;
                 }
 
                 return actionID;
             }
         }
 
-    }
-
-    internal class WHMogcdHealsShieldsFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHMogcdHealsShieldsFeature;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class WhiteMageAfflatusFeature : CustomCombo
         {
-            var tetraHP = Service.Configuration.GetCustomIntValue(WHM.Config.WHMogcdHealsShieldsFeature);
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WhiteMageAfflatusFeature;
 
-            if (actionID == WHM.Cure2)
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (level >= WHM.Levels.DivineBenison && HasCharges(WHM.DivineBenison) && !TargetHasEffectAny(WHM.Buffs.DivineBenison)
-                    && (GetCooldown(WHM.DivineBenison).RemainingCharges == 2 || GetCooldown(WHM.DivineBenison).ChargeCooldownRemaining <= 29))
+                var gauge = GetJobGauge<WHMGauge>();
+                var tetraHP = Service.Configuration.GetCustomIntValue(Config.WHMogcdHealsShieldsFeature);
+
+
+                if (actionID == Cure2)
                 {
-                    if (IsEnabled(CustomComboPreset.WHMBenisonOGCDOption) && CanSpellWeave(actionID)) { return WHM.DivineBenison; }
-                    if (IsEnabled(CustomComboPreset.WHMBenisonGCDOption)) { return WHM.DivineBenison; }
+                    if (IsEnabled(CustomComboPreset.WHMPrioritizeoGCDHealsShields) && IsEnabled(CustomComboPreset.WHMBenisonGCDOption) //Is the priority option enabled
+                        && level >= Levels.DivineBenison && !TargetHasEffectAny(Buffs.DivineBenison) && HasCharges(DivineBenison) //Can I use Divine Benison
+                         && (GetCooldown(DivineBenison).RemainingCharges == 2 || GetCooldown(DivineBenison).ChargeCooldownRemaining <= 29)) //Did I just use Divine Benison
+                        return actionID;
+                    if (IsEnabled(CustomComboPreset.WHMPrioritizeoGCDHealsShields) && IsEnabled(CustomComboPreset.WHMTetraOnGCDOption)
+                        && IsOffCooldown(Tetragrammaton) && level >= Levels.Tetragrammaton && EnemyHealthPercentage() <= tetraHP)
+                        return actionID;
+                    else if (IsEnabled(CustomComboPreset.WhiteMageAfflatusMiseryCure2Feature) && gauge.BloodLily == 3)
+                        return AfflatusMisery;
+                    if (level >= Levels.AfflatusSolace && gauge.Lily > 0)
+                        return AfflatusSolace;
+
+                    return actionID;
                 }
-                if (level >= WHM.Levels.Tetragrammaton && IsOffCooldown(WHM.Tetragrammaton) && EnemyHealthPercentage() <= tetraHP)
+
+                if (actionID == Medica)
                 {
-                    if (IsEnabled(CustomComboPreset.WHMTetraOnOGCDOption) && CanSpellWeave(actionID)) { return WHM.Tetragrammaton; }
-                    if (IsEnabled(CustomComboPreset.WHMTetraOnGCDOption)) { return WHM.Tetragrammaton; }
+                    if (level >= Levels.AfflatusRapture && gauge.Lily > 0)
+                        return AfflatusRapture;
+
+                    return actionID;
+                }
+
+                return actionID;
+            }
+
+            internal class WHMRaiseFeature : CustomCombo
+            {
+                protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHMRaiseFeature;
+
+                protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+                {
+                    if (actionID == All.Swiftcast)
+                    {
+                        var thinairCD = GetCooldown(ThinAir);
+                        var hasThinAirBuff = HasEffect(Buffs.ThinAir);
+
+                        if (IsEnabled(CustomComboPreset.WHMThinAirFeature) && thinairCD.RemainingCharges > 0 && HasEffect(All.Buffs.Swiftcast) && !hasThinAirBuff && level >= Levels.ThinAir)
+                            return ThinAir;
+                        if (HasEffect(All.Buffs.Swiftcast))
+                            return Raise;
+                    }
+
+                    return actionID;
                 }
             }
 
-            return actionID;
+            internal class WHMCDsonMainComboGroup : CustomCombo
+            {
+                protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHMCDsonMainComboGroup;
+                internal static uint glare3Count = 0;
+                internal static bool usedGlare3 = false;
+
+                protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+                {
+                    if (actionID == Glare3 || actionID == Glare1 || actionID == Stone1 || actionID == Stone2 || actionID == Stone3 || actionID == Stone4)
+                    {
+                        var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                        var diaDebuff = FindTargetEffect(Debuffs.Dia);
+                        var aero1Debuff = FindTargetEffect(Debuffs.Aero);
+                        var aero2Debuff = FindTargetEffect(Debuffs.Aero2);
+                        var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.WHMLucidDreamingFeature);
+                        var gauge = GetJobGauge<WHMGauge>();
+
+                        //WHM_NO_SWIFT_OPENER_MACHINE
+                        //COUNTER_RESET
+                        if (!inCombat) glare3Count = 0; // Resets counter
+                                                        //CHECK_GLARE3_USE
+                        if (inCombat && usedGlare3 == false && lastComboMove == Glare3 && GetCooldownRemainingTime(Glare3) > 1)
+                        {
+                            usedGlare3 = true; // Registers that Glare3 was used and blocks further incrementation of glare3Count
+                            glare3Count++; // Increments Glare3 counter
+                        }
+                        //CHECK_GLARE3_USE_RESET
+                        if (usedGlare3 == true && GetCooldownRemainingTime(Glare3) < 1) usedGlare3 = false; // Resets block to allow CHECK_GLARE3_USE
+                                                                                                                //BYPASS_COUNTER_WHEN_DISABLED
+                        if (IsNotEnabled(CustomComboPreset.WHMNoSwiftOpenerOption) || level < Levels.Glare3) glare3Count = 3;
+
+                        if (CanSpellWeave(actionID) && glare3Count >= 3)
+                        {
+                            if (IsEnabled(CustomComboPreset.WHMPresenceOfMindFeature) && level >= Levels.PresenceOfMind && IsOffCooldown(PresenceOfMind))
+                                return PresenceOfMind;
+                            if (IsEnabled(CustomComboPreset.WHMAssizeFeature) && level >= Levels.Assize && IsOffCooldown(Assize))
+                                return Assize;
+                            if (IsEnabled(CustomComboPreset.WHMLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
+                                return All.LucidDreaming;
+                        }
+
+                        if (IsEnabled(CustomComboPreset.WHMDotMainComboFeature) && inCombat)
+                        {
+                            if (level >= Levels.Aero1 && level < Levels.Aero2)
+                            {
+                                if ((aero1Debuff is null) || (aero1Debuff.RemainingTime <= 3))
+                                    return Aero1;
+                            }
+
+                            if (level >= Levels.Aero2 && level < Levels.Dia)
+                            {
+                                if ((aero2Debuff is null) || (aero2Debuff.RemainingTime <= 3))
+                                    return Aero2;
+                            }
+
+                            if (level >= Levels.Dia)
+                            {
+                                if ((diaDebuff is null) || (diaDebuff.RemainingTime <= 3))
+                                    return Dia;
+                            }
+                        }
+
+                        if (IsEnabled(CustomComboPreset.WHMLilyOvercapFeature) && level >= Levels.AfflatusRapture && ((gauge.Lily == 3) || (gauge.Lily == 2 && gauge.LilyTimer >= 17000)))
+                            return AfflatusRapture;
+
+                        if (IsEnabled(CustomComboPreset.WHMAfflatusMiseryOGCDFeature) && level >= Levels.AfflatusMisery && gauge.BloodLily >= 3 && glare3Count >= 3)
+                            return AfflatusMisery;
+                    }
+
+                    return actionID;
+                }
+            }
+
+            internal class WHMMedicaFeature : CustomCombo
+            {
+                protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHMMedicaFeature;
+
+                protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+                {
+                    if (actionID == Medica2)
+                    {
+                        var gauge = GetJobGauge<WHMGauge>();
+                        var medica2Buff = FindEffect(Buffs.Medica2);
+                        if (level < Levels.Medica2)
+                            return Medica1;
+                        if (IsEnabled(CustomComboPreset.WhiteMageAfflatusMiseryMedicaFeature) && gauge.BloodLily == 3)
+                            return AfflatusMisery;
+                        if (IsEnabled(CustomComboPreset.WhiteMageAfflatusRaptureMedicaFeature) && level >= Levels.AfflatusRapture && gauge.Lily > 0 && medica2Buff.RemainingTime > 2)
+                            return AfflatusRapture;
+                        if (HasEffect(Buffs.Medica2) && medica2Buff.RemainingTime > 2)
+                            return Medica1;
+                    }
+
+                    return actionID;
+                }
+            }
+
+        }
+
+        internal class WHMogcdHealsShieldsFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHMogcdHealsShieldsFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var tetraHP = Service.Configuration.GetCustomIntValue(Config.WHMogcdHealsShieldsFeature);
+
+                if (actionID == Cure2)
+                {
+                    if (level >= Levels.DivineBenison && HasCharges(DivineBenison) && !TargetHasEffectAny(Buffs.DivineBenison)
+                        && (GetCooldown(DivineBenison).RemainingCharges == 2 || GetCooldown(DivineBenison).ChargeCooldownRemaining <= 29))
+                    {
+                        if (IsEnabled(CustomComboPreset.WHMBenisonOGCDOption) && CanSpellWeave(actionID)) { return DivineBenison; }
+                        if (IsEnabled(CustomComboPreset.WHMBenisonGCDOption)) { return DivineBenison; }
+                    }
+                    if (level >= Levels.Tetragrammaton && IsOffCooldown(Tetragrammaton) && EnemyHealthPercentage() <= tetraHP)
+                    {
+                        if (IsEnabled(CustomComboPreset.WHMTetraOnOGCDOption) && CanSpellWeave(actionID)) { return Tetragrammaton; }
+                        if (IsEnabled(CustomComboPreset.WHMTetraOnGCDOption)) { return Tetragrammaton; }
+                    }
+                }
+
+                return actionID;
+            }
         }
     }
 

--- a/XIVSlothCombo/CombosPVP/BRDPVP.cs
+++ b/XIVSlothCombo/CombosPVP/BRDPVP.cs
@@ -32,30 +32,30 @@ namespace XIVSlothComboPlugin.Combos
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 
-                if (actionID == BRDPvP.PowerfulShot)
+                if (actionID == PowerfulShot)
                 {
                     var canWeave = CanWeave(actionID, 0.5);
                     //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
                     if (canWeave)
                     {
-                        if (GetCooldown(BRDPvP.EmpyrealArrow).RemainingCharges == 3)
-                            return OriginalHook(BRDPvP.EmpyrealArrow);
+                        if (GetCooldown(EmpyrealArrow).RemainingCharges == 3)
+                            return OriginalHook(EmpyrealArrow);
 
-                        if (!GetCooldown(BRDPvP.SilentNocturne).IsCooldown)
-                            return OriginalHook(BRDPvP.SilentNocturne);
+                        if (!GetCooldown(SilentNocturne).IsCooldown)
+                            return OriginalHook(SilentNocturne);
                     }
 
-                    if (HasEffect(BRDPvP.Buffs.BlastArrowReady))
-                        return OriginalHook(BRDPvP.BlastArrow);
+                    if (HasEffect(Buffs.BlastArrowReady))
+                        return OriginalHook(BlastArrow);
 
-                    if (HasEffect(BRDPvP.Buffs.Repertoire))
-                        return OriginalHook(BRDPvP.PowerfulShot);
+                    if (HasEffect(Buffs.Repertoire))
+                        return OriginalHook(PowerfulShot);
 
-                    if (!GetCooldown(BRDPvP.ApexArrow).IsCooldown)
-                        return OriginalHook(BRDPvP.ApexArrow);
+                    if (!GetCooldown(ApexArrow).IsCooldown)
+                        return OriginalHook(ApexArrow);
 
-                    return OriginalHook(BRDPvP.PowerfulShot);
+                    return OriginalHook(PowerfulShot);
                 }
                 
                 return actionID;

--- a/XIVSlothCombo/CombosPVP/DNCPVP.cs
+++ b/XIVSlothCombo/CombosPVP/DNCPVP.cs
@@ -39,54 +39,55 @@ namespace XIVSlothComboPlugin
             public const string
                 DNCWaltzThreshold = "DNCWaltzThreshold";
         }
-    }
 
-    internal class DNCBurstMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNCBurstMode;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class DNCBurstMode : CustomCombo
         {
-            if (actionID is DNCPVP.Cascade or DNCPVP.Fountain or DNCPVP.ReverseCascade or DNCPVP.Fountainfall)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNCBurstMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                bool starfallDanceReady = !GetCooldown(DNCPVP.StarfallDance).IsCooldown;
-                bool starfallDance = HasEffect(DNCPVP.Buffs.StarfallDance);
-                bool enAvant = HasEffect(DNCPVP.Buffs.EnAvant);
-                var enAvantCharges = GetCooldown(DNCPVP.EnAvant).RemainingCharges;
-                bool curingWaltzReady = !GetCooldown(DNCPVP.CuringWaltz).IsCooldown;
-                bool honingDanceReady = !GetCooldown(DNCPVP.HoningDance).IsCooldown;
-                var acclaimStacks = GetBuffStacks(DNCPVP.Buffs.Acclaim);
-                bool canWeave = CanWeave(actionID);
-                var distance = GetTargetDistance();
-                var HPThreshold = Service.Configuration.GetCustomIntValue(DNCPVP.Config.DNCWaltzThreshold);
-                var HP = PlayerHealthPercentageHp();
-
-                // Honing Dance Option
-                if (IsEnabled(CustomComboPreset.DNCHoningDanceOption) && honingDanceReady && HasTarget() && distance <= 5)
+                if (actionID is Cascade or Fountain or ReverseCascade or Fountainfall)
                 {
-                    if (HasEffect(DNCPVP.Buffs.Acclaim) && acclaimStacks < 4)
-                        return WHM.Assize;
+                    bool starfallDanceReady = !GetCooldown(StarfallDance).IsCooldown;
+                    bool starfallDance = HasEffect(Buffs.StarfallDance);
+                    bool enAvant = HasEffect(Buffs.EnAvant);
+                    var enAvantCharges = GetCooldown(EnAvant).RemainingCharges;
+                    bool curingWaltzReady = !GetCooldown(CuringWaltz).IsCooldown;
+                    bool honingDanceReady = !GetCooldown(HoningDance).IsCooldown;
+                    var acclaimStacks = GetBuffStacks(Buffs.Acclaim);
+                    bool canWeave = CanWeave(actionID);
+                    var distance = GetTargetDistance();
+                    var HPThreshold = Service.Configuration.GetCustomIntValue(Config.DNCWaltzThreshold);
+                    var HP = PlayerHealthPercentageHp();
 
-                    return DNCPVP.HoningDance;
+                    // Honing Dance Option
+                    if (IsEnabled(CustomComboPreset.DNCHoningDanceOption) && honingDanceReady && HasTarget() && distance <= 5)
+                    {
+                        if (HasEffect(Buffs.Acclaim) && acclaimStacks < 4)
+                            return WHM.Assize;
+
+                        return HoningDance;
+                    }
+
+                    if (canWeave)
+                    {
+                        // Curing Waltz Option
+                        if (IsEnabled(CustomComboPreset.DNCCuringWaltzOption) && curingWaltzReady && HP <= HPThreshold)
+                            return OriginalHook(CuringWaltz);
+
+                        // Fan Dance weave
+                        if (IsOffCooldown(FanDance) && distance < 13) // 2y below max to avoid waste
+                            return OriginalHook(FanDance);
+                    }
+
+                    // Starfall Dance
+                    if (!starfallDance && starfallDanceReady && distance < 20) // 5y below max to avoid waste
+                        return OriginalHook(StarfallDance);
                 }
 
-                if (canWeave)
-                {
-                    // Curing Waltz Option
-                    if (IsEnabled(CustomComboPreset.DNCCuringWaltzOption) && curingWaltzReady && HP <= HPThreshold)
-                        return OriginalHook(DNCPVP.CuringWaltz);
-
-                    // Fan Dance weave
-                    if (IsOffCooldown(DNCPVP.FanDance) && distance < 13) // 2y below max to avoid waste
-                        return OriginalHook(DNCPVP.FanDance);
-                }
-
-                // Starfall Dance
-                if (!starfallDance && starfallDanceReady && distance < 20) // 5y below max to avoid waste
-                    return OriginalHook(DNCPVP.StarfallDance);
+                return actionID;
             }
-
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/CombosPVP/MCHPVP.cs
+++ b/XIVSlothCombo/CombosPVP/MCHPVP.cs
@@ -35,51 +35,52 @@ namespace XIVSlothComboPlugin.Combos
             public const ushort
                 Wildfire = 1323;
         }
-    }
 
-    internal class HeatedCleanShotFeature : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCHBurstMode;
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class HeatedCleanShotFeature : CustomCombo
         {
-            if (actionID == MCHPVP.BlastCharge)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCHBurstMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var canWeave = CanWeave(actionID);
-                var analysisStacks = GetRemainingCharges(MCHPVP.Analysis);
-                var bigDamageStacks = GetRemainingCharges(OriginalHook(MCHPVP.Drill));
-                var overheated = HasEffect(MCHPVP.Buffs.Overheated);
-
-                if (canWeave && HasEffect(MCHPVP.Buffs.Overheated) && IsOffCooldown(MCHPVP.Wildfire))
-                    return OriginalHook(MCHPVP.Wildfire);
-
-                if (overheated)
-                    return OriginalHook(MCHPVP.HeatBlast);
-
-                if ((HasEffect(MCHPVP.Buffs.DrillPrimed) || 
-                    (HasEffect(MCHPVP.Buffs.ChainSawPrimed) && !IsEnabled(CustomComboPreset.MCHAltAnalysis)) ||
-                    (HasEffect(MCHPVP.Buffs.AirAnchorPrimed) && IsEnabled(CustomComboPreset.MCHAltAnalysis))) &&
-                    !HasEffect(MCHPVP.Buffs.Analysis) && analysisStacks > 0 && (!IsEnabled(CustomComboPreset.MCHAltDrill)
-                    || IsOnCooldown(MCHPVP.Wildfire)) && !canWeave && !overheated && bigDamageStacks > 0)
-                    return OriginalHook(MCHPVP.Analysis);
-
-                if (bigDamageStacks > 0)
+                if (actionID == BlastCharge)
                 {
-                    if (HasEffect(MCHPVP.Buffs.DrillPrimed))
-                        return OriginalHook(MCHPVP.Drill);
+                    var canWeave = CanWeave(actionID);
+                    var analysisStacks = GetRemainingCharges(Analysis);
+                    var bigDamageStacks = GetRemainingCharges(OriginalHook(Drill));
+                    var overheated = HasEffect(Buffs.Overheated);
 
-                    if (HasEffect(MCHPVP.Buffs.BioblasterPrimed) && GetTargetDistance() <= 12)
-                        return OriginalHook(MCHPVP.BioBlaster);
+                    if (canWeave && HasEffect(Buffs.Overheated) && IsOffCooldown(Wildfire))
+                        return OriginalHook(Wildfire);
 
-                    if (HasEffect(MCHPVP.Buffs.AirAnchorPrimed))
-                        return OriginalHook(MCHPVP.AirAnchor);
+                    if (overheated)
+                        return OriginalHook(HeatBlast);
 
-                    if (HasEffect(MCHPVP.Buffs.ChainSawPrimed))
-                        return OriginalHook(MCHPVP.ChainSaw);
+                    if ((HasEffect(Buffs.DrillPrimed) ||
+                        (HasEffect(Buffs.ChainSawPrimed) && !IsEnabled(CustomComboPreset.MCHAltAnalysis)) ||
+                        (HasEffect(Buffs.AirAnchorPrimed) && IsEnabled(CustomComboPreset.MCHAltAnalysis))) &&
+                        !HasEffect(Buffs.Analysis) && analysisStacks > 0 && (!IsEnabled(CustomComboPreset.MCHAltDrill)
+                        || IsOnCooldown(Wildfire)) && !canWeave && !overheated && bigDamageStacks > 0)
+                        return OriginalHook(Analysis);
+
+                    if (bigDamageStacks > 0)
+                    {
+                        if (HasEffect(Buffs.DrillPrimed))
+                            return OriginalHook(Drill);
+
+                        if (HasEffect(Buffs.BioblasterPrimed) && GetTargetDistance() <= 12)
+                            return OriginalHook(BioBlaster);
+
+                        if (HasEffect(Buffs.AirAnchorPrimed))
+                            return OriginalHook(AirAnchor);
+
+                        if (HasEffect(Buffs.ChainSawPrimed))
+                            return OriginalHook(ChainSaw);
+                    }
                 }
-            }
 
-            return actionID;
+                return actionID;
+            }
         }
     }
 }

--- a/XIVSlothCombo/CombosPVP/NINPVP.cs
+++ b/XIVSlothCombo/CombosPVP/NINPVP.cs
@@ -45,121 +45,122 @@ namespace XIVSlothComboPlugin
                 SeakedForkedRaiju = 3195,
                 SealedMeisui = 3198;
         }
-    }
 
-    internal class NINBurstMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NINBurstMode;
 
-        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        internal class NINBurstMode : CustomCombo
         {
-            if (actionID is NINPVP.SpinningEdge or NINPVP.AeolianEdge or NINPVP.GustSlash)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NINBurstMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                var threeMudrasCD = GetCooldown(NINPVP.ThreeMudra);
-                var fumaCD = GetCooldown(NINPVP.FumaShuriken);
-                var bunshinStacks = HasEffect(NINPVP.Buffs.Bunshin) ? GetBuffStacks(NINPVP.Buffs.Bunshin) : 0;
-                bool raijuLocked = HasEffect(NINPVP.Debuffs.SeakedForkedRaiju);
-                bool meisuiLocked = HasEffect(NINPVP.Debuffs.SealedMeisui);
-                bool hyoshoLocked = HasEffect(NINPVP.Debuffs.SealedHyoshoRanryu);
-                bool dotonLocked = HasEffect(NINPVP.Debuffs.SealedDoton);
-                bool gokaLocked = HasEffect(NINPVP.Debuffs.SealedGokaMekkyaku);
-                bool hutonLocked = HasEffect(NINPVP.Debuffs.SealedHuton);
-                bool mudraMode = HasEffect(NINPVP.Buffs.ThreeMudra);
-                bool canWeave = CanWeave(actionID);
-
-                if (HasEffect(NINPVP.Buffs.Hidden))
-                    return OriginalHook(NINPVP.Assassinate);
-
-                if (canWeave)
+                if (actionID is SpinningEdge or AeolianEdge or GustSlash)
                 {
-                    if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown)
-                        return OriginalHook(NINPVP.Mug);
+                    var threeMudrasCD = GetCooldown(ThreeMudra);
+                    var fumaCD = GetCooldown(FumaShuriken);
+                    var bunshinStacks = HasEffect(Buffs.Bunshin) ? GetBuffStacks(Buffs.Bunshin) : 0;
+                    bool raijuLocked = HasEffect(Debuffs.SeakedForkedRaiju);
+                    bool meisuiLocked = HasEffect(Debuffs.SealedMeisui);
+                    bool hyoshoLocked = HasEffect(Debuffs.SealedHyoshoRanryu);
+                    bool dotonLocked = HasEffect(Debuffs.SealedDoton);
+                    bool gokaLocked = HasEffect(Debuffs.SealedGokaMekkyaku);
+                    bool hutonLocked = HasEffect(Debuffs.SealedHuton);
+                    bool mudraMode = HasEffect(Buffs.ThreeMudra);
+                    bool canWeave = CanWeave(actionID);
 
-                    if (!GetCooldown(NINPVP.Bunshin).IsCooldown)
-                        return OriginalHook(NINPVP.Bunshin);
+                    if (HasEffect(Buffs.Hidden))
+                        return OriginalHook(Assassinate);
 
-                    if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
-                        return OriginalHook(NINPVP.ThreeMudra);
+                    if (canWeave)
+                    {
+                        if (InMeleeRange() && !GetCooldown(Mug).IsCooldown)
+                            return OriginalHook(Mug);
+
+                        if (!GetCooldown(Bunshin).IsCooldown)
+                            return OriginalHook(Bunshin);
+
+                        if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
+                            return OriginalHook(ThreeMudra);
+                    }
+
+                    if (mudraMode)
+                    {
+                        if (!hyoshoLocked)
+                            return OriginalHook(HyoshoRanryu);
+
+                        if (!raijuLocked && bunshinStacks > 0)
+                            return OriginalHook(ForkedRaiju);
+
+                        if (!hutonLocked)
+                            return Huton;
+                    }
+
+                    if (fumaCD.RemainingCharges > 0)
+                        return OriginalHook(FumaShuriken);
+
                 }
 
-                if (mudraMode)
-                {
-                    if (!hyoshoLocked)
-                        return OriginalHook(NINPVP.HyoshoRanryu);
-
-                    if (!raijuLocked && bunshinStacks > 0)
-                        return OriginalHook(NINPVP.ForkedRaiju);
-
-                    if (!hutonLocked)
-                        return NINPVP.Huton;
-                }
-
-                if (fumaCD.RemainingCharges > 0)
-                    return OriginalHook(NINPVP.FumaShuriken);
-
+                return actionID;
             }
-
-            return actionID;
         }
-    }
 
-    internal class NINAoEBurstMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NINAoEBurstMode;
-
-        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        internal class NINAoEBurstMode : CustomCombo
         {
-            if (actionID == NINPVP.FumaShuriken)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NINAoEBurstMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                var threeMudrasCD = GetCooldown(NINPVP.ThreeMudra);
-                var fumaCD = GetCooldown(NINPVP.FumaShuriken);
-                var bunshinStacks = HasEffect(NINPVP.Buffs.Bunshin) ? GetBuffStacks(NINPVP.Buffs.Bunshin) : 0;
-                bool raijuLocked = HasEffect(NINPVP.Debuffs.SeakedForkedRaiju);
-                bool meisuiLocked = HasEffect(NINPVP.Debuffs.SealedMeisui);
-                bool hyoshoLocked = HasEffect(NINPVP.Debuffs.SealedHyoshoRanryu);
-                bool dotonLocked = HasEffect(NINPVP.Debuffs.SealedDoton);
-                bool gokaLocked = HasEffect(NINPVP.Debuffs.SealedGokaMekkyaku);
-                bool hutonLocked = HasEffect(NINPVP.Debuffs.SealedHuton);
-                bool mudraMode = HasEffect(NINPVP.Buffs.ThreeMudra);
-                bool canWeave = CanWeave(actionID);
-
-                if (canWeave)
+                if (actionID == FumaShuriken)
                 {
-                    if (InMeleeRange() && !GetCooldown(NINPVP.Mug).IsCooldown)
-                        return NINPVP.Mug;
+                    var threeMudrasCD = GetCooldown(ThreeMudra);
+                    var fumaCD = GetCooldown(FumaShuriken);
+                    var bunshinStacks = HasEffect(Buffs.Bunshin) ? GetBuffStacks(Buffs.Bunshin) : 0;
+                    bool raijuLocked = HasEffect(Debuffs.SeakedForkedRaiju);
+                    bool meisuiLocked = HasEffect(Debuffs.SealedMeisui);
+                    bool hyoshoLocked = HasEffect(Debuffs.SealedHyoshoRanryu);
+                    bool dotonLocked = HasEffect(Debuffs.SealedDoton);
+                    bool gokaLocked = HasEffect(Debuffs.SealedGokaMekkyaku);
+                    bool hutonLocked = HasEffect(Debuffs.SealedHuton);
+                    bool mudraMode = HasEffect(Buffs.ThreeMudra);
+                    bool canWeave = CanWeave(actionID);
 
-                    if (!GetCooldown(NINPVP.Bunshin).IsCooldown)
-                        return NINPVP.Bunshin;
+                    if (canWeave)
+                    {
+                        if (InMeleeRange() && !GetCooldown(Mug).IsCooldown)
+                            return Mug;
 
-                    if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
-                        return OriginalHook(NINPVP.ThreeMudra);
+                        if (!GetCooldown(Bunshin).IsCooldown)
+                            return Bunshin;
+
+                        if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
+                            return OriginalHook(ThreeMudra);
+                    }
+
+                    if (mudraMode)
+                    {
+                        if (!dotonLocked)
+                            return OriginalHook(Doton);
+
+                        if (!gokaLocked)
+                            return OriginalHook(GokaMekkyaku);
+                    }
+
+                    if (fumaCD.RemainingCharges > 0)
+                        return OriginalHook(FumaShuriken);
+
+                    if (InMeleeRange())
+                    {
+                        if (lastComboActionID == GustSlash)
+                            return OriginalHook(AeolianEdge);
+
+                        if (lastComboActionID == SpinningEdge)
+                            return OriginalHook(GustSlash);
+
+                        return OriginalHook(SpinningEdge);
+                    }
                 }
 
-                if (mudraMode)
-                {
-                    if (!dotonLocked)
-                        return OriginalHook(NINPVP.Doton);
-
-                    if (!gokaLocked)
-                        return OriginalHook(NINPVP.GokaMekkyaku);
-                }
-
-                if (fumaCD.RemainingCharges > 0)
-                    return OriginalHook(NINPVP.FumaShuriken);
-
-                if (InMeleeRange())
-                {
-                    if (lastComboActionID == NINPVP.GustSlash)
-                        return OriginalHook(NINPVP.AeolianEdge);
-
-                    if (lastComboActionID == NINPVP.SpinningEdge)
-                        return OriginalHook(NINPVP.GustSlash);
-
-                    return OriginalHook(NINPVP.SpinningEdge);
-                }
+                return actionID;
             }
-
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/CombosPVP/RDMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/RDMPVP.cs
@@ -37,42 +37,43 @@ namespace XIVSlothComboPlugin
                 VermilionRadiance = 3233,
                 MagickBarrier = 3240;
         }
-    }
 
-    internal class RedMageBurstMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDMBurstMode;
 
-        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        internal class RedMageBurstMode : CustomCombo
         {
-            if (actionID is RDMPVP.Verstone or RDMPVP.Verfire)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDMBurstMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-
-                if (!GetCooldown(RDMPVP.Frazzle).IsCooldown && HasEffect(RDMPVP.Buffs.BlackShift))
-                    return OriginalHook(RDMPVP.Frazzle);
-
-                if (!GetCooldown(RDMPVP.Resolution).IsCooldown)
-                    return OriginalHook(RDMPVP.Resolution);
-
-                if (!InMeleeRange() && GetCooldown(RDMPVP.CorpsACorps).RemainingCharges > 0 && !GetCooldown(RDMPVP.EnchantedRiposte).IsCooldown)
-                    return OriginalHook(RDMPVP.CorpsACorps);
-
-                if (InMeleeRange())
+                if (actionID is Verstone or Verfire)
                 {
-                    if (!GetCooldown(RDMPVP.EnchantedRiposte).IsCooldown || lastComboActionID == RDMPVP.EnchantedRiposte || lastComboActionID == RDMPVP.EnchantedZwerchhau)
-                        return OriginalHook(RDMPVP.EnchantedRiposte);
 
-                    if (lastComboActionID == RDMPVP.EnchantedRedoublement && GetCooldown(RDMPVP.Displacement).RemainingCharges > 0)
-                        return OriginalHook(RDMPVP.Displacement);
+                    if (!GetCooldown(Frazzle).IsCooldown && HasEffect(Buffs.BlackShift))
+                        return OriginalHook(Frazzle);
+
+                    if (!GetCooldown(Resolution).IsCooldown)
+                        return OriginalHook(Resolution);
+
+                    if (!InMeleeRange() && GetCooldown(CorpsACorps).RemainingCharges > 0 && !GetCooldown(EnchantedRiposte).IsCooldown)
+                        return OriginalHook(CorpsACorps);
+
+                    if (InMeleeRange())
+                    {
+                        if (!GetCooldown(EnchantedRiposte).IsCooldown || lastComboActionID == EnchantedRiposte || lastComboActionID == EnchantedZwerchhau)
+                            return OriginalHook(EnchantedRiposte);
+
+                        if (lastComboActionID == EnchantedRedoublement && GetCooldown(Displacement).RemainingCharges > 0)
+                            return OriginalHook(Displacement);
+                    }
+
+                    if (HasEffect(Buffs.VermilionRadiance))
+                        return OriginalHook(EnchantedRiposte);
+
+                    return OriginalHook(Verstone);
                 }
 
-                if (HasEffect(RDMPVP.Buffs.VermilionRadiance))
-                    return OriginalHook(RDMPVP.EnchantedRiposte);
-
-                return OriginalHook(RDMPVP.Verstone);
+                return actionID;
             }
-
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/CombosPVP/RPRPVP.cs
+++ b/XIVSlothCombo/CombosPVP/RPRPVP.cs
@@ -50,115 +50,116 @@ namespace XIVSlothComboPlugin
             public const string
                 RPRPvPArcaneCircleOption = "RPRPvPArcaneCircleOption";
         }
-    }
 
-    internal class RPRBurstMode : CustomCombo // Burst Mode
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RPRBurstMode; // Burst Mode Preset Name
 
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class RPRBurstMode : CustomCombo // Burst Mode
         {
-            if (actionID is RPRPVP.Slice or RPRPVP.WaxingSlice or RPRPVP.InfernalSlice)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RPRBurstMode; // Burst Mode Preset Name
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                
-                bool grimSwatheReady = !GetCooldown(RPRPVP.GrimSwathe).IsCooldown;
-                bool lemuresSliceReady = !GetCooldown(RPRPVP.LemuresSlice).IsCooldown;
-                bool arcaneReady = !GetCooldown(RPRPVP.ArcaneCrest).IsCooldown;
-                var arcaneThreshold = Service.Configuration.GetCustomIntValue(RPRPVP.Config.RPRPvPArcaneCircleOption);
-                bool deathWarrantReady = !GetCooldown(RPRPVP.DeathWarrant).IsCooldown;
-                bool plentifulReady = !GetCooldown(RPRPVP.PlentifulHarvest).IsCooldown;
-                var plentifulCD = GetCooldown(RPRPVP.PlentifulHarvest).CooldownRemaining;
-                bool enshrouded = HasEffect(RPRPVP.Buffs.Enshrouded);
-                var enshroudStacks = GetBuffStacks(RPRPVP.Buffs.Enshrouded);
-                var immortalStacks = GetBuffStacks(RPRPVP.Buffs.ImmortalSacrifice);
-                var immortalThreshold = Service.Configuration.GetCustomIntValue(RPRPVP.Config.RPRPvPImmortalStackThreshold);
-                bool soulsow = HasEffect(RPRPVP.Buffs.Soulsow);
-                bool canBind = !TargetHasEffect(PVPCommon.Debuffs.Bind);
-                bool GCDStopped = !GetCooldown(OriginalHook(RPRPVP.Slice)).IsCooldown;
-                bool enemyGuarded = TargetHasEffectAny(PVPCommon.Buffs.Guard);
-                var HP = PlayerHealthPercentageHp();
-                bool canWeave = CanWeave(actionID);
-                var distance = GetTargetDistance();
-
-                // Arcane Cirle Option
-                if (IsEnabled(CustomComboPreset.RPRPvPArcaneCircleOption) && arcaneReady && HP <= arcaneThreshold)
-                    return RPRPVP.ArcaneCrest;
-
-                if (!enemyGuarded)
+                if (actionID is Slice or WaxingSlice or InfernalSlice)
                 {
-                    // Plentiful Harvest Opener
-                    if (IsEnabled(CustomComboPreset.RPRPvPPlentifulOpenerOption) && !InCombat() && plentifulReady && distance <= 15)
-                        return RPRPVP.PlentifulHarvest;
 
-                    // Harvest Moon Ranged Option
-                    if (IsEnabled(CustomComboPreset.RPRPvPRangedHarvestMoonOption) && distance > 5 && soulsow && GCDStopped)
-                        return RPRPVP.HarvestMoon;
+                    bool grimSwatheReady = !GetCooldown(GrimSwathe).IsCooldown;
+                    bool lemuresSliceReady = !GetCooldown(LemuresSlice).IsCooldown;
+                    bool arcaneReady = !GetCooldown(ArcaneCrest).IsCooldown;
+                    var arcaneThreshold = Service.Configuration.GetCustomIntValue(Config.RPRPvPArcaneCircleOption);
+                    bool deathWarrantReady = !GetCooldown(DeathWarrant).IsCooldown;
+                    bool plentifulReady = !GetCooldown(PlentifulHarvest).IsCooldown;
+                    var plentifulCD = GetCooldown(PlentifulHarvest).CooldownRemaining;
+                    bool enshrouded = HasEffect(Buffs.Enshrouded);
+                    var enshroudStacks = GetBuffStacks(Buffs.Enshrouded);
+                    var immortalStacks = GetBuffStacks(Buffs.ImmortalSacrifice);
+                    var immortalThreshold = Service.Configuration.GetCustomIntValue(Config.RPRPvPImmortalStackThreshold);
+                    bool soulsow = HasEffect(Buffs.Soulsow);
+                    bool canBind = !TargetHasEffect(PVPCommon.Debuffs.Bind);
+                    bool GCDStopped = !GetCooldown(OriginalHook(Slice)).IsCooldown;
+                    bool enemyGuarded = TargetHasEffectAny(PVPCommon.Buffs.Guard);
+                    var HP = PlayerHealthPercentageHp();
+                    bool canWeave = CanWeave(actionID);
+                    var distance = GetTargetDistance();
 
-                    // Occurring inside of Enshroud burst
-                    if (IsEnabled(CustomComboPreset.RPRPvPEnshroudedOption) && enshrouded)
+                    // Arcane Cirle Option
+                    if (IsEnabled(CustomComboPreset.RPRPvPArcaneCircleOption) && arcaneReady && HP <= arcaneThreshold)
+                        return ArcaneCrest;
+
+                    if (!enemyGuarded)
                     {
-                        if (canWeave)
+                        // Plentiful Harvest Opener
+                        if (IsEnabled(CustomComboPreset.RPRPvPPlentifulOpenerOption) && !InCombat() && plentifulReady && distance <= 15)
+                            return PlentifulHarvest;
+
+                        // Harvest Moon Ranged Option
+                        if (IsEnabled(CustomComboPreset.RPRPvPRangedHarvestMoonOption) && distance > 5 && soulsow && GCDStopped)
+                            return HarvestMoon;
+
+                        // Occurring inside of Enshroud burst
+                        if (IsEnabled(CustomComboPreset.RPRPvPEnshroudedOption) && enshrouded)
                         {
-                            // Enshrouded Death Warrant Option
-                            if (IsEnabled(CustomComboPreset.RPRPvPEnshroudedDeathWarrantOption) && deathWarrantReady && enshroudStacks >= 3 && distance <= 25)
-                                return OriginalHook(RPRPVP.DeathWarrant);
+                            if (canWeave)
+                            {
+                                // Enshrouded Death Warrant Option
+                                if (IsEnabled(CustomComboPreset.RPRPvPEnshroudedDeathWarrantOption) && deathWarrantReady && enshroudStacks >= 3 && distance <= 25)
+                                    return OriginalHook(DeathWarrant);
 
-                            // Lemure's Slice
-                            if (lemuresSliceReady && canBind && distance <= 8)
-                                return RPRPVP.LemuresSlice;
+                                // Lemure's Slice
+                                if (lemuresSliceReady && canBind && distance <= 8)
+                                    return LemuresSlice;
 
-                            // Harvest Moon proc
-                            if (soulsow && distance <= 25)
-                                return OriginalHook(RPRPVP.DeathWarrant);
+                                // Harvest Moon proc
+                                if (soulsow && distance <= 25)
+                                    return OriginalHook(DeathWarrant);
+                            }
+
+                            // Communio Option
+                            if (IsEnabled(CustomComboPreset.RPRPvPEnshroudedCommunioOption) && enshroudStacks == 1 && distance <= 25)
+                            {
+                                // Holds Communio when moving & Enshrouded Time Remaining > 2s
+                                // Returns a Void/Cross Reaping if under 2s to avoid charge waste
+                                if (this.IsMoving && GetBuffRemainingTime(Buffs.Enshrouded) > 2)
+                                    return BLM.Xenoglossy;
+
+                                // Returns Communio if stationary
+                                // This doesn't work as an 'else if' and I can't be bothered to refactor it further
+                                if (!this.IsMoving)
+                                    return Communio;
+                            }
                         }
 
-                        // Communio Option
-                        if (IsEnabled(CustomComboPreset.RPRPvPEnshroudedCommunioOption) && enshroudStacks == 1 && distance <= 25)
+                        // Occurring outside of Enshroud burst
+                        if (!enshrouded)
                         {
-                            // Holds Communio when moving & Enshrouded Time Remaining > 2s
-                            // Returns a Void/Cross Reaping if under 2s to avoid charge waste
-                            if (this.IsMoving && GetBuffRemainingTime(RPRPVP.Buffs.Enshrouded) > 2)
-                                return BLM.Xenoglossy;
+                            // Death Warrant Option
+                            if (IsEnabled(CustomComboPreset.RPRPvPDeathWarrantOption) && deathWarrantReady && distance <= 25
+                                && (plentifulCD > 20 && immortalStacks < immortalThreshold || plentifulReady && immortalStacks >= immortalThreshold))
+                                return OriginalHook(DeathWarrant);
 
-                            // Returns Communio if stationary
-                            // This doesn't work as an 'else if' and I can't be bothered to refactor it further
-                            if (!this.IsMoving)
-                                return RPRPVP.Communio;
+                            // Plentiful Harvest Pooling Option
+                            if (IsEnabled(CustomComboPreset.RPRPvPImmortalPoolingOption) && plentifulReady && immortalStacks >= immortalThreshold && TargetHasEffect(Debuffs.DeathWarrant) && distance <= 15)
+                                return PlentifulHarvest;
+
+                            // Weaves
+                            if (canWeave)
+                            {
+                                // Harvest Moon Proc
+                                if (soulsow && distance <= 25)
+                                    return OriginalHook(DeathWarrant);
+
+                                // Grim Swathe Option
+                                if (IsEnabled(CustomComboPreset.RPRPvPGrimSwatheOption) && grimSwatheReady && distance <= 8)
+                                    return GrimSwathe;
+                            }
                         }
                     }
 
-                    // Occurring outside of Enshroud burst
-                    if (!enshrouded)
-                    {
-                        // Death Warrant Option
-                        if (IsEnabled(CustomComboPreset.RPRPvPDeathWarrantOption) && deathWarrantReady && distance <= 25
-                            && (plentifulCD > 20 && immortalStacks < immortalThreshold || plentifulReady && immortalStacks >= immortalThreshold))
-                            return OriginalHook(RPRPVP.DeathWarrant);
-
-                        // Plentiful Harvest Pooling Option
-                        if (IsEnabled(CustomComboPreset.RPRPvPImmortalPoolingOption) && plentifulReady && immortalStacks >= immortalThreshold && TargetHasEffect(RPRPVP.Debuffs.DeathWarrant) && distance <= 15)
-                            return RPRPVP.PlentifulHarvest;
-
-                        // Weaves
-                        if (canWeave)
-                        {
-                            // Harvest Moon Proc
-                            if (soulsow && distance <= 25)
-                                return OriginalHook(RPRPVP.DeathWarrant);
-
-                            // Grim Swathe Option
-                            if (IsEnabled(CustomComboPreset.RPRPvPGrimSwatheOption) && grimSwatheReady && distance <= 8)
-                                return RPRPVP.GrimSwathe;
-                        }
-                    }
+                    // Soul Slice
+                    if (!enshrouded && distance <= 5 && (GetRemainingCharges(SoulSlice) == 2 || GetRemainingCharges(SoulSlice) > 0 && !HasEffect(Buffs.GallowsOiled) && !HasEffect(Buffs.SoulReaver)))
+                        return SoulSlice;
                 }
 
-                // Soul Slice
-                if (!enshrouded && distance <= 5 && (GetRemainingCharges(RPRPVP.SoulSlice) == 2 || GetRemainingCharges(RPRPVP.SoulSlice) > 0 && !HasEffect(RPRPVP.Buffs.GallowsOiled) && !HasEffect(RPRPVP.Buffs.SoulReaver)))
-                    return RPRPVP.SoulSlice;
+                return actionID;
             }
-
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/CombosPVP/SAMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/SAMPVP.cs
@@ -42,31 +42,31 @@
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var sotenCharges = Service.Configuration.GetCustomIntValue(SAMPvP.Config.SamSotenCharges);
+                var sotenCharges = Service.Configuration.GetCustomIntValue(Config.SamSotenCharges);
                 
-                if ((IsNotEnabled(CustomComboPreset.SamPVPMainComboFeature) && actionID == SAMPvP.MeikyoShisui) ||
-                    (IsEnabled(CustomComboPreset.SamPVPMainComboFeature) && actionID is SAMPvP.Yukikaze or SAMPvP.Gekko or SAMPvP.Kasha or SAMPvP.Hyosetsu or SAMPvP.Oka or SAMPvP.Mangetsu))
+                if ((IsNotEnabled(CustomComboPreset.SamPVPMainComboFeature) && actionID == MeikyoShisui) ||
+                    (IsEnabled(CustomComboPreset.SamPVPMainComboFeature) && actionID is Yukikaze or Gekko or Kasha or Hyosetsu or Oka or Mangetsu))
                 {
                     //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
                     if (!TargetHasEffectAny(PVPCommon.Buffs.Guard))
                     {
-                        if (IsOffCooldown(SAMPvP.MeikyoShisui))
-                            return OriginalHook(SAMPvP.MeikyoShisui);
-                        if (IsEnabled(CustomComboPreset.SAMBurstChitenFeature) && IsOffCooldown(SAMPvP.Chiten) && InCombat() && PlayerHealthPercentageHp() <= 95)
-                            return OriginalHook(SAMPvP.Chiten);
-                        if (GetCooldownRemainingTime(SAMPvP.Soten) < 1 && CanWeave(SAMPvP.Yukikaze))
-                            return OriginalHook(SAMPvP.Soten);
-                        if (OriginalHook(SAMPvP.MeikyoShisui) == SAMPvP.Midare && !this.IsMoving)
-                            return OriginalHook(SAMPvP.MeikyoShisui);
-                        if (IsEnabled(CustomComboPreset.SAMBurstStunFeature) && IsOffCooldown(SAMPvP.Mineuchi))
-                            return OriginalHook(SAMPvP.Mineuchi);
-                        if (IsOffCooldown(SAMPvP.OgiNamikiri) && !this.IsMoving)
-                            return OriginalHook(SAMPvP.OgiNamikiri);
-                        if (GetRemainingCharges(SAMPvP.Soten) > sotenCharges && CanWeave(SAMPvP.Yukikaze))
-                            return OriginalHook(SAMPvP.Soten);
-                        if (OriginalHook(SAMPvP.OgiNamikiri) == SAMPvP.Kaeshi)
-                            return OriginalHook(SAMPvP.OgiNamikiri);
+                        if (IsOffCooldown(MeikyoShisui))
+                            return OriginalHook(MeikyoShisui);
+                        if (IsEnabled(CustomComboPreset.SAMBurstChitenFeature) && IsOffCooldown(Chiten) && InCombat() && PlayerHealthPercentageHp() <= 95)
+                            return OriginalHook(Chiten);
+                        if (GetCooldownRemainingTime(Soten) < 1 && CanWeave(Yukikaze))
+                            return OriginalHook(Soten);
+                        if (OriginalHook(MeikyoShisui) == Midare && !this.IsMoving)
+                            return OriginalHook(MeikyoShisui);
+                        if (IsEnabled(CustomComboPreset.SAMBurstStunFeature) && IsOffCooldown(Mineuchi))
+                            return OriginalHook(Mineuchi);
+                        if (IsOffCooldown(OgiNamikiri) && !this.IsMoving)
+                            return OriginalHook(OgiNamikiri);
+                        if (GetRemainingCharges(Soten) > sotenCharges && CanWeave(Yukikaze))
+                            return OriginalHook(Soten);
+                        if (OriginalHook(OgiNamikiri) == Kaeshi)
+                            return OriginalHook(OgiNamikiri);
                     }
                 }
 
@@ -80,15 +80,15 @@
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var SamSotenHP = Service.Configuration.GetCustomIntValue(SAMPvP.Config.SamSotenHP);
+                var SamSotenHP = Service.Configuration.GetCustomIntValue(Config.SamSotenHP);
 
-                if (actionID is SAMPvP.Yukikaze or SAMPvP.Gekko or SAMPvP.Kasha or SAMPvP.Hyosetsu or SAMPvP.Mangetsu or SAMPvP.Oka)
+                if (actionID is Yukikaze or Gekko or Kasha or Hyosetsu or Mangetsu or Oka)
                 {
                     if (!InMeleeRange())
                     {
-                        if (IsEnabled(CustomComboPreset.SamGapCloserFeature) && GetRemainingCharges(SAMPvP.Soten) > 0 && EnemyHealthPercentage() <= SamSotenHP)
-                            return OriginalHook(SAMPvP.Soten);
-                        if (IsEnabled(CustomComboPreset.SamAOEMeleeFeature) && !IsOriginal(SAMPvP.Yukikaze) && !HasEffect(SAMPvP.Buffs.Midare) && IsOnCooldown(SAMPvP.MeikyoShisui) && IsOnCooldown(SAMPvP.OgiNamikiri) && OriginalHook(SAMPvP.OgiNamikiri) != SAMPvP.Kaeshi)
+                        if (IsEnabled(CustomComboPreset.SamGapCloserFeature) && GetRemainingCharges(Soten) > 0 && EnemyHealthPercentage() <= SamSotenHP)
+                            return OriginalHook(Soten);
+                        if (IsEnabled(CustomComboPreset.SamAOEMeleeFeature) && !IsOriginal(Yukikaze) && !HasEffect(Buffs.Midare) && IsOnCooldown(MeikyoShisui) && IsOnCooldown(OgiNamikiri) && OriginalHook(OgiNamikiri) != Kaeshi)
                             return SAM.Yukikaze;
                     }
                 }

--- a/XIVSlothCombo/CombosPVP/SGEPVP.cs
+++ b/XIVSlothCombo/CombosPVP/SGEPVP.cs
@@ -33,44 +33,45 @@ namespace XIVSlothComboPlugin
                 Haimatinon = 3111;
         }
 
-    }
 
 
-    internal class SGEBurstMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGEBurstMode;
 
-        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        internal class SGEBurstMode : CustomCombo
         {
-            if (actionID == SGEPVP.Dosis)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGEBurstMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
+                if (actionID == Dosis)
+                {
+                    //uint globalAction = PVPCommon.ExecutePVPGlobal.ExecuteGlobal(actionID);
 
-                //if (globalAction != actionID) return globalAction;
+                    //if (globalAction != actionID) return globalAction;
 
-                if (!HasEffectAny(SGEPVP.Buffs.Kardia))
-                    return SGEPVP.Kardia;
+                    if (!HasEffectAny(Buffs.Kardia))
+                        return Kardia;
 
-                if (!GetCooldown(SGEPVP.Pneuma).IsCooldown)
-                    return SGEPVP.Pneuma;
+                    if (!GetCooldown(Pneuma).IsCooldown)
+                        return Pneuma;
 
-                if (InMeleeRange() && !HasEffect(SGEPVP.Buffs.Eukrasia) && GetCooldown(SGEPVP.Phlegma).RemainingCharges > 0)
-                    return SGEPVP.Phlegma;
+                    if (InMeleeRange() && !HasEffect(Buffs.Eukrasia) && GetCooldown(Phlegma).RemainingCharges > 0)
+                        return Phlegma;
 
-                if (HasEffect(SGEPVP.Buffs.Addersting) && !HasEffect(SGEPVP.Buffs.Eukrasia))
-                    return SGEPVP.Toxicon2;
+                    if (HasEffect(Buffs.Addersting) && !HasEffect(Buffs.Eukrasia))
+                        return Toxicon2;
 
-                if (!TargetHasEffectAny(SGEPVP.Debuffs.EukrasianDosis) && GetCooldown(SGEPVP.Eukrasia).RemainingCharges > 0 && !HasEffect(SGEPVP.Buffs.Eukrasia))
-                    return SGEPVP.Eukrasia;
+                    if (!TargetHasEffectAny(Debuffs.EukrasianDosis) && GetCooldown(Eukrasia).RemainingCharges > 0 && !HasEffect(Buffs.Eukrasia))
+                        return Eukrasia;
 
-                if (HasEffect(SGEPVP.Buffs.Eukrasia))
-                    return OriginalHook(SGEPVP.Dosis);
+                    if (HasEffect(Buffs.Eukrasia))
+                        return OriginalHook(Dosis);
 
-                if (!TargetHasEffect(SGEPVP.Debuffs.Toxicon) && GetCooldown(SGEPVP.Toxikon).RemainingCharges > 0)
-                    return OriginalHook(SGEPVP.Toxikon);
+                    if (!TargetHasEffect(Debuffs.Toxicon) && GetCooldown(Toxikon).RemainingCharges > 0)
+                        return OriginalHook(Toxikon);
 
+                }
+                return actionID;
             }
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/CombosPVP/WARPVP.cs
+++ b/XIVSlothCombo/CombosPVP/WARPVP.cs
@@ -15,48 +15,49 @@ namespace XIVSlothComboPlugin
             Orogeny = 29080,
             Blota = 29081,
             Bloodwhetting = 29082;
-            
+
         internal class Buffs
         {
             internal const ushort
                 NascentChaos = 1992,
                 InnerRelease = 1303;
         }
-    }
 
-    internal class WARBurstMode : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WARBurstMode;
 
-        protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+        internal class WARBurstMode : CustomCombo
         {
-            if (actionID is WARPVP.HeavySwing or WARPVP.Maim or WARPVP.StormsPath)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WARBurstMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                var canWeave = CanWeave(actionID);
-
-                if (!GetCooldown(WARPVP.Bloodwhetting).IsCooldown && (IsEnabled(CustomComboPreset.WARBurstOption) || canWeave))
-                    return OriginalHook(WARPVP.Bloodwhetting);
-                    
-                if (!GetCooldown(WARPVP.PrimalRend).IsCooldown)
-                    return OriginalHook(WARPVP.PrimalRend);
-                
-                if (!InMeleeRange() && !GetCooldown(WARPVP.Blota).IsCooldown && !TargetHasEffectAny(PVPCommon.Debuffs.Stun) && 
-                    (IsNotEnabled(CustomComboPreset.WARBurstBlotaOption) || GetCooldown(WARPVP.PrimalRend).CooldownRemaining >= 5))
-                    return OriginalHook(WARPVP.Blota);
-
-                if (!GetCooldown(WARPVP.Onslaught).IsCooldown && canWeave)
-                    return OriginalHook(WARPVP.Onslaught);
-
-                if (InMeleeRange())
+                if (actionID is HeavySwing or Maim or StormsPath)
                 {
-                    if (HasEffect(WARPVP.Buffs.NascentChaos))
-                        return OriginalHook(WARPVP.Bloodwhetting);
+                    var canWeave = CanWeave(actionID);
 
-                    if (!GetCooldown(WARPVP.Orogeny).IsCooldown && canWeave)
-                        return OriginalHook(WARPVP.Orogeny);
+                    if (!GetCooldown(Bloodwhetting).IsCooldown && (IsEnabled(CustomComboPreset.WARBurstOption) || canWeave))
+                        return OriginalHook(Bloodwhetting);
+
+                    if (!GetCooldown(PrimalRend).IsCooldown)
+                        return OriginalHook(PrimalRend);
+
+                    if (!InMeleeRange() && !GetCooldown(Blota).IsCooldown && !TargetHasEffectAny(PVPCommon.Debuffs.Stun) &&
+                        (IsNotEnabled(CustomComboPreset.WARBurstBlotaOption) || GetCooldown(PrimalRend).CooldownRemaining >= 5))
+                        return OriginalHook(Blota);
+
+                    if (!GetCooldown(Onslaught).IsCooldown && canWeave)
+                        return OriginalHook(Onslaught);
+
+                    if (InMeleeRange())
+                    {
+                        if (HasEffect(Buffs.NascentChaos))
+                            return OriginalHook(Bloodwhetting);
+
+                        if (!GetCooldown(Orogeny).IsCooldown && canWeave)
+                            return OriginalHook(Orogeny);
+                    }
                 }
+                return actionID;
             }
-            return actionID;
         }
     }
 }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -442,7 +442,28 @@ namespace XIVSlothComboPlugin
             }
             else
             {
+                if (preset.GetAttribute<ReplaceSkillAttribute>() != null)
+                {
+                    string skills = string.Join(", ", preset.GetAttribute<ReplaceSkillAttribute>().ActionNames);
+
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.BeginTooltip();
+                        ImGui.TextUnformatted($"Replaces: {skills}");
+                        ImGui.EndTooltip();
+                    }
+                }
                 ImGui.TextWrapped($"#{i}: {info.Description}");
+
+                if (preset.GetAttribute<HoverInfoAttribute>() != null)
+                {
+                    if (ImGui.IsItemHovered())
+                    {
+                        ImGui.BeginTooltip();
+                        ImGui.TextUnformatted(preset.GetAttribute<HoverInfoAttribute>().HoverText);
+                        ImGui.EndTooltip();
+                    }
+                }
             }
 
             ImGui.PopStyleColor();

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -337,6 +337,10 @@ namespace XIVSlothComboPlugin
                 else
                 {
                     i += this.groupedPresets[jobName].Count;
+                    foreach(var preset in this.groupedPresets[jobName])
+                    {
+                        i += AllChildren(this.presetChildren[preset.Preset]);
+                    }
                 }
 
             }

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -6,6 +6,7 @@ using Dalamud.Game.ClientState.Party;
 using Dalamud.Game.ClientState.Statuses;
 using Dalamud.Utility;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
 using System.Timers;
@@ -800,14 +801,69 @@ namespace XIVSlothComboPlugin.Combos
             P8
         }
 
+        /// <summary>
+        /// Checks if the player is in a PVP enabled zone.
+        /// </summary>
+        /// <returns></returns>
         protected static bool InPvP()
             => Service.ClientState.IsPvP ||
             Service.ClientState.TerritoryType == 250 || //Wolves Den
-            (Service.ClientState.TerritoryType == 376 && Service.PartyList.Count() > 1) || //Borderland Ruins
-            (Service.ClientState.TerritoryType == 431 && Service.PartyList.Count() > 1) || //Seal Rock
-            (Service.ClientState.TerritoryType == 554 && Service.PartyList.Count() > 1) || //Fields of Glory
-            (Service.ClientState.TerritoryType == 888 && Service.PartyList.Count() > 1) || //Onsal Hakair
-            (Service.ClientState.TerritoryType == 729 && Service.PartyList.Count() > 1) || //Astragalos
-            (Service.ClientState.TerritoryType == 791 && Service.PartyList.Count() > 1);   //Hidden Gorge
+            (Service.ClientState.TerritoryType == 376 && Service.PartyList.Length > 1) || //Borderland Ruins
+            (Service.ClientState.TerritoryType == 431 && Service.PartyList.Length > 1) || //Seal Rock
+            (Service.ClientState.TerritoryType == 554 && Service.PartyList.Length > 1) || //Fields of Glory
+            (Service.ClientState.TerritoryType == 888 && Service.PartyList.Length > 1) || //Onsal Hakair
+            (Service.ClientState.TerritoryType == 729 && Service.PartyList.Length > 1) || //Astragalos
+            (Service.ClientState.TerritoryType == 791 && Service.PartyList.Length > 1);   //Hidden Gorge
+
+        private static Dictionary<uint, Lumina.Excel.GeneratedSheets.Action>? ActionSheet = Service.DataManager?.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>()?
+            .Where(i => i.RowId is not 7)
+            .ToDictionary(i => i.RowId, i => i);
+
+        private static Dictionary<uint, Lumina.Excel.GeneratedSheets.Status>? StatusSheet = Service.DataManager?.GetExcelSheet<Lumina.Excel.GeneratedSheets.Status>()?
+            .ToDictionary(i => i.RowId, i => i);
+
+        public int GetLevel(uint id)
+        {
+            if (ActionSheet.TryGetValue(id, out var action))
+            {
+                return action.ClassJobLevel;
+            }
+
+            return 0;
+        }
+
+        public string GetActionName(uint id)
+        {
+            if (ActionSheet.TryGetValue(id, out var action))
+            {
+                return action.Name;
+            }
+
+            return "UNKNOWN ABILITY";
+        }
+
+        public bool LevelChecked(uint id)
+        {
+            if (LocalPlayer.Level < GetLevel(id))
+                return false;
+
+            return true;
+        }
+
+        public string GetStatusName(uint id)
+        {
+            if (StatusSheet.TryGetValue(id, out var status))
+            {
+                return status.Name;
+            }
+
+            return "Unknown Status";
+        }
+
+        public bool WasLastAction(uint id)
+            => ActionWatching.LastAbility == id;
+
+        public int LastActionCounter()
+            => ActionWatching.LastAbilityUseCount;
     }
 }

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -861,9 +861,19 @@ namespace XIVSlothComboPlugin.Combos
         }
 
         public bool WasLastAction(uint id)
-            => ActionWatching.LastAbility == id;
+            => ActionWatching.LastAction == id;
 
         public int LastActionCounter()
-            => ActionWatching.LastAbilityUseCount;
+            => ActionWatching.LastActionUseCount;
+
+        public bool WasLastWeaponskill(uint id)
+            => ActionWatching.LastWeaponskill == id;
+
+        public bool WasLastSpell(uint id)
+            => ActionWatching.LastSpell == id;
+
+        public bool WasLastAbility(uint id)
+            => ActionWatching.LastAbility == id;
+
     }
 }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -92,6 +92,7 @@ namespace XIVSlothComboPlugin
         AllTankFeatures = 100099,
 
             #region Global Tank Features
+            [ReplaceSkill(All.LowBlow, PLD.ShieldBash)]
             [ParentCombo(AllTankFeatures)]
             [CustomComboInfo("Tank: Interrupt Feature", "Replaces Low Blow (Stun) with Interject (Interrupt) when the target can be interrupted.\nPLDs can slot Shield Bash to have the feature to work with Shield Bash.", ADV.JobID)]
             AllTankInterruptFeature = 100000,
@@ -106,6 +107,7 @@ namespace XIVSlothComboPlugin
         AllHealerFeatures = 100098,
 
             #region Global Healer Features
+            [ReplaceSkill(AST.Ascend, WHM.Raise, SCH.Resurrection, SGE.Egeiro)]
             [ConflictingCombos(AstrologianAscendFeature, SCH_RaiseFeature, SGE_RaiseFeature, WHMRaiseFeature)]
             [ParentCombo(AllHealerFeatures)]
             [CustomComboInfo("Healer: Raise Feature", "Changes the class' Raise Ability into Swiftcast.", ADV.JobID)]
@@ -148,25 +150,33 @@ namespace XIVSlothComboPlugin
             AllRangedPhysicalMitigationFeature = 100040,
             #endregion
 
+        //Non-gameplay Features
+        [CustomComboInfo("Output Combat Log", "Outputs your performed actions to the chat.", ADV.JobID)]
+        AllOutputCombatLog = 100094,
+
 
         #endregion
         // ====================================================================================
         #region ASTROLOGIAN
 
-
+        [ReplaceSkill(AST.Play)]
         [CustomComboInfo("Draw on Play", "Play turns into Draw when no card is drawn, as well as the usual Play behavior.", AST.JobID, 0, "Pot of Greed", "Draw some cards, or something. Idk, you're the one that chose to play AST.")]
         AstrologianCardsOnDrawFeaturelikewhat = 1000,
 
+        [ReplaceSkill(AST.CrownPlay)]
         [CustomComboInfo("Crown Play to Minor Arcana", "Changes Crown Play to Minor Arcana when a card is not drawn or has Lord Or Lady Buff.", AST.JobID, 0, "Bestow Royalty", "This one's for the Lords and Ladies, lemme get a HYEEEAAAAAH!")]
         AstrologianCrownPlayFeature = 1001,
 
+        [ReplaceSkill(AST.Benefic2)]
         [CustomComboInfo("Benefic 2 Downgrade", "Changes Benefic 2 to Benefic when Benefic 2 is not unlocked or available.", AST.JobID, 0, "Sprout's Benedict Cumberbatch", "Changes Big Benedict into Little Benedict when you visit the sprout universe.")]
         AstrologianBeneficFeature = 1002,
 
+        [ReplaceSkill(All.Swiftcast)]
         [ConflictingCombos(AllHealerRaiseFeature)]
         [CustomComboInfo("AST Alternative Raise Feature", "Changes Swiftcast to Ascend", AST.JobID, 0, "Rez-bot-3000", "Does your job for you, but faster. You're welcome, little sloth.")]
         AstrologianAscendFeature = 1003,
 
+        [ReplaceSkill(AST.Malefic1, AST.Malefic2, AST.Malefic3, AST.Malefic4, AST.FallMalefic)]
         [ConflictingCombos(AstrologianAlternateDpsFeature, CustomValuesTest)]
         [CustomComboInfo("DPS Feature(On Malefic)", "Adds Combust to the main malefic combo whenever the debuff is not present or about to expire", AST.JobID, 0, "Green DPS? Look no further", "Adds fatter deeps to your combo. Just pick another job already...")]
         AstrologianDpsFeature = 1004,
@@ -178,6 +188,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Astrodyne Feature", "Adds Astrodyne to the DPS feature when ready", AST.JobID, 0, "Astro-whine Feature", "Astro-whining again? Sorry, everyone's busy looking at the SGE's cool floating sticks.")]
         AstrologianAstrodyneFeature = 1009,
 
+        [ReplaceSkill(AST.AspectedHelios)]
         [CustomComboInfo("Aspected Helios Feature", "Replaces Aspected Helios whenever you are under Aspected Helios regen with Helios", AST.JobID, 0, "HELIOSCOPTER", "HELIOSCOPTER HELIOSCOPTER")]
         AstrologianHeliosFeature = 1010,
 
@@ -195,9 +206,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Lazy Lord Feature", "Adds Lord Of Crowns Onto Main DPS/AoE Feature", AST.JobID, 0, "Brainless Lord Feature", "You're like that tiny guy from Shrek. - E -")]
         AstrologianLazyLordFeature = 1014,
 
+        [ReplaceSkill(AST.Play)]
         [CustomComboInfo("Astrodyne on Play", "Play becomes Astrodyne when you have 3 seals.", AST.JobID, 0, "Astro-whine on Play", "Seal me up and let me die, baby")]
         AstrologianAstrodyneOnPlayFeature = 1015,
 
+        [ReplaceSkill(AST.Combust, AST.Combust2, AST.Combust3)]
         [ConflictingCombos(AstrologianDpsFeature, CustomValuesTest)]
         [CustomComboInfo("Alternate DPS Feature (On Combust)", "Adds Combust to the main malefic combo whenever the debuff is not present or about to expire", AST.JobID, 0, "Alternate Deeps, buddy", "Now we're really doing your job for you. Damn.")]
         AstrologianAlternateDpsFeature = 1016,
@@ -222,6 +235,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Lazy Lady Feature", "Adds Lady of Crowns, if the card is drawn", AST.JobID, 0)]
         AstrologianLazyLadyFeature = 1022,
 
+        [ReplaceSkill(AST.Benefic2)]
         [CustomComboInfo("Simple Heal", "Single target healing", AST.JobID, 0)]
         AstrologianSimpleSingleTargetHeal = 1023,
 
@@ -277,45 +291,57 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region BLACK MAGE
 
+        [ReplaceSkill(BLM.Scathe)]
         [ConflictingCombos(BlackSimpleFeature)]
         [CustomComboInfo("Scathe Feature", "Replaces Scathe with Fire 4 or Blizzard 4 depending on Astral Fire/Umbral Ice.", BLM.JobID, 2, "BrainLess Mage", "One button, BAYBEE!")]
         BlackEnochianFeature = 2000,
 
+        [ReplaceSkill(BLM.Transpose)]
         [CustomComboInfo("Umbral Soul/Transpose Feature", "Replaces Transpose with Umbral Soul when Umbral Soul is available.", BLM.JobID, 0, "Eh? Huh?", "Just does BLM things. Probably.")]
         BlackManaFeature = 2001,
 
+        [ReplaceSkill(BLM.LeyLines)]
         [CustomComboInfo("Between the Ley Lines Feature", "Replaces Ley Lines with Between the Ley Lines when Ley Lines is active.", BLM.JobID, 0, "BLT Sandwich feature", "Look between, and you shall find")]
         BlackLeyLinesFeature = 2002,
 
+        [ReplaceSkill(BLM.Blizzard, BLM.Freeze)]
         [CustomComboInfo("Blizzard 1/2/3 Feature", "Replaces Blizzard 1 with Blizzard 3 when out of Umbral Ice. Replaces Freeze with Blizzard 2 when synced.", BLM.JobID, 0, "Chilly boi", "Chill out, for real. It's sleepy sloth time")]
         BlackBlizzardFeature = 2003,
 
+        [ReplaceSkill(BLM.Scathe)]
         [ConflictingCombos(BlackEnochianFeature, BlackSimpleFeature)]
         [CustomComboInfo("Xenoglossy Feature", "Replaces Scathe with Xenoglossy when available.", BLM.JobID, 0, "Glossy paint", "So shiny, so glossy...")]
         BlackScatheFeature = 2004,
 
+        [ReplaceSkill(BLM.Fire)]
         [CustomComboInfo("Fire 1/3 Feature", "Replaces Fire 1 with Fire 3 outside of Astral Fire or when Firestarter proc is up.", BLM.JobID, 0, "Burna boi", "It's getting hot in here...")]
         BlackFire13Feature = 2005,
 
+        [ReplaceSkill(BLM.Scathe)]
         [ParentCombo(BlackEnochianFeature)]
         [CustomComboInfo("Thundercloud Option", "Replaces Scathe with Thunder 1/3 when the debuff isn't present or expiring and Thundercloud is available.", BLM.JobID, 0, "Plug Socket Mode", "Forks at the ready!")]
         BlackThunderFeature = 2006,
 
+        [ReplaceSkill(BLM.Fire4)]
         [ParentCombo(BlackEnochianFeature)]
         [CustomComboInfo("Despair Option", "Replaces Fire 4 with Despair when below 2400 MP.", BLM.JobID, 0, "My MP!", "The horror! The despair!")]
         BlackDespairFeature = 2007,
 
+        [ReplaceSkill(BLM.Flare)]
         [CustomComboInfo("Simple AoE Feature", "Replaces Flare with a full one button rotation.", BLM.JobID, 0, "Dungeon Tesla Mode", "Asleep at the wheel? We've got you!")]
         BlackAoEComboFeature = 2008,
 
+        [ReplaceSkill(BLM.Scathe)]
         [ParentCombo(BlackEnochianFeature)]
         [CustomComboInfo("Aspect Swap Option", "Replaces Scathe with Blizzard 3 when at 0 MP in Astral Fire or with Fire 3 when at 10000 MP in Umbral Ice with 3 Umbral Hearts.", BLM.JobID, 0, "", "")]
         BlackAspectSwapFeature = 2010,
 
+        [ReplaceSkill(BLM.Scathe)]
         [ParentCombo(BlackThunderFeature)]
         [CustomComboInfo("Thunder 1/3 Option", "Replaces Scathe with Thunder 1/3 when the debuff isn't present or expiring.", BLM.JobID, 0, "Bzzt", "Shocking!")]
         BlackThunderUptimeFeature = 2011,
 
+        [ReplaceSkill(BLM.Scathe)]
         [ConflictingCombos(BlackEnochianFeature, BlackScatheFeature, BlackSimpleTransposeFeature, BlackSimpleParadoxFeature)]
         [CustomComboInfo("Simple BLM Feature", "Replaces Scathe with a full one button rotation.", BLM.JobID, -2, "", "")]
         BlackSimpleFeature = 2012,
@@ -352,6 +378,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Foul / Manafont Flare Option", "Adds Foul when available during Astral Fire. Weaves Manafont after Foul for additional Flare", BLM.JobID, 0, "", "")]
         BlackAoEFoulOption = 2020,
 
+        [ReplaceSkill(BLM.Scathe)]
         [ConflictingCombos(BlackEnochianFeature, BlackScatheFeature, BlackSimpleFeature, BlackSimpleParadoxFeature)]
         [CustomComboInfo("Advanced BLM Feature", "Replaces Scathe with a full one button rotation that uses Transpose. Requires level 90.", BLM.JobID, -1, "", "")]
         BlackSimpleTransposeFeature = 2021,
@@ -360,6 +387,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Pool Triplecast Option", "Keep one triplecast usage for movement in the Advanced BLM feature.", BLM.JobID, -1, "", "")]
         BlackSimpleTransposePoolingFeature = 2022,
 
+        [ReplaceSkill(BLM.Scathe)]
         [ConflictingCombos(BlackEnochianFeature, BlackScatheFeature, BlackSimpleFeature, BlackSimpleTransposeFeature)]
         [CustomComboInfo("Paradox BLM Feature", "Replaces Scathe with a full one button rotation that has minimal casts (~9% less damage than Simple BLM). Requires level 90.", BLM.JobID, -1, "", "")]
         BlackSimpleParadoxFeature = 2023,
@@ -368,12 +396,15 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region BLUE MAGE
 
+        [ReplaceSkill(BLU.SongOfTorment)]
         [CustomComboInfo("Buffed Song of Torment", "Turns Song of Torment into Bristle so SoT is buffed. \nSpells Required: Song of Torment.", BLU.JobID)]
         BluBuffedSoT = 70000,
 
+        [ReplaceSkill(BLU.MoonFlute)]
         [CustomComboInfo("Moon Flute Opener", "Puts the Full Moon Flute Opener on Moon Flute or Whistle. \nSpells Required: Whistle, Tingle, Moon Flute, J Kick, Triple Trident, Nightbloom, Rose of Destruction, Feather Rain, Bristle, Glass Dance, Surpanakha, Matra Magic, Shock Strike, Phantom Flurry.", BLU.JobID)]
         BluOpener = 70001,
 
+        [ReplaceSkill(BLU.FinalSting)]
         [CustomComboInfo("Final Sting Combo", "Turns Final Sting into the buff combo of: Moon Flute, Tingle, Whistle, Final Sting. Will use any primals off CD before casting Final Sting. \nSpells Required: Moon Flute, Tingle, Whistle, Final Sting", BLU.JobID)]
         BluFinalSting = 70002,
 
@@ -381,21 +412,27 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Off CD Primal Additions", "Adds any Primals that are off CD to the Final Sting Combo. \nPrimals Used: Feather Rain, Shock Strike, Glass Dance, J Kick, Rose of Destruction. ", BLU.JobID)]
         BluPrimals = 70003,
 
+        [ReplaceSkill(BLU.Ultravibration)]
         [CustomComboInfo("Ram's Voice into Ultravibration", "Turns Ultravibration into Ram's Voice if Deep Freeze isn't on the target. Will swiftcast Ultravibration if available. \nSpells Required: Ram's Voice, Ultravibration. ", BLU.JobID)]
         BluUltravibrate = 70005,
 
+        [ReplaceSkill(BLU.Devour, BLU.Offguard, BLU.BadBreath)]
         [CustomComboInfo("Tank Debuff Feature", "Puts Devour, Off-Guard, Lucid Dreaming, and Bad Breath into one button when under Tank Mimicry. \nSpells Required: Devour, Off-Guard, Bad Breath.", BLU.JobID)]
         BluDebuffCombo = 70006,
 
+        [ReplaceSkill(BLU.MagicHammer)]
         [CustomComboInfo("Addle/Magic Hammer Debuff Feature", "Turns Magic Hammer into Addle when off CD. \nSpells Required: Magic Hammer.", BLU.JobID)]
         BluAddleFeature = 70007,
 
+        [ReplaceSkill(BLU.FeatherRain)]
         [CustomComboInfo("Primal Feature", "Turns Feather Rain into any Primals that are off CD. \nSpells Required: Feather Rain, Shock Strike, The Rose of Destruction, Glass Dance, J Kick. \nWill cause primals to desync from Moon Flute burst phases if used on CD.", BLU.JobID)]
         BluPrimalFeature = 70008,
 
+        [ReplaceSkill(BLU.BlackKnightsTour, BLU.WhiteKnightsTour)]
         [CustomComboInfo("Knight's Tour Feature", "Turns Black Knight's Tour or White Knight's Tour into its counterpart when the enemy is under the effect of the spell's debuff. \nSpells Required: White Knight's Tour, Black Knight's Tour", BLU.JobID)]
         BluKnightFeature = 70009,
 
+        [ReplaceSkill(BLU.PeripheralSynthesis)]
         [CustomComboInfo("Peripheral Synthesis into Mustard Bomb", "Turns Peripheral Synthesis into Mustard Bomb when target is under the effect of Lightheaded. \nSpells Required: Peripheral Synthesis, Mustard Bomb.", BLU.JobID)]
         BluLightheadedCombo = 70010,
 
@@ -404,6 +441,7 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region BARD
 
+        [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(SimpleBardFeature)]
         [CustomComboInfo("Heavy Shot into Straight Shot", "Replaces Heavy Shot/Burst Shot with Straight Shot/Refulgent Arrow when procced.", BRD.JobID, 0, "This shot into that shot", "You're still using a bow? In this day and age?\nJust play MCH. They have guns, dude.")]
         BardStraightShotUpgradeFeature = 3001,
@@ -413,30 +451,37 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("DoT Maintenance Option", "Enabling this option will make Heavy Shot into Straight Shot refresh your DoTs on your current.", BRD.JobID, 0, "Butter Maintenance Option", "Slathers butter on your target if butter is not present.")]
         BardDoTMaintain = 3002,
 
+        [ReplaceSkill(BRD.IronJaws)]
         [ConflictingCombos(BardIronJawsAlternateFeature)]
         [CustomComboInfo("Iron Jaws Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nAlternates between the two if Iron Jaws isn't available.", BRD.JobID, 0, "Jaws", "Wasn't this guy a James Bond villain in the '70s?")]
         BardIronJawsFeature = 3003,
 
+        [ReplaceSkill(BRD.IronJaws)]
         [ConflictingCombos(BardIronJawsFeature)]
         [CustomComboInfo("Iron Jaws Alternate Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.", BRD.JobID, 0, "Mr. Larson", "Oh, and Happy Gilmore!!")]
         BardIronJawsAlternateFeature = 3004,
 
+        [ReplaceSkill(BRD.BurstShot, BRD.QuickNock)]
         [ConflictingCombos(SimpleBardFeature)]
         [CustomComboInfo("Burst Shot/Quick Nock into Apex Arrow", "Replaces Burst Shot and Quick Nock with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID, 0, "Robin Hood Feature", "Steal from Lolorito and give to Garlemald, I guess?\nGood on ya.")]
         BardApexFeature = 3005,
 
+        [ReplaceSkill(BRD.Bloodletter)]
         [ConflictingCombos(SimpleBardFeature)]
         [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter (+ Songs rotation) depending on their CD.", BRD.JobID, 0, "oGCD's spilling everywhere", "The Algorithm between the lines. Trademark")]
         BardoGCDSingleTargetFeature = 3006,
 
+        [ReplaceSkill(BRD.RainOfDeath)]
         [ConflictingCombos(BardAoEComboFeature)]
         [CustomComboInfo("AoE oGCD Feature", "All AoE oGCD's on Rain of Death depending on their CD.", BRD.JobID, 0, "", "Arrows! Everywhere! Run!")]
         BardoGCDAoEFeature = 3007,
 
+        [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
         [ConflictingCombos(BardSimpleAoEFeature)]
         [CustomComboInfo("AoE Combo Feature", "Replaces Quick Nock/Ladonsbite with Shadowbite when ready", BRD.JobID, 0, "", "C-C-C-Combo!")]
         BardAoEComboFeature = 3008,
 
+        [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(BardStraightShotUpgradeFeature, BardDoTMaintain, BardApexFeature, BardoGCDSingleTargetFeature, BardIronJawsApexFeature)]
         [CustomComboInfo("Simple Bard", "Adds every single target ability to one button,\nIf there are DoTs on target Simple Bard will try to maintain their uptime.", BRD.JobID, 0, "Sbimple Sbard", "Goodbye, brain. And then there's this feature, too!")]
         SimpleBardFeature = 3009,
@@ -459,6 +504,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("One Button Songs", "Add Mage's Ballad and Army's Paeon to Wanderer's Minuet depending on cooldowns", BRD.JobID, 0, "EDM songs", "They all sound the same, anyway.")]
         BardOneButtonSongs = 3014,
 
+        [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
         [CustomComboInfo("Simple AoE Bard", "Weaves oGCDs onto Quick Nock/Ladonsbite", BRD.JobID, 0, "", "Group attacks to make you feel like you're not the worst Ranged DPS in the room")]
         BardSimpleAoEFeature = 3015,
 
@@ -515,6 +561,7 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region DANCER
 
+        [ReplaceSkill(DNC.Cascade)]
         // Single Target Multibutton Section
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
         [CustomComboInfo("Single Target Multibutton", "Change Cascade into procs and combos as available.", DNC.JobID, 0, "", "")]
@@ -538,9 +585,10 @@ namespace XIVSlothComboPlugin
             [ParentCombo(DancerSingleTargetMultibutton)]
             [CustomComboInfo("Fan Dance On Cascade Feature", "Adds Fan Dance 3/4 onto Cascade when available.", DNC.JobID, 0, "", "")]
             DancerFanDance34OnMainComboFeature = 4004,
-            #endregion
+        #endregion
 
         // AoE Multibutton Section
+        [ReplaceSkill(DNC.Windmill)]
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
         [CustomComboInfo("AoE Multibutton", "Change Windmill into procs and combos as available.", DNC.JobID, 0, "", "")]
         DancerAoEMultibutton = 4010,
@@ -571,25 +619,27 @@ namespace XIVSlothComboPlugin
         DancerMenuDanceFeatures = 4020,
 
             #region Dance Features
+            [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
             [ParentCombo(DancerMenuDanceFeatures)]
             [ConflictingCombos(DancerCombinedDanceFeature, DancerDanceComboCompatibility)]
             [CustomComboInfo("Dance Step Combo", "Change Standard Step and Technical Step into each dance step while dancing.\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
             DancerDanceStepCombo = 4021,
 
+            [ReplaceSkill(DNC.StandardStep)]
             [ParentCombo(DancerMenuDanceFeatures)]
             [ConflictingCombos(DancerDanceStepCombo, DancerDanceComboCompatibility)]
             [CustomComboInfo("Combined Dance Feature", "Standard And Technical Dance on one button (SS). Standard > Technical. This combos out into Tillana and Starfall Dance.", DNC.JobID, 0, "", "")]
             DancerCombinedDanceFeature = 4022,
 
-            #region Combined Dance Feature
-            [ParentCombo(DancerCombinedDanceFeature)]
-            [CustomComboInfo("Devilment Plus Option", "Adds Devilment right after Technical finish.", DNC.JobID, 0, "", "")]
-            DancerDevilmentOnCombinedDanceFeature = 4023,
+                #region Combined Dance Feature
+                [ParentCombo(DancerCombinedDanceFeature)]
+                [CustomComboInfo("Devilment Plus Option", "Adds Devilment right after Technical finish.", DNC.JobID, 0, "", "")]
+                DancerDevilmentOnCombinedDanceFeature = 4023,
 
-            [ParentCombo(DancerCombinedDanceFeature)]
-            [CustomComboInfo("Flourish Plus Option", "Adds Flourish to the Combined Dance Feature.", DNC.JobID, 0, "", "")]
-            DancerFlourishOnCombinedDanceFeature = 4024,
-            #endregion
+                [ParentCombo(DancerCombinedDanceFeature)]
+                [CustomComboInfo("Flourish Plus Option", "Adds Flourish to the Combined Dance Feature.", DNC.JobID, 0, "", "")]
+                DancerFlourishOnCombinedDanceFeature = 4024,
+                #endregion
 
             [ParentCombo(DancerMenuDanceFeatures)]
             [ConflictingCombos(DancerDanceStepCombo, DancerCombinedDanceFeature)]
@@ -608,6 +658,7 @@ namespace XIVSlothComboPlugin
         DancerMenuFlourishingFeatures = 4030,
 
             #region Flourishing Features
+            [ReplaceSkill(DNC.Flourish)]
             [ParentCombo(DancerMenuFlourishingFeatures)]
             [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
             [CustomComboInfo("Flourishing Fan Dance Feature", "Replace Flourish with Fan Dance 3 & 4 during weave-windows, when Flourish is on cooldown.", DNC.JobID, 0, "", "")]
@@ -621,30 +672,36 @@ namespace XIVSlothComboPlugin
         DancerFanDanceComboFeatures = 4033,
 
             #region Fan Dance Combo Features
+            [ReplaceSkill(DNC.FanDance1)]
             [ParentCombo(DancerFanDanceComboFeatures)]
             [CustomComboInfo("Fan Dance 1 -> 3", "Changes Fan Dance 1 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
             DancerFanDance1_3Combo = 4034,
 
+            [ReplaceSkill(DNC.FanDance1)]
             [ParentCombo(DancerFanDanceComboFeatures)]
             [CustomComboInfo("Fan Dance 1 -> 4", "Changes Fan Dance 1 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
             DancerFanDance1_4Combo = 4035,
 
+            [ReplaceSkill(DNC.FanDance2)]
             [ParentCombo(DancerFanDanceComboFeatures)]
             [CustomComboInfo("Fan Dance 2 -> 3", "Changes Fan Dance 2 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
             DancerFanDance2_3Combo = 4036,
 
+            [ReplaceSkill(DNC.FanDance2)]
             [ParentCombo(DancerFanDanceComboFeatures)]
             [CustomComboInfo("Fan Dance 2 -> 4", "Changes Fan Dance 2 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
             DancerFanDance2_4Combo = 4037,
             #endregion
 
         // Devilment --> Starfall
+        [ReplaceSkill(DNC.Devilment)]
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
         [CustomComboInfo("Devilment to Starfall Feature", "Change Devilment into Starfall Dance after use.", DNC.JobID, 0, "", "")]
         DancerDevilmentFeature = 4038,
 
 
         // Simple Dancer Section
+        [ReplaceSkill(DNC.Cascade)]
         [ConflictingCombos(DancerSingleTargetMultibutton, DancerAoEMultibutton, DancerCombinedDanceFeature, DancerDanceComboCompatibility, DancerMenuFlourishingFeatures, DancerDevilmentFeature)]
         [CustomComboInfo("Simple Dancer (Single Target)", "Single button, single target. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
         DancerSimpleFeature = 4050,
@@ -692,6 +749,7 @@ namespace XIVSlothComboPlugin
             #endregion
 
         // Simple Dancer AoE Section
+        [ReplaceSkill(DNC.Windmill)]
         [ConflictingCombos(DancerSingleTargetMultibutton, DancerAoEMultibutton, DancerCombinedDanceFeature, DancerDanceComboCompatibility, DancerMenuFlourishingFeatures, DancerDevilmentFeature)]
         [CustomComboInfo("Simple Dancer (AoE)", "Single button, AoE. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
         DancerSimpleAoEFeature = 4070,
@@ -751,16 +809,20 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("CDs on Main Combo", "Collection of CDs to add to Main Combo", DRK.JobID)]
         DarkMainComboCDsGroup = 5099,
 
+        [ReplaceSkill(DRK.Souleater)]
         [CustomComboInfo("Souleater Combo", "Replace Souleater with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Simple Dark Knight)", DRK.JobID, 0, "Fetch me their souls!", "Heheheheheh")]
         DarkSouleaterCombo = 5000,
 
+        [ReplaceSkill(DRK.StalwartSoul)]
         [CustomComboInfo("Stalwart Soul Combo", "Replace Stalwart Soul with its combo chain.", DRK.JobID, 0, "", "Ugly name for an ugly job")]
         DarkStalwartSoulCombo = 5001,
 
+        [ReplaceSkill(DRK.Souleater)]
         [ParentCombo(DarkMainComboBuffsGroup)]
         [CustomComboInfo("Delirium Feature", "Replace Souleater and Stalwart Soul with Bloodspiller and Quietus when Delirium is active.", DRK.JobID, 0, "", "Delirium is what you have if you choose to play DRK.\nDoc's words, not mine")]
         DeliriumFeature = 5002,
 
+        [ReplaceSkill(DRK.StalwartSoul)]
         [ParentCombo(DarkStalwartSoulCombo)]
         [CustomComboInfo("Dark Knight Gauge Overcap Feature", "Replace AoE combo with gauge spender if you are about to overcap.", DRK.JobID, 0, "", "Hey big spenderrrrr")]
         DRKOvercapFeature = 5003,
@@ -773,6 +835,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("EoS Overcap Feature", "Uses EoS if you are above 8.5k mana or Darkside is about to expire (10sec or less)", DRK.JobID, 0, "Something about mana", "You're basically a black mage! Well done!")]
         DarkManaOvercapFeature = 5005,
 
+        [ReplaceSkill(DRK.CarveAndSpit, DRK.AbyssalDrain)]
         [ConflictingCombos(DarkMainComboCDsGroup)]
         [CustomComboInfo("oGCD Feature", "Adds Living Shadow > Salted Earth > Carve And Spit > Salt And Darkness to Carve And Spit and Abysal Drain", DRK.JobID, 0, "", "Just does your whole job for you, really")]
         DarkoGCDFeature = 5006,
@@ -862,10 +925,12 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region DRAGOON
 
+        [ReplaceSkill(DRG.CoerthanTorment)]
         [ConflictingCombos(DragoonSimpleAoE)]
         [CustomComboInfo("Coerthan Torment Combo", "Replace Coerthan Torment with its combo chain.", DRG.JobID, 1, "", "")]
         DragoonCoerthanTormentCombo = 6100,
 
+        [ReplaceSkill(DRG.ChaosThrust)]
         [ConflictingCombos(DragoonSimple)]
         [CustomComboInfo("Chaos Thrust Combo", "Replace Chaos Thrust with its combo chain.", DRG.JobID, 2, "", "")]
         DragoonChaosThrustCombo = 6200,
@@ -876,6 +941,7 @@ namespace XIVSlothComboPlugin
             DragoonPiercingTalonChaosFeature = 6201,
             #endregion
 
+        [ReplaceSkill(DRG.FullThrust)]
         [ConflictingCombos(DragoonFullThrustComboPlus, DragoonSimple)]
         [CustomComboInfo("Full Thrust Combo", "Replace Full Thrust with its combo chain.", DRG.JobID, 4, "", "")]
         DragoonFullThrustCombo = 6300,
@@ -884,8 +950,9 @@ namespace XIVSlothComboPlugin
             [ParentCombo(DragoonFullThrustCombo)]
             [CustomComboInfo("Full Piercing Talon Uptime", "Replaces Full Thrust Combo with Piercing Talon when you are out of range.", DRG.JobID, 5, "", "")]
             DragoonPiercingTalonFullFeature = 6301,
-            #endregion
+        #endregion
 
+        [ReplaceSkill(DRG.FullThrust)]
         [ConflictingCombos(DragoonFullThrustCombo, DragoonSimple)]
         [CustomComboInfo("Full Thrust Combo Plus", "Replace Full Thrust Plus Combo with its combo chain (Disembowel/Chaosthrust/life surge added).", DRG.JobID, 6, "", "")]
         DragoonFullThrustComboPlus = 6400,
@@ -906,8 +973,9 @@ namespace XIVSlothComboPlugin
             [ParentCombo(DragoonFullThrustComboPlus)]
             [CustomComboInfo("Plus Piercing Talon Uptime", "Replaces Full Thrust with Piercing Talon when you are out of range.", DRG.JobID, 10, "", "")]
             DragoonPiercingTalonPlusFeature = 6403,
-            #endregion
+        #endregion
 
+        [ReplaceSkill(DRG.FullThrust)]
         [ConflictingCombos(DragoonFullThrustCombo, DragoonFullThrustComboPlus, DragoonChaosThrustCombo, DragoonFangThrustFeature, DragoonFangAndClawFeature)]
         [CustomComboInfo("Simple Dragoon", "Replaces Full Thrust with the entire DRG combo chain. Conflicts with every non-AoE feature.", DRG.JobID, 11, "", "")]
         DragoonSimple = 6500,
@@ -972,8 +1040,9 @@ namespace XIVSlothComboPlugin
             [ParentCombo(DragoonSimple)]
             [CustomComboInfo("Ranged Uptime Option", "Replaces Main Combo with Piercing Talon when you are out of melee range.\nNOT OPTIMAL.", DRG.JobID, 25, "", "")]
             DRGSimpleRangedUptimeST = 6513,
-            #endregion
+        #endregion
 
+        [ReplaceSkill(DRG.CoerthanTorment)]
         [ConflictingCombos(DragoonCoerthanTormentCombo)]
         [CustomComboInfo("Simple Dragoon AoE", "One Button, many enemies hit.", DRG.JobID, 26, "", "")]
         DragoonSimpleAoE = 6600,
@@ -987,7 +1056,7 @@ namespace XIVSlothComboPlugin
             [CustomComboInfo("Geirskogul and Nastrond AoE Feature", "Includes Geirskogul and Nastrond in the AoE rotation.", DRG.JobID, 28, "", "")]
             DragoonAoEGeirskogulNastrondFeature = 6602,
 
-            [ConflictingCombos(DragoonAoELitanyDiveFeature, DragoonAoELifeLitanyDiveFeature)]
+            [ConflictingCombos(DragoonAoELitanyDiveFeature, DragoonAoELifeLitanyDiveFeature, DragoonAoELanceDiveFeature)]
             [ParentCombo(DragoonSimpleAoE)]
             [CustomComboInfo("Dives AoE Feature", "Includes Spineshatter Dive, Dragonfire Dive and Stardiver in the AoE rotation.", DRG.JobID, 29, "", "")]
             DragoonAoEDiveFeature = 6603,
@@ -1038,6 +1107,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Wheeling Thrust/Fang and Claw Option", "When you have either Enhanced Fang and Claw or Wheeling Thrust, Chaos Thrust Combo becomes Wheeling Thrust and Full Thrust Combo becomes Fang and Claw. Requires Chaos Thrust Combo and Full Thrust Combo.", DRG.JobID, 38, "", "")]
         DragoonFangThrustFeature = 6700,
 
+        [ReplaceSkill(DRG.FangAndClaw)]
         [ConflictingCombos(DragoonSimple)]
         [CustomComboInfo("Wheeling Thrust/Fang and Claw Feature", "Fang And Claw Becomes Wheeling Thrust when under Enhanced Wheeling Thrust Buff.", DRG.JobID, 39, "", "")]
         DragoonFangAndClawFeature = 6701,
@@ -1046,6 +1116,7 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region GUNBREAKER
 
+        [ReplaceSkill(GNB.SolidBarrel)]
         [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Simple Gunbreaker)", GNB.JobID, 0, "Floppy Barrel Combo", "Not so solid NOW, are ya?")]
         GunbreakerSolidBarrelCombo = 7000,
 
@@ -1069,12 +1140,15 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Danger Zone/Blasting Zone on Main Combo", "Adds Danger Zone/Blasting Zone to the Main Combo", GNB.JobID, 0)]
         GunbreakerDZOnMainComboFeature = 7005,
 
+        [ReplaceSkill(GNB.DemonSlaughter)]
         [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain.", GNB.JobID, 0, "dEmOn SlAuGhTeR", "Demon Slaughter? Really? What is this, RPR?")]
         GunbreakerDemonSlaughterCombo = 7006,
 
+        [ReplaceSkill(GNB.SolidBarrel, GNB.DemonSlaughter)]
         [CustomComboInfo("Ammo Overcap Feature", "Uses Burst Strike/Fated Circle on the respective ST/AoE combos when ammo is about to overcap.", GNB.JobID, 0, "Pew Pew Forever", "The whole nine yards")]
         GunbreakerAmmoOvercapFeature = 7007,
 
+        [ReplaceSkill(GNB.GnashingFang)]
         [CustomComboInfo("Gnashing Fang Continuation Combo", "Adds Continuation to Gnashing Fang.", GNB.JobID, 0, "More Mercy", "More, no wait, less, no wait, MORE Mercy! No, wait...")]
         GunbreakerGnashingFangCombo = 7008,
 
@@ -1090,9 +1164,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("CDs on Gnashing Fang", "Adds Sonic Break/Bow Shock/Blasting Zone on Gnashing Fang, order dependent on No Mercy buff. \nBurst Strike added if there's charges while No Mercy buff is up.", GNB.JobID, 0, "More Teeth", "Gnashing fang, but like, if a shark did it. Or something.")]
         GunbreakerCDsOnGF = 7011,
 
+        [ReplaceSkill(GNB.BurstStrike, GNB.SolidBarrel, GNB.GnashingFang)]
         [CustomComboInfo("BurstStrikeContinuation", "Adds Hypervelocity on Burst Strike Continuation combo and main combo and Gnashing Fang.", GNB.JobID, 0, "Swish, swoosh", "Now we're cooking with gas! Hyper!")]
         GunbreakerBurstStrikeConFeature = 7012,
 
+        [ReplaceSkill(GNB.BurstStrike)]
         [CustomComboInfo("Burst Strike to Bloodfest Feature", "Replace Burst Strike with Bloodfest if you have no powder gauge.", GNB.JobID, 0, "P4S Vampire man Bloodfest Feature", "Again with the edgelord names?\nTut, tut, Yoshi-P. Do better.")]
         GunbreakerBloodfestOvercapFeature = 7013,
 
@@ -1128,6 +1204,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Sonic Break on Main Combo", "Adds Sonic Break to the Main Combo", GNB.JobID, 0)]
         GunbreakerSBOnMainComboFeature = 7021,
 
+        [ReplaceSkill(GNB.NoMercy)]
         [CustomComboInfo("Sonic Break/Bow Shock on NM", "Adds Sonic Break and Bow Shock to No Mercy when NM is on CD", GNB.JobID, 0)]
         GunbreakerCDsonNMFeature = 7022,
 
@@ -1155,15 +1232,19 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region MACHINIST
 
+        [ReplaceSkill(MCH.CleanShot, MCH.HeatedCleanShot, MCH.SplitShot, MCH.HeatedSplitShot)]
         [CustomComboInfo("(Heated) Shot Combo", "Replace either form of Clean Shot with its combo chain.", MCH.JobID, 0, "Alright, Hotshot -", "Is there really such a thing as a clean shot? Let's find out.")]
         MachinistMainCombo = 8000,
 
+        [ReplaceSkill(MCH.RookAutoturret, MCH.AutomatonQueen)]
         [CustomComboInfo("Overdrive Feature", "Replace Rook Autoturret and Automaton Queen with Overdrive while active.", MCH.JobID, 0, "Drive (2011) Feature", "Insert synthwave soundtrack here.")]
         MachinistOverdriveFeature = 8002,
 
+        [ReplaceSkill(MCH.GaussRound, MCH.Ricochet)]
         [CustomComboInfo("Gauss Round / Ricochet Feature", "Replace Gauss Round and Ricochet with one or the other depending on which has more charges.", MCH.JobID, 0, "Gatling feature", "It's just a lot of bullets, really.")]
         MachinistGaussRoundRicochetFeature = 8003,
 
+        [ReplaceSkill(MCH.Drill, MCH.AirAnchor, MCH.HotShot)]
         [CustomComboInfo("Drill / Air Anchor (Hot Shot) Feature", "Replace Drill and Air Anchor (Hot Shot) with one or the other (or Chainsaw) depending on which is on cooldown.", MCH.JobID, 0, "Multi-tool", "Why does MCH have a drill and a chainsaw? What is this, DoH?")]
         MachinistHotShotDrillChainsawFeature = 8004,
 
@@ -1172,10 +1253,12 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Drill/Air/Chain Saw Feature On Main Combo", "Air Anchor followed by Drill is added onto main combo if you use Reassemble.\nIf Air Anchor is on cooldown and you use Reassemble, Chainsaw will be added to main combo instead.", MCH.JobID, 0, "A bit of everything feature", "Don't rub your last two brain-cells together! We got you!")]
         MachinistDrillAirOnMainCombo = 8005,
 
+        [ReplaceSkill(MCH.HeatBlast)]
         [ConflictingCombos(MachinistSimpleFeature)]
         [CustomComboInfo("Single Button Heat Blast", "Switches Heat Blast to Hypercharge.", MCH.JobID, 0, "So-called 'Heat Blast'", "Basically a large hair-dryer.")]
         MachinistHeatblastGaussRicochetFeature = 8006,
 
+        [ReplaceSkill(MCH.AutoCrossbow)]
         [CustomComboInfo("Single Button Auto Crossbow", "Switches Auto Crossbow to Hypercharge and weaves gauss/rico.", MCH.JobID, 0, "Laser Crossbow", "It's a crossbow, from the future!")]
         MachinistAutoCrossBowGaussRicochetFeature = 8018,
 
@@ -1229,6 +1312,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Barrel Feature", "Adds Barrel Stabalizer to Single Button Heat Blast and Single Button Auto Crossbow Features when below 50 heat and is off cooldown", MCH.JobID, 0, "Hot Cross Bow", "Now multi-purpose!")]
         MachinistAutoBarrel = 8019,
 
+        [ReplaceSkill(MCH.SplitShot, MCH.HeatedSplitShot)]
         [ConflictingCombos(MachinistMainCombo, MachinistHeatblastGaussRicochetFeature)]
         [CustomComboInfo("Simple Machinist", "Single button single target machinist, including buffs and overprotections.\nConflicts with other single target toggles!!\nMade to work optimally with a 2.5 GCD.", MCH.JobID, 0, "", "Goodbye, brain!")]
         MachinistSimpleFeature = 8020,
@@ -1261,6 +1345,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Hypercharge", "Adds hypercharge to the AoE.", MCH.JobID, 0, "Sugar Rush", "I'm gonna slap @augporto for putting in so many damn MCH features.\nHow full of witty one-liners do you think I am?!")]
         MachinistAoEHyperchargeFeature = 8027,
 
+        [ReplaceSkill(MCH.SpreadShot)]
         [CustomComboInfo("Simple Machinist AOE", "Spread Shot turns into Scattergun when lvl 82 or higher, Both turn into Auto Crossbow when overheated\nand Bioblaster is used first whenever it is off cooldown.", MCH.JobID, 0, "Dungeon go zzzz", "AoE, but you're just not here. Go make a coffee.")]
         MachinistSpreadShotFeature = 8028,
 
@@ -1292,32 +1377,41 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region MONK
 
+        [ReplaceSkill(MNK.ArmOfTheDestroyer)]
         [CustomComboInfo("Arm of the Destroyer Combo", "Replaces Arm Of The Destroyer with its combo chain.", MNK.JobID, 0, "", "Punching, but wide. It's like having extra hands!")]
         MnkArmOfTheDestroyerCombo = 9000,
 
+        [ReplaceSkill(MNK.DragonKick)]
         [CustomComboInfo("Bootshine Feature", "Replaces Dragon Kick with Bootshine if both a form and Leaden Fist are up.", MNK.JobID, 0, "", "Shine ya shoes, guv'na?")]
         MnkBootshineFeature = 9001,
 
+        [ReplaceSkill(MNK.TrueStrike)]
         [CustomComboInfo("Twin Snakes Feature", "Replaces True Strike with Twin Snakes if Disciplined Fist is not applied or is less than 6 seconds from falling off.", MNK.JobID, 0, "", "I've had it with these MF snakes on this MF plane!")]
         MnkTwinSnakesFeature = 9011,
 
+        [ReplaceSkill(MNK.Bootshine)]
         [ConflictingCombos(MnkBootshineCombo)]
         [CustomComboInfo("Basic Rotation", "Basic Monk Combo on one button", MNK.JobID, 0, "", "I presses the buttons, I does the deeps")]
         MnkBasicCombo = 9002,
 
+        [ReplaceSkill(MNK.PerfectBalance)]
         [CustomComboInfo("Perfect Balance Feature", "Perfect Balance becomes Masterful Blitz while you have 3 Beast Chakra.", MNK.JobID, 0, "", "They say life is like walking a tightrope...")]
         MonkPerfectBalanceFeature = 9003,
 
+        [ReplaceSkill(MNK.DragonKick)]
         [CustomComboInfo("Bootshine Balance Feature", "Replaces Dragon Kick with Masterful Blitz if you have 3 Beast Chakra.", MNK.JobID, 0, "The tin", "Does what it says on the tin")]
         MnkBootshineBalanceFeature = 9004,
 
+        [ReplaceSkill(MNK.HowlingFist, MNK.Enlightenment)]
         [CustomComboInfo("Howling Fist/Meditation Feature", "Replaces Howling Fist/Enlightenment with Meditation when the Fifth Chakra is not open.", MNK.JobID, 0, "", "Imagine using your fist to scream at someone. Welcome to MNK!\nEnjoy your stay.")]
         MonkHowlingFistMeditationFeature = 9005,
 
+        [ReplaceSkill(MNK.Bootshine)]
         [ConflictingCombos(MnkBasicCombo)]
         [CustomComboInfo("Bootshine Combo", "Replace Bootshine with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Simple Monk).  Slider values can be used to control Disciplined Fist + Demolish uptime.", MNK.JobID, 0, "", "They call it 'basic' for a reason, you donkey")]
         MnkBootshineCombo = 9006,
 
+        [ReplaceSkill(MNK.MasterfulBlitz)]
         [CustomComboInfo("Perfect Balance Feature Plus", "All of the (Optimal?) Blitz combos on Masterful Blitz when Perfect Balance Is Active", MNK.JobID, 0, "", "Try not to fall over, eh")]
         MnkPerfectBalancePlus = 9007,
 
@@ -1329,6 +1423,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Masterful Blitz to AoE Combo", "Adds Masterful Blitz to the AoE Combo.", MNK.JobID, 0, "", "It's maths, but for your AoE combo!")]
         MonkMasterfulBlitzOnAoECombo = 9009,
 
+        [ReplaceSkill(MNK.RiddleOfFire)]
         [CustomComboInfo("Riddle of Fire/Brotherhood Feature", "Replaces Riddle of Fire with Brotherhood when Riddle of Fire is on cooldown.", MNK.JobID, 0, "", "Riddle me this, brotha'")]
         MnkRiddleOfFireBrotherhoodFeature = 9012,
 
@@ -1388,10 +1483,12 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region NINJA
 
+        [ReplaceSkill(NIN.ArmorCrush)]
         [ConflictingCombos(NinSimpleSingleTarget)]
         [CustomComboInfo("Armor Crush Combo", "Replace Armor Crush with its combo chain.", NIN.JobID, 3, "One, Two, Three", "It's a Ninja's life for me")]
         NinjaArmorCrushCombo = 10000,
 
+        [ReplaceSkill(NIN.AeolianEdge)]
         [ConflictingCombos(NinSimpleSingleTarget)]
         [CustomComboInfo("Aeolian Edge Combo", "Replace Aeolian Edge with its combo chain.", NIN.JobID, 2, "Edgy Edge Combo", "Knife go stab")]
         NinjaAeolianEdgeCombo = 10001,
@@ -1402,18 +1499,23 @@ namespace XIVSlothComboPlugin
         //[CustomComboInfo("Dream to Assassinate", "Replace Dream Within a Dream with Assassinate when Assassinate Ready.", NIN.JobID)]
         //NinjaAssassinateFeature = 10003,
 
+        [ReplaceSkill(NIN.Kassatsu)]
         [CustomComboInfo("Kassatsu to Trick", "Replaces Kassatsu with Trick Attack while Suiton or Hidden is up.\nCooldown tracking plugin recommended.", NIN.JobID, 4, "Katsu Curry to Trick", "This is how we eat at a restaurant and don't pay the bill.\nRUN!")]
         NinjaKassatsuTrickFeature = 10004,
 
+        [ReplaceSkill(NIN.TenChiJin)]
         [CustomComboInfo("Ten Chi Jin to Meisui", "Replaces Ten Chi Jin (the move) with Meisui while Suiton is up.\nCooldown tracking plugin recommended.", NIN.JobID, 5, "Ten Chin Scratches to Chop-Suey", "Does something, probably.\nHow do you deal with all these attack names?")]
         NinjaTCJMeisuiFeature = 10005,
 
+        [ReplaceSkill(NIN.Chi)]
         [CustomComboInfo("Kassatsu Chi/Jin Feature", "Replaces Chi with Jin while Kassatsu is up if you have Enhanced Kassatsu.", NIN.JobID, 6, "", "Swaps your Katsu curry with a Chi Chin-scratch.")]
         NinjaKassatsuChiJinFeature = 10006,
 
+        [ReplaceSkill(NIN.Hide)]
         [CustomComboInfo("Hide to Mug", "Replaces Hide with Mug while in combat.", NIN.JobID, 7, "Stand and Deliver", "John Cena is a thief, now?")]
         NinjaHideMugFeature = 10007,
 
+        [ReplaceSkill(NIN.AeolianEdge)]
         [CustomComboInfo("Aeolian to Ninjutsu Feature", "Replaces Aeolian Edge (combo) with Ninjutsu if any Mudra are used.", NIN.JobID, 8, "Hand signs and all that", "Do the Naruto thing, I think.\nIdk I don't watch anime, sorry")]
         NinjaNinjutsuFeature = 10008,
 
@@ -1421,6 +1523,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("GCDs to Ninjutsu Feature", "Every GCD combo becomes Ninjutsu while Mudras are being used.", NIN.JobID, 9, "Full-on Sign Language", "NOW you're really communicating with the party.")]
         NinjaGCDNinjutsuFeature = 10009,
 
+        [ReplaceSkill(NIN.Huraijin)]
         [CustomComboInfo("Huraijin / Raiju Feature", "Replaces Huraijin with Forked and Fleeting Raiju when available.", NIN.JobID, 10, "Pikachu / Raichu Feature", "Does something? Maybe? Evolutions? Combos? Probably.")]
         NinjaHuraijinRaijuFeature = 10010,
 
@@ -1456,17 +1559,21 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Throwing Dagger Uptime Feature", "Replace Aeolian Edge with Throwing Daggers when targer is our of range.", NIN.JobID, 18, "", "Would probably make more sense for NIN to be a Ranged DPS, anyway.")]
         NinjaRangedUptimeFeature = 10018,
 
+        [ReplaceSkill(NIN.Ten, NIN.Chi, NIN.Jin)]
         [CustomComboInfo("Simple Mudras", "Simplify the mudra casting to avoid failing.", NIN.JobID, 19, "Simple Murder", "Murder, made simple. For the everyday user.")]
         NinjaSimpleMudras = 10020,
 
+        [ReplaceSkill(NIN.TenChiJin)]
         [ParentCombo(NinjaTCJMeisuiFeature)]
         [CustomComboInfo("Ten Chi Jin Feature", "Turns Ten Chi Jin (the move) into Ten, Chi, and Jin.", NIN.JobID, 20, "", "Does literally nothing. Ever")]
         NinTCJFeature = 10021,
 
+        [ReplaceSkill(NIN.SpinningEdge)]
         [ConflictingCombos(NinjaArmorCrushCombo, NinjaAeolianEdgeCombo, NinjaGCDNinjutsuFeature)]
         [CustomComboInfo("Simple Ninja Single Target", "Turns Spinning Edge into a one-button full single target rotation.\nUses Ninjitsus, applies Trick Attack and uses Armor Crush to upkeep Huton buff.", NIN.JobID, 0, "", "")]
         NinSimpleSingleTarget = 10022,
 
+        [ReplaceSkill(NIN.DeathBlossom)]
         [CustomComboInfo("Simple Ninja AoE", "Turns Death Blossom into a one-button full AoE rotation.", NIN.JobID, 1, "Dote-on AoE", "Uses /dote on every target.")]
         NinSimpleAoE = 10023,
 
@@ -1502,6 +1609,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Add Mug", "Adds Mug to this Simple Feature.", NIN.JobID, 2)]
         NinSimpleMug = 10031,
 
+        [ReplaceSkill(NIN.Huraijin)]
         [CustomComboInfo("Huraijin / Armor Crush Combo", "Replace Huraijin with Armor Crush after using Gust Slash", NIN.JobID, 8)]
         NinHuraijinArmorCrush = 10032,
 
@@ -1517,9 +1625,11 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region PALADIN
 
+        [ReplaceSkill(PLD.GoringBlade)]
         [CustomComboInfo("Goring Blade Combo", "Replace Goring Blade with its combo chain.", PLD.JobID, 0, "These aren't heals... huh?", "Just take the armour off and don a robe, we all know you're green on the inside.")]
         PaladinGoringBladeCombo = 11000,
 
+        [ReplaceSkill(PLD.RoyalAuthority, PLD.RageOfHalone)]
         [CustomComboInfo("Royal Authority Combo", "All-in-one main combo adds Royal Authority/Rage of Halone.\nToggle all sub-options on to make this a 1 button rotation", PLD.JobID, 0, "", "Lmao, 'Authority'... If you say so, buddy.")]
         PaladinRoyalAuthorityCombo = 11001,
 
@@ -1527,6 +1637,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Atonement drop Feature", "Will drop the last Atonement charge right before FoF comes back off cooldown.\nPlease note that this assumes you use both FoF and Req according to the full FoF opener and standard loop\nRequires a skill speed tier of 2.45-2.40", PLD.JobID, 1, "", "Atonement for what? Picking the weakest Tank?")]
         PaladinAtonementDropFeature = 11002,
 
+        [ReplaceSkill(PLD.Prominence)]
         [CustomComboInfo("Prominence Combo", "Replace Prominence with its combo chain.", PLD.JobID, 0, "Promenade feature", "Long walks on the promenade...")]
         PaladinProminenceCombo = 11003,
 
@@ -1538,6 +1649,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Confiteor Combo Feature", "Replace Holy Spirit/Circle with Confiteor when Requiescat is up and MP is under 2000 or only one stack remains \nand adds Faith/Truth/Valor Combo after Confiteor.", PLD.JobID, 0, "Confetti Feature", "This is gonna be a nightmare to clean up.")]
         PaladinConfiteorFeature = 11005,
 
+        [ReplaceSkill(PLD.SpiritsWithin, PLD.CircleOfScorn)]
         [CustomComboInfo("Scornful Spirits Feature", "Replace Spirits Within and Circle of Scorn with whichever is available soonest.", PLD.JobID, 0, "", "Two for the price of one!")]
         PaladinScornfulSpiritsFeature = 11006,
 
@@ -1545,9 +1657,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Goring Blade Feature", "Insert Goring Blade into the main combo when appropriate.", PLD.JobID, 0, "", "")]
         PaladinRoyalGoringOption = 11007,
 
+        [ReplaceSkill(PLD.HolySpirit)]
         [CustomComboInfo("Standalone Holy Spirit Feature", "Replaces Holy Spirit with Confiteor and Confiteor combo", PLD.JobID, 0, "", "It's Christmas already?")]
         PaladinStandaloneHolySpiritFeature = 11008,
 
+        [ReplaceSkill(PLD.HolyCircle)]
         [CustomComboInfo("Standalone Holy Circle Feature", "Replaces Holy Circle with Confiteor and Confiteor combo", PLD.JobID, 0, "", "This is MY circle.")]
         PaladinStandaloneHolyCircleFeature = 11009,
 
@@ -1611,6 +1725,7 @@ namespace XIVSlothComboPlugin
         #region REAPER
 
         // Single Target Combo Section
+        [ReplaceSkill(RPR.Slice)]
         [CustomComboInfo("Slice Combo Feature", "Replace Slice with its combo chain. Features and options inside.\nCollapsing this category disables the features inside.", RPR.JobID, 0, "One, Two, Three", "It's a slicer's life for me~")]
         ReaperSliceCombo = 12000,
 
@@ -1636,6 +1751,7 @@ namespace XIVSlothComboPlugin
 
 
         // AoE Combo Section
+        [ReplaceSkill(RPR.SpinningScythe)]
         [CustomComboInfo("Scythe Combo Feature", "Replace Spinning Scythe with its combo chain. Features and options inside.\nCollapsing this category disables the features inside.", RPR.JobID, 0, "One, Two, Th-", "Oh. It's barely a combo!")]
         ReaperScytheCombo = 12010,
 
@@ -1652,20 +1768,24 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("[Unveiled Features]", "Features and options involving Gibbet, Gallows and Guillotine.\nCollapsing this category does NOT disable the features inside.", RPR.JobID, 0, "Gubbins, Gibberish and Globular", "They all do the same thing, really.")]
         ReaperMenuUnveiledFeatures = 12020,
 
+        [ReplaceSkill(RPR.Slice, RPR.ShadowOfDeath)]
         [ParentCombo(ReaperMenuUnveiledFeatures)]
         [ConflictingCombos(ReaperGibbetGallowsInverseFeature)]
         [CustomComboInfo("Gibbet/Gallows Feature", "Slice and Shadow of Death are replaced with Gibbet and Gallows while Soul Reaver or Shroud is active.", RPR.JobID, 0, "Drown in FX!", "Now with even less buttons!")]
         ReaperGibbetGallowsFeature = 12021,
 
+        [ReplaceSkill(RPR.Slice)]
         [ParentCombo(ReaperGibbetGallowsFeature)]
         [CustomComboInfo("Gibbet/Gallows One-Button Option", "Slice is instead replaced with whichever move is procced, and Shadow of Death remains untouched.", RPR.JobID, 0, "Gubbins/Gibberish One-Button Option", "Positionals were SO last patch, anyway.")]
         ReaperGibbetGallowsOption = 12022,
 
+        [ReplaceSkill(RPR.Slice, RPR.ShadowOfDeath)]
         [ParentCombo(ReaperMenuUnveiledFeatures)]
         [ConflictingCombos(ReaperGibbetGallowsFeature)]
         [CustomComboInfo("Gallows/Gibbet (Inverse) Feature - BROKEN (Currently same effect as above)", "Slice and Shadow of Death are replaced with Gallows and Gibbet while Soul Reaver or Shroud is active.\n(Positional replacements swapped)", RPR.JobID, 0, "BoRkEd", "Don't use this bruh, you KNOW it's broken.\nShit the bed!")]
         ReaperGibbetGallowsInverseFeature = 12023,
 
+        [ReplaceSkill(RPR.SpinningScythe)]
         [ParentCombo(ReaperMenuUnveiledFeatures)]
         [CustomComboInfo("Guillotine Feature", "Spinning Scythe's combo gets replaced with Guillotine while Soul Reaver or Shroud is active.", RPR.JobID, 0, "", "As if this job wasn't the easiest Melee already. You're welcome, little sloth.")]
         ReaperGuillotineFeature = 12024,
@@ -1675,21 +1795,25 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("[Soul Reaver Features]", "Features and options involving Blood Stalk, Grim Swathe and Gluttony.\nCollapsing this category does NOT disable the features inside.", RPR.JobID, 0, "Grass Farmer Features", "oGCDs? You betcha")]
         ReaperMenuSoulReaverFeatures = 12030,
 
+        [ReplaceSkill(RPR.BloodStalk, RPR.GrimSwathe)]
         [ParentCombo(ReaperMenuSoulReaverFeatures)]
         [ConflictingCombos(ReaperBloodStalkComboFeature, ReaperBloodStalkAlternateComboOption, ReaperGrimSwatheComboFeature)]
         [CustomComboInfo("Blood Stalk/Grim Swathe Feature", "When Gluttony is off-cooldown, Blood Stalk and Grim Swathe will turn into Gluttony.", RPR.JobID, 0, "Buttony", "It's like the normal buttons, but better! Double the fun!")]
         ReaperBloodSwatheFeature = 12031,
 
+        [ReplaceSkill(RPR.BloodStalk)]
         [ParentCombo(ReaperMenuSoulReaverFeatures)]
         [ConflictingCombos(ReaperBloodSwatheFeature, ReaperBloodStalkAlternateComboOption)]
         [CustomComboInfo("Blood Stalk Multi-Combo Feature", "Turns Blood Stalk into Gluttony when off-cooldown and puts Gibbet and Gallows on the same button as Blood Stalk. Also adds Enshrouded Combo.", RPR.JobID, 0, "", "Play the job properly u stinker!")]
         ReaperBloodStalkComboFeature = 12032,
 
+        [ReplaceSkill(RPR.BloodStalk)]
         [ParentCombo(ReaperMenuSoulReaverFeatures)]
         [ConflictingCombos(ReaperBloodSwatheFeature, ReaperBloodStalkComboFeature)]
         [CustomComboInfo("Blood Stalk Multi-Combo Feature Alternative - Same but better (?)", "Turns Blood Stalk into Gluttony when off-cooldown and puts Gibbet and Gallows on the same button as Blood Stalk. Also adds Enshrouded Combo.\n[Seems like the code is more effective in edge cases. Both features need further review.", RPR.JobID, 0, "", "You heard me the first time!")]
         ReaperBloodStalkAlternateComboOption = 12033,
 
+        [ReplaceSkill(RPR.GrimSwathe)]
         [ParentCombo(ReaperMenuSoulReaverFeatures)]
         [ConflictingCombos(ReaperBloodSwatheFeature)]
         [CustomComboInfo("Grim Swathe Multi-Combo Feature", "Turns Grim Swathe into Gluttony when off-cooldown and puts Guillotine on the same button as Grim Swathe. Also adds Enshrouded Combo.", RPR.JobID, 0, "", "I SAID - Play the job u stinker!!!!")]
@@ -1700,14 +1824,17 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("[Enshroud Features]", "Features and options involving the Enshrouded burst phase.\nCollapsing this category does NOT disable the features inside.", RPR.JobID, 0, "Edgelord mode", "Devil May Cry reboot when?")]
         ReaperMenuEnshroudFeatures = 12040,
 
+        [ReplaceSkill(RPR.Gibbet, RPR.Gallows, RPR.Guillotine)]
         [ParentCombo(ReaperMenuEnshroudFeatures)]
         [CustomComboInfo("Lemure Feature", "When you have two or more stacks of Void Shroud, Lemure Slice replaces Gibbet/Gallows and Lemure Scythe replaces Guillotine.", RPR.JobID, 0, "One-button farming burst", "Who is Lemure and what do they want?")]
         ReaperLemureFeature = 12041,
 
+        [ReplaceSkill(RPR.Gibbet, RPR.Gallows, RPR.Guillotine)]
         [ParentCombo(ReaperMenuEnshroudFeatures)]
         [CustomComboInfo("Combo Communio Feature", "When one stack of Lemure Shroud remains, Communio replaces Gibbet/Gallows/Guillotine.", RPR.JobID, 0, "", "They say strong communio is the key to a healthy relationship")]
         ReaperComboCommunioFeature = 12042,
 
+        [ReplaceSkill(RPR.Communio)]
         [ParentCombo(ReaperMenuEnshroudFeatures)]
         // [ConflictingCombos(ReaperEnshroudComboFeature)]
         [CustomComboInfo("Enshroud Communio Feature", "Replace Enshroud with Communio when Enshrouded.", RPR.JobID, 0, "", "Go on, press it as soon as you enter Enshroud.\nI dare you. Dingus.")]
@@ -1724,17 +1851,21 @@ namespace XIVSlothComboPlugin
         ReaperMenuExtraFeatures = 12050,
 
         [ParentCombo(ReaperMenuExtraFeatures)]
+        [ReplaceSkill(RPR.ArcaneCircle)]
         [CustomComboInfo("Arcane Circle Harvest Feature", "Replace Arcane Circle with Plentiful Harvest when you have stacks of Immortal Sacrifice.", RPR.JobID, 0, "Farming Simulator 2022", "You might as well buy a tractor at this point")]
         ReaperHarvestFeature = 12051,
 
+        [ReplaceSkill(RPR.HellsEgress, RPR.HellsIngress)]
         [ParentCombo(ReaperMenuExtraFeatures)]
         [CustomComboInfo("Regress Feature", "Both Hell's Ingress and Hell's Egress turn into Regress when Threshold is active, instead of just the opposite of the one you used.", RPR.JobID, 0, "You're a DRG now, son", "GO WHENCE YOU CAME")]
         ReaperRegressFeature = 12052,
 
+        [ReplaceSkill(RPR.Harpe)]
         [ParentCombo(ReaperMenuExtraFeatures)]
         [CustomComboInfo("Harpe Soulsow Feature", "Changes Harpe into Soulsow when you are out of combat or have no target, and are not already under the effect of Soulsow.", RPR.JobID, 0, "", "Gotta have something to do before the pull, right?")]
         ReaperHarpeSoulsowFeature = 12053,
 
+        [ReplaceSkill(RPR.Harpe)]
         [ParentCombo(ReaperMenuExtraFeatures)]
         [CustomComboInfo("Harpe Harvest Moon Feature", "Changes Harpe into Harvest Moon when you are in combat with Soulsow active.", RPR.JobID, 0, "Dumb reaper be dumb", "Good luck finding the best place to use this kek")]
         ReaperHarpeHarvestMoonFeature = 12054,
@@ -1869,7 +2000,7 @@ namespace XIVSlothComboPlugin
 
             #region Single Target DPS Feature
             [ParentCombo(SGE_ST_DosisFeature)]
-            [CustomComboInfo("Lucid Dreaming Option###SGEST", "Adds Lucid Dreaming to Dosis when MP drops below slider value", SGE.JobID, 111)]
+            [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to Dosis when MP drops below slider value", SGE.JobID, 111)]
             SGE_ST_Dosis_Lucid = 14111,
 
             [ParentCombo(SGE_ST_DosisFeature)]
@@ -1889,7 +2020,7 @@ namespace XIVSlothComboPlugin
                 #endregion
 
             [ParentCombo(SGE_ST_DosisFeature)]
-            [CustomComboInfo("Toxikon Option###SGEST", "Use Toxikon when you have Addersting charges", SGE.JobID, 113)]
+            [CustomComboInfo("Toxikon Option", "Use Toxikon when you have Addersting charges", SGE.JobID, 113)]
             SGE_ST_Dosis_Toxikon = 14113,
             #endregion
 
@@ -1898,7 +2029,7 @@ namespace XIVSlothComboPlugin
 
             #region AoE DPS Feature
             [ParentCombo(SGE_AoE_PhlegmaFeature)]
-            [CustomComboInfo("Toxikon Option###SGEAoE", "Use Toxikon when you have Addersting charges\nTakes priority over Dyskrasia SubOption", SGE.JobID, 122, "", "")]
+            [CustomComboInfo("Toxikon Option", "Use Toxikon when you have Addersting charges\nTakes priority over Dyskrasia SubOption", SGE.JobID, 122, "", "")]
             SGE_AoE_Phlegma_Toxikon = 14122,
 
             [ParentCombo(SGE_AoE_PhlegmaFeature)]
@@ -1936,7 +2067,7 @@ namespace XIVSlothComboPlugin
             SGE_ST_Heal_Zoe = 14214,
 
             [ParentCombo(SGE_ST_HealFeature)]
-            [CustomComboInfo("Pepsis Option###SGEST", "Triggers Pepsis if a shield is present and the selected target is at or above the set HP percentage.", SGE.JobID, 215)]
+            [CustomComboInfo("Pepsis Option", "Triggers Pepsis if a shield is present and the selected target is at or above the set HP percentage.", SGE.JobID, 215)]
             SGE_ST_Heal_Pepsis = 14215,
 
             [ParentCombo(SGE_ST_HealFeature)]
@@ -1948,7 +2079,7 @@ namespace XIVSlothComboPlugin
             SGE_ST_Heal_Haima = 14217,
 
             [ParentCombo(SGE_ST_HealFeature)]
-            [CustomComboInfo("Rhizomata Option###SGEST", "Adds Rhizomata when Addersgall is 0", SGE.JobID, 218)]
+            [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0", SGE.JobID, 218)]
             SGE_ST_Heal_Rhizomata = 14218,
 
             [ParentCombo(SGE_ST_HealFeature)]
@@ -1982,7 +2113,7 @@ namespace XIVSlothComboPlugin
             SGE_AoE_Heal_Panhaima = 14224,
 
             [ParentCombo(SGE_AoE_HealFeature)]
-            [CustomComboInfo("Pepsis Option##SGEAoE", "Triggers Pepsis if a shield is present.", SGE.JobID, 225)]
+            [CustomComboInfo("Pepsis Option", "Triggers Pepsis if a shield is present.", SGE.JobID, 225)]
             SGE_AoE_Heal_Pepsis = 14225,
 
             [ParentCombo(SGE_AoE_HealFeature)]
@@ -1994,7 +2125,7 @@ namespace XIVSlothComboPlugin
             SGE_AoE_Heal_Kerachole = 14227,
 
             [ParentCombo(SGE_AoE_HealFeature)]
-            [CustomComboInfo("Rhizomata Option###SGEAOE", "Adds Rhizomata when Addersgall is 0", SGE.JobID, 228)]
+            [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0", SGE.JobID, 228)]
             SGE_AoE_Heal_Rhizomata = 14228,
             #endregion
 
@@ -2006,7 +2137,7 @@ namespace XIVSlothComboPlugin
 
         //SECTION_3_Utility
         [ConflictingCombos(AllHealerRaiseFeature)]
-        [CustomComboInfo("Swiftcast Raise Feature###SGE", "Changes Swiftcast to Egeiro while Swiftcast is on cooldown.", SGE.JobID, 310)]
+        [CustomComboInfo("Swiftcast Raise Feature", "Changes Swiftcast to Egeiro while Swiftcast is on cooldown.", SGE.JobID, 310)]
         SGE_RaiseFeature = 14310,
 
         [CustomComboInfo("Soteria to Kardia Feature", "Soteria turns into Kardia when not active or Soteria is on-cooldown.", SGE.JobID, 320)]
@@ -2207,11 +2338,12 @@ namespace XIVSlothComboPlugin
         //New features should be added to the appropriate sections.
 
         //Section_1_DPS
+        [ReplaceSkill(SCH.Ruin1, SCH.Broil1, SCH.Broil2, SCH.Broil3, SCH.Broil4)]
         [CustomComboInfo("Single Target DPS Feature", "Replace Ruin 1 / Broils with options below", SCH.JobID, 110)]
         SCH_ST_BroilFeature = 16110,
 
             [ParentCombo(SCH_ST_BroilFeature)]
-            [CustomComboInfo("Lucid Dreaming Option###SCHST", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID, 111)]
+            [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID, 111)]
             SCH_ST_Broil_Lucid = 16111,
 
             [ParentCombo(SCH_ST_BroilFeature)]
@@ -2243,11 +2375,13 @@ namespace XIVSlothComboPlugin
 
 
         //Section_2_Healing
+        [ReplaceSkill(SCH.FeyBlessing)]
         [CustomComboInfo("Fey Blessing to Seraph's Consolation Feature", "Change Fey Blessing into Consolation when Seraph is out.", SCH.JobID, 210, "", "Stupid little fairy thing")]
         SCH_ConsolationFeature = 16210,
 
 
         //Section_3_Utilities
+        [ReplaceSkill(SCH.EnergyDrain, SCH.Lustrate, SCH.SacredSoil, SCH.Indomitability, SCH.Excogitation)]
         [CustomComboInfo("Aetherflow Helper Feature", "Change Aetherflow using skills to Aetherflow, Recitation, or Dissipation as selected", SCH.JobID, 310, "", "Stop trying to pretend you're a SMN. You're not fooling anyone")]
         SCH_AetherflowFeature = 16310,
 
@@ -2267,21 +2401,25 @@ namespace XIVSlothComboPlugin
             [CustomComboInfo("Dissipation Option", "Show Dissipation if Aetherflow is on cooldown and you have no Aetherflow stacks", SCH.JobID, 312, "", "Oh wow look at that that one...it looks so delicious")]
             SCH_Aetherflow_Dissipation = 16312,
 
+        [ReplaceSkill(All.Swiftcast)]
         [ConflictingCombos(AllHealerRaiseFeature)]
-        [CustomComboInfo("Swiftcast Raise Combo Feature###SCH", "Changes Swiftcast to Resurrection while Swiftcast is on cooldown", SCH.JobID, 410, "", "BRING OUT YOUR DEAD")]
+        [CustomComboInfo("Swiftcast Raise Combo Feature", "Changes Swiftcast to Resurrection while Swiftcast is on cooldown", SCH.JobID, 410, "", "BRING OUT YOUR DEAD")]
         SCH_RaiseFeature = 16410,
 
+        [ReplaceSkill(SCH.WhisperingDawn, SCH.FeyBlessing, SCH.FeyBlessing, SCH.Aetherpact, SCH.Dissipation)]
         [CustomComboInfo("Fairy Feature", "Change all fairy actions into Fairy Summons if you do not have a fairy summoned.", SCH.JobID, 510, "", "You're really gonna forget? Really?")]
         SCH_FairyFeature = 16510,
 
- 
+
         #endregion
         // ====================================================================================
         #region SUMMONER
 
+        [ReplaceSkill(SMN.Ruin, SMN.Ruin2)]
         [CustomComboInfo("Enable Single Target Combo Features", "Enables features tied to Ruin, or Ruin II.\nIf all sub options are toggled will turn into a full one button rotation (Simple Summoner)\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
         SummonerMainComboFeature = 17000,
 
+        [ReplaceSkill(SMN.Tridisaster)]
         [CustomComboInfo("Enable AOE Combo Features", "Enables features tied to Tridisaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple AOE)", SMN.JobID, 0, "", "Can't deal with dungeons on your own? Fear not.")]
         SummonerAOEComboFeature = 17001,
 
@@ -2306,9 +2444,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Titan Mountain Buster Feature", "Adds Mountain Buster on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 0, "Mountain, BUSTA", "Bring the mountain to Mohammed, as they say")]
         SummonerTitanUniqueFeature = 17007,
 
+        [ReplaceSkill(SMN.Fester)]
         [CustomComboInfo("ED Fester", "Change Fester into Energy Drain when out of Aetherflow stacks.", SMN.JobID, 0, "Festering", "Festering? Go take a shower, bro")]
         SummonerEDFesterCombo = 17008,
 
+        [ReplaceSkill(SMN.Painflare)]
         [CustomComboInfo("ES Painflare", "Change Painflare into Energy Siphon when out of Aetherflow stacks.", SMN.JobID, 0, "Old age", "I sometimes get a painflare in my middle-back, too.")]
         SummonerESPainflareCombo = 17009,
 
@@ -2398,9 +2538,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Rekindle on AOE Combo option", "Adds Rekindle to the AOE Combo.", SMN.JobID, 0, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
         SummonerAOETargetRekindleOption = 17029,
 
+        [ReplaceSkill(SMN.Ruin4)]
         [CustomComboInfo("Ruin III Mobility Feature", "Puts Ruin III on Ruin IV when you don't have Further Ruin.", SMN.JobID, 0, "Yo Dawg I Heard You Like Ruin Feature", "Ruin while you Ruin")]
         SummonerSpecialRuinFeature = 17030,
 
+        [ReplaceSkill(SMN.Ruin, SMN.Ruin2)]
         [CustomComboInfo("Lucid Dreaming Feature", "Adds Lucid dreaming to the Main Combo when below set MP value.", SMN.JobID, 0, "", "")]
         SMNLucidDreamingFeature = 17031,
 
@@ -2416,12 +2558,15 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region WARRIOR
 
+        [ReplaceSkill(WAR.StormsEye)]
         [CustomComboInfo("Storms Path Combo", "All in one main combo feature adds Storm's Eye/Path. \nIf all sub options and Fell Cleave/Decimate Options are toggled will turn into a full one button rotation (Simple Warrior)", WAR.JobID, 0, "", "Follow the yellow-brick road.")]
         WarriorStormsPathCombo = 18000,
 
+        [ReplaceSkill(WAR.StormsEye)]
         [CustomComboInfo("Storms Eye Combo", "Replace Storms Eye with its combo chain", WAR.JobID, 0, "", "Ow! My fucking eye!")]
         WarriorStormsEyeCombo = 18001,
 
+        [ReplaceSkill(WAR.Overpower)]
         [CustomComboInfo("Overpower Combo", "Add combos to Overpower", WAR.JobID, 0, "Underpower", "Bet you wish you had damage like DRK right now, huh")]
         WarriorMythrilTempestCombo = 18002,
 
@@ -2429,6 +2574,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Warrior Gauge Overcap Feature", "Replace Single target or AoE combo with gauge spender if you are about to overcap and are before a step of a combo that would generate beast gauge", WAR.JobID, 0, "", "Taming the beast... for now.")]
         WarriorGaugeOvercapFeature = 18003,
 
+        [ReplaceSkill(WAR.NascentFlash)]
         [CustomComboInfo("Nascent Flash Feature", "Replace Nascent Flash with Raw intuition when level synced below 76", WAR.JobID, 0, "Nasty-ass Flash", "Jeez. Keep it to yourself.")]
         WarriorNascentFlashFeature = 18005,
 
@@ -2464,9 +2610,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Tomahawk Uptime Feature", "Replace Storm's Path Combo Feature with Tomahawk when you are out of range.", WAR.JobID, 0, "Tomahawk!", "You heard me! Tomahawk! Ka-chow!")]
         WARRangedUptimeFeature = 18016,
 
+        [ReplaceSkill(WAR.FellCleave, WAR.Decimate)]
         [CustomComboInfo("Infuriate on Fell Cleave / Decimate", "Turns Fell Cleave and Decimate into Infuriate if at or under set rage value", WAR.JobID)]
         WarriorInfuriateFellCleave = 18018,
 
+        [ReplaceSkill(WAR.InnerRelease)]
         [CustomComboInfo("Primal Rend Option", "Turns Inner Release into Primal Rend on use.", WAR.JobID)]
         WarriorPrimalRendOnInnerRelease = 18019,
 
@@ -2496,29 +2644,37 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region WHITE MAGE
 
+        [ReplaceSkill(WHM.Stone1, WHM.Stone2, WHM.Stone3, WHM.Stone4, WHM.Glare1, WHM.Glare3)]
         [CustomComboInfo("CDs on Glare/Stone", "Collection of CDs and spell features on Glare/Stone.", WHM.JobID, 0, "Weak", "WHM DPS rotation too much?")]
         WHMCDsonMainComboGroup = 19099,
 
+        [ReplaceSkill(WHM.AfflatusSolace)]
         [CustomComboInfo("Solace into Misery", "Replaces Afflatus Solace with Afflatus Misery when Misery is ready to be used", WHM.JobID, 0, "Misery", "I'd be miserable too if this were one of my DPS options.")]
         WhiteMageSolaceMiseryFeature = 19000,
 
+        [ReplaceSkill(WHM.AfflatusRapture)]
         [CustomComboInfo("Rapture into Misery", "Replaces Afflatus Rapture with Afflatus Misery when Misery is ready to be used", WHM.JobID, 0, "Misery, but with freinds", "Let's cry together!")]
         WhiteMageRaptureMiseryFeature = 19001,
 
+        [ReplaceSkill(WHM.Cure2)]
         [CustomComboInfo("Cure 2 to Cure Level Sync", "Changes Cure 2 to Cure when below level 30 in synced content.", WHM.JobID, 0, "Weenie Cure", "Bet you forgot Cure 1 existed for a sec, huh")]
         WhiteMageCureFeature = 19002,
 
+        [ReplaceSkill(WHM.Cure2)]
         [CustomComboInfo("Afflatus Feature", "Changes Cure 2 into Afflatus Solace, and Medica into Afflatus Rapture, when lilies are up.", WHM.JobID, 0, "Inflatus Feature", "Pumps you full of air. Boing!")]
         WhiteMageAfflatusFeature = 19003,
 
+        [ReplaceSkill(All.Swiftcast)]
         [ConflictingCombos(AllHealerRaiseFeature)]
         [CustomComboInfo("WHM Alternative Raise Feature", "Changes Swiftcast to Raise", WHM.JobID, 0, "What you're really here for", "You're the best at this. You got this.")]
         WHMRaiseFeature = 19004,
 
+        [ReplaceSkill(WHM.Stone1, WHM.Stone2, WHM.Stone3, WHM.Stone4, WHM.Glare1, WHM.Glare3)]
         [ParentCombo(WHMCDsonMainComboGroup)]
         [CustomComboInfo("Lucid Dreaming Feature", "Adds Lucid dreaming to the DPS feature when below set MP value.", WHM.JobID, 0, "Dream within a Dream", "Awake, yet wholly asleep")]
         WHMLucidDreamingFeature = 19006,
 
+        [ReplaceSkill(WHM.Medica2)]
         [CustomComboInfo("Medica Feature", "Replaces Medica2 whenever you are under Medica2 regen with Medica1", WHM.JobID, 0, "Big Brain AoE Heals", "God bless us all, eh")]
         WHMMedicaFeature = 19007,
 
@@ -2538,6 +2694,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Afflatus Rapture On Medica Feature", "Adds Afflatus Rapture onto the Medica Feature", WHM.JobID, 0, "CRapture", "The final days are upon us!")]
         WhiteMageAfflatusRaptureMedicaFeature = 19011,
 
+        [ReplaceSkill(WHM.Cure2)]
         [CustomComboInfo("Afflatus Misery Feature", "Changes Cure 2 into Afflatus Misery.", WHM.JobID, 0, "", "Cures? Who needs 'em?")]
         WhiteMageAfflatusMiseryCure2Feature = 19012,
 
@@ -2545,6 +2702,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Adds DoT to Glare/Stone", "Adds DoT to DPS feature and refreshes it with 3 seconds remaining.", WHM.JobID, 0, "I'm an idiot", "Yes, one serving of less DPS, please.")]
         WHMDotMainComboFeature = 19013,
 
+        [ReplaceSkill(WHM.Raise)]
         [CustomComboInfo("Thin Air Raise Feature", "Adds Thin Air to the WHM Raise Feature/Alternative Feature", WHM.JobID, 0, "", "I can hardly breathe as it is!")]
         WHMThinAirFeature = 19014,
 

--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -43,6 +43,7 @@ namespace XIVSlothComboPlugin
 
             Service.ComboCache = new CustomComboCache();
             Service.IconReplacer = new IconReplacer();
+            ActionWatching.Enable();
 
             this.configWindow = new();
             this.windowSystem = new("XIVSlothCombo");
@@ -108,6 +109,7 @@ namespace XIVSlothComboPlugin
 
             Service.IconReplacer?.Dispose();
             Service.ComboCache?.Dispose();
+            ActionWatching.Dispose();
         }
 
         private void OnOpenConfigUi()


### PR DESCRIPTION
[Framework]
- Simplified access to job classes. Now part of the overall job class which should enable developers to write more "natural" code if desired.
- New `ActionWatching` module added. Tracks the last used action, regardless of action type (excluding mounts and items) along with how many times it was used in a row. 
- New features added to `Custom Combo`:
  - `GetActionName` - Returns the plain name of the action ID provided.
  - `GetStatusName` - Returns the plain name of the status ID provided.
  - `GetLevel` - Returns the level the action ID is unlocked at.
  - `LevelChecked` - Returns a bool value indicating if current player is sufficient level for the action ID provided.
  - `WasLastAction` - Returns a bool value indicating if the action ID provided was the actual last used action, regardless of action category.
  - `LastActionCounter` - Returns an int value indicating how many times the previous action was used in a row.
  - `WasLastWeaponskill` - Returns a bool value indicating if the action ID provided was the last used weaponskill.
  - `WasLastSpell` - Returns a bool value indicating if the action ID provided was the last used spell.
  - `WasLastAbility` - Returns a bool value indicating if the action ID provided was the last used ability.
- New attributes:
  - `ReplaceSkill` - Used to indicate which skills a feature replaces. These appear as a hover on the feature itself in the config window.
  - `HoverInfo` - Used to return a hover on top of the feature's description. Useful for further explanation without making the description very big.

[DRG]
- AoE features cleaned up slightly and bug fixed.

[Misc]
- New feature added to all jobs: `Output Combat Log`.
