### PR TITLE
SCH & SGE Discord Feedback

### DIFF
--- a/XIVSlothCombo/Combos/SCH.cs
+++ b/XIVSlothCombo/Combos/SCH.cs
@@ -109,8 +109,6 @@ namespace XIVSlothComboPlugin.Combos
             public const string
                 SCH_ST_Broil_Lucid = "SCH_ST_Broil_Lucid",
                 SCH_ST_Broil_BioHPPer = "SCH_ST_Broil_BioHPPer",
-                SCH_ST_Broil_BioHPMax = "SCH_ST_Broil_BioHPMax",
-                SCH_ST_Broil_BioCurHP = "SCH_ST_Broil_BioCurHP",
                 SCH_ST_Broil_ChainStratagem = "SCH_ST_Broil_ChainStratagem",
                 SCH_Aetherflow_Display = "SCH_Aetherflow_Display",
                 SCH_Aetherflow_Recite_Excog = "SCH_Aetherflow_Recite_Excog",
@@ -283,15 +281,9 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             //Advanced Options Enabled to procede with auto-bio
                             //Incompatible with ToT due to Enemy checks that are using CurrentTarget.
-                            if (IsEnabled(CustomComboPreset.SCH_ST_Broil_BioHPLimiters))
+                            if (IsEnabled(CustomComboPreset.SCH_ST_Broil_BioHPPer))
                             {
-                                var MaxHpValue = GetOptionValue(Config.SCH_ST_Broil_BioHPMax);
-                                var PercentageHpValue = GetOptionValue(Config.SCH_ST_Broil_BioHPPer);
-                                var CurrentHpValue = GetOptionValue(Config.SCH_ST_Broil_BioCurHP);
-
-                                if ((BioDebuffID is null && EnemyHealthMaxHp() > MaxHpValue && EnemyHealthPercentage() > PercentageHpValue) ||
-                                    ((BioDebuffID?.RemainingTime <= 3) && EnemyHealthPercentage() > PercentageHpValue && EnemyHealthCurrentHp() > CurrentHpValue))
-                                    return OriginalHook(Bio1);
+                                if (EnemyHealthPercentage() > GetOptionValue(Config.SCH_ST_Broil_BioHPPer)) return OriginalHook(Bio1);
                             }
                             else return OriginalHook(Bio1);
                         }

--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -117,8 +117,6 @@ namespace XIVSlothComboPlugin.Combos
             public const string
                 //GUI Customization Storage Names
                 SGE_ST_Dosis_EDosisHPPer = "SGE_ST_Dosis_EDosisHPPer",
-                SGE_ST_Dosis_EDosisHPMax = "SGE_ST_Dosis_EDosisHPMax",
-                SGE_ST_Dosis_EDosisCurHP = "SGE_ST_Dosis_EDosisCurHP",
                 SGE_ST_Dosis_Lucid = "SGE_ST_Dosis_Lucid",
                 SGE_ST_Dosis_Toxikon = "SGE_ST_Dosis_Toxikon",
                 SGE_ST_Heal_Zoe = "SGE_ST_Heal_Zoe",
@@ -158,6 +156,7 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID is Taurochole or Druochole or Ixochole or Kerachole &&
                     level >= Levels.Rhizomata &&
+                    IsOffCooldown(actionID) &&
                     GetJobGauge<SGEGauge>().Addersgall == 0
                    ) return Rhizomata;
                 else return actionID;
@@ -262,24 +261,18 @@ namespace XIVSlothComboPlugin.Combos
                             //Ekrasia Dosis unlocks with Eukrasia, checked at the start
                             _ => FindEffect(Debuffs.EukrasianDosis1, OurTarget, LocalPlayer?.ObjectId),
                         };
