### PR TITLE
RDM Cleanup and Fixes/Tweaks

### DIFF
--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -102,543 +102,544 @@ namespace XIVSlothComboPlugin.Combos
             public const string RDM_MeleeFinisher_OnAction = "RDM_MeleeFinisher_OnAction";
             public const string RDM_LucidDreaming_Threshold = "RDM_LucidDreaming_Threshold";
         }
-    
 
-    internal class RDM_Main_Combos : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RdmAny;
 
-        internal static bool inOpener = false;
-        internal static bool readyOpener = false;
-        internal static bool openerStarted = false;
-        internal static byte step = 0;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-
+        internal class RDM_Main_Combos : CustomCombo
         {
-            //MAIN_COMBO_VARIABLES
-            RDMGauge gauge = GetJobGauge<RDMGauge>();
-            int black = gauge.BlackMana;
-            int white = gauge.WhiteMana;
-            //END_MAIN_COMBO_VARIABLES
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RdmAny;
 
-            //RDM_BALANCE_OPENER
-            if (IsEnabled(CustomComboPreset.RDM_Balance_Opener) && level >= 90 && actionID is Jolt or Jolt2)
+            internal static bool inOpener = false;
+            internal static bool readyOpener = false;
+            internal static bool openerStarted = false;
+            internal static byte step = 0;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+
             {
-                bool inCombat = HasCondition(ConditionFlag.InCombat);
+                //MAIN_COMBO_VARIABLES
+                RDMGauge gauge = GetJobGauge<RDMGauge>();
+                int black = gauge.BlackMana;
+                int white = gauge.WhiteMana;
+                //END_MAIN_COMBO_VARIABLES
 
-                // Check to start opener
-                if (openerStarted && lastComboMove is RDM.Verthunder3 && HasEffect(Buffs.Dualcast)) { inOpener = true; openerStarted = false; readyOpener = false; }
-                if ((readyOpener || openerStarted) && !inOpener && LocalPlayer.CastActionId == Verthunder3) { openerStarted = true; return Veraero3; } else { openerStarted = false; }
-
-                // Reset check for opener
-                if ((IsEnabled(CustomComboPreset.RDM_Opener_Any_Mana) || (gauge.BlackMana == 0 && gauge.WhiteMana == 0)) 
-                    && IsOffCooldown(Embolden) && IsOffCooldown(Manafication) && IsOffCooldown(All.Swiftcast)
-                    && GetCooldown(Acceleration).RemainingCharges == 2 && GetCooldown(Corpsacorps).RemainingCharges == 2 && GetCooldown(Engagement).RemainingCharges == 2
-                    && IsOffCooldown(Fleche) && IsOffCooldown(ContreSixte)
-                    && EnemyHealthPercentage() == 100 && !inOpener && !openerStarted)
+                //RDM_BALANCE_OPENER
+                if (IsEnabled(CustomComboPreset.RDM_Balance_Opener) && level >= 90 && actionID is Jolt or Jolt2)
                 {
-                    readyOpener = true;
-                    inOpener = false;
-                    step = 0;
-                    return Verthunder3;
+                    bool inCombat = HasCondition(ConditionFlag.InCombat);
+
+                    // Check to start opener
+                    if (openerStarted && lastComboMove is Verthunder3 && HasEffect(Buffs.Dualcast)) { inOpener = true; openerStarted = false; readyOpener = false; }
+                    if ((readyOpener || openerStarted) && !inOpener && LocalPlayer.CastActionId == Verthunder3) { openerStarted = true; return Veraero3; } else { openerStarted = false; }
+
+                    // Reset check for opener
+                    if ((IsEnabled(CustomComboPreset.RDM_Opener_Any_Mana) || (gauge.BlackMana == 0 && gauge.WhiteMana == 0))
+                        && IsOffCooldown(Embolden) && IsOffCooldown(Manafication) && IsOffCooldown(All.Swiftcast)
+                        && GetCooldown(Acceleration).RemainingCharges == 2 && GetCooldown(Corpsacorps).RemainingCharges == 2 && GetCooldown(Engagement).RemainingCharges == 2
+                        && IsOffCooldown(Fleche) && IsOffCooldown(ContreSixte)
+                        && EnemyHealthPercentage() == 100 && !inOpener && !openerStarted)
+                    {
+                        readyOpener = true;
+                        inOpener = false;
+                        step = 0;
+                        return Verthunder3;
+                    }
+                    else
+                    { readyOpener = false; }
+
+                    // Reset if opener is interrupted, requires step 0 and 1 to be explicit since the inCombat check can be slow
+                    if ((step == 0 && lastComboMove is Verthunder3 && !HasEffect(Buffs.Dualcast))
+                        || (inOpener && step >= 1 && IsOffCooldown(actionID) && !inCombat)) inOpener = false;
+
+                    // Start Opener
+                    if (inOpener)
+                    {
+                        //veraero
+                        //swiftcast
+                        //accel
+                        //verthunder
+                        //verthunder
+                        //embolden
+                        //manafication
+                        //Riposte
+                        //Fleche
+                        //Zwercchau
+                        //Contre-sixte
+                        //Redoublement
+                        //Corps-a-corps
+                        //Engagement
+                        //Verholy
+                        //Corps-a-corps
+                        //Engagement
+                        //Scorch
+                        //Resolution
+
+                        //we do it in steps to be able to control it
+                        if (step == 0)
+                        {
+                            if (lastComboMove == Veraero3) step++;
+                            else return Veraero3;
+                        }
+
+                        if (step == 1)
+                        {
+                            if (IsOnCooldown(All.Swiftcast)) step++;
+                            else return All.Swiftcast;
+                        }
+
+                        if (step == 2)
+                        {
+                            if (GetRemainingCharges(Acceleration) < 2) step++;
+                            else return Acceleration;
+                        }
+
+                        if (step == 3)
+                        {
+                            if (lastComboMove == Verthunder3 && !HasEffect(Buffs.Acceleration)) step++;
+                            else return Verthunder3;
+                        }
+
+                        if (step == 4)
+                        {
+                            if (lastComboMove == Verthunder3 && !HasEffect(All.Buffs.Swiftcast)) step++;
+                            else return Verthunder3;
+                        }
+
+                        if (step == 5)
+                        {
+                            if (IsOnCooldown(Embolden)) step++;
+                            else return Embolden;
+                        }
+
+                        if (step == 6)
+                        {
+                            if (IsOnCooldown(Manafication)) step++;
+                            else return Manafication;
+                        }
+
+                        if (step == 7)
+                        {
+                            if (lastComboMove == Riposte) step++;
+                            else return EnchantedRiposte;
+                        }
+
+                        if (step == 8)
+                        {
+                            if (IsOnCooldown(Fleche)) step++;
+                            else return Fleche;
+                        }
+
+                        if (step == 9)
+                        {
+                            if (lastComboMove == Zwerchhau) step++;
+                            else return EnchantedZwerchhau;
+                        }
+
+                        if (step == 10)
+                        {
+                            if (IsOnCooldown(ContreSixte)) step++;
+                            else return ContreSixte;
+                        }
+
+                        if (step == 11)
+                        {
+                            if (lastComboMove == Redoublement || gauge.ManaStacks == 3) step++;
+                            else return EnchantedRedoublement;
+                        }
+
+                        if (step == 12)
+                        {
+                            if (GetRemainingCharges(Corpsacorps) < 2) step++;
+                            else return Corpsacorps;
+                        }
+
+                        if (step == 13)
+                        {
+                            if (GetRemainingCharges(Engagement) < 2) step++;
+                            else return Engagement;
+                        }
+
+                        if (step == 14)
+                        {
+                            if (lastComboMove == Verholy) step++;
+                            else return Verholy;
+                        }
+
+                        if (step == 15)
+                        {
+                            if (GetRemainingCharges(Corpsacorps) < 1) step++;
+                            else return Corpsacorps;
+                        }
+
+                        if (step == 16)
+                        {
+                            if (GetRemainingCharges(Engagement) < 1) step++;
+                            else return Engagement;
+                        }
+
+                        if (step == 17)
+                        {
+                            if (lastComboMove == Scorch) step++;
+                            else return Scorch;
+                        }
+
+                        if (step == 18)
+                        {
+                            if (lastComboMove == Resolution) step++;
+                            else return Resolution;
+                        }
+
+                        inOpener = false;
+                    }
                 }
-                else
-                { readyOpener = false; }
+                //END_RDM_BALANCE_OPENER
 
-                // Reset if opener is interrupted, requires step 0 and 1 to be explicit since the inCombat check can be slow
-                if ((step == 0 && lastComboMove is RDM.Verthunder3 && !HasEffect(Buffs.Dualcast))
-                    || (inOpener && step >= 1 && IsOffCooldown(actionID) && !inCombat)) inOpener = false;
-
-                // Start Opener
-                if (inOpener)
+                //RDM_ST_MANAFICATIONEMBOLDEN
+                if (IsEnabled(CustomComboPreset.RDM_ST_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
+                    && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
+                    && (GetTargetDistance() <= 3 || (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && GetCooldown(Corpsacorps).RemainingCharges >= 1)))
                 {
-                    //veraero
-                    //swiftcast
-                    //accel
-                    //verthunder
-                    //verthunder
-                    //embolden
-                    //manafication
-                    //Riposte
-                    //Fleche
-                    //Zwercchau
-                    //Contre-sixte
-                    //Redoublement
-                    //Corps-a-corps
-                    //Engagement
-                    //Verholy
-                    //Corps-a-corps
-                    //Engagement
-                    //Scorch
-                    //Resolution
+                    var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_ST_MeleeCombo_OnAction);
 
-                    //we do it in steps to be able to control it
-                    if (step == 0)
+                    if ((radioButton == 1 && actionID is Riposte or EnchantedRiposte)
+                        || (radioButton == 2 && actionID is Jolt or Jolt2)
+                        || (radioButton == 3 && actionID is Riposte or EnchantedRiposte or Jolt or Jolt2))
                     {
-                        if (lastComboMove == Veraero3) step++;
-                        else return Veraero3;
-                    }
+                        //Situation 1: Manafication first
+                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
+                        && System.Math.Max(black, white) <= 50 && System.Math.Max(black, white) >= 42 && System.Math.Min(black, white) >= 31
+                        && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
+                        && (IsOffCooldown(Embolden) || GetCooldown(Embolden).CooldownRemaining <= 3))
+                        {
+                            return Manafication;
+                        }
+                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
+                            && lastComboMove is Zwerchhau && level >= Levels.Redoublement
+                            && System.Math.Max(black, white) >= 55 && System.Math.Min(black, white) >= 46
+                            && GetCooldown(Manafication).CooldownRemaining >= 100
+                            && IsOffCooldown(Embolden))
+                        {
+                            return Embolden;
+                        }
 
-                    if (step == 1)
-                    {
-                        if (IsOnCooldown(All.Swiftcast)) step++;
-                        else return All.Swiftcast;
-                    }
+                        //Situation 2: Embolden first
+                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
+                            && lastComboMove is Zwerchhau && level >= Levels.Redoublement
+                            && System.Math.Max(black, white) <= 57 && System.Math.Min(black, white) <= 46
+                            && (GetCooldown(Manafication).CooldownRemaining <= 7 || IsOffCooldown(Manafication))
+                            && IsOffCooldown(Embolden))
+                        {
+                            return Embolden;
+                        }
+                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
+                            && System.Math.Max(black, white) <= 50
+                            && IsOffCooldown(Manafication)
+                            && (gauge.ManaStacks == 3 || lastComboMove is Resolution)
+                            && GetCooldown(Embolden).CooldownRemaining >= 105)
+                        {
+                            return Manafication;
+                        }
 
