### PR TITLE
[DNC] Features & Fixes

### DIFF
--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -97,7 +97,13 @@ namespace XIVSlothComboPlugin.Combos
                 FanDance4 = 86,
                 StarfallDance = 90;
         }
-    
+        public static class Config
+        {
+            public const string
+                DNCFinalSSBurstPercent = "DNCFinalSSBurstPercent";
+            public const string
+                DNCFinalTSBurstPercent = "DNCFinalTSBurstPercent";
+        }
 
     internal class DancerDanceComboCompatibility : CustomCombo
     {
@@ -425,6 +431,8 @@ namespace XIVSlothComboPlugin.Combos
                 var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
                 var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
                 var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
+                var DNCFinalSSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSBurstPercent);
+                var DNCFinalTSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSBurstPercent);
 
                 // Simple ST Interrupt
                 if (IsEnabled(CustomComboPreset.DancerSimpleInterruptFeature) && interruptable)
@@ -443,15 +451,13 @@ namespace XIVSlothComboPlugin.Combos
                         : StandardFinish2;
 
                 // Simple ST Standard/Tech (activates dances with no target, or when target is over 2% HP)
-                if (!HasTarget() || EnemyHealthPercentage() > 2)
+                if (!HasTarget())
                 {
-                    if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) &&
-                        IsOffCooldown(StandardStep) && ((!HasEffect(Buffs.TechnicalStep) && !techBurst) ||
-                        techBurstTimer.RemainingTime > 5))
+                    if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) && IsOffCooldown(StandardStep) && EnemyHealthPercentage() > DNCFinalSSBurstPercent &&
+                        ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer.RemainingTime > 5))
                         return StandardStep;
 
-                    if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) &&
-                        !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
+                    if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep) && EnemyHealthPercentage() > DNCFinalTSBurstPercent)
                         return TechnicalStep;
                 }
 

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -103,6 +103,8 @@ namespace XIVSlothComboPlugin.Combos
                 DNCFinalSSBurstPercent = "DNCFinalSSBurstPercent";
             public const string
                 DNCFinalTSBurstPercent = "DNCFinalTSBurstPercent";
+            public const string
+                DNCFeatherBurstPercent = "DNCFeatherBurstPercent";
         }
 
     internal class DancerDanceComboCompatibility : CustomCombo
@@ -433,6 +435,7 @@ namespace XIVSlothComboPlugin.Combos
                 var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
                 var DNCFinalSSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSBurstPercent);
                 var DNCFinalTSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSBurstPercent);
+                var DNCFeatherBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFeatherBurstPercent);
 
                 // Simple ST Interrupt
                 if (IsEnabled(CustomComboPreset.DancerSimpleInterruptFeature) && interruptable)
@@ -493,7 +496,7 @@ namespace XIVSlothComboPlugin.Combos
                         var minFeathers = IsEnabled(CustomComboPreset.DancerSimpleFeatherPoolingFeature) && level >= Levels.TechnicalStep ? 3 : 0;
 
                         // Simple ST Feather Overcap & Burst
-                        if (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) || EnemyHealthPercentage() < 2)
+                        if (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) || EnemyHealthPercentage() < DNCFeatherBurstPercent && gauge.Feathers > 0)
                             return FanDance1;
                     }
 

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -100,6 +100,12 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
+                DNCEspritThreshold_ST = "DNCEspritThreshold_ST";
+            public const string
+                DNCEspritThreshold_AoE = "DNCEspritThreshold_AoE";
+
+            #region Simple ST Sliders
+            public const string
                 DNCSimpleSSBurstPercent = "DNCSimpleSSBurstPercent";
             public const string
                 DNCSimpleTSBurstPercent = "DNCSimpleTSBurstPercent";
@@ -109,7 +115,9 @@ namespace XIVSlothComboPlugin.Combos
                 DNCSimplePanicHealWaltzPercent = "DNCSimplePanicHealWaltzPercent";
             public const string
                 DNCSimplePanicHealWindPercent = "DNCSimplePanicHealWindPercent";
+            #endregion
 
+            #region Simple AoE Sliders
             public const string
                 DNCSimpleSSAoEBurstPercent = "DNCSimpleSSAoEBurstPercent";
             public const string
@@ -118,9 +126,10 @@ namespace XIVSlothComboPlugin.Combos
                 DNCSimpleAoEPanicHealWaltzPercent = "DNCSimpleAoEPanicHealWaltzPercent";
             public const string
                 DNCSimpleAoEPanicHealWindPercent = "DNCSimpleAoEPanicHealWindPercent";
+            #endregion
         }
 
-    internal class DancerDanceComboCompatibility : CustomCombo
+        internal class DancerDanceComboCompatibility : CustomCombo
     {
         protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DancerDanceComboCompatibility;
 
@@ -255,11 +264,10 @@ namespace XIVSlothComboPlugin.Combos
                 var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
                 var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
                 var canWeave = CanWeave(actionID);
+                var espritThreshold = Service.Configuration.GetCustomIntValue(Config.DNCEspritThreshold_ST);
 
                 // ST Esprit overcap options
-                if (level >= Levels.SaberDance &&
-                   (gauge.Esprit >= 50 && IsEnabled(CustomComboPreset.DancerEspritOvercapSTInstantOption) ||
-                    gauge.Esprit >= 85 && IsEnabled(CustomComboPreset.DancerEspritOvercapSTFeature)))
+                if (level >= Levels.SaberDance && gauge.Esprit >= espritThreshold && IsEnabled(CustomComboPreset.DancerEspritOvercapSTFeature))
                         return SaberDance;
 
                 if (canWeave)
@@ -310,11 +318,10 @@ namespace XIVSlothComboPlugin.Combos
                 var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
                 var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
                 var canWeave = CanWeave(actionID);
+                var espritThreshold = Service.Configuration.GetCustomIntValue(Config.DNCEspritThreshold_AoE);
 
                 // AoE Esprit overcap options
-                if (level >= Levels.SaberDance &&
-                   (gauge.Esprit >= 50 && IsEnabled(CustomComboPreset.DancerEspritOvercapAoEInstantOption) ||
-                    gauge.Esprit >= 85 && IsEnabled(CustomComboPreset.DancerEspritOvercapAoEFeature)))
+                if (level >= Levels.SaberDance && gauge.Esprit >= espritThreshold && IsEnabled(CustomComboPreset.DancerEspritOvercapAoEFeature))
                     return SaberDance;
 
                 if (canWeave)

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -106,9 +106,18 @@ namespace XIVSlothComboPlugin.Combos
             public const string
                 DNCSimpleFeatherBurstPercent = "DNCSimpleFeatherBurstPercent";
             public const string
+                DNCSimplePanicHealWaltzPercent = "DNCSimplePanicHealWaltzPercent";
+            public const string
+                DNCSimplePanicHealWindPercent = "DNCSimplePanicHealWindPercent";
+
+            public const string
                 DNCSimpleSSAoEBurstPercent = "DNCSimpleSSAoEBurstPercent";
             public const string
                 DNCSimpleTSAoEBurstPercent = "DNCSimpleTSAoEBurstPercent";
+            public const string
+                DNCSimpleAoEPanicHealWaltzPercent = "DNCSimpleAoEPanicHealWaltzPercent";
+            public const string
+                DNCSimpleAoEPanicHealWindPercent = "DNCSimpleAoEPanicHealWindPercent";
         }
 
     internal class DancerDanceComboCompatibility : CustomCombo