-                    
+
                         //Got our Debuff for our level, check for it and procede 
                         if ((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3))
                         {
                             //Advanced Options Enabled to procede with auto-Eukrasia
                             //Incompatible with ToT due to Enemy checks that are using CurrentTarget.
-                            if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosisHPLimiters))
+                            if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosisHPPer))
                             {
-                                var MaxHpValue = GetOptionValue(Config.SGE_ST_Dosis_EDosisHPMax);
-                                var PercentageHpValue = GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer);
-                                var CurrentHpValue = GetOptionValue(Config.SGE_ST_Dosis_EDosisCurHP);
-
-                                if ( (DosisDebuffID is null && EnemyHealthMaxHp() > MaxHpValue && EnemyHealthPercentage() > PercentageHpValue) ||
-                                    ((DosisDebuffID?.RemainingTime <= 3) && EnemyHealthPercentage() > PercentageHpValue && EnemyHealthCurrentHp() > CurrentHpValue) )
-                                   return Eukrasia;
+                                if (EnemyHealthPercentage() > GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer)) return Eukrasia;
                             }
                             else return Eukrasia;
-                        } 
+                        }
                     }
 
                     //Toxikon

--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -119,6 +119,7 @@ namespace XIVSlothComboPlugin.Combos
                 SGE_ST_Dosis_EDosisHPPer = "SGE_ST_Dosis_EDosisHPPer",
                 SGE_ST_Dosis_Lucid = "SGE_ST_Dosis_Lucid",
                 SGE_ST_Dosis_Toxikon = "SGE_ST_Dosis_Toxikon",
+                SGE_AoE_Phlegma_Lucid = "SGE_AoE_Phlegma_Lucid",
                 SGE_ST_Heal_Zoe = "SGE_ST_Heal_Zoe",
                 SGE_ST_Heal_Haima = "SGE_ST_Heal_Haima",
                 SGE_ST_Heal_Krasis = "SGE_ST_Heal_Krasis",
@@ -186,6 +187,14 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID is Phlegma or Phlegma2 or Phlegma3)
                 {
+                    //Lucid Dreaming
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) &&
+                        level >= All.Levels.LucidDreaming &&
+                        IsOffCooldown(All.LucidDreaming) &&
+                        LocalPlayer.CurrentMp <= GetOptionValue(Config.SGE_AoE_Phlegma_Lucid) &&
+                        CanSpellWeave(actionID)
+                       ) return All.LucidDreaming;
+
                     var NoPhlegmaToxikon  = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoPhlegmaToxikon);
                     var OutOfRangeToxikon = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_OutOfRangeToxikon);
                     if ((NoPhlegmaToxikon || OutOfRangeToxikon) &&

--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -178,6 +178,18 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
+        //SageZoePneumaFeature
+        //Places Zoe on top of Pneuma when both are available.
+        internal class SageZoePneumaFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneumaFeature;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Pneuma && level >= Levels.Pneuma && IsOffCooldown(Pneuma) && IsOffCooldown(Zoe)) return Zoe;
+                else return actionID;
+            }
+        }
+
         //Sage AoE / Phlegma Replacement
         //Replaces Zero Charges/Stacks of Phlegma with Toxikon (if you can use it) or Dyskrasia 
         internal class SageAoEPhlegmaFeature : CustomCombo

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -846,44 +846,40 @@ namespace XIVSlothComboPlugin
             // ====================================================================================
             #region SAGE
 
-            if (preset == CustomComboPreset.SGE_ST_Dosis_EDosisHPLimiters)
-            {
+            if (preset is CustomComboPreset.SGE_ST_Dosis_EDosisHPPer)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Dosis_EDosisHPPer, "Enemy HP % Threshold");
-                ConfigWindowFunctions.DrawIntBox(SGE.Config.SGE_ST_Dosis_EDosisHPMax, "Enemy Max HP");
-                ConfigWindowFunctions.DrawIntBox(SGE.Config.SGE_ST_Dosis_EDosisCurHP, "Enemy Current HP");
-            }
 