-                    if (step == 2)
-                    {
-                        if (GetRemainingCharges(Acceleration) < 2) step++;
-                        else return Acceleration;
-                    }
+                        //Situation 3: Just use them together
+                        if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Embolden
+                            && System.Math.Max(black, white) <= 50
+                            && (IsOffCooldown(Manafication) || level < Levels.Manafication) && IsOffCooldown(Embolden))
+                        {
+                            return Embolden;
+                        }
+                        if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Manafication
+                            && System.Math.Max(black, white) <= 50
+                            && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
+                            && GetCooldown(Embolden).CooldownRemaining >= 110)
+                        {
+                            return Manafication;
+                        }
 
-                    if (step == 3)
-                    {
-                        if (lastComboMove == Verthunder3 && !HasEffect(Buffs.Acceleration)) step++;
-                        else return Verthunder3;
+                        //Situation 4: Level 58 or 59
+                        if (level < Levels.Manafication && level >= Levels.Embolden
+                            && System.Math.Min(black, white) >= 50 && IsOffCooldown(Embolden))
+                        {
+                            return Embolden;
+                        }
                     }
-
-                    if (step == 4)
-                    {
-                        if (lastComboMove == Verthunder3 && !HasEffect(All.Buffs.Swiftcast)) step++;
-                        else return Verthunder3;
-                    }
-
-                    if (step == 5)
-                    {
-                        if (IsOnCooldown(Embolden)) step++;
-                        else return Embolden;
-                    }
-
-                    if (step == 6)
-                    {
-                        if (IsOnCooldown(Manafication)) step++;
-                        else return Manafication;
-                    }
-
-                    if (step == 7)
-                    {
-                        if (lastComboMove == Riposte) step++;
-                        else return EnchantedRiposte;
-                    }
-
-                    if (step == 8)
-                    {
-                        if (IsOnCooldown(Fleche)) step++;
-                        else return Fleche;
-                    }
-
-                    if (step == 9)
-                    {
-                        if (lastComboMove == Zwerchhau) step++;
-                        else return EnchantedZwerchhau;
-                    }
-
-                    if (step == 10)
-                    {
-                        if (IsOnCooldown(ContreSixte)) step++;
-                        else return ContreSixte;
-                    }
-
-                    if (step == 11)
-                    {
-                        if (lastComboMove == Redoublement || gauge.ManaStacks == 3) step++;
-                        else return EnchantedRedoublement;
-                    }
-
-                    if (step == 12)
-                    {
-                        if (GetRemainingCharges(Corpsacorps) < 2) step++;
-                        else return Corpsacorps;
-                    }
-
-                    if (step == 13)
-                    {
-                        if (GetRemainingCharges(Engagement) < 2) step++;
-                        else return Engagement;
-                    }
-
-                    if (step == 14)
-                    {
-                        if (lastComboMove == Verholy) step++;
-                        else return Verholy;
-                    }
-
-                    if (step == 15)
-                    {
-                        if (GetRemainingCharges(Corpsacorps) < 1) step++;
-                        else return Corpsacorps;
-                    }
-
-                    if (step == 16)
-                    {
-                        if (GetRemainingCharges(Engagement) < 1) step++;
-                        else return Engagement;
-                    }
-
-                    if (step == 17)
-                    {
-                        if (lastComboMove == Scorch) step++;
-                        else return Scorch;
-                    }
-
-                    if (step == 18)
-                    {
-                        if (lastComboMove == Resolution) step++;
-                        else return Resolution;
-                    }
-
-                    inOpener = false;
                 }
-            }
-            //END_RDM_BALANCE_OPENER
+                //END_RDM_ST_MANAFICATIONEMBOLDEN
 