@@ -437,9 +446,11 @@ namespace XIVSlothComboPlugin.Combos
                 var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
                 var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
                 var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
-                var DNCFinalSSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
-                var DNCFinalTSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
-                var DNCFeatherBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
+                var standardStepBurstThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
+                var technicalStepBurstThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
+                var featherBurstThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
+                var waltzThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent);
+                var secondWindThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent);
 
                 // Simple ST Interrupt
                 if (IsEnabled(CustomComboPreset.DancerSimpleInterruptFeature) && interruptable)
@@ -460,11 +471,11 @@ namespace XIVSlothComboPlugin.Combos
                 // Simple ST Standard/Tech (activates dances with no target, or when target is over 2% HP)
                 if (!HasTarget())
                 {
-                    if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) && IsOffCooldown(StandardStep) && EnemyHealthPercentage() > DNCFinalSSBurstPercent &&
+                    if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) && IsOffCooldown(StandardStep) && EnemyHealthPercentage() > standardStepBurstThreshold &&
                         ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer.RemainingTime > 5))
                         return StandardStep;
 
-                    if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep) && EnemyHealthPercentage() > DNCFinalTSBurstPercent)
+                    if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep) && EnemyHealthPercentage() > technicalStepBurstThreshold)
                         return TechnicalStep;
                 }
 
@@ -500,7 +511,7 @@ namespace XIVSlothComboPlugin.Combos
                         var minFeathers = IsEnabled(CustomComboPreset.DancerSimpleFeatherPoolingFeature) && level >= Levels.TechnicalStep ? 3 : 0;
 
                         // Simple ST Feather Overcap & Burst
-                        if (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) || EnemyHealthPercentage() < DNCFeatherBurstPercent && gauge.Feathers > 0)
+                        if (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) || EnemyHealthPercentage() < featherBurstThreshold && gauge.Feathers > 0)
                             return FanDance1;
                     }
 
@@ -511,10 +522,10 @@ namespace XIVSlothComboPlugin.Combos
                     // Simple ST Panic Heals
                     if (IsEnabled(CustomComboPreset.DancerSimplePanicHealsFeature))
                     {
-                        if (PlayerHealthPercentageHp() < 30 && curingWaltzReady)
+                        if (PlayerHealthPercentageHp() < waltzThreshold && curingWaltzReady)
                             return CuringWaltz;
 
-                        if (PlayerHealthPercentageHp() < 50 && secondWindReady)
+                        if (PlayerHealthPercentageHp() < secondWindThreshold && secondWindReady)
                             return All.SecondWind;
                     }
                     
@@ -571,8 +582,10 @@ namespace XIVSlothComboPlugin.Combos
                     var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
                     var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
                     var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
-                    var DNCFinalSSAoEBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
-                    var DNCFinalTSAoEBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
+                    var standardStepBurstThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
+                    var technicalStepBurstThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
+                    var waltzThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent);
+                    var secondWindThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent);
 
                     // Simple AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DancerSimpleAoEInterruptFeature) && interruptable)
@@ -593,12 +606,12 @@ namespace XIVSlothComboPlugin.Combos
                     // Simple AoE Standard/Tech (activates dances with no target, or when target is over 5% HP)
                     if (!HasTarget())
                     {
-                        if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) && IsOffCooldown(StandardStep) && EnemyHealthPercentage() > DNCFinalSSAoEBurstPercent &&
+                        if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) && IsOffCooldown(StandardStep) && EnemyHealthPercentage() > standardStepBurstThreshold &&
                             ((!HasEffect(Buffs.TechnicalStep) && !techBurst) ||
                             techBurstTimer.RemainingTime > 5))
                             return StandardStep;
 
-                        if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep) && EnemyHealthPercentage() > DNCFinalTSAoEBurstPercent)
+                        if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep) && EnemyHealthPercentage() > technicalStepBurstThreshold)
                             return TechnicalStep;
                     }
 
@@ -649,10 +662,10 @@ namespace XIVSlothComboPlugin.Combos
                         // Simple AoE Panic Heals
                         if (IsEnabled(CustomComboPreset.DancerSimpleAoEPanicHealsFeature))
                         {
-                            if (PlayerHealthPercentageHp() < 30 && curingWaltzReady)
+                            if (PlayerHealthPercentageHp() < waltzThreshold && curingWaltzReady)
                                 return CuringWaltz;
 
-                            if (PlayerHealthPercentageHp() < 50 && secondWindReady)
+                            if (PlayerHealthPercentageHp() < secondWindThreshold && secondWindReady)
                                 return All.SecondWind;
                         }
 

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -426,34 +426,6 @@ namespace XIVSlothComboPlugin.Combos
                 var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
                 var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
 
-                // Dance Step Replacement
-                if (IsEnabled(CustomComboPreset.DancerSimpleDanceStepFeature))
-                {
-                    // Standard Step
-                    if (actionID is DNC.StandardStep)
-                    {
-                        if (gauge.IsDancing && HasEffect(Buffs.StandardStep))
-                        {
-                            if (gauge.CompletedSteps < 2)
-                                return (uint)gauge.NextStep;
-
-                            return StandardFinish2;
-                        }
-                    }
-
-                    // Technical Step
-                    if ((actionID is DNC.TechnicalStep) && level >= Levels.TechnicalStep)
-                    {
-                        if (gauge.IsDancing && HasEffect(Buffs.TechnicalStep))
-                        {
-                            if (gauge.CompletedSteps < 4)
-                                return (uint)gauge.NextStep;
-
-                            return TechnicalFinish4;
-                        }
-                    }
-                }
-
                 // Simple ST Interrupt
                 if (IsEnabled(CustomComboPreset.DancerSimpleInterruptFeature) && interruptable)
                         return All.HeadGraze;
@@ -566,7 +538,7 @@ namespace XIVSlothComboPlugin.Combos
         }
     }
 
-        internal class DancerSimpleAoeFeature : CustomCombo
+    internal class DancerSimpleAoeFeature : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DancerSimpleAoEFeature;
 
@@ -586,34 +558,6 @@ namespace XIVSlothComboPlugin.Combos
                     var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
                     var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
                     var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
-
-                    // Simple AoE Dance Step Replacement
-                    if (IsEnabled(CustomComboPreset.DancerSimpleAoEDanceStepFeature))
-                    {
-                        // Simple AoE Standard Steps
-                        if (actionID is DNC.StandardStep)
-                        {
-                            if (gauge.IsDancing && HasEffect(Buffs.StandardStep))
-                            {
-                                if (gauge.CompletedSteps < 2)
-                                    return (uint)gauge.NextStep;
-
-                                return StandardFinish2;
-                            }
-                        }
-
-                        // Simple AoE Technical Steps
-                        if ((actionID is DNC.TechnicalStep) && level >= Levels.TechnicalStep)
-                        {
-                            if (gauge.IsDancing && HasEffect(Buffs.TechnicalStep))
-                            {
-                                if (gauge.CompletedSteps < 4)
-                                    return (uint)gauge.NextStep;
-
-                                return TechnicalFinish4;
-                            }
-                        }
-                    }
 
                     // Simple AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DancerSimpleAoEInterruptFeature) && interruptable)

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -475,15 +475,19 @@ namespace XIVSlothComboPlugin.Combos
                         ? (uint)gauge.NextStep
                         : StandardFinish2;
 