-            if (preset == CustomComboPreset.SGE_ST_Dosis_Lucid)
+            if (preset is CustomComboPreset.SGE_ST_Dosis_Lucid)
                 ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_Dosis_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
 
-            if (preset == CustomComboPreset.SGE_ST_Dosis_Toxikon)
+            if (preset is CustomComboPreset.SGE_ST_Dosis_Toxikon)
                 ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show when moving only", "", 1);
 
-            if (preset == CustomComboPreset.SGE_ST_Dosis_Toxikon)
+            if (preset is CustomComboPreset.SGE_ST_Dosis_Toxikon)
                 ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show at all times", "", 2);
 
-            if (preset == CustomComboPreset.SGE_ST_Heal_Soteria)
+            if (preset is CustomComboPreset.SGE_ST_Heal_Soteria)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Soteria, "Set HP percentage value for Soteria to trigger");
 
-            if (preset == CustomComboPreset.SGE_ST_Heal_Zoe)
+            if (preset is CustomComboPreset.SGE_ST_Heal_Zoe)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Zoe, "Set HP percentage value for Zoe to trigger");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Pepsis)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Pepsis, "Set HP percentage value for Pepsis to trigger");
 
-            if (preset == CustomComboPreset.SGE_ST_Heal_Taurochole)
+            if (preset is CustomComboPreset.SGE_ST_Heal_Taurochole)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Taurochole, "Set HP percentage value for Taurochole to trigger");
 
-            if (preset == CustomComboPreset.SGE_ST_Heal_Haima)
+            if (preset is CustomComboPreset.SGE_ST_Heal_Haima)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Haima, "Set HP percentage value for Haima to trigger");
 
-            if (preset == CustomComboPreset.SGE_ST_Heal_Krasis)
+            if (preset is CustomComboPreset.SGE_ST_Heal_Krasis)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Krasis, "Set HP percentage value for Krasis to trigger");
 
-            if (preset == CustomComboPreset.SGE_ST_Heal_Druochole)
+            if (preset is CustomComboPreset.SGE_ST_Heal_Druochole)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Druochole, "Set HP percentage value for Druochole to trigger");
 
-            if (preset == CustomComboPreset.SGE_ST_Heal_Diagnosis)
+            if (preset is CustomComboPreset.SGE_ST_Heal_Diagnosis)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Diagnosis, "Set HP percentage value for Eukrasian Diagnosis to trigger");
             #endregion
             // ====================================================================================
@@ -907,32 +903,28 @@ namespace XIVSlothComboPlugin
             #endregion
             // ====================================================================================
             #region SCHOLAR
-            if (preset == CustomComboPreset.SCH_ST_Broil_Lucid)
+            if (preset is CustomComboPreset.SCH_ST_Broil_Lucid)
                 ConfigWindowFunctions.DrawSliderInt(4000, 9500, SCH.Config.SCH_ST_Broil_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
-            if (preset == CustomComboPreset.SCH_ST_Broil_BioHPLimiters)
-            {
+            if (preset is CustomComboPreset.SCH_ST_Broil_BioHPPer)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SCH.Config.SCH_ST_Broil_BioHPPer, "Enemy HP % Threshold");
-                ConfigWindowFunctions.DrawIntBox(SCH.Config.SCH_ST_Broil_BioHPMax, "Enemy Max HP");
-                ConfigWindowFunctions.DrawIntBox(SCH.Config.SCH_ST_Broil_BioCurHP, "Enemy Current HP");
-            }
-            if (preset == CustomComboPreset.SCH_ST_Broil_ChainStratagem)
+            if (preset is CustomComboPreset.SCH_ST_Broil_ChainStratagem)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SCH.Config.SCH_ST_Broil_ChainStratagem, "Enemy HP% Threshold");
-            if (preset == CustomComboPreset.SCH_FairyFeature)
+            if (preset is CustomComboPreset.SCH_FairyFeature)
             {
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Eos", "", 1);
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Selene", "", 2);
             }