-            //RDM_ST_MANAFICATIONEMBOLDEN
-            if (IsEnabled(CustomComboPreset.RDM_ST_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
-                && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration) 
-                && (GetTargetDistance() <= 3 || (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && GetCooldown(Corpsacorps).RemainingCharges >= 1)))
-            {
-                var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_ST_MeleeCombo_OnAction);
-
-                if ((radioButton == 1 && actionID is Riposte or EnchantedRiposte)
-                    || (radioButton == 2 && actionID is Jolt or Jolt2)
-                    || (radioButton == 3 && actionID is Riposte or EnchantedRiposte or Jolt or Jolt2))
+                //RDM_AOE_MANAFICATIONEMBOLDEN
+                if (IsEnabled(CustomComboPreset.RDM_AoE_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
+                    && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
+                    && GetTargetDistance() < 8 && actionID is Scatter or Impact)
                 {
-                    //Situation 1: Manafication first
-                    if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                    && System.Math.Max(black, white) <= 50 && System.Math.Max(black, white) >= 42 && System.Math.Min(black, white) >= 31
-                    && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
-                    && (IsOffCooldown(Embolden) || GetCooldown(Embolden).CooldownRemaining <= 3))
-                    {
-                        return Manafication;
-                    }
-                    if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                        && lastComboMove is RDM.Zwerchhau && level >= Levels.Redoublement
-                        && System.Math.Max(black, white) >= 55 && System.Math.Min(black, white) >= 46
-                        && GetCooldown(Manafication).CooldownRemaining >= 100
-                        && IsOffCooldown(Embolden))
+                    if (level >= Levels.Manafication
+                    && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
+                    && (IsOffCooldown(Manafication) || level < Levels.Manafication) && IsOffCooldown(Embolden))
                     {
                         return Embolden;
                     }
-
-                    //Situation 2: Embolden first
-                    if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                        && lastComboMove is RDM.Zwerchhau && level >= Levels.Redoublement
-                        && System.Math.Max(black, white) <= 57 && System.Math.Min(black, white) <= 46
-                        && (GetCooldown(Manafication).CooldownRemaining <= 7 || IsOffCooldown(Manafication))
-                        && IsOffCooldown(Embolden))
-                    {
-                        return Embolden;
-                    }
-                    if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                        && System.Math.Max(black, white) <= 50
-                        && IsOffCooldown(Manafication)
-                        && (gauge.ManaStacks == 3 || lastComboMove is RDM.Resolution)
-                        && GetCooldown(Embolden).CooldownRemaining >= 105)
-                    {
-                        return Manafication;
-                    }
-
-                    //Situation 3: Just use them together
-                    if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Embolden
-                        && System.Math.Max(black, white) <= 50
-                        && (IsOffCooldown(Manafication) || level < Levels.Manafication) && IsOffCooldown(Embolden))
-                    {
-                        return Embolden;
-                    }
-                    if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Manafication
-                        && System.Math.Max(black, white) <= 50
+                    if (level >= Levels.Manafication
+                        && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
                         && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
                         && GetCooldown(Embolden).CooldownRemaining >= 110)
                     {
                         return Manafication;
                     }
-
-                    //Situation 4: Level 58 or 59
                     if (level < Levels.Manafication && level >= Levels.Embolden
-                        && System.Math.Min(black, white) >= 50 && IsOffCooldown(Embolden))
+                        && System.Math.Min(black, white) >= 20 && IsOffCooldown(Embolden))
                     {
                         return Embolden;
                     }
                 }
-            }
-            //END_RDM_ST_MANAFICATIONEMBOLDEN
+                //END_RDM_AOE_MANAFICATIONEMBOLDEN
 
-            //RDM_AOE_MANAFICATIONEMBOLDEN
-            if (IsEnabled(CustomComboPreset.RDM_AoE_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
-                && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
-                && GetTargetDistance() < 8 && actionID is Scatter or Impact)
-            {
-                if (level >= Levels.Manafication
-                && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
-                && (IsOffCooldown(Manafication) || level < Levels.Manafication) && IsOffCooldown(Embolden))
+                //RDM_OGCD
+                if (IsEnabled(CustomComboPreset.RDM_OGCD) && level >= Levels.Corpsacorps)
                 {
-                    return Embolden;
-                }
-                if (level >= Levels.Manafication
-                    && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
-                    && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
-                    && GetCooldown(Embolden).CooldownRemaining >= 110)
-                {
-                    return Manafication;
-                }
-                if (level < Levels.Manafication && level >= Levels.Embolden
-                    && System.Math.Min(black, white) >= 20 && IsOffCooldown(Embolden))
-                {
-                    return Embolden;
-                }
-            }
-            //END_RDM_AOE_MANAFICATIONEMBOLDEN
+                    var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_OGCD_OnAction);
+                    //Radio Button Settings:
+                    //1: Fleche
+                    //2: Jolt
+                    //3: Impact
+                    //4: Jolt + Impact
 
-            //RDM_OGCD
-            if (IsEnabled(CustomComboPreset.RDM_OGCD) && level >= Levels.Corpsacorps)
-            {
-                var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_OGCD_OnAction);
-                //Radio Button Settings:
-                //1: Fleche
-                //2: Jolt
-                //3: Impact
-                //4: Jolt + Impact
+                    uint placeOGCD = 0;
 
-                uint placeOGCD = 0;
+                    var distance = GetTargetDistance();
+                    var corpacorpsRange = 25;
+                    var corpsacorpsPool = 0;
 
-                var distance = GetTargetDistance();
-                var corpacorpsRange = 25;
-                var corpsacorpsPool = 0;
+                    if (IsEnabled(CustomComboPreset.RDM_Corpsacorps_MeleeRange)) corpacorpsRange = 3;
+                    if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && IsEnabled(CustomComboPreset.RDM_ST_PoolCorps)) corpsacorpsPool = 1;
 