-                // Simple ST Standard/Tech (activates dances with no target, or when target is over 2% HP)
-                if (!HasTarget())
+                // Simple ST Standard (activates dance with no target, or when target is over HP% threshold)
+                if (!HasTarget() || EnemyHealthPercentage() > standardStepBurstThreshold)
                 {
-                    if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) && IsOffCooldown(StandardStep) && EnemyHealthPercentage() > standardStepBurstThreshold &&
-                        ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer.RemainingTime > 5))
-                        return StandardStep;
+                    if (level >= DNC.Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) && IsOffCooldown(DNC.StandardStep)
+                        && ((!HasEffect(DNC.Buffs.TechnicalStep) && !techBurst) || techBurstTimer.RemainingTime > 5))
+                        return DNC.StandardStep;
+                }
 
-                    if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep) && EnemyHealthPercentage() > technicalStepBurstThreshold)
-                        return TechnicalStep;
+                // Simple ST Tech (activates dance with no target, or when target is over HP% threshold)
+                if (!HasTarget() || EnemyHealthPercentage() > technicalStepBurstThreshold)
+                {
+                    if (level >= DNC.Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) && !HasEffect(DNC.Buffs.StandardStep) && IsOffCooldown(DNC.TechnicalStep))
+                        return DNC.TechnicalStep;
                 }
 
                 if (canWeave)
@@ -610,16 +614,19 @@ namespace XIVSlothComboPlugin.Combos
                             ? (uint)gauge.NextStep
                             : TechnicalFinish4;
 
-                    // Simple AoE Standard/Tech (activates dances with no target, or when target is over 5% HP)
-                    if (!HasTarget())
+                    // Simple AoE Standard (activates dance with no target, or when target is over HP% threshold)
+                    if (!HasTarget() || EnemyHealthPercentage() > standardStepBurstThreshold)
                     {
-                        if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) && IsOffCooldown(StandardStep) && EnemyHealthPercentage() > standardStepBurstThreshold &&
-                            ((!HasEffect(Buffs.TechnicalStep) && !techBurst) ||
-                            techBurstTimer.RemainingTime > 5))
-                            return StandardStep;
+                        if (level >= DNC.Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) && IsOffCooldown(DNC.StandardStep)
+                            && ((!HasEffect(DNC.Buffs.TechnicalStep) && !techBurst) || techBurstTimer.RemainingTime > 5))
+                            return DNC.StandardStep;
+                    }
 
-                        if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep) && EnemyHealthPercentage() > technicalStepBurstThreshold)
-                            return TechnicalStep;
+                    // Simple AoE Tech (activates dance with no target, or when target is over HP% threshold)
+                    if (!HasTarget() || EnemyHealthPercentage() > technicalStepBurstThreshold)
+                    {
+                        if (level >= DNC.Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) && !HasEffect(DNC.Buffs.StandardStep) && IsOffCooldown(DNC.TechnicalStep))
+                            return DNC.TechnicalStep;
                     }
 
                     if (canWeave)

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -100,15 +100,15 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
-                DNCFinalSSBurstPercent = "DNCFinalSSBurstPercent";
+                DNCSimpleSSBurstPercent = "DNCSimpleSSBurstPercent";
             public const string
-                DNCFinalTSBurstPercent = "DNCFinalTSBurstPercent";
+                DNCSimpleTSBurstPercent = "DNCSimpleTSBurstPercent";
             public const string
-                DNCFeatherBurstPercent = "DNCFeatherBurstPercent";
+                DNCSimpleFeatherBurstPercent = "DNCSimpleFeatherBurstPercent";
             public const string
-                DNCFinalSSAoEBurstPercent = "DNCFinalSSAoEBurstPercent";
+                DNCSimpleSSAoEBurstPercent = "DNCSimpleSSAoEBurstPercent";
             public const string
-                DNCFinalTSAoEBurstPercent = "DNCFinalTSAoEBurstPercent";
+                DNCSimpleTSAoEBurstPercent = "DNCSimpleTSAoEBurstPercent";
         }
 
     internal class DancerDanceComboCompatibility : CustomCombo
@@ -437,9 +437,9 @@ namespace XIVSlothComboPlugin.Combos
                 var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
                 var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
                 var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
-                var DNCFinalSSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSBurstPercent);
-                var DNCFinalTSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSBurstPercent);
-                var DNCFeatherBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFeatherBurstPercent);
+                var DNCFinalSSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
+                var DNCFinalTSBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
+                var DNCFeatherBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
 
                 // Simple ST Interrupt
                 if (IsEnabled(CustomComboPreset.DancerSimpleInterruptFeature) && interruptable)
@@ -571,8 +571,8 @@ namespace XIVSlothComboPlugin.Combos
                     var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
                     var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
                     var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
-                    var DNCFinalSSAoEBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSAoEBurstPercent);
-                    var DNCFinalTSAoEBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSAoEBurstPercent);
+                    var DNCFinalSSAoEBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
+                    var DNCFinalTSAoEBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
 
                     // Simple AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DancerSimpleAoEInterruptFeature) && interruptable)

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -105,6 +105,10 @@ namespace XIVSlothComboPlugin.Combos
                 DNCFinalTSBurstPercent = "DNCFinalTSBurstPercent";
             public const string
                 DNCFeatherBurstPercent = "DNCFeatherBurstPercent";
+            public const string
+                DNCFinalSSAoEBurstPercent = "DNCFinalSSAoEBurstPercent";
+            public const string
+                DNCFinalTSAoEBurstPercent = "DNCFinalTSAoEBurstPercent";
         }
 
     internal class DancerDanceComboCompatibility : CustomCombo
@@ -567,6 +571,8 @@ namespace XIVSlothComboPlugin.Combos
                     var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
                     var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
                     var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
+                    var DNCFinalSSAoEBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSAoEBurstPercent);
+                    var DNCFinalTSAoEBurstPercent = Service.Configuration.GetCustomIntValue(Config.DNCFinalSSAoEBurstPercent);
 
                     // Simple AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DancerSimpleAoEInterruptFeature) && interruptable)
@@ -585,15 +591,14 @@ namespace XIVSlothComboPlugin.Combos
                             : TechnicalFinish4;
 
                     // Simple AoE Standard/Tech (activates dances with no target, or when target is over 5% HP)
-                    if (!HasTarget() || EnemyHealthPercentage() > 5)
+                    if (!HasTarget())
                     {
-                        if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) &&
-                            IsOffCooldown(StandardStep) && ((!HasEffect(Buffs.TechnicalStep) && !techBurst) ||
+                        if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) && IsOffCooldown(StandardStep) && EnemyHealthPercentage() > DNCFinalSSAoEBurstPercent &&
+                            ((!HasEffect(Buffs.TechnicalStep) && !techBurst) ||
                             techBurstTimer.RemainingTime > 5))
                             return StandardStep;
 
-                        if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) &&
-                            !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
+                        if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep) && EnemyHealthPercentage() > DNCFinalTSAoEBurstPercent)
                             return TechnicalStep;
                     }
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -674,6 +674,12 @@ namespace XIVSlothComboPlugin
 
             }
 