-            if (preset == CustomComboPreset.SCH_AetherflowFeature)
+            if (preset is CustomComboPreset.SCH_AetherflowFeature)
             {
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Display, "Show Aetherflow On Energy Drain Only","", 1);
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Display, "Show Aetherflow On All Aetherflow Skills", "", 2);
             }
-            if (preset == CustomComboPreset.SCH_Aetherflow_Recite_Excog)
+            if (preset is CustomComboPreset.SCH_Aetherflow_Recite_Excog)
             {
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Excog, "Always when available", "", 1);
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Excog, "Only when out of Aetherflow Stacks", "", 2);
             }
-            if (preset == CustomComboPreset.SCH_Aetherflow_Recite_Indom)
+            if (preset is CustomComboPreset.SCH_Aetherflow_Recite_Indom)
             {
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Indom, "Always when available", "", 1);
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Indom, "Only when out of Aetherflow Stacks", "", 2);

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -853,10 +853,13 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_Dosis_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
 
             if (preset is CustomComboPreset.SGE_ST_Dosis_Toxikon)
+            {
                 ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show when moving only", "", 1);
-
-            if (preset is CustomComboPreset.SGE_ST_Dosis_Toxikon)
                 ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show at all times", "", 2);
+            }
+
+            if (preset is CustomComboPreset.SGE_AoE_Phlegma_Lucid)
+                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGE_AoE_Phlegma_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Soteria)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Soteria, "Set HP percentage value for Soteria to trigger");

--- a/XIVSlothCombo/ConfigWindowFunctions.cs
+++ b/XIVSlothCombo/ConfigWindowFunctions.cs
@@ -105,23 +105,6 @@ namespace XIVSlothComboPlugin.ConfigFunctions
             ImGui.Spacing();
         }
 