-                if (IsEnabled(CustomComboPreset.RDM_Corpsacorps_MeleeRange)) corpacorpsRange = 3;
-                if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && IsEnabled(CustomComboPreset.RDM_ST_PoolCorps)) corpsacorpsPool = 1;
-
-                if (actionID is Jolt or Jolt2 or Scatter or Impact or Fleche)
-                {
-                    if (IsEnabled(CustomComboPreset.RDM_Engagement) && GetCooldown(Engagement).RemainingCharges > 0
-                        && level >= Levels.Engagement && distance <= 3) placeOGCD = Engagement;
-                    if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && GetCooldown(Corpsacorps).RemainingCharges > corpsacorpsPool
-                        && ((GetCooldown(Corpsacorps).RemainingCharges >= GetCooldown(Engagement).RemainingCharges) || level < Levels.Engagement) // Try to alternate between Corps-a-corps and Engagement
-                        && level >= Levels.Corpsacorps && distance <= corpacorpsRange) placeOGCD = Corpsacorps;
-                    if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && IsOffCooldown(ContreSixte) && level >= Levels.ContreSixte) placeOGCD = ContreSixte;
-                    if ((radioButton == 1 || IsEnabled(CustomComboPreset.RDM_Fleche)) && IsOffCooldown(Fleche) && level >= Levels.Fleche) placeOGCD = Fleche;
-
-                    if ((actionID is Jolt or Jolt2) && (radioButton is 2 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
-                    if ((actionID is Scatter or Impact) && (radioButton is 3 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
-                    if (actionID is RDM.Fleche && radioButton == 1 && placeOGCD == 0) // All actions are on cooldown, determine the lowest CD to display on Fleche.
+                    if (actionID is Jolt or Jolt2 or Scatter or Impact or Fleche)
                     {
-                        placeOGCD = Fleche;
-                        if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && level >= Levels.ContreSixte
-                            && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(ContreSixte).CooldownRemaining) placeOGCD = ContreSixte;
-                        if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && level >= Levels.Corpsacorps
-                            && ((IsNotEnabled(CustomComboPreset.RDM_ST_PoolCorps) && GetCooldown(Corpsacorps).RemainingCharges >= 0) || GetCooldown(Corpsacorps).RemainingCharges >= 2)
-                            && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Corpsacorps).ChargeCooldownRemaining
-                            && distance <= corpacorpsRange) placeOGCD = Corpsacorps;
-                        if (placeOGCD == Corpsacorps)
+                        if (IsEnabled(CustomComboPreset.RDM_Engagement) && GetCooldown(Engagement).RemainingCharges > 0
+                            && level >= Levels.Engagement && distance <= 3) placeOGCD = Engagement;
+                        if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && GetCooldown(Corpsacorps).RemainingCharges > corpsacorpsPool
+                            && ((GetCooldown(Corpsacorps).RemainingCharges >= GetCooldown(Engagement).RemainingCharges) || level < Levels.Engagement) // Try to alternate between Corps-a-corps and Engagement
+                            && level >= Levels.Corpsacorps && distance <= corpacorpsRange) placeOGCD = Corpsacorps;
+                        if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && IsOffCooldown(ContreSixte) && level >= Levels.ContreSixte) placeOGCD = ContreSixte;
+                        if ((radioButton == 1 || IsEnabled(CustomComboPreset.RDM_Fleche)) && IsOffCooldown(Fleche) && level >= Levels.Fleche) placeOGCD = Fleche;
+
+                        if ((actionID is Jolt or Jolt2) && (radioButton is 2 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
+                        if ((actionID is Scatter or Impact) && (radioButton is 3 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
+                        if (actionID is Fleche && radioButton == 1 && placeOGCD == 0) // All actions are on cooldown, determine the lowest CD to display on Fleche.
                         {
-                            if (IsEnabled(CustomComboPreset.RDM_Engagement) && level >= Levels.Engagement
-                                && GetCooldown(placeOGCD).ChargeCooldownRemaining > GetCooldown(Engagement).ChargeCooldownRemaining
-                                && distance <= 3) placeOGCD = Engagement;
-                        } else if (IsEnabled(CustomComboPreset.RDM_Engagement)
-                            && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Engagement).ChargeCooldownRemaining
-                            && distance <= 3) placeOGCD = Engagement;
-                    }
-                    if (actionID is RDM.Fleche && radioButton == 1) return placeOGCD;
-                }
-            }
-            //END_RDM_OGCD
-
-            //SYSTEM_MANA_BALANCING_MACHINE
-            //Machine to decide which ver spell should be used.
-            //Rules:
-            //1.Avoid perfect balancing [NOT DONE]
-            //   - Jolt adds 2/2 mana
-            //   - Scatter/Impact adds 3/3 mana
-            //   - Verstone/Verfire add 5 mana
-            //   - Veraero/Verthunder add 6 mana
-            //   - Veraero2/Verthunder2 add 7 mana
-            //   - Verholy/Verflare add 11 mana
-            //   - Scorch adds 4/4 mana
-            //   - Resolution adds 4/4 mana
-            //2.Stay within difference limit [DONE]
-            //3.Strive to achieve correct mana for double melee combo burst [DONE]
-            bool useFire = false;
-            bool useStone = false;
-            bool useThunder = false;
-            bool useAero = false;
-            bool useThunder2 = false;
-            bool useAero2 = false;
-
-            if (level >= Levels.Verthunder && (HasEffect(Buffs.Dualcast) || HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Acceleration)))
-            {
-                if (black <= white || HasEffect(Buffs.VerstoneReady)) useThunder = true;
-                if (white <= black || HasEffect(Buffs.VerfireReady)) useAero = true;
-                if (level < Levels.Veraero) useThunder = true;
-            }
-            if (!HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))
-            {
-                if (black <= white && HasEffect(Buffs.VerfireReady)) useFire = true;
-                if (white <= black && HasEffect(Buffs.VerstoneReady)) useStone = true;
-                if (!useFire && !useStone && HasEffect(Buffs.VerfireReady)) useFire = true;
-                if (!useFire && !useStone && HasEffect(Buffs.VerstoneReady)) useStone = true;
-            }
-            if (level >= Levels.Verthunder2 && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))
-            {
-                if (black <= white || level < Levels.Veraero2) useThunder2 = true;
-                else useAero2 = true;
-            }
-            //END_SYSTEM_MANA_BALANCING_MACHINE
-
-            //RDM_MELEEFINISHER
-            if (IsEnabled(CustomComboPreset.RDM_MeleeFinisher))
-            {
-                var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_MeleeFinisher_OnAction);
-
-                if ((radioButton == 1 && actionID is RDM.Riposte or RDM.EnchantedRiposte or RDM.Moulinet or RDM.EnchantedMoulinet)
-                    || (radioButton == 2 && actionID is RDM.Jolt or RDM.Jolt2 or RDM.Scatter or RDM.Impact)
-                    || (radioButton == 3 && actionID is RDM.Riposte or RDM.EnchantedRiposte or RDM.Moulinet or RDM.EnchantedMoulinet or RDM.Jolt or RDM.Jolt2 or RDM.Scatter or RDM.Impact)
-                    || (radioButton == 4 && actionID is RDM.Veraero or RDM.Veraero2 or RDM.Veraero3 or RDM.Verthunder or RDM.Verthunder2 or RDM.Verthunder3))
-                {
-                    if (gauge.ManaStacks >= 3)
-                    {
-                        if (black >= white && level >= Levels.Verholy)
-                        {
-                            if (HasEffect(Buffs.VerstoneReady) && (!HasEffect(Buffs.VerfireReady) || HasEffect(Buffs.Embolden)) && (black - white <= 9))
-                                return Verflare;
-
-                            return Verholy;
+                            placeOGCD = Fleche;
+                            if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && level >= Levels.ContreSixte
+                                && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(ContreSixte).CooldownRemaining) placeOGCD = ContreSixte;
+                            if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && level >= Levels.Corpsacorps
+                                && ((IsNotEnabled(CustomComboPreset.RDM_ST_PoolCorps) && GetCooldown(Corpsacorps).RemainingCharges >= 0) || GetCooldown(Corpsacorps).RemainingCharges >= 2)
+                                && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Corpsacorps).ChargeCooldownRemaining
+                                && distance <= corpacorpsRange) placeOGCD = Corpsacorps;
+                            if (placeOGCD == Corpsacorps)
+                            {
+                                if (IsEnabled(CustomComboPreset.RDM_Engagement) && level >= Levels.Engagement
+                                    && GetCooldown(placeOGCD).ChargeCooldownRemaining > GetCooldown(Engagement).ChargeCooldownRemaining
+                                    && distance <= 3) placeOGCD = Engagement;
+                            }
+                            else if (IsEnabled(CustomComboPreset.RDM_Engagement)
+                              && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Engagement).ChargeCooldownRemaining
+                              && distance <= 3) placeOGCD = Engagement;
                         }