+            if (preset == CustomComboPreset.DancerEspritOvercapSTFeature)
+                ConfigWindowFunctions.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_ST, "Esprit", 150, SliderIncrements.Ones);
+
+            if (preset == CustomComboPreset.DancerEspritOvercapAoEFeature)
+                ConfigWindowFunctions.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_AoE, "Esprit", 150, SliderIncrements.Ones);
+
             #region Simple ST Sliders
             if (preset == CustomComboPreset.DancerSimpleStandardFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleSSBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
@@ -685,10 +691,10 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleFeatherBurstPercent, "Target HP percentage to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimplePanicHealsFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWaltzPercent, "Curing Waltz HP percent", 150, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWaltzPercent, "Curing Waltz HP percent", 200, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimplePanicHealsFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWindPercent, "Second Wind HP percent", 150, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWindPercent, "Second Wind HP percent", 200, SliderIncrements.Ones);
             #endregion
 
             #region Simple AoE Sliders
@@ -699,10 +705,10 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawSliderInt(0, 10, DNC.Config.DNCSimpleTSAoEBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimpleAoEPanicHealsFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWaltzPercent, "Curing Waltz HP percent", 150, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWaltzPercent, "Curing Waltz HP percent", 200, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimpleAoEPanicHealsFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWindPercent, "Second Wind HP percent", 150, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWindPercent, "Second Wind HP percent", 200, SliderIncrements.Ones);
             #endregion
 
             #region PvP Sliders

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -674,8 +674,14 @@ namespace XIVSlothComboPlugin
 
             }
 
+            if (preset == CustomComboPreset.DancerSimpleStandardFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalSSBurstPercent, "Target HP percentage to stop using Standard Step below.", 75, SliderIncrements.Ones);
+
+            if (preset == CustomComboPreset.DancerSimpleTechnicalFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalTSBurstPercent, "Target HP percentage to stop using Technical Step below.", 75, SliderIncrements.Ones);
+
             if (preset == CustomComboPreset.DNCCuringWaltzOption)
