### PR TITLE
[DNC] Simple Step Fill Options

### DIFF
--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -459,21 +459,21 @@ namespace XIVSlothComboPlugin.Combos
                 var waltzThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent);
                 var secondWindThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent);
 
-                // Simple ST Interrupt
-                if (IsEnabled(CustomComboPreset.DancerSimpleInterruptFeature) && interruptable)
-                        return All.HeadGraze;
-
                 // Simple ST Tech Steps
-                if (HasEffect(Buffs.TechnicalStep) && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature))
+                if (HasEffect(Buffs.TechnicalStep) && (IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) || IsEnabled(CustomComboPreset.DancerSimpleStepFillFeature)))
                     return gauge.CompletedSteps < 4
                         ? (uint)gauge.NextStep
                         : TechnicalFinish4;
 
                 // Simple ST Standard Steps
-                if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature))
+                if (HasEffect(Buffs.StandardStep) && (IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) || IsEnabled(CustomComboPreset.DancerSimpleStepFillFeature)))
                     return gauge.CompletedSteps < 2
                         ? (uint)gauge.NextStep
                         : StandardFinish2;
+
+                // Simple ST Interrupt
+                if (IsEnabled(CustomComboPreset.DancerSimpleInterruptFeature) && interruptable)
+                        return All.HeadGraze;
 
                 // Simple ST Standard (activates dance with no target, or when target is over HP% threshold)
                 if (!HasTarget() || EnemyHealthPercentage() > standardStepBurstThreshold)
@@ -598,21 +598,21 @@ namespace XIVSlothComboPlugin.Combos
                     var waltzThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent);
                     var secondWindThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent);
 
-                    // Simple AoE Interrupt
-                    if (IsEnabled(CustomComboPreset.DancerSimpleAoEInterruptFeature) && interruptable)
-                        return All.HeadGraze;
-
                     // Simple AoE Standard Step (step function)
-                    if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature))
+                    if (HasEffect(Buffs.StandardStep) && (IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) || IsEnabled(CustomComboPreset.DancerSimpleAoEStepFillFeature)))
                         return gauge.CompletedSteps < 2
                             ? (uint)gauge.NextStep
                             : StandardFinish2;
 
                     // Simple AoE Tech Step (step function)
-                    if (HasEffect(Buffs.TechnicalStep) && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature))
+                    if (HasEffect(Buffs.TechnicalStep) && (IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) || IsEnabled(CustomComboPreset.DancerSimpleAoEStepFillFeature)))
                         return gauge.CompletedSteps < 4
                             ? (uint)gauge.NextStep
                             : TechnicalFinish4;
+
+                    // Simple AoE Interrupt
+                    if (IsEnabled(CustomComboPreset.DancerSimpleAoEInterruptFeature) && interruptable)
+                        return All.HeadGraze;
 
                     // Simple AoE Standard (activates dance with no target, or when target is over HP% threshold)
                     if (!HasTarget() || EnemyHealthPercentage() > standardStepBurstThreshold)

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -459,17 +459,17 @@ namespace XIVSlothComboPlugin.Combos
                 var waltzThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent);
                 var secondWindThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent);
 
-                // Simple ST Tech Steps
-                if (HasEffect(Buffs.TechnicalStep) && (IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) || IsEnabled(CustomComboPreset.DancerSimpleStepFillFeature)))
-                    return gauge.CompletedSteps < 4
-                        ? (uint)gauge.NextStep
-                        : TechnicalFinish4;
-
                 // Simple ST Standard Steps
-                if (HasEffect(Buffs.StandardStep) && (IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) || IsEnabled(CustomComboPreset.DancerSimpleStepFillFeature)))
+                if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature))
                     return gauge.CompletedSteps < 2
                         ? (uint)gauge.NextStep
                         : StandardFinish2;
+
+                // Simple ST Tech Steps & Fill Feature
+                if (HasEffect(Buffs.TechnicalStep) && (IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) || IsEnabled(CustomComboPreset.DancerSimpleTechFillFeature)))
+                    return gauge.CompletedSteps < 4
+                        ? (uint)gauge.NextStep
+                        : TechnicalFinish4;
 
                 // Simple ST Interrupt
                 if (IsEnabled(CustomComboPreset.DancerSimpleInterruptFeature) && interruptable)