-                        else if (level >= Levels.Verflare)
+                        if (actionID is Fleche && radioButton == 1) return placeOGCD;
+                    }
+                }
+                //END_RDM_OGCD
+
+                //SYSTEM_MANA_BALANCING_MACHINE
+                //Machine to decide which ver spell should be used.
+                //Rules:
+                //1.Avoid perfect balancing [NOT DONE]
+                //   - Jolt adds 2/2 mana
+                //   - Scatter/Impact adds 3/3 mana
+                //   - Verstone/Verfire add 5 mana
+                //   - Veraero/Verthunder add 6 mana
+                //   - Veraero2/Verthunder2 add 7 mana
+                //   - Verholy/Verflare add 11 mana
+                //   - Scorch adds 4/4 mana
+                //   - Resolution adds 4/4 mana
+                //2.Stay within difference limit [DONE]
+                //3.Strive to achieve correct mana for double melee combo burst [DONE]
+                bool useFire = false;
+                bool useStone = false;
+                bool useThunder = false;
+                bool useAero = false;
+                bool useThunder2 = false;
+                bool useAero2 = false;
+
+                if (level >= Levels.Verthunder && (HasEffect(Buffs.Dualcast) || HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Acceleration)))
+                {
+                    if (black <= white || HasEffect(Buffs.VerstoneReady)) useThunder = true;
+                    if (white <= black || HasEffect(Buffs.VerfireReady)) useAero = true;
+                    if (level < Levels.Veraero) useThunder = true;
+                }
+                if (!HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))
+                {
+                    if (black <= white && HasEffect(Buffs.VerfireReady)) useFire = true;
+                    if (white <= black && HasEffect(Buffs.VerstoneReady)) useStone = true;
+                    if (!useFire && !useStone && HasEffect(Buffs.VerfireReady)) useFire = true;
+                    if (!useFire && !useStone && HasEffect(Buffs.VerstoneReady)) useStone = true;
+                }
+                if (level >= Levels.Verthunder2 && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))
+                {
+                    if (black <= white || level < Levels.Veraero2) useThunder2 = true;
+                    else useAero2 = true;
+                }
+                //END_SYSTEM_MANA_BALANCING_MACHINE
+
+                //RDM_MELEEFINISHER
+                if (IsEnabled(CustomComboPreset.RDM_MeleeFinisher))
+                {
+                    var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_MeleeFinisher_OnAction);
+
+                    if ((radioButton == 1 && actionID is Riposte or EnchantedRiposte or Moulinet or EnchantedMoulinet)
+                        || (radioButton == 2 && actionID is Jolt or Jolt2 or Scatter or Impact)
+                        || (radioButton == 3 && actionID is Riposte or EnchantedRiposte or Moulinet or EnchantedMoulinet or Jolt or Jolt2 or Scatter or Impact)
+                        || (radioButton == 4 && actionID is Veraero or Veraero2 or Veraero3 or Verthunder or Verthunder2 or Verthunder3))
+                    {
+                        if (gauge.ManaStacks >= 3)
                         {
-                            if (!HasEffect(Buffs.VerstoneReady) && (HasEffect(Buffs.VerfireReady) || HasEffect(Buffs.Embolden)) && level >= Levels.Verholy && (white - black <= 9))
+                            if (black >= white && level >= Levels.Verholy)
+                            {
+                                if (HasEffect(Buffs.VerstoneReady) && (!HasEffect(Buffs.VerfireReady) || HasEffect(Buffs.Embolden)) && (black - white <= 9))
+                                    return Verflare;
+
                                 return Verholy;
+                            }
+                            else if (level >= Levels.Verflare)
+                            {
+                                if (!HasEffect(Buffs.VerstoneReady) && (HasEffect(Buffs.VerfireReady) || HasEffect(Buffs.Embolden)) && level >= Levels.Verholy && (white - black <= 9))
+                                    return Verholy;
 
-                            return Verflare;
+                                return Verflare;
+                            }
+                        }
+                        if ((lastComboMove is Verflare or Verholy) && level >= Levels.Scorch)
+                            return Scorch;
+
+                        if (lastComboMove is Scorch && level >= Levels.Resolution)
+                            return Resolution;
+                    }
+                }
+                //END_RDM_MELEEFINISHER
+
+                //RDM_ST_MELEECOMBO
+                if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo) && LocalPlayer.IsCasting == false)
+                {
+                    var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_ST_MeleeCombo_OnAction);
+                    var distance = GetTargetDistance();
+
+                    if ((radioButton == 1 && actionID is Riposte or EnchantedRiposte)
+                        || (radioButton == 2 && actionID is Jolt or Jolt2)
+                        || (radioButton == 3 && actionID is Riposte or EnchantedRiposte or Jolt or Jolt2))
+                    {
+                        if ((lastComboMove is Riposte or EnchantedRiposte) && level >= Levels.Zwerchhau)
+                            return OriginalHook(Zwerchhau);
+
+                        if (lastComboMove is Zwerchhau && level >= Levels.Redoublement)
+                            return OriginalHook(Redoublement);
+
+                        if (((System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 50 && level >= Levels.Redoublement)
+                                || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 35 && level < Levels.Redoublement)
+                                || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 20 && level < Levels.Zwerchhau))
+                            && (!HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))) //Not sure if Swift and Accel are necessary, but better to clear I think.
+                        {
+                            if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && level >= Levels.Corpsacorps && GetCooldown(Corpsacorps).RemainingCharges >= 1 && distance > 3) return Corpsacorps;
+                            if (distance <= 3) return OriginalHook(Riposte);
                         }
                     }
-                    if ((lastComboMove is Verflare or Verholy) && level >= Levels.Scorch)
-                        return Scorch;
-
-                    if (lastComboMove is RDM.Scorch && level >= Levels.Resolution)
-                        return Resolution;
                 }
-            }
-            //END_RDM_MELEEFINISHER
+                //END_RDM_ST_MELEECOMBO
 
-            //RDM_ST_MELEECOMBO
-            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo) && LocalPlayer.IsCasting == false)
-            {
-                var radioButton = Service.Configuration.GetCustomIntValue(Config.RDM_ST_MeleeCombo_OnAction);
-                var distance = GetTargetDistance();
+                //RDM_AOE_MELEECOMBO
+                if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo) && level >= Levels.Moulinet && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
+                    && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
+                    && (System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60 || (level < Levels.Manafication && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
+                    && ((GetTargetDistance() <= 7 && gauge.ManaStacks == 0) || gauge.ManaStacks > 0))
+                    return OriginalHook(EnchantedMoulinet);
+                //END_RDM_AOE_MELEECOMBO
 
-                if ((radioButton == 1 && actionID is Riposte or EnchantedRiposte)
-                    || (radioButton == 2 && actionID is Jolt or Jolt2)
-                    || (radioButton == 3 && actionID is Riposte or EnchantedRiposte or Jolt or Jolt2))
+                //RDM_ST_ACCELERATION
+                if (IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && actionID is Jolt or Jolt2 && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
+                    && !HasEffect(Buffs.VerfireReady) && !HasEffect(Buffs.VerstoneReady) && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
                 {
-                    if ((lastComboMove is Riposte or EnchantedRiposte) && level >= Levels.Zwerchhau)
-                        return OriginalHook(Zwerchhau);
-
-                    if (lastComboMove is RDM.Zwerchhau && level >= Levels.Redoublement)
-                        return OriginalHook(Redoublement);
-
-                    if (((System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 50 && level >= Levels.Redoublement) 
-                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 35 && level < Levels.Redoublement)
-                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 20 && level < Levels.Zwerchhau))
-                        && (!HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))) //Not sure if Swift and Accel are necessary, but better to clear I think.
-                    {
-                        if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && level >= Levels.Corpsacorps && GetCooldown(Corpsacorps).RemainingCharges >= 1 && distance > 3) return Corpsacorps;
-                        if (distance <= 3) return OriginalHook(Riposte);
-                    }
+                    if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54)
+                        return Acceleration;
+                    if (IsEnabled(CustomComboPreset.RDM_ST_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(Acceleration).RemainingCharges == 0)
+                        return All.Swiftcast;
                 }
+                //END_RDM_ST_ACCELERATION
+
+                //RDM_AoE_ACCELERATION
+                if (IsEnabled(CustomComboPreset.RDM_AoE_Acceleration) && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
+                    && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
+                {
+                    if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54)
+                        return Acceleration;
+                    if (IsEnabled(CustomComboPreset.RDM_AoE_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(Acceleration).RemainingCharges == 0)
+                        return All.Swiftcast;
+                }
+                //END_RDM_AoE_ACCELERATION
+
+                //RDM_VERFIREVERSTONE
+                if (IsEnabled(CustomComboPreset.RDM_VerfireVerstone) && actionID is Jolt or Jolt2
+                    && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast))
+                {
+                    if (useFire) return Verfire;
+                    if (useStone) return Verstone;
+                }
+                //END_RDM_VERFIREVERSTONE
+
+                //RDM_VERTHUNDERVERAERO
+                if (IsEnabled(CustomComboPreset.RDM_VerthunderVeraero) && actionID is Jolt or Jolt2)
+                {
+                    if (useThunder) return OriginalHook(Verthunder);
+                    if (useAero) return OriginalHook(Veraero);
+                }
+                //END_RDM_VERTHUNDERVERAERO
+
+                //RDM_VERTHUNDERIIVVERAEROII
+                if (IsEnabled(CustomComboPreset.RDM_VerthunderIIVeraeroII) && actionID is Scatter or Impact)
+                {
+                    if (useThunder2) return Verthunder2;
+                    if (useAero2) return Veraero2;
+                }
+                //END_RDM_VERTHUNDERIIVVERAEROII
+
+                //NO_CONDITIONS_MET
+                if (level < Levels.Jolt && actionID is Jolt or Jolt2) { return Riposte; }
+                return actionID;
             }