-                ConfigWindowFunctions.DrawSliderInt(0, 90, DNCPVP.Config.DNCWaltzThreshold, "Set a HP percentage value. Caps at 90 to prevent waste.###DNC", 150, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 90, DNCPVP.Config.DNCWaltzThreshold, "Caps at 90 to prevent waste.###DNCPvP", 150, SliderIncrements.Ones);
 
             #endregion
             // ====================================================================================

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -675,10 +675,13 @@ namespace XIVSlothComboPlugin
             }
 
             if (preset == CustomComboPreset.DancerSimpleStandardFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalSSBurstPercent, "Target HP percentage to stop using Standard Step below.", 75, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalSSBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimpleTechnicalFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalTSBurstPercent, "Target HP percentage to stop using Technical Step below.", 75, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalTSBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
+
+            if (preset == CustomComboPreset.DancerSimpleFeatherPoolingFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFeatherBurstPercent, "Target HP percentage to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNCCuringWaltzOption)
                 ConfigWindowFunctions.DrawSliderInt(0, 90, DNCPVP.Config.DNCWaltzThreshold, "Caps at 90 to prevent waste.###DNCPvP", 150, SliderIncrements.Ones);

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -683,6 +683,12 @@ namespace XIVSlothComboPlugin
             if (preset == CustomComboPreset.DancerSimpleFeatherPoolingFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFeatherBurstPercent, "Target HP percentage to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
+            if (preset == CustomComboPreset.DancerSimpleAoEStandardFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalSSAoEBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
+
+            if (preset == CustomComboPreset.DancerSimpleAoETechnicalFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalTSAoEBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
+
             if (preset == CustomComboPreset.DNCCuringWaltzOption)
                 ConfigWindowFunctions.DrawSliderInt(0, 90, DNCPVP.Config.DNCWaltzThreshold, "Caps at 90 to prevent waste.###DNCPvP", 150, SliderIncrements.Ones);
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -674,6 +674,7 @@ namespace XIVSlothComboPlugin
 
             }
 
+            #region Simple ST Sliders
             if (preset == CustomComboPreset.DancerSimpleStandardFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleSSBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
 
@@ -683,14 +684,31 @@ namespace XIVSlothComboPlugin
             if (preset == CustomComboPreset.DancerSimpleFeatherPoolingFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleFeatherBurstPercent, "Target HP percentage to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
+            if (preset == CustomComboPreset.DancerSimplePanicHealsFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWaltzPercent, "Curing Waltz HP percent", 150, SliderIncrements.Ones);
+
+            if (preset == CustomComboPreset.DancerSimplePanicHealsFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWindPercent, "Second Wind HP percent", 150, SliderIncrements.Ones);
+            #endregion
+
+            #region Simple AoE Sliders
             if (preset == CustomComboPreset.DancerSimpleAoEStandardFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleSSAoEBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 10, DNC.Config.DNCSimpleSSAoEBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimpleAoETechnicalFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleTSAoEBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 10, DNC.Config.DNCSimpleTSAoEBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
 
+            if (preset == CustomComboPreset.DancerSimpleAoEPanicHealsFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWaltzPercent, "Curing Waltz HP percent", 150, SliderIncrements.Ones);
+
+            if (preset == CustomComboPreset.DancerSimpleAoEPanicHealsFeature)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWindPercent, "Second Wind HP percent", 150, SliderIncrements.Ones);
+            #endregion
+
+            #region PvP Sliders
             if (preset == CustomComboPreset.DNCCuringWaltzOption)
                 ConfigWindowFunctions.DrawSliderInt(0, 90, DNCPVP.Config.DNCWaltzThreshold, "Caps at 90 to prevent waste.###DNCPvP", 150, SliderIncrements.Ones);
+            #endregion
 
             #endregion
             // ====================================================================================

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -675,19 +675,19 @@ namespace XIVSlothComboPlugin
             }
 
             if (preset == CustomComboPreset.DancerSimpleStandardFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalSSBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleSSBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimpleTechnicalFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalTSBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleTSBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimpleFeatherPoolingFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFeatherBurstPercent, "Target HP percentage to dump all pooled feathers below", 75, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleFeatherBurstPercent, "Target HP percentage to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimpleAoEStandardFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalSSAoEBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleSSAoEBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DancerSimpleAoETechnicalFeature)
-                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCFinalTSAoEBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
+                ConfigWindowFunctions.DrawSliderInt(0, 5, DNC.Config.DNCSimpleTSAoEBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNCCuringWaltzOption)
                 ConfigWindowFunctions.DrawSliderInt(0, 90, DNCPVP.Config.DNCWaltzThreshold, "Caps at 90 to prevent waste.###DNCPvP", 150, SliderIncrements.Ones);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -561,18 +561,17 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region DANCER
 
+        #region Single Target Multibutton
         [ReplaceSkill(DNC.Cascade)]
-        // Single Target Multibutton Section
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
         [CustomComboInfo("Single Target Multibutton", "Change Cascade into procs and combos as available.", DNC.JobID, 0, "", "")]
         DancerSingleTargetMultibutton = 4000,
 
-            #region Single Target Multibutton
+            #region ST Espirit Overcap Options
             [ParentCombo(DancerSingleTargetMultibutton)]
             [CustomComboInfo("ST Esprit Overcap Option", "Adds Saber Dance to the Cascade combo if you are at 85 or more Esprit.", DNC.JobID, 0, "", "")]
             DancerEspritOvercapSTFeature = 4001,
 
-                #region ST Espirit Overcap Option
                 [ParentCombo(DancerEspritOvercapSTFeature)]
                 [CustomComboInfo("ST Instant Saber Option", "Adds Saber Dance to the Cascade combo if you have at least 50 Esprit.\nOverrides 'ST Esprit Overcap Option'.", DNC.JobID, 0, "", "")]
                 DancerEspritOvercapSTInstantOption = 4002,
@@ -585,20 +584,19 @@ namespace XIVSlothComboPlugin
             [ParentCombo(DancerSingleTargetMultibutton)]
             [CustomComboInfo("Fan Dance On Cascade Feature", "Adds Fan Dance 3/4 onto Cascade when available.", DNC.JobID, 0, "", "")]
             DancerFanDance34OnMainComboFeature = 4004,
-        #endregion
+            #endregion
 
-        // AoE Multibutton Section
+        #region AoE Multibutton
         [ReplaceSkill(DNC.Windmill)]
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
         [CustomComboInfo("AoE Multibutton", "Change Windmill into procs and combos as available.", DNC.JobID, 0, "", "")]
         DancerAoEMultibutton = 4010,
 
-            #region AoE Multibutton
+            #region AoE Espirit Overcap Options
             [ParentCombo(DancerAoEMultibutton)]
             [CustomComboInfo("AoE Esprit Overcap Option", "Adds Saber Dance to the Windmill combo if you are at 85 or more Esprit.", DNC.JobID, 0, "", "")]
             DancerEspritOvercapAoEFeature = 4011,
 
-            #region AoE Espirit Overcap Option
             [ParentCombo(DancerEspritOvercapAoEFeature)]
             [CustomComboInfo("AoE Instant Saber Option", "Adds Saber Dance to the Windmill combo if you have at least 50 Esprit.\nOverrides 'AoE Esprit Overcap Option'.", DNC.JobID, 0, "", "")]
             DancerEspritOvercapAoEInstantOption = 4012,
@@ -611,26 +609,20 @@ namespace XIVSlothComboPlugin
             [ParentCombo(DancerAoEMultibutton)]
             [CustomComboInfo("AoE Fan Dance On Windmill Feature", "Adds FanDance 3/4 Onto Windmill When available.", DNC.JobID, 0, "", "")]
             DancerFanDanceOnAoEComboFeature = 4014,
-        #endregion
+            #endregion
 
-        // Dance Features Section (SS/TS)
+        #region Dance Features
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
         [CustomComboInfo("Dance Features", "Features and options involving Standard Step and Technical Step.\nCollapsing this category does NOT disable the features inside.", DNC.JobID, 0, "", "")]
         DancerMenuDanceFeatures = 4020,
 
-            #region Dance Features
-            [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
-            [ConflictingCombos(DancerCombinedDanceFeature, DancerDanceComboCompatibility)]
-            [CustomComboInfo("Dance Step Combo", "Change Standard Step and Technical Step into each dance step while dancing.\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
-            DancerDanceStepCombo = 4021,
-
+            #region Combined Dance Feature
             [ReplaceSkill(DNC.StandardStep)]
             [ParentCombo(DancerMenuDanceFeatures)]
             [ConflictingCombos(DancerDanceStepCombo, DancerDanceComboCompatibility, DancerSimpleFeature, DancerSimpleAoEFeature)]
             [CustomComboInfo("Combined Dance Feature", "Standard And Technical Dance on one button (SS). Standard > Technical. This combos out into Tillana and Starfall Dance.", DNC.JobID, 0, "", "")]
             DancerCombinedDanceFeature = 4022,
 
-                #region Combined Dance Feature
                 [ParentCombo(DancerCombinedDanceFeature)]
                 [CustomComboInfo("Devilment Plus Option", "Adds Devilment right after Technical finish.", DNC.JobID, 0, "", "")]
                 DancerDevilmentOnCombinedDanceFeature = 4023,
@@ -651,12 +643,11 @@ namespace XIVSlothComboPlugin
             DancerDanceComboCompatibility = 4025,
             #endregion
 
-        // Flourishing Features Section
+        #region Flourishing Features
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
         [CustomComboInfo("Flourishing Features", "Features and options involving Fourfold Feathers and Flourish.\nCollapsing this category does NOT disable the features inside.", DNC.JobID, 0, "", "")]
         DancerMenuFlourishingFeatures = 4030,
 
-            #region Flourishing Features
             [ReplaceSkill(DNC.Flourish)]
             [ParentCombo(DancerMenuFlourishingFeatures)]
             [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
@@ -664,13 +655,12 @@ namespace XIVSlothComboPlugin
             DancerFlourishingFanDanceFeature = 4032,
             #endregion
 
-        // Fan Dance Combo Features Subsection
+        #region Fan Dance Combo Features
         [ParentCombo(DancerMenuFlourishingFeatures)]
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
         [CustomComboInfo("Fan Dance Combo Features", "Options for Fan Dance combos. Fan Dance 3 takes priority over Fan Dance 4.\nCollapsing this category disables the options inside.", DNC.JobID, 0, "", "")]
         DancerFanDanceComboFeatures = 4033,
 
-            #region Fan Dance Combo Features
             [ReplaceSkill(DNC.FanDance1)]
             [ParentCombo(DancerFanDanceComboFeatures)]
             [CustomComboInfo("Fan Dance 1 -> 3", "Changes Fan Dance 1 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
@@ -698,14 +688,17 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Devilment to Starfall Feature", "Change Devilment into Starfall Dance after use.", DNC.JobID, 0, "", "")]
         DancerDevilmentFeature = 4038,
 
+        [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
+        [ConflictingCombos(DancerCombinedDanceFeature, DancerDanceComboCompatibility)]
+        [CustomComboInfo("Dance Step Combo", "Change Standard Step and Technical Step into each dance step while dancing.\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
+        DancerDanceStepCombo = 4039,
 
-        // Simple Dancer Section
+        #region Simple Dancer (Single Target)
         [ReplaceSkill(DNC.Cascade)]
         [ConflictingCombos(DancerSingleTargetMultibutton, DancerAoEMultibutton, DancerCombinedDanceFeature, DancerDanceComboCompatibility, DancerMenuFlourishingFeatures, DancerDevilmentFeature)]
         [CustomComboInfo("Simple Dancer (Single Target)", "Single button, single target. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
         DancerSimpleFeature = 4050,
 
-            #region Simple Dancer (Single Target)
             [ParentCombo(DancerSimpleFeature)]
             [CustomComboInfo("Simple Interrupt", "Includes an interrupt in the rotation (if applicable to your current target).", DNC.JobID, 0, "", "")]
             DancerSimpleInterruptFeature = 4051,
@@ -743,13 +736,12 @@ namespace XIVSlothComboPlugin
             DancerSimpleImprovFeature = 4060,
             #endregion
 
-        // Simple Dancer AoE Section
+        #region Simple Dancer (AoE)
         [ReplaceSkill(DNC.Windmill)]
         [ConflictingCombos(DancerSingleTargetMultibutton, DancerAoEMultibutton, DancerCombinedDanceFeature, DancerDanceComboCompatibility, DancerMenuFlourishingFeatures, DancerDevilmentFeature)]
         [CustomComboInfo("Simple Dancer (AoE)", "Single button, AoE. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
         DancerSimpleAoEFeature = 4070,
 
-            #region Simple Dancer (AoE)
             [ParentCombo(DancerSimpleAoEFeature)]
             [CustomComboInfo("Simple AoE Interrupt", "Includes an interrupt in the AoE rotation (if your current target can be interrupted).", DNC.JobID, 0, "", "")]
             DancerSimpleAoEInterruptFeature = 4071,

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -767,7 +767,7 @@ namespace XIVSlothComboPlugin
             DancerSimpleAoEFeatherFeature = 4077,
 
             [ParentCombo(DancerSimpleAoEFeatherFeature)]
-            [CustomComboInfo("Simple AoE Feather Pooling", "Makes it so the AoE rotation only uses feathers when you have more than 3.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Feather Pooling", "Expends a feather in the next available weave window when capped.", DNC.JobID, 0, "", "")]
             DancerSimpleAoEFeatherPoolingFeature = 4078,
 
             [ParentCombo(DancerSimpleAoEFeature)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -724,7 +724,7 @@ namespace XIVSlothComboPlugin
             DancerSimpleFeatherFeature = 4057,
 
             [ParentCombo(DancerSimpleFeatherFeature)]
-            [CustomComboInfo("Simple Feather Pooling", "Makes the rotation only use feathers when you have more than 3, or when you're under the effects of Technical Step.\nWill expend feathers when your target is under 2 percent HP.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple Feather Pooling", "Expends a feather in the next available weave window when capped.\nWeaves feathers where possible during Technical Finish.\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 0, "")]
             DancerSimpleFeatherPoolingFeature = 4058,
 
             [ParentCombo(DancerSimpleFeature)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -704,11 +704,11 @@ namespace XIVSlothComboPlugin
             DancerSimpleInterruptFeature = 4051,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Standard Step", "Includes Standard Step in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Standard Step", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleStandardFeature = 4052,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Technical Step", "Includes Technical Step in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Technical Step", "Includes Technical Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleTechnicalFeature = 4053,
 
             [ParentCombo(DancerSimpleFeature)]
@@ -747,11 +747,11 @@ namespace XIVSlothComboPlugin
             DancerSimpleAoEInterruptFeature = 4071,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Standard Step", "Includes Standard Step in the AoE rotation.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple AoE Standard Step", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoEStandardFeature = 4072,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Technical Step", "Includes Technical Step in the AoE rotation.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple AoE Technical Step", "Includes Technical Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoETechnicalFeature = 4073,
 
             [ParentCombo(DancerSimpleAoEFeature)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -621,13 +621,13 @@ namespace XIVSlothComboPlugin
             #region Dance Features
             [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
             [ParentCombo(DancerMenuDanceFeatures)]
-            [ConflictingCombos(DancerCombinedDanceFeature, DancerDanceComboCompatibility)]
+            [ConflictingCombos(DancerCombinedDanceFeature, DancerDanceComboCompatibility, DancerSimpleFeature, DancerSimpleAoEFeature)]
             [CustomComboInfo("Dance Step Combo", "Change Standard Step and Technical Step into each dance step while dancing.\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
             DancerDanceStepCombo = 4021,
 
             [ReplaceSkill(DNC.StandardStep)]
             [ParentCombo(DancerMenuDanceFeatures)]
-            [ConflictingCombos(DancerDanceStepCombo, DancerDanceComboCompatibility)]
+            [ConflictingCombos(DancerDanceStepCombo, DancerDanceComboCompatibility, DancerSimpleFeature, DancerSimpleAoEFeature)]
             [CustomComboInfo("Combined Dance Feature", "Standard And Technical Dance on one button (SS). Standard > Technical. This combos out into Tillana and Starfall Dance.", DNC.JobID, 0, "", "")]
             DancerCombinedDanceFeature = 4022,
 
@@ -642,7 +642,7 @@ namespace XIVSlothComboPlugin
                 #endregion
 
             [ParentCombo(DancerMenuDanceFeatures)]
-            [ConflictingCombos(DancerDanceStepCombo, DancerCombinedDanceFeature)]
+            [ConflictingCombos(DancerDanceStepCombo, DancerCombinedDanceFeature, DancerSimpleFeature, DancerSimpleAoEFeature)]
             [CustomComboInfo("Custom Dance Step Feature",
             "Change custom actions into dance steps while dancing." +
             "\nThis helps ensure you can still dance with combos on, without using auto dance." +

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -567,15 +567,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Single Target Multibutton Feature", "Single target combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
         DancerSingleTargetMultibutton = 4000,
 
-            #region ST Espirit Overcap Options
             [ParentCombo(DancerSingleTargetMultibutton)]
-            [CustomComboInfo("ST Esprit Overcap Option", "Adds Saber Dance if you are at 85 or more Esprit.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("ST Esprit Overcap Option", "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0, "", "")]
             DancerEspritOvercapSTFeature = 4001,
-
-                [ParentCombo(DancerEspritOvercapSTFeature)]
-                [CustomComboInfo("ST Instant Saber Option", "Adds Saber Dance if you have at least 50 Esprit.\nOverrides 'ST Esprit Overcap Option'.", DNC.JobID, 0, "", "")]
-                DancerEspritOvercapSTInstantOption = 4002,
-                #endregion
 
             [ParentCombo(DancerSingleTargetMultibutton)]
             [CustomComboInfo("Fan Dance Overcap Protection Option", "Adds Fan Dance 1 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
@@ -592,15 +586,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("AoE Multibutton Feature", "AoE combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
         DancerAoEMultibutton = 4010,
 
-            #region AoE Espirit Overcap Options
             [ParentCombo(DancerAoEMultibutton)]
-            [CustomComboInfo("AoE Esprit Overcap Option", "Adds Saber Dance if you are at 85 or more Esprit.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("AoE Esprit Overcap Option", "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0, "", "")]
             DancerEspritOvercapAoEFeature = 4011,
-
-                [ParentCombo(DancerEspritOvercapAoEFeature)]
-                [CustomComboInfo("AoE Instant Saber Option", "Adds Saber Dance if you have at least 50 Esprit.\nOverrides 'AoE Esprit Overcap Option'.", DNC.JobID, 0, "", "")]
-                DancerEspritOvercapAoEInstantOption = 4012,
-                #endregion
 
             [ParentCombo(DancerAoEMultibutton)]
             [CustomComboInfo("AoE Fan Dance Overcap Protection Option", "Adds Fan Dance 2 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
@@ -658,7 +646,7 @@ namespace XIVSlothComboPlugin
         #region Fan Dance Combo Features
         [ParentCombo(DancerMenuFlourishingFeatures)]
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
-        [CustomComboInfo("Fan Dance Combo Features", "Options for Fan Dance combos. Fan Dance 3 takes priority over Fan Dance 4.\nCollapsing this category disables the options inside.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Fan Dance Combo Features", "Options for Fan Dance combos. Fan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0, "", "")]
         DancerFanDanceComboFeatures = 4033,
 
             [ReplaceSkill(DNC.FanDance1)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -728,7 +728,7 @@ namespace XIVSlothComboPlugin
             DancerSimpleFeatherPoolingFeature = 4058,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Panic Heals", "Includes Curing Waltz and Second Wind in the rotation when available and below 30 and 50 percent HP, respectively.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Panic Heals", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 0, "", "")]
             DancerSimplePanicHealsFeature = 4059,
 
             [ParentCombo(DancerSimpleFeature)]
@@ -771,7 +771,7 @@ namespace XIVSlothComboPlugin
             DancerSimpleAoEFeatherPoolingFeature = 4078,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Panic Heals", "Includes Curing Waltz and Second Wind in the AoE rotation when available and below 30 and 50 percent HP, respectively.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Panic Heals", "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 0, "", "")]
             DancerSimpleAoEPanicHealsFeature = 4079,
 
             [ParentCombo(DancerSimpleAoEFeature)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -646,27 +646,27 @@ namespace XIVSlothComboPlugin
         #region Fan Dance Combo Features
         [ParentCombo(DancerMenuFlourishingFeatures)]
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
-        [CustomComboInfo("Fan Dance Combo Features", "Options for Fan Dance combos. Fan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Fan Dance Combo Feature", "Options for Fan Dance combos. Fan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0, "", "")]
         DancerFanDanceComboFeatures = 4033,
 
             [ReplaceSkill(DNC.FanDance1)]
             [ParentCombo(DancerFanDanceComboFeatures)]
-            [CustomComboInfo("Fan Dance 1 -> 3", "Changes Fan Dance 1 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Fan Dance 1 -> 3 Option", "Changes Fan Dance 1 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
             DancerFanDance1_3Combo = 4034,
 
             [ReplaceSkill(DNC.FanDance1)]
             [ParentCombo(DancerFanDanceComboFeatures)]
-            [CustomComboInfo("Fan Dance 1 -> 4", "Changes Fan Dance 1 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Fan Dance 1 -> 4 Option", "Changes Fan Dance 1 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
             DancerFanDance1_4Combo = 4035,
 
             [ReplaceSkill(DNC.FanDance2)]
             [ParentCombo(DancerFanDanceComboFeatures)]
-            [CustomComboInfo("Fan Dance 2 -> 3", "Changes Fan Dance 2 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Fan Dance 2 -> 3 Option", "Changes Fan Dance 2 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
             DancerFanDance2_3Combo = 4036,
 
             [ReplaceSkill(DNC.FanDance2)]
             [ParentCombo(DancerFanDanceComboFeatures)]
-            [CustomComboInfo("Fan Dance 2 -> 4", "Changes Fan Dance 2 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Fan Dance 2 -> 4 Option", "Changes Fan Dance 2 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
             DancerFanDance2_4Combo = 4037,
             #endregion
 
@@ -678,92 +678,92 @@ namespace XIVSlothComboPlugin
 
         [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
         [ConflictingCombos(DancerCombinedDanceFeature, DancerDanceComboCompatibility)]
-        [CustomComboInfo("Dance Step Combo", "Change Standard Step and Technical Step into each dance step while dancing.\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Dance Step Combo Feature", "Change Standard Step and Technical Step into each dance step while dancing.\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
         DancerDanceStepCombo = 4039,
 
         #region Simple Dancer (Single Target)
         [ReplaceSkill(DNC.Cascade)]
         [ConflictingCombos(DancerSingleTargetMultibutton, DancerAoEMultibutton, DancerCombinedDanceFeature, DancerDanceComboCompatibility, DancerMenuFlourishingFeatures, DancerDevilmentFeature)]
-        [CustomComboInfo("Simple Dancer (Single Target)", "Single button, single target. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Simple Dancer (Single Target) Feature", "Single button, single target. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
         DancerSimpleFeature = 4050,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Interrupt", "Includes an interrupt in the rotation (if applicable to your current target).", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Interrupt Option", "Includes an interrupt in the rotation (if applicable to your current target).", DNC.JobID, 0, "", "")]
             DancerSimpleInterruptFeature = 4051,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Standard Step", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Standard Step Option", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleStandardFeature = 4052,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Technical Step", "Includes Technical Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Technical Step Option", "Includes Technical Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleTechnicalFeature = 4053,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Tech Devilment", "Includes Devilment in the rotation.\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation.\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 0, "", "")]
             DancerSimpleDevilmentFeature = 4055,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Flourish", "Includes Flourish in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Flourish Option", "Includes Flourish in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleFlourishFeature = 4056,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Feathers", "Includes Feather usage in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Feathers Option", "Includes Feather usage in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleFeatherFeature = 4057,
 
             [ParentCombo(DancerSimpleFeatherFeature)]
-            [CustomComboInfo("Simple Feather Pooling", "Expends a feather in the next available weave window when capped.\nWeaves feathers where possible during Technical Finish.\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple Feather Pooling Option", "Expends a feather in the next available weave window when capped.\nWeaves feathers where possible during Technical Finish.\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 0, "")]
             DancerSimpleFeatherPoolingFeature = 4058,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Panic Heals", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Panic Heals Option", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 0, "", "")]
             DancerSimplePanicHealsFeature = 4059,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Improvisation", "Includes Improvisation in the rotation when available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Improvisation Option", "Includes Improvisation in the rotation when available.", DNC.JobID, 0, "", "")]
             DancerSimpleImprovFeature = 4060,
             #endregion
 
         #region Simple Dancer (AoE)
         [ReplaceSkill(DNC.Windmill)]
         [ConflictingCombos(DancerSingleTargetMultibutton, DancerAoEMultibutton, DancerCombinedDanceFeature, DancerDanceComboCompatibility, DancerMenuFlourishingFeatures, DancerDevilmentFeature)]
-        [CustomComboInfo("Simple Dancer (AoE)", "Single button, AoE. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Simple Dancer (AoE) Feature", "Single button, AoE. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
         DancerSimpleAoEFeature = 4070,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Interrupt", "Includes an interrupt in the AoE rotation (if your current target can be interrupted).", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Interrupt Option", "Includes an interrupt in the AoE rotation (if your current target can be interrupted).", DNC.JobID, 0, "", "")]
             DancerSimpleAoEInterruptFeature = 4071,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Standard Step", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple AoE Standard Step Option", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoEStandardFeature = 4072,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Technical Step", "Includes Technical Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple AoE Technical Step Option", "Includes Technical Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoETechnicalFeature = 4073,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Tech Devilment", "Includes Devilment in the AoE rotation.\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation.\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 0, "", "")]
             DancerSimpleAoEDevilmentFeature = 4075,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Flourish", "Includes Flourish in the AoE rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Flourish Option", "Includes Flourish in the AoE rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleAoEFlourishFeature = 4076,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Feathers", "Includes feather usage in the AoE rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Feathers Option", "Includes feather usage in the AoE rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleAoEFeatherFeature = 4077,
 
             [ParentCombo(DancerSimpleAoEFeatherFeature)]
-            [CustomComboInfo("Simple AoE Feather Pooling", "Expends a feather in the next available weave window when capped.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Feather Pooling Option", "Expends a feather in the next available weave window when capped.", DNC.JobID, 0, "", "")]
             DancerSimpleAoEFeatherPoolingFeature = 4078,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Panic Heals", "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Panic Heals Option", "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 0, "", "")]
             DancerSimpleAoEPanicHealsFeature = 4079,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Improvisation", "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Improvisation Option", "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 0, "", "")]
             DancerSimpleAoEImprovFeature = 4080,
             #endregion
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -564,50 +564,50 @@ namespace XIVSlothComboPlugin
         #region Single Target Multibutton
         [ReplaceSkill(DNC.Cascade)]
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
-        [CustomComboInfo("Single Target Multibutton", "Change Cascade into procs and combos as available.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Single Target Multibutton Feature", "Single target combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
         DancerSingleTargetMultibutton = 4000,
 
             #region ST Espirit Overcap Options
             [ParentCombo(DancerSingleTargetMultibutton)]
-            [CustomComboInfo("ST Esprit Overcap Option", "Adds Saber Dance to the Cascade combo if you are at 85 or more Esprit.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("ST Esprit Overcap Option", "Adds Saber Dance if you are at 85 or more Esprit.", DNC.JobID, 0, "", "")]
             DancerEspritOvercapSTFeature = 4001,
 
                 [ParentCombo(DancerEspritOvercapSTFeature)]
-                [CustomComboInfo("ST Instant Saber Option", "Adds Saber Dance to the Cascade combo if you have at least 50 Esprit.\nOverrides 'ST Esprit Overcap Option'.", DNC.JobID, 0, "", "")]
+                [CustomComboInfo("ST Instant Saber Option", "Adds Saber Dance if you have at least 50 Esprit.\nOverrides 'ST Esprit Overcap Option'.", DNC.JobID, 0, "", "")]
                 DancerEspritOvercapSTInstantOption = 4002,
                 #endregion
 
             [ParentCombo(DancerSingleTargetMultibutton)]
-            [CustomComboInfo("Fan Dance Overcap Protection", "Adds Fan Dance 1 onto Cascade when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Fan Dance Overcap Protection Option", "Adds Fan Dance 1 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
             DancerFanDanceMainComboOvercapFeature = 4003,
 
             [ParentCombo(DancerSingleTargetMultibutton)]
-            [CustomComboInfo("Fan Dance On Cascade Feature", "Adds Fan Dance 3/4 onto Cascade when available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Fan Dance Option", "Adds Fan Dance 3/4 when available.", DNC.JobID, 0, "", "")]
             DancerFanDance34OnMainComboFeature = 4004,
             #endregion
 
         #region AoE Multibutton
         [ReplaceSkill(DNC.Windmill)]
         [ConflictingCombos(DancerSimpleFeature, DancerSimpleAoEFeature)]
-        [CustomComboInfo("AoE Multibutton", "Change Windmill into procs and combos as available.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("AoE Multibutton Feature", "AoE combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
         DancerAoEMultibutton = 4010,
 
             #region AoE Espirit Overcap Options
             [ParentCombo(DancerAoEMultibutton)]
-            [CustomComboInfo("AoE Esprit Overcap Option", "Adds Saber Dance to the Windmill combo if you are at 85 or more Esprit.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("AoE Esprit Overcap Option", "Adds Saber Dance if you are at 85 or more Esprit.", DNC.JobID, 0, "", "")]
             DancerEspritOvercapAoEFeature = 4011,
 
-            [ParentCombo(DancerEspritOvercapAoEFeature)]
-            [CustomComboInfo("AoE Instant Saber Option", "Adds Saber Dance to the Windmill combo if you have at least 50 Esprit.\nOverrides 'AoE Esprit Overcap Option'.", DNC.JobID, 0, "", "")]
-            DancerEspritOvercapAoEInstantOption = 4012,
-            #endregion
+                [ParentCombo(DancerEspritOvercapAoEFeature)]
+                [CustomComboInfo("AoE Instant Saber Option", "Adds Saber Dance if you have at least 50 Esprit.\nOverrides 'AoE Esprit Overcap Option'.", DNC.JobID, 0, "", "")]
+                DancerEspritOvercapAoEInstantOption = 4012,
+                #endregion
 
             [ParentCombo(DancerAoEMultibutton)]
-            [CustomComboInfo("AoE Fan Dance Overcap Protection", "Adds Fan Dance 2 onto Windmill when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("AoE Fan Dance Overcap Protection Option", "Adds Fan Dance 2 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
             DancerFanDanceAoEComboOvercapFeature = 4013,
 
             [ParentCombo(DancerAoEMultibutton)]
-            [CustomComboInfo("AoE Fan Dance On Windmill Feature", "Adds FanDance 3/4 Onto Windmill When available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("AoE Fan Dance Option", "Adds Fan Dance 3/4 when available.", DNC.JobID, 0, "", "")]
             DancerFanDanceOnAoEComboFeature = 4014,
             #endregion
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -620,8 +620,7 @@ namespace XIVSlothComboPlugin
 
             #region Dance Features
             [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
-            [ParentCombo(DancerMenuDanceFeatures)]
-            [ConflictingCombos(DancerCombinedDanceFeature, DancerDanceComboCompatibility, DancerSimpleFeature, DancerSimpleAoEFeature)]
+            [ConflictingCombos(DancerCombinedDanceFeature, DancerDanceComboCompatibility)]
             [CustomComboInfo("Dance Step Combo", "Change Standard Step and Technical Step into each dance step while dancing.\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
             DancerDanceStepCombo = 4021,
 
@@ -720,10 +719,6 @@ namespace XIVSlothComboPlugin
             DancerSimpleTechnicalFeature = 4053,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Dance Step Combo", "Changes Standard Step and Technical Step into each dance step while dancing.", DNC.JobID, 0, "", "")]
-            DancerSimpleDanceStepFeature = 4054,
-
-            [ParentCombo(DancerSimpleFeature)]
             [CustomComboInfo("Simple Tech Devilment", "Includes Devilment in the rotation.\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 0, "", "")]
             DancerSimpleDevilmentFeature = 4055,
 
@@ -766,10 +761,6 @@ namespace XIVSlothComboPlugin
             [ParentCombo(DancerSimpleAoEFeature)]
             [CustomComboInfo("Simple AoE Technical Step", "Includes Technical Step in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoETechnicalFeature = 4073,
-
-            [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Dance Step Combo", "Changes Standard Step and Technical Step into each dance step while dancing.", DNC.JobID, 0, "", "")]
-            DancerSimpleAoEDanceStepFeature = 4074,
 
             [ParentCombo(DancerSimpleAoEFeature)]
             [CustomComboInfo("Simple AoE Tech Devilment", "Includes Devilment in the AoE rotation.\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 0, "", "")]


### PR DESCRIPTION
- [x] Check all added sliders
- [x] Check conflicts
- [x] Implement Simple Dance Fix
- [x] Test changes in combat 

Removed `ST Instant Saber Option` ✔️
Removed `AoE Instant Saber Option` ✔️
Added slider for Esprit threshold to `ST Esprit Overcap Option` ✔️
Added slider for Esprit threshold to `AoE Esprit Overcap Option` ✔️
Removed `Simple Dance Step Combo` ✔️
Removed `Simple AoE Dance Step Combo` ✔️
Added `Dance Step Combo Feature` (works with all modes) ✔️
Added Target HP% slider to stop `Simple Standard Step` ✔️
Added Target HP% slider to stop `Simple Technical Step` ✔️
Added Target HP% slider to expend `Simple Feather Pooling` ✔️
Added `Curing Waltz` slider to `Simple Panic Heals` ✔️
Added `Second Wind` slider to `Simple Panic Heals` ✔️
Added Target HP% slider to stop `Simple AoE Standard Step` ✔️
Added Target HP% slider to stop `Simple AoE Technical Step` ✔️
Added `Curing Waltz` slider to `Simple AoE Panic Heals` ✔️
Added `Second Wind` slider to `Simple AoE Panic Heals` ✔️
Updated descriptions
Resolved conflicts
Refactoring