@@ -599,13 +599,13 @@ namespace XIVSlothComboPlugin.Combos
                     var secondWindThreshold = Service.Configuration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent);
 
                     // Simple AoE Standard Step (step function)
-                    if (HasEffect(Buffs.StandardStep) && (IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) || IsEnabled(CustomComboPreset.DancerSimpleAoEStepFillFeature)))
+                    if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature))
                         return gauge.CompletedSteps < 2
                             ? (uint)gauge.NextStep
                             : StandardFinish2;
 
                     // Simple AoE Tech Step (step function)
-                    if (HasEffect(Buffs.TechnicalStep) && (IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) || IsEnabled(CustomComboPreset.DancerSimpleAoEStepFillFeature)))
+                    if (HasEffect(Buffs.TechnicalStep) && (IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) || IsEnabled(CustomComboPreset.DancerSimpleAoETechFillFeature)))
                         return gauge.CompletedSteps < 4
                             ? (uint)gauge.NextStep
                             : TechnicalFinish4;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -700,12 +700,12 @@ namespace XIVSlothComboPlugin
             DancerSimpleInterruptFeature = 4051,
 
             [ParentCombo(DancerSimpleFeature)]
-            [CustomComboInfo("Simple Standard Step Option", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Standard Dance Option", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleStandardFeature = 4052,
 
             [ParentCombo(DancerSimpleFeature)]
             [ConflictingCombos(DancerSimpleTechFillFeature)]
-            [CustomComboInfo("Simple Technical Step Option", "Includes Technical Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleTechnicalFeature = 4053,
 
             [ParentCombo(DancerSimpleFeature)]
@@ -749,12 +749,12 @@ namespace XIVSlothComboPlugin
             DancerSimpleAoEInterruptFeature = 4071,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [CustomComboInfo("Simple AoE Standard Step Option", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple AoE Standard Dance Option", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoEStandardFeature = 4072,
 
             [ParentCombo(DancerSimpleAoEFeature)]
             [ConflictingCombos(DancerSimpleAoETechFillFeature)]
-            [CustomComboInfo("Simple AoE Technical Step Option", "Includes Technical Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple AoE Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoETechnicalFeature = 4073,
 
             [ParentCombo(DancerSimpleAoEFeature)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -700,12 +700,19 @@ namespace XIVSlothComboPlugin
             DancerSimpleInterruptFeature = 4051,
 
             [ParentCombo(DancerSimpleFeature)]
+            [ConflictingCombos(DancerSimpleStepFillFeature)]
             [CustomComboInfo("Simple Standard Step Option", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleStandardFeature = 4052,
 
             [ParentCombo(DancerSimpleFeature)]
+            [ConflictingCombos(DancerSimpleStepFillFeature)]
             [CustomComboInfo("Simple Technical Step Option", "Includes Technical Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleTechnicalFeature = 4053,
+
+            [ParentCombo(DancerSimpleFeature)]
+            [ConflictingCombos(DancerSimpleStandardFeature, DancerSimpleTechnicalFeature)]
+            [CustomComboInfo("Simple Step Fill Option", "Adds ONLY dance steps and finishes to the rotation.\nThe dances themselves need to be initiated manually when using this option.", DNC.JobID, 0, "", "")]
+            DancerSimpleStepFillFeature = 4054,
 
             [ParentCombo(DancerSimpleFeature)]
             [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation.\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 0, "", "")]
@@ -743,12 +750,19 @@ namespace XIVSlothComboPlugin
             DancerSimpleAoEInterruptFeature = 4071,
 
             [ParentCombo(DancerSimpleAoEFeature)]
+            [ConflictingCombos(DancerSimpleAoEStepFillFeature)]
             [CustomComboInfo("Simple AoE Standard Step Option", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoEStandardFeature = 4072,
 
             [ParentCombo(DancerSimpleAoEFeature)]
+            [ConflictingCombos(DancerSimpleAoEStepFillFeature)]
             [CustomComboInfo("Simple AoE Technical Step Option", "Includes Technical Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoETechnicalFeature = 4073,
+
+            [ParentCombo(DancerSimpleAoEFeature)]
+            [ConflictingCombos(DancerSimpleAoEStandardFeature, DancerSimpleAoETechnicalFeature)]
+            [CustomComboInfo("Simple AoE Step Fill Option", "Adds ONLY dance steps and finishes to the AoE rotation.\nThe dances themselves need to be initiated manually when using this option.", DNC.JobID, 0, "", "")]
+            DancerSimpleAoEStepFillFeature = 4074,
 
             [ParentCombo(DancerSimpleAoEFeature)]
             [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation.\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 0, "", "")]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -700,19 +700,18 @@ namespace XIVSlothComboPlugin
             DancerSimpleInterruptFeature = 4051,
 
             [ParentCombo(DancerSimpleFeature)]
-            [ConflictingCombos(DancerSimpleStepFillFeature)]
             [CustomComboInfo("Simple Standard Step Option", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleStandardFeature = 4052,
 
             [ParentCombo(DancerSimpleFeature)]
-            [ConflictingCombos(DancerSimpleStepFillFeature)]
+            [ConflictingCombos(DancerSimpleTechFillFeature)]
             [CustomComboInfo("Simple Technical Step Option", "Includes Technical Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
             DancerSimpleTechnicalFeature = 4053,
 
             [ParentCombo(DancerSimpleFeature)]
-            [ConflictingCombos(DancerSimpleStandardFeature, DancerSimpleTechnicalFeature)]
-            [CustomComboInfo("Simple Step Fill Option", "Adds ONLY dance steps and finishes to the rotation.\nThe dances themselves need to be initiated manually when using this option.", DNC.JobID, 0, "", "")]
-            DancerSimpleStepFillFeature = 4054,
+            [ConflictingCombos(DancerSimpleTechnicalFeature)]
+            [CustomComboInfo("Simple Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the rotation.\nTechnical Step itself needs to be initiated manually when using this option.", DNC.JobID, 0, "", "")]
+            DancerSimpleTechFillFeature = 4054,
 
             [ParentCombo(DancerSimpleFeature)]
             [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation.\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 0, "", "")]
@@ -750,19 +749,18 @@ namespace XIVSlothComboPlugin
             DancerSimpleAoEInterruptFeature = 4071,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [ConflictingCombos(DancerSimpleAoEStepFillFeature)]
             [CustomComboInfo("Simple AoE Standard Step Option", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoEStandardFeature = 4072,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [ConflictingCombos(DancerSimpleAoEStepFillFeature)]
+            [ConflictingCombos(DancerSimpleAoETechFillFeature)]
             [CustomComboInfo("Simple AoE Technical Step Option", "Includes Technical Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
             DancerSimpleAoETechnicalFeature = 4073,
 
             [ParentCombo(DancerSimpleAoEFeature)]
-            [ConflictingCombos(DancerSimpleAoEStandardFeature, DancerSimpleAoETechnicalFeature)]
-            [CustomComboInfo("Simple AoE Step Fill Option", "Adds ONLY dance steps and finishes to the AoE rotation.\nThe dances themselves need to be initiated manually when using this option.", DNC.JobID, 0, "", "")]
-            DancerSimpleAoEStepFillFeature = 4074,
+            [ConflictingCombos(DancerSimpleAoETechnicalFeature)]
+            [CustomComboInfo("Simple AoE Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation.\nTechnical Step itself needs to be initiated manually when using this option.", DNC.JobID, 0, "", "")]
+            DancerSimpleAoETechFillFeature = 4074,
 
             [ParentCombo(DancerSimpleAoEFeature)]
             [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation.\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 0, "", "")]


### PR DESCRIPTION
- [x] Implement
- [x] Change to TS-only
- [x] Test

~~Added `Simple Step Fill Option`~~
~~Added `Simple AoE Step Fill Option`~~
Added `Simple Tech Fill Option`
Added `Simple AoE Tech Fill Option`
> (Initially, these two features applied to both SS and TS. Now, the new features only apply to TS, and allow for combined use with `Simple Standard Step Option` and `Simple AoE Standard Step Option`.

Adjusted priority of `Simple Interrupt Option`
Adjusted priority of `Simple AoE Interrupt Option`
Added relevant conflicts