-            //END_RDM_ST_MELEECOMBO
-
-            //RDM_AOE_MELEECOMBO
-            if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo) && level >= Levels.Moulinet && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
-                && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
-                && (System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60 || (level < Levels.Manafication && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
-                && ((GetTargetDistance() <= 7 && gauge.ManaStacks == 0) || gauge.ManaStacks > 0))
-                return OriginalHook(EnchantedMoulinet);
-            //END_RDM_AOE_MELEECOMBO
-
-            //RDM_ST_ACCELERATION
-            if (IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && actionID is Jolt or Jolt2 && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
-                && !HasEffect(Buffs.VerfireReady) && !HasEffect(Buffs.VerstoneReady) && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
-            {
-                if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54)
-                    return Acceleration;
-                if (IsEnabled(CustomComboPreset.RDM_ST_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(Acceleration).RemainingCharges == 0)
-                    return All.Swiftcast;
-            }
-            //END_RDM_ST_ACCELERATION
-
-            //RDM_AoE_ACCELERATION
-            if (IsEnabled(CustomComboPreset.RDM_AoE_Acceleration) && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
-                && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
-            {
-                if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54)
-                    return Acceleration;
-                if (IsEnabled(CustomComboPreset.RDM_AoE_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(Acceleration).RemainingCharges == 0)
-                    return All.Swiftcast;
-            }
-            //END_RDM_AoE_ACCELERATION
-
-            //RDM_VERFIREVERSTONE
-            if (IsEnabled(CustomComboPreset.RDM_VerfireVerstone) && actionID is Jolt or Jolt2
-                && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast))
-            {
-                if (useFire) return Verfire;
-                if (useStone) return Verstone;
-            }
-            //END_RDM_VERFIREVERSTONE
-
-            //RDM_VERTHUNDERVERAERO
-            if (IsEnabled(CustomComboPreset.RDM_VerthunderVeraero) && actionID is Jolt or Jolt2)
-            {
-                if (useThunder) return OriginalHook(Verthunder);
-                if (useAero) return OriginalHook(Veraero);
-            }
-            //END_RDM_VERTHUNDERVERAERO
-
-            //RDM_VERTHUNDERIIVVERAEROII
-            if (IsEnabled(CustomComboPreset.RDM_VerthunderIIVeraeroII) && actionID is Scatter or Impact)
-            {
-                if (useThunder2) return Verthunder2;
-                if (useAero2) return Veraero2;
-            }
-            //END_RDM_VERTHUNDERIIVVERAEROII
-
-            //NO_CONDITIONS_MET
-            if (level < Levels.Jolt && actionID is Jolt or Jolt2) { return Riposte; }
-            return actionID;
         }
-    }
 
-    internal class RDM_LucidDreaming : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_LucidDreaming;
-
-        internal static bool showLucid = false;
-
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class RDM_LucidDreaming : CustomCombo
         {
-            if (actionID is RDM.Jolt or RDM.Jolt2 or RDM.Veraero or RDM.Veraero2 or RDM.Veraero3 or RDM.Verthunder or RDM.Verthunder2 or RDM.Verthunder3 or RDM.Scatter or RDM.Impact)
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_LucidDreaming;
+
+            internal static bool showLucid = false;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.RDM_LucidDreaming_Threshold);
-
-                if (level >= All.Levels.LucidDreaming && LocalPlayer.CurrentMp <= lucidThreshold) // Check to show Lucid Dreaming
+                if (actionID is Jolt or Jolt2 or Veraero or Veraero2 or Veraero3 or Verthunder or Verthunder2 or Verthunder3 or Scatter or Impact)
                 {
-                    showLucid = true;
-                }
+                    var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.RDM_LucidDreaming_Threshold);
 
-                if (showLucid && CanSpellWeave(actionID) && HasCondition(ConditionFlag.InCombat) && IsOffCooldown(All.LucidDreaming) && !HasEffect(Buffs.Dualcast)
-                    && lastComboMove != EnchantedRiposte && lastComboMove != EnchantedZwerchhau
-                    && lastComboMove != EnchantedRedoublement && lastComboMove != Verflare
-                    && lastComboMove != Verholy && lastComboMove != Scorch) // Change abilities to Lucid Dreaming for entire weave window
-                {
-                    return All.LucidDreaming;
+                    if (level >= All.Levels.LucidDreaming && LocalPlayer.CurrentMp <= lucidThreshold) // Check to show Lucid Dreaming
+                    {
+                        showLucid = true;
+                    }
+
+                    if (showLucid && CanSpellWeave(actionID) && HasCondition(ConditionFlag.InCombat) && IsOffCooldown(All.LucidDreaming) && !HasEffect(Buffs.Dualcast)
+                        && lastComboMove != EnchantedRiposte && lastComboMove != EnchantedZwerchhau
+                        && lastComboMove != EnchantedRedoublement && lastComboMove != Verflare
+                        && lastComboMove != Verholy && lastComboMove != Scorch) // Change abilities to Lucid Dreaming for entire weave window
+                    {
+                        return All.LucidDreaming;
+                    }
+                    showLucid = false;
                 }
-                showLucid = false;
+                return actionID;
             }
-            return actionID;
         }
-    }
 
         // RDM_Verraise
         // Swiftcast combos to Verraise when:
@@ -662,17 +663,18 @@ namespace XIVSlothComboPlugin.Combos
                 return actionID;
             }
         }
-    }
 
-    internal class RDM_CorpsDisplacement : CustomCombo
-    {
-        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_CorpsDisplacement;
-        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        internal class RDM_CorpsDisplacement : CustomCombo
         {
-            var distance = GetTargetDistance();
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_CorpsDisplacement;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                var distance = GetTargetDistance();
 
-            if (actionID is RDM.Corpsacorps && level >= RDM.Levels.Displacement && HasTarget() && distance <= 5) { return RDM.Displacement; }
-            else return actionID;
+                if (actionID is Corpsacorps && level >= Levels.Displacement && HasTarget() && distance <= 5) { return Displacement; }
+                else return actionID;
+            }
         }
     }
+
 }

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -605,6 +605,7 @@ namespace XIVSlothComboPlugin.Combos
                 }
                 //END_RDM_VERTHUNDERIIVVERAEROII
 
+
                 //NO_CONDITIONS_MET
                 if (level < Levels.Jolt && actionID is Jolt or Jolt2) { return Riposte; }
                 return actionID;
@@ -671,10 +672,10 @@ namespace XIVSlothComboPlugin.Combos
             {
                 var distance = GetTargetDistance();
 
-                if (actionID is Corpsacorps && level >= Levels.Displacement && HasTarget() && distance <= 5) { return Displacement; }
-                else return actionID;
+                if (actionID is Displacement && level >= Levels.Displacement && HasTarget() && distance >= 5) { return Corpsacorps; }
+                return actionID;
             }
         }
-    }
 