-        public static void DrawIntBox(string config, string intboxDescription, float itemWidth = 150)
-        {
-            var output = Service.Configuration.GetCustomIntValue(config);
-            var inputChanged = false;
-            ImGui.PushItemWidth(itemWidth);
-            inputChanged |= ImGui.InputInt($"{intboxDescription}###{config}", ref output, 1, 100);
-
-            if (inputChanged) 
-            {
-                output = Math.Max(0, output); //Positive number only check
-                Service.Configuration.SetCustomIntValue(config, output);
-                Service.Configuration.Save();
-            }
-
-            ImGui.Spacing();
-        }
-
         public static void DrawPvPStatusMultiChoice(string config)
         {
             var values = Service.Configuration.GetCustomBoolArrayValue(config);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2034,10 +2034,10 @@ namespace XIVSlothComboPlugin
                         [ParentCombo(SGE_ST_Dosis_EDosis)]
                         [ConflictingCombos(SGE_ST_Dosis_EDosisToT)]
                         [CustomComboInfo("Enemy HP Limiter Options", "Stop using Eukrasian Dosis when Enemy HP values match\nEnable to see input boxes", SGE.JobID, 121)]
-                        SGE_ST_Dosis_EDosisHPLimiters = 14121,
+                        SGE_ST_Dosis_EDosisHPPer = 14121,
 
                         [ParentCombo(SGE_ST_Dosis_EDosis)]
-                        [ConflictingCombos(SGE_ST_Dosis_EDosisHPLimiters)]
+                        [ConflictingCombos(SGE_ST_Dosis_EDosisHPPer)]
                         [CustomComboInfo("Target of Target Dosis Option", "Target of Target checking for Dosis", SGE.JobID, 122)]
                         SGE_ST_Dosis_EDosisToT = 14122,
 
@@ -2367,9 +2367,9 @@ namespace XIVSlothComboPlugin
         #region SCHOLAR
 
             //SCHOLAR_FEATURE_NUMBERING
-        //Numbering Scheme: 16[Feature][Option][Sub-Option]
-        //Example: 16110 (Feature Number 1, Option 1, no suboption)
-        //New features should be added to the appropriate sections.
+            //Numbering Scheme: 16[Feature][Option][Sub-Option]
+            //Example: 16110 (Feature Number 1, Option 1, no suboption)
+            //New features should be added to the appropriate sections.
 
             #region SCHOLAR_DPS
 
@@ -2401,10 +2401,10 @@ namespace XIVSlothComboPlugin
                         [ParentCombo(SCH_ST_Broil_Bio)]
                         [ConflictingCombos(SCH_ST_Broil_BioToT)]
                         [CustomComboInfo("Enemy HP Limiter Options", "Stop using Bio when Enemy HP values match below:", SCH.JobID, 151)]
-                        SCH_ST_Broil_BioHPLimiters = 16151,
+                        SCH_ST_Broil_BioHPPer = 16151,
 
                         [ParentCombo(SCH_ST_Broil_Bio)]
-                        [ConflictingCombos(SCH_ST_Broil_BioHPLimiters)]
+                        [ConflictingCombos(SCH_ST_Broil_BioHPPer)]
                         [CustomComboInfo("Target of Target Bio Option", "Target of Target checking for Bio", SCH.JobID, 152)]
                         SCH_ST_Broil_BioToT = 16152,
             #endregion

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2166,8 +2166,13 @@ namespace XIVSlothComboPlugin
             [CustomComboInfo("Rhizomata Feature", "Replaces Addersgall skills with Rhizomata when empty.", SGE.JobID, 600)]
             SGE_RhizoFeature = 14600,
 
+            [ReplaceSkill(SGE.Druochole)]
             [CustomComboInfo("Druochole to Taurochole Feature", "Upgrades Druochole to Taurochole when Taurochole is available", SGE.JobID, 700)]
             SGE_DruoTauroFeature = 14700,
+
+            [ReplaceSkill(SGE.Pneuma)]
+            [CustomComboInfo("Zoe Buff for Pneuma Feature", "Places Zoe ontop of Pneuma when both actions are on cooldown", SGE.JobID, 701)]//Temporary to keep the order
+            SGE_ZoePneumaFeature = 141000,
             #endregion
 
             #region Utility

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2067,6 +2067,10 @@ namespace XIVSlothComboPlugin
                     [CustomComboInfo("Dyskrasia No-Target Option", "Use Dyskrasia when no target is selected", SGE.JobID, 240, "", "")]
                     SGE_AoE_Phlegma_NoTargetDyskrasia = 14240,
 
+                    [ParentCombo(SGE_AoE_PhlegmaFeature)]
+                    [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming to Phlegma when MP drops below slider value", SGE.JobID, 250)]
+                    SGE_AoE_Phlegma_Lucid = 14250,
+
                 #endregion
 
             #endregion


### PR DESCRIPTION
20220511 : Revised Changelog
SGE: Removed Role Action IDs under SGE. Added Phlegma's attack range
SGE SageAoEPhlegmaFeature: Restructured for adding Phlegma out of range to Toxikon option. Lucid Dreaming added
SGE SageSTDosisFeature Eukrasian Dosis: Moved the buff check before debuff check, as the point of the routine is to enable the buff.
SGE SageZoePneumaFeature Added (resolves #621)
SCH: Removed Esuna Role ID
SCH ScholarAetherflowFeature: Aetherflow stopped from showing on top of abilities on cooldown. Option to show Aetherflow/Dissipation on Energy Drain only (previous design, resolves #673) or on all abilities (like Sage) added.
SCH ScholarBroilFeature: Aetherflow is now weaved, not forced, and moved up in priority after Lucid. Ruin 2 moved up in priority above Bio, to reduce seizure icon replacement occurrence. Sage's HP % Limiter added
CustomComboPreset: Updated to reflect changes to SCH & SGE