+    }
 }

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -96,7 +96,6 @@ namespace XIVSlothComboPlugin.Combos
 
         public static class Config
         {
-            //            public const string RdmLucidMpThreshold = "RdmLucidMpThreshold";
             public const string RDM_OGCD_OnAction = "RDM_OGCD_OnAction";
             public const string RDM_ST_MeleeCombo_OnAction = "RDM_ST_MeleeCombo_OnAction";
             public const string RDM_MeleeFinisher_OnAction = "RDM_MeleeFinisher_OnAction";

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -492,7 +492,8 @@ namespace XIVSlothComboPlugin.Combos
 
                 if ((radioButton == 1 && actionID is RDM.Riposte or RDM.EnchantedRiposte or RDM.Moulinet or RDM.EnchantedMoulinet)
                     || (radioButton == 2 && actionID is RDM.Jolt or RDM.Jolt2 or RDM.Scatter or RDM.Impact)
-                    || (radioButton == 3 && actionID is RDM.Riposte or RDM.EnchantedRiposte or RDM.Moulinet or RDM.EnchantedMoulinet or RDM.Jolt or RDM.Jolt2 or RDM.Scatter or RDM.Impact))
+                    || (radioButton == 3 && actionID is RDM.Riposte or RDM.EnchantedRiposte or RDM.Moulinet or RDM.EnchantedMoulinet or RDM.Jolt or RDM.Jolt2 or RDM.Scatter or RDM.Impact)
+                    || (radioButton == 4 && actionID is RDM.Veraero or RDM.Veraero2 or RDM.Veraero3 or RDM.Verthunder or RDM.Verthunder2 or RDM.Verthunder3))
                 {
                     if (gauge.ManaStacks >= 3)
                     {
@@ -617,7 +618,7 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is RDM.Verthunder or RDM.Veraero or RDM.Scatter or RDM.Verthunder3 or RDM.Veraero3 or RDM.Verthunder2 or RDM.Veraero2 or RDM.Impact or RDM.Jolt or RDM.Jolt2)
+            if (actionID is RDM.Jolt or RDM.Jolt2 or RDM.Veraero or RDM.Veraero2 or RDM.Veraero3 or RDM.Verthunder or RDM.Verthunder2 or RDM.Verthunder3 or RDM.Scatter or RDM.Impact)
             {
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(RDM.Config.RDM_LucidDreaming_Threshold);
 
@@ -659,6 +660,18 @@ namespace XIVSlothComboPlugin.Combos
 
             // Else we just exit normally and return SwiftCast
             return actionID;
+        }
+    }
+
+    internal class RDM_CorpsDisplacement : CustomCombo
+    {
+        protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_CorpsDisplacement;
+        protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+        {
+            var distance = GetTargetDistance();
+
+            if (actionID is RDM.Corpsacorps && level >= RDM.Levels.Displacement && HasTarget() && distance <= 5) { return RDM.Displacement; }
+            else return actionID;
         }
     }
 }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -799,13 +799,16 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_ST_MeleeCombo_OnAction, "Use on Riposte & Jolt/Jolt II", "[Choose Jolt or Impact for a one button rotation]\n---------------------------------------------------------------", 3);
 
             if (preset == CustomComboPreset.RDM_MeleeFinisher)
-                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "Use on Riposte", "", 1);
+                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "Use on Riposte & Moulinet", "", 1);
 
             if (preset == CustomComboPreset.RDM_MeleeFinisher)
                 ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "Use on Jolt/Jolt II & Scatter/Impact", "", 2);
 
             if (preset == CustomComboPreset.RDM_MeleeFinisher)
-                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "Use on Riposte, Jolt/Jolt II & Scatter/Impact", "[Choose Jolt or Impact for a one button rotation]\n---------------------------------------------------------------", 3);
+                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "Use on Riposte, Moulinet, Jolt/Jolt II & Scatter/Impact", "", 3);
+
+            if (preset == CustomComboPreset.RDM_MeleeFinisher)
+                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "Use on Veraero 1/2/3 and Verthunder 1/2/3", "[Choose Jolt or Impact for a one button rotation]\n---------------------------------------------------------------", 4);
 
             if (preset == CustomComboPreset.RDM_LucidDreaming && enabled)
                 ConfigWindowFunctions.DrawSliderInt(0, 10000, RDM.Config.RDM_LucidDreaming_Threshold, "Add Lucid Dreaming when below this MP.", 300, SliderIncrements.Hundreds);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1759,6 +1759,7 @@ namespace XIVSlothComboPlugin
         //The three digets after RDM.JobID can be used to reorder items in the list
 
         //SECTION_1_OPENERS
+        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
         [CustomComboInfo("Balance Opener [Lv.90]", "Replaces Jolt with the Balance opener ending with Resolution\n**Must move into melee range before melee combo**", RDM.JobID, 110)]
         RDM_Balance_Opener = 13110,
 
@@ -1767,6 +1768,7 @@ namespace XIVSlothComboPlugin
         RDM_Opener_Any_Mana = 13111,
 
         //SECTION_2to3_ROTATION
+        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
         [CustomComboInfo("Verthunder/Veraero", "Replace Jolt with Verthunder and Veraero", RDM.JobID, 210)]
         RDM_VerthunderVeraero = 13210,
 
@@ -1778,9 +1780,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Include Swiftcast", "Add Swiftcast when all Acceleration charges are used", RDM.JobID, 212)]
         RDM_ST_AccelSwiftCast = 13212,
 
+        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
         [CustomComboInfo("Verfire/Verstone", "Replace Jolt with Verfire and Verstone", RDM.JobID,220)]
         RDM_VerfireVerstone = 13220,
 
+        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte)]
         [CustomComboInfo("Weave OGCD Damage", "Use oGCD actions on specified action", RDM.JobID, 240)]
         RDM_OGCD = 13240,
 
@@ -1804,9 +1808,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Only in Melee Range", "Use Corps-a-corps only when in melee range", RDM.JobID, 245)]
         RDM_Corpsacorps_MeleeRange = 13245,
 
+        //[ReplaceSkill(RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("Verthunder II/Veraero II", "Replace Scatter/Impact with Verthunder II or Veraero II", RDM.JobID, 310)]
         RDM_VerthunderIIVeraeroII = 13310,
 
+        //[ReplaceSkill(RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("AoE Acceleration", "Use Acceleration on Scatter/Scorch for increased damage", RDM.JobID, 320)]
         RDM_AoE_Acceleration = 13320,
 
@@ -1815,6 +1821,7 @@ namespace XIVSlothComboPlugin
         RDM_AoE_AccelSwiftCast = 13321,
 
         //SECTION_4to5_MELEE
+        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte)]
         [CustomComboInfo("Single Target Melee Combo", "Stack Reposte Combo on specified action\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 410)]
         RDM_ST_MeleeCombo = 13410,
 
@@ -1826,6 +1833,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Hold for Double Melee Combo [Lv.90]", "Hold both actions until you can perform a double melee combo", RDM.JobID, 412)]
         RDM_ST_DoubleMeleeCombo = 13412,
 
+        //[ReplaceSkill(RDM.Moulinet)]
         [CustomComboInfo("AoE Melee Combo", "Use Moulinet on Scatter/Impact when over 60/60 mana", RDM.JobID, 420)]
         RDM_AoE_MeleeCombo = 13420,
 
@@ -1841,17 +1849,23 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Reserve one charge", "Pool one charge of Corp-a-corps for use", RDM.JobID, 431)]
         RDM_ST_PoolCorps = 13431,
 
+        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet)]
         [CustomComboInfo("Melee Finisher", "Add Verflare/Verholy and other finishing moves to specified action", RDM.JobID, 510)]
         RDM_MeleeFinisher = 13510,
 
         //SECTION_6to7_QOL
-        [CustomComboInfo("Lucid Dreaming", "Use Lucid Dreaming on Veraero, Verthunder and Scatter when below threshold.", RDM.JobID, 610, "Lucid Dreaming the day away", "OOM? Git gud.")]
+        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3, RDM.Scatter, RDM.Impact)]
+        [CustomComboInfo("Lucid Dreaming", "Use Lucid Dreaming on Jolt 1/2, Veraero 1/2/3, Verthunder 1/2/3, and Scatter/Impact when below threshold.", RDM.JobID, 610, "Lucid Dreaming the day away", "OOM? Git gud.")]
         RDM_LucidDreaming = 13610,
 
+        //[ReplaceSkill(All.Swiftcast)]
         [CustomComboInfo("Verraise", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620, "Swifty Verraise", "You're panicing right now, aren't you?")]
         RDM_Verraise = 13620,
 
         //SECTION_8to9_OTHERS                   
+        //[ReplaceSkill(RDM.Corpsacorps)]
+        [CustomComboInfo("Corps-a-corps <> Displacement", "Replace Corps-a-corps with Displacement when in melee range.", RDM.JobID, 810, "I take two steps forward, you take two steps back.", "We come together because opposites attract.")]
+        RDM_CorpsDisplacement = 13810,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1915,7 +1915,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Verfire/Verstone", "Replace Jolt with Verfire and Verstone", RDM.JobID,220)]
         RDM_VerfireVerstone = 13220,
 
-        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Fleche)]
         [CustomComboInfo("Weave OGCD Damage", "Use oGCD actions on specified action", RDM.JobID, 240)]
         RDM_OGCD = 13240,
 
@@ -1944,7 +1944,7 @@ namespace XIVSlothComboPlugin
         RDM_VerthunderIIVeraeroII = 13310,
 
         [ReplaceSkill(RDM.Scatter, RDM.Impact)]
-        [CustomComboInfo("AoE Acceleration", "Use Acceleration on Scatter/Scorch for increased damage", RDM.JobID, 320)]
+        [CustomComboInfo("AoE Acceleration", "Use Acceleration on Scatter/Impact for increased damage", RDM.JobID, 320)]
         RDM_AoE_Acceleration = 13320,
 
         [ParentCombo(RDM_AoE_Acceleration)]
@@ -1952,7 +1952,7 @@ namespace XIVSlothComboPlugin
         RDM_AoE_AccelSwiftCast = 13321,
 
         //SECTION_4to5_MELEE
-        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Riposte)]
         [CustomComboInfo("Single Target Melee Combo", "Stack Reposte Combo on specified action\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 410)]
         RDM_ST_MeleeCombo = 13410,
 
@@ -1965,6 +1965,7 @@ namespace XIVSlothComboPlugin
         RDM_ST_DoubleMeleeCombo = 13412,
 
         //[ReplaceSkill(RDM.Moulinet)]
+        [ReplaceSkill(RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("AoE Melee Combo", "Use Moulinet on Scatter/Impact when over 60/60 mana", RDM.JobID, 420)]
         RDM_AoE_MeleeCombo = 13420,
 
@@ -1980,7 +1981,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Reserve one charge", "Pool one charge of Corp-a-corps for use", RDM.JobID, 431)]
         RDM_ST_PoolCorps = 13431,
 
-        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3)]
         [CustomComboInfo("Melee Finisher", "Add Verflare/Verholy and other finishing moves to specified action", RDM.JobID, 510)]
         RDM_MeleeFinisher = 13510,
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1890,7 +1890,7 @@ namespace XIVSlothComboPlugin
         //The three digets after RDM.JobID can be used to reorder items in the list
 
         //SECTION_1_OPENERS
-        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
         [CustomComboInfo("Balance Opener [Lv.90]", "Replaces Jolt with the Balance opener ending with Resolution\n**Must move into melee range before melee combo**", RDM.JobID, 110)]
         RDM_Balance_Opener = 13110,
 
@@ -1899,7 +1899,7 @@ namespace XIVSlothComboPlugin
         RDM_Opener_Any_Mana = 13111,
 
         //SECTION_2to3_ROTATION
-        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
         [CustomComboInfo("Verthunder/Veraero", "Replace Jolt with Verthunder and Veraero", RDM.JobID, 210)]
         RDM_VerthunderVeraero = 13210,
 
@@ -1911,11 +1911,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Include Swiftcast", "Add Swiftcast when all Acceleration charges are used", RDM.JobID, 212)]
         RDM_ST_AccelSwiftCast = 13212,
 
-        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
         [CustomComboInfo("Verfire/Verstone", "Replace Jolt with Verfire and Verstone", RDM.JobID,220)]
         RDM_VerfireVerstone = 13220,
 
-        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte)]
         [CustomComboInfo("Weave OGCD Damage", "Use oGCD actions on specified action", RDM.JobID, 240)]
         RDM_OGCD = 13240,
 
@@ -1939,11 +1939,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Only in Melee Range", "Use Corps-a-corps only when in melee range", RDM.JobID, 245)]
         RDM_Corpsacorps_MeleeRange = 13245,
 
-        //[ReplaceSkill(RDM.Scatter, RDM.Impact)]
+        [ReplaceSkill(RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("Verthunder II/Veraero II", "Replace Scatter/Impact with Verthunder II or Veraero II", RDM.JobID, 310)]
         RDM_VerthunderIIVeraeroII = 13310,
 
-        //[ReplaceSkill(RDM.Scatter, RDM.Impact)]
+        [ReplaceSkill(RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("AoE Acceleration", "Use Acceleration on Scatter/Scorch for increased damage", RDM.JobID, 320)]
         RDM_AoE_Acceleration = 13320,
 
@@ -1952,7 +1952,7 @@ namespace XIVSlothComboPlugin
         RDM_AoE_AccelSwiftCast = 13321,
 
         //SECTION_4to5_MELEE
-        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte)]
         [CustomComboInfo("Single Target Melee Combo", "Stack Reposte Combo on specified action\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 410)]
         RDM_ST_MeleeCombo = 13410,
 
@@ -1980,22 +1980,22 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Reserve one charge", "Pool one charge of Corp-a-corps for use", RDM.JobID, 431)]
         RDM_ST_PoolCorps = 13431,
 
-        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet)]
         [CustomComboInfo("Melee Finisher", "Add Verflare/Verholy and other finishing moves to specified action", RDM.JobID, 510)]
         RDM_MeleeFinisher = 13510,
 
         //SECTION_6to7_QOL
-        //[ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3, RDM.Scatter, RDM.Impact)]
+        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3, RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("Lucid Dreaming", "Use Lucid Dreaming on Jolt 1/2, Veraero 1/2/3, Verthunder 1/2/3, and Scatter/Impact when below threshold.", RDM.JobID, 610, "Lucid Dreaming the day away", "OOM? Git gud.")]
         RDM_LucidDreaming = 13610,
 
-        //[ReplaceSkill(All.Swiftcast)]
+        [ReplaceSkill(All.Swiftcast)]
         [CustomComboInfo("Verraise", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620, "Swifty Verraise", "You're panicing right now, aren't you?")]
         RDM_Verraise = 13620,
 
         //SECTION_8to9_OTHERS                   
-        //[ReplaceSkill(RDM.Corpsacorps)]
-        [CustomComboInfo("Corps-a-corps <> Displacement", "Replace Corps-a-corps with Displacement when in melee range.", RDM.JobID, 810, "I take two steps forward, you take two steps back.", "We come together because opposites attract.")]
+        [ReplaceSkill(RDM.Displacement)]
+        [CustomComboInfo("Displacement <> Corps-a-corps", "Replace Displacement with Corps-a-corps when out of range.", RDM.JobID, 810, "I take two steps forward, you take two steps back.", "We come together because opposites attract.")]
         RDM_CorpsDisplacement = 13810,
 
         #endregion


### PR DESCRIPTION
[RDM]
 - Updated descriptions to include correct `ReplaceSkill`
 - Cleaned up code to remove `RDM.` from actions and removed old comments
 - Added `Displacement <> Corps-a-corps` feature
 - Added option to `Melee Finisher`: `Use on Veraero 1/2/3 and Verthunder 1/2/3`