### PR TITLE
RDM Tweaks, fixes and options

### DIFF
--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -135,7 +135,7 @@ namespace XIVSlothComboPlugin.Combos
                         && IsOffCooldown(Embolden) && IsOffCooldown(Manafication) && IsOffCooldown(All.Swiftcast)
                         && GetCooldown(Acceleration).RemainingCharges == 2 && GetCooldown(Corpsacorps).RemainingCharges == 2 && GetCooldown(Engagement).RemainingCharges == 2
                         && IsOffCooldown(Fleche) && IsOffCooldown(ContreSixte)
-                        && EnemyHealthPercentage() == 100 && !inOpener && !openerStarted)
+                        && EnemyHealthPercentage() == 100 && !inCombat && !inOpener && !openerStarted)
                     {
                         readyOpener = true;
                         inOpener = false;
@@ -304,15 +304,16 @@ namespace XIVSlothComboPlugin.Combos
                         || (radioButton == 3 && actionID is Riposte or EnchantedRiposte or Jolt or Jolt2))
                     {
                         //Situation 1: Manafication first
-                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                        && System.Math.Max(black, white) <= 50 && System.Math.Max(black, white) >= 42 && System.Math.Min(black, white) >= 31
-                        && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
-                        && (IsOffCooldown(Embolden) || GetCooldown(Embolden).CooldownRemaining <= 3))
+                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90 && gauge.ManaStacks == 0
+                            && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
+                            && System.Math.Max(black, white) <= 50 && System.Math.Max(black, white) >= 42 && System.Math.Min(black, white) >= 31
+                            && IsOffCooldown(Manafication)
+                            && (IsOffCooldown(Embolden) || GetCooldown(Embolden).CooldownRemaining <= 3))
                         {
                             return Manafication;
                         }
                         if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                            && lastComboMove is Zwerchhau && level >= Levels.Redoublement
+                            && lastComboMove is Zwerchhau
                             && System.Math.Max(black, white) >= 55 && System.Math.Min(black, white) >= 46
                             && GetCooldown(Manafication).CooldownRemaining >= 100
                             && IsOffCooldown(Embolden))
@@ -321,33 +322,33 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //Situation 2: Embolden first
-                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                            && lastComboMove is Zwerchhau && level >= Levels.Redoublement
+                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90 && lastComboMove is Zwerchhau
                             && System.Math.Max(black, white) <= 57 && System.Math.Min(black, white) <= 46
                             && (GetCooldown(Manafication).CooldownRemaining <= 7 || IsOffCooldown(Manafication))
                             && IsOffCooldown(Embolden))
                         {
                             return Embolden;
                         }
-                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
+                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90 && (gauge.ManaStacks == 3 || lastComboMove is Resolution)
+                            && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                             && System.Math.Max(black, white) <= 50
-                            && IsOffCooldown(Manafication)
-                            && (gauge.ManaStacks == 3 || lastComboMove is Resolution)
-                            && GetCooldown(Embolden).CooldownRemaining >= 105)
+                            && GetCooldown(Embolden).CooldownRemaining >= 105
+                            && IsOffCooldown(Manafication))
                         {
                             return Manafication;
                         }
 
                         //Situation 3: Just use them together
-                        if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Embolden
+                        if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Embolden && gauge.ManaStacks == 0
                             && System.Math.Max(black, white) <= 50
                             && (IsOffCooldown(Manafication) || level < Levels.Manafication) && IsOffCooldown(Embolden))
                         {
                             return Embolden;
                         }
-                        if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Manafication
+                        if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Manafication && (gauge.ManaStacks == 0 || gauge.ManaStacks == 3)
+                            && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                             && System.Math.Max(black, white) <= 50
-                            && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
+                            && IsOffCooldown(Manafication)
                             && GetCooldown(Embolden).CooldownRemaining >= 110)
                         {
                             return Manafication;
@@ -368,19 +369,38 @@ namespace XIVSlothComboPlugin.Combos
                     && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
                     && GetTargetDistance() < 8 && actionID is Scatter or Impact)
                 {
-                    if (level >= Levels.Manafication
-                    && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
-                    && (IsOffCooldown(Manafication) || level < Levels.Manafication) && IsOffCooldown(Embolden))
+                    //Situation 1: Embolden First (Double)
+                    if (level >= Levels.Manafication && gauge.ManaStacks == 2
+                    && System.Math.Min(black, white) >= 22
+                    && IsOffCooldown(Manafication) && IsOffCooldown(Embolden))
                     {
                         return Embolden;
                     }
                     if (level >= Levels.Manafication
-                        && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
-                        && IsOffCooldown(Manafication) && gauge.ManaStacks == 0
-                        && GetCooldown(Embolden).CooldownRemaining >= 110)
+                        && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
+                        && System.Math.Max(black, white) <= 50 && ((gauge.ManaStacks == 3 && System.Math.Min(black, white) >= 2) || (gauge.ManaStacks == 0 && System.Math.Min(black, white) >= 10))
+                        && IsOffCooldown(Manafication) && GetCooldown(Embolden).CooldownRemaining >= 110)
                     {
                         return Manafication;
                     }
+
+                    //Situation 2: Manafication first (Single)
+                    if (level >= Levels.Manafication && gauge.ManaStacks == 0
+                    && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
+                    && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
+                    && IsOffCooldown(Manafication) && IsOffCooldown(Embolden))
+                    {
+                        return Embolden;
+                    }
+                    if (level >= Levels.Manafication && gauge.ManaStacks == 0 
+                        && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
+                        && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
+                        && IsOffCooldown(Manafication) && GetCooldown(Embolden).CooldownRemaining >= 110)
+                    {
+                        return Manafication;
+                    }
+
+                    //Below Manafication Level
                     if (level < Levels.Manafication && level >= Levels.Embolden
                         && System.Math.Min(black, white) >= 20 && IsOffCooldown(Embolden))
                     {
@@ -549,16 +569,16 @@ namespace XIVSlothComboPlugin.Combos
                 //RDM_AOE_MELEECOMBO
                 if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo) && level >= Levels.Moulinet && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
                     && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
-                    && (System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60 || (level < Levels.Manafication && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
+                    && ((System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60) || (level < Levels.Manafication && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
                     && ((GetTargetDistance() <= 7 && gauge.ManaStacks == 0) || gauge.ManaStacks > 0))
                     return OriginalHook(EnchantedMoulinet);
                 //END_RDM_AOE_MELEECOMBO
 
                 //RDM_ST_ACCELERATION
-                if (IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && actionID is Jolt or Jolt2 && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
+                if (IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && actionID is Jolt or Jolt2 && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false && gauge.ManaStacks == 0
                     && !HasEffect(Buffs.VerfireReady) && !HasEffect(Buffs.VerstoneReady) && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
                 {
-                    if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54)
+                    if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54.5)
                         return Acceleration;
                     if (IsEnabled(CustomComboPreset.RDM_ST_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(Acceleration).RemainingCharges == 0)
                         return All.Swiftcast;
@@ -566,12 +586,15 @@ namespace XIVSlothComboPlugin.Combos
                 //END_RDM_ST_ACCELERATION
 
                 //RDM_AoE_ACCELERATION
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Acceleration) && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
+                if (IsEnabled(CustomComboPreset.RDM_AoE_Acceleration) && actionID is Scatter or Impact && LocalPlayer.IsCasting == false && gauge.ManaStacks == 0
+                    && (IsNotEnabled(CustomComboPreset.RDM_AoE_WeaveAcceleration) || CanSpellWeave(actionID))
                     && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
                 {
-                    if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54)
+                    if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0
+                        && GetCooldown(Acceleration).ChargeCooldownRemaining < 54.5)
                         return Acceleration;
-                    if (IsEnabled(CustomComboPreset.RDM_AoE_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(Acceleration).RemainingCharges == 0)
+                    if (IsEnabled(CustomComboPreset.RDM_AoE_AccelSwiftCast) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) && GetCooldown(Acceleration).RemainingCharges == 0
+                        && GetCooldown(Acceleration).ChargeCooldownRemaining < 54.5)
                         return All.Swiftcast;
                 }
                 //END_RDM_AoE_ACCELERATION

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -369,7 +369,7 @@ namespace XIVSlothComboPlugin.Combos
                 //RDM_AOE_MANAFICATIONEMBOLDEN
                 if (IsEnabled(CustomComboPreset.RDM_AoE_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
                     && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
-                    && GetTargetDistance() < moulinetRange && actionID is Scatter or Impact)
+                    && GetTargetDistance() <= moulinetRange && actionID is Scatter or Impact)
                 {
                     //Situation 1: Embolden First (Double)
                     if (level >= Levels.Manafication && gauge.ManaStacks == 2

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -371,8 +371,8 @@ namespace XIVSlothComboPlugin.Combos
                 {
                     //Situation 1: Embolden First (Double)
                     if (level >= Levels.Manafication && gauge.ManaStacks == 2
-                    && System.Math.Min(black, white) >= 22
-                    && IsOffCooldown(Manafication) && IsOffCooldown(Embolden))
+                        && System.Math.Min(black, white) >= 22
+                        && IsOffCooldown(Manafication) && IsOffCooldown(Embolden))
                     {
                         return Embolden;
                     }
@@ -386,9 +386,9 @@ namespace XIVSlothComboPlugin.Combos
 
                     //Situation 2: Manafication first (Single)
                     if (level >= Levels.Manafication && gauge.ManaStacks == 0
-                    && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
-                    && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
-                    && IsOffCooldown(Manafication) && IsOffCooldown(Embolden))
+                        && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
+                        && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
+                        && IsOffCooldown(Manafication) && IsOffCooldown(Embolden))
                     {
                         return Embolden;
                     }
@@ -555,8 +555,8 @@ namespace XIVSlothComboPlugin.Combos
                             return OriginalHook(Redoublement);
 
                         if (((System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 50 && level >= Levels.Redoublement)
-                                || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 35 && level < Levels.Redoublement)
-                                || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 20 && level < Levels.Zwerchhau))
+                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 35 && level < Levels.Redoublement)
+                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 20 && level < Levels.Zwerchhau))
                             && (!HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))) //Not sure if Swift and Accel are necessary, but better to clear I think.
                         {
                             if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && level >= Levels.Corpsacorps && GetCooldown(Corpsacorps).RemainingCharges >= 1 && distance > 3) return Corpsacorps;
@@ -576,6 +576,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 //RDM_ST_ACCELERATION
                 if (IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && actionID is Jolt or Jolt2 && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false && gauge.ManaStacks == 0
+                    && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                     && !HasEffect(Buffs.VerfireReady) && !HasEffect(Buffs.VerstoneReady) && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
                 {
                     if (level >= Levels.Acceleration && GetCooldown(Acceleration).RemainingCharges > 0 && GetCooldown(Acceleration).ChargeCooldownRemaining < 54.5)
@@ -587,6 +588,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 //RDM_AoE_ACCELERATION
                 if (IsEnabled(CustomComboPreset.RDM_AoE_Acceleration) && actionID is Scatter or Impact && LocalPlayer.IsCasting == false && gauge.ManaStacks == 0
+                    && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                     && (IsNotEnabled(CustomComboPreset.RDM_AoE_WeaveAcceleration) || CanSpellWeave(actionID))
                     && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
                 {

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -100,6 +100,7 @@ namespace XIVSlothComboPlugin.Combos
             public const string RDM_ST_MeleeCombo_OnAction = "RDM_ST_MeleeCombo_OnAction";
             public const string RDM_MeleeFinisher_OnAction = "RDM_MeleeFinisher_OnAction";
             public const string RDM_LucidDreaming_Threshold = "RDM_LucidDreaming_Threshold";
+            public const string RDM_MoulinetRange = "RDM_MoulinetRange";
         }
 
 
@@ -117,6 +118,7 @@ namespace XIVSlothComboPlugin.Combos
             {
                 //MAIN_COMBO_VARIABLES
                 RDMGauge gauge = GetJobGauge<RDMGauge>();
+                var moulinetRange = Service.Configuration.GetCustomIntValue(Config.RDM_MoulinetRange);
                 int black = gauge.BlackMana;
                 int white = gauge.WhiteMana;
                 //END_MAIN_COMBO_VARIABLES
@@ -367,7 +369,7 @@ namespace XIVSlothComboPlugin.Combos
                 //RDM_AOE_MANAFICATIONEMBOLDEN
                 if (IsEnabled(CustomComboPreset.RDM_AoE_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
                     && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
-                    && GetTargetDistance() < 8 && actionID is Scatter or Impact)
+                    && GetTargetDistance() < moulinetRange && actionID is Scatter or Impact)
                 {
                     //Situation 1: Embolden First (Double)
                     if (level >= Levels.Manafication && gauge.ManaStacks == 2
@@ -570,7 +572,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo) && level >= Levels.Moulinet && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
                     && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
                     && ((System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60) || (level < Levels.Manafication && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
-                    && ((GetTargetDistance() <= 7 && gauge.ManaStacks == 0) || gauge.ManaStacks > 0))
+                    && ((GetTargetDistance() <= moulinetRange && gauge.ManaStacks == 0) || gauge.ManaStacks > 0))
                     return OriginalHook(EnchantedMoulinet);
                 //END_RDM_AOE_MELEECOMBO
 

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -404,15 +404,19 @@ namespace XIVSlothComboPlugin.Combos
                     var distance = GetTargetDistance();
                     var corpacorpsRange = 25;
                     var corpsacorpsPool = 0;
+                    var engagementPool = 0;
 
                     if (IsEnabled(CustomComboPreset.RDM_Corpsacorps_MeleeRange)) corpacorpsRange = 3;
-                    if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && IsEnabled(CustomComboPreset.RDM_ST_PoolCorps)) corpsacorpsPool = 1;
+                    if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && IsEnabled(CustomComboPreset.RDM_PoolCorps)) corpsacorpsPool = 1;
+                    if (IsEnabled(CustomComboPreset.RDM_Engagement) && IsEnabled(CustomComboPreset.RDM_PoolEngage)) engagementPool = 1;
 
                     if (actionID is Jolt or Jolt2 or Scatter or Impact or Fleche)
                     {
-                        if (IsEnabled(CustomComboPreset.RDM_Engagement) && GetCooldown(Engagement).RemainingCharges > 0
+                        if (IsEnabled(CustomComboPreset.RDM_Engagement) && GetCooldown(Engagement).RemainingCharges >= engagementPool 
+                            && (GetCooldown(Engagement).ChargeCooldownRemaining < 3 || IsNotEnabled(CustomComboPreset.RDM_PoolEngage))
                             && level >= Levels.Engagement && distance <= 3) placeOGCD = Engagement;
-                        if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && GetCooldown(Corpsacorps).RemainingCharges > corpsacorpsPool
+                        if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && GetCooldown(Corpsacorps).RemainingCharges >= corpsacorpsPool
+                            && (GetCooldown(Corpsacorps).ChargeCooldownRemaining < 3 || IsNotEnabled(CustomComboPreset.RDM_PoolCorps))
                             && ((GetCooldown(Corpsacorps).RemainingCharges >= GetCooldown(Engagement).RemainingCharges) || level < Levels.Engagement) // Try to alternate between Corps-a-corps and Engagement
                             && level >= Levels.Corpsacorps && distance <= corpacorpsRange) placeOGCD = Corpsacorps;
                         if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && IsOffCooldown(ContreSixte) && level >= Levels.ContreSixte) placeOGCD = ContreSixte;
@@ -426,18 +430,11 @@ namespace XIVSlothComboPlugin.Combos
                             if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && level >= Levels.ContreSixte
                                 && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(ContreSixte).CooldownRemaining) placeOGCD = ContreSixte;
                             if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && level >= Levels.Corpsacorps
-                                && ((IsNotEnabled(CustomComboPreset.RDM_ST_PoolCorps) && GetCooldown(Corpsacorps).RemainingCharges >= 0) || GetCooldown(Corpsacorps).RemainingCharges >= 2)
-                                && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Corpsacorps).ChargeCooldownRemaining
-                                && distance <= corpacorpsRange) placeOGCD = Corpsacorps;
-                            if (placeOGCD == Corpsacorps)
-                            {
-                                if (IsEnabled(CustomComboPreset.RDM_Engagement) && level >= Levels.Engagement
-                                    && GetCooldown(placeOGCD).ChargeCooldownRemaining > GetCooldown(Engagement).ChargeCooldownRemaining
-                                    && distance <= 3) placeOGCD = Engagement;
-                            }
-                            else if (IsEnabled(CustomComboPreset.RDM_Engagement)
-                              && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Engagement).ChargeCooldownRemaining
-                              && distance <= 3) placeOGCD = Engagement;
+                                && GetCooldown(Corpsacorps).RemainingCharges == 0
+                                && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Corpsacorps).CooldownRemaining) placeOGCD = Corpsacorps;
+                            if (IsEnabled(CustomComboPreset.RDM_Engagement) && level >= Levels.Engagement
+                                && GetCooldown(Engagement).RemainingCharges == 0
+                                && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Engagement).CooldownRemaining) placeOGCD = Engagement;
                         }
                         if (actionID is Fleche && radioButton == 1) return placeOGCD;
                     }

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -52,7 +52,7 @@ namespace XIVSlothComboPlugin.Combos
                 Dualcast = 1249,
                 Chainspell = 2560,
                 Acceleration = 1238,
-                Embolden = 2282;
+                Embolden = 1239;
         }
 
         public static class Debuffs
@@ -295,7 +295,7 @@ namespace XIVSlothComboPlugin.Combos
                 //END_RDM_BALANCE_OPENER
 
                 //RDM_ST_MANAFICATIONEMBOLDEN
-                if (IsEnabled(CustomComboPreset.RDM_ST_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
+                if (IsEnabled(CustomComboPreset.RDM_ST_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat)
                     && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
                     && (GetTargetDistance() <= 3 || (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) && GetCooldown(Corpsacorps).RemainingCharges >= 1)))
                 {
@@ -315,8 +315,8 @@ namespace XIVSlothComboPlugin.Combos
                             return Manafication;
                         }
                         if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
-                            && lastComboMove is Zwerchhau
-                            && System.Math.Max(black, white) >= 55 && System.Math.Min(black, white) >= 46
+                            && lastComboMove is Zwerchhau or EnchantedZwerchhau
+                            && System.Math.Max(black, white) >= 57 && System.Math.Min(black, white) >= 46
                             && GetCooldown(Manafication).CooldownRemaining >= 100
                             && IsOffCooldown(Embolden))
                         {
@@ -324,17 +324,18 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //Situation 2: Embolden first
-                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90 && lastComboMove is Zwerchhau
+                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90
+                            && lastComboMove is Zwerchhau or EnchantedZwerchhau
                             && System.Math.Max(black, white) <= 57 && System.Math.Min(black, white) <= 46
                             && (GetCooldown(Manafication).CooldownRemaining <= 7 || IsOffCooldown(Manafication))
                             && IsOffCooldown(Embolden))
                         {
                             return Embolden;
                         }
-                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90 && (gauge.ManaStacks == 3 || lastComboMove is Resolution)
+                        if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90 && (gauge.ManaStacks == 0 || gauge.ManaStacks == 3)
                             && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                             && System.Math.Max(black, white) <= 50
-                            && GetCooldown(Embolden).CooldownRemaining >= 105
+                            && HasEffect(Buffs.Embolden)
                             && IsOffCooldown(Manafication))
                         {
                             return Manafication;
@@ -343,15 +344,16 @@ namespace XIVSlothComboPlugin.Combos
                         //Situation 3: Just use them together
                         if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Embolden && gauge.ManaStacks == 0
                             && System.Math.Max(black, white) <= 50
-                            && (IsOffCooldown(Manafication) || level < Levels.Manafication) && IsOffCooldown(Embolden))
+                            && (IsOffCooldown(Manafication) || level < Levels.Manafication)
+                            && IsOffCooldown(Embolden))
                         {
                             return Embolden;
                         }
                         if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Manafication && (gauge.ManaStacks == 0 || gauge.ManaStacks == 3)
                             && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                             && System.Math.Max(black, white) <= 50
-                            && IsOffCooldown(Manafication)
-                            && GetCooldown(Embolden).CooldownRemaining >= 110)
+                            && HasEffect(Buffs.Embolden)
+                            && IsOffCooldown(Manafication))
                         {
                             return Manafication;
                         }
@@ -367,9 +369,9 @@ namespace XIVSlothComboPlugin.Combos
                 //END_RDM_ST_MANAFICATIONEMBOLDEN
 
                 //RDM_AOE_MANAFICATIONEMBOLDEN
-                if (IsEnabled(CustomComboPreset.RDM_AoE_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false
+                if (IsEnabled(CustomComboPreset.RDM_AoE_ManaficationEmbolden) && level >= Levels.Embolden && HasCondition(ConditionFlag.InCombat)
                     && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
-                    && GetTargetDistance() <= moulinetRange && actionID is Scatter or Impact)
+                    && ((GetTargetDistance() <= moulinetRange && gauge.ManaStacks == 0) || gauge.ManaStacks > 0) && actionID is Scatter or Impact)
                 {
                     //Situation 1: Embolden First (Double)
                     if (level >= Levels.Manafication && gauge.ManaStacks == 2
@@ -378,10 +380,11 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         return Embolden;
                     }
-                    if (level >= Levels.Manafication
+                    if (level >= Levels.Manafication && ((gauge.ManaStacks == 3 && System.Math.Min(black, white) >= 2) || (gauge.ManaStacks == 0 && System.Math.Min(black, white) >= 10))
                         && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
-                        && System.Math.Max(black, white) <= 50 && ((gauge.ManaStacks == 3 && System.Math.Min(black, white) >= 2) || (gauge.ManaStacks == 0 && System.Math.Min(black, white) >= 10))
-                        && IsOffCooldown(Manafication) && GetCooldown(Embolden).CooldownRemaining >= 110)
+                        && System.Math.Max(black, white) <= 50
+                        && HasEffect(Buffs.Embolden)
+                        && IsOffCooldown(Manafication))
                     {
                         return Manafication;
                     }
@@ -397,7 +400,8 @@ namespace XIVSlothComboPlugin.Combos
                     if (level >= Levels.Manafication && gauge.ManaStacks == 0 
                         && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                         && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
-                        && IsOffCooldown(Manafication) && GetCooldown(Embolden).CooldownRemaining >= 110)
+                        && HasEffect(Buffs.Embolden)
+                        && IsOffCooldown(Manafication))
                     {
                         return Manafication;
                     }

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -577,7 +577,7 @@ namespace XIVSlothComboPlugin.Combos
                 //END_RDM_AOE_MELEECOMBO
 
                 //RDM_ST_ACCELERATION
-                if (IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && actionID is Jolt or Jolt2 && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false && gauge.ManaStacks == 0
+                if (IsEnabled(CustomComboPreset.RDM_VerthunderVeraero) && IsEnabled(CustomComboPreset.RDM_ST_Acceleration) && actionID is Jolt or Jolt2 && HasCondition(ConditionFlag.InCombat) && LocalPlayer.IsCasting == false && gauge.ManaStacks == 0
                     && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                     && !HasEffect(Buffs.VerfireReady) && !HasEffect(Buffs.VerstoneReady) && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
                 {

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -663,29 +663,6 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
-        // RDM_Verraise
-        // Swiftcast combos to Verraise when:
-        //  -Swiftcast is on cooldown.
-        //  -Swiftcast is available, but we we have Dualcast (Dualcasting verraise)
-        // Using this variation other than the alternatefeature style, as verrise is level 63
-        // and swiftcast is unlocked way earlier and in theory, on a hotbar somewhere
-        internal class RDM_Verraise : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Verraise;
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is All.Swiftcast && level >= Levels.Verraise)
-                {
-                    if (GetCooldown(All.Swiftcast).CooldownRemaining > 0 ||   // Condition 1: Swiftcast is on cooldown
-                        HasEffect(Buffs.Dualcast))                        // Condition 2: Swiftcast is available, but we have DualCast)
-                        return Verraise;
-                }
-
-                // Else we just exit normally and return SwiftCast
-                return actionID;
-            }
-        }
-
         internal class RDM_CorpsDisplacement : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_CorpsDisplacement;

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -663,6 +663,29 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
+        // RDM_Verraise
+        // Swiftcast combos to Verraise when:
+        //  -Swiftcast is on cooldown.
+        //  -Swiftcast is available, but we we have Dualcast (Dualcasting verraise)
+        // Using this variation other than the alternatefeature style, as verrise is level 63
+        // and swiftcast is unlocked way earlier and in theory, on a hotbar somewhere
+        internal class RDM_Verraise : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Verraise;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is All.Swiftcast && level >= Levels.Verraise)
+                {
+                    if (GetCooldown(All.Swiftcast).CooldownRemaining > 0 ||   // Condition 1: Swiftcast is on cooldown
+                        HasEffect(Buffs.Dualcast))                        // Condition 2: Swiftcast is available, but we have DualCast)
+                        return Verraise;
+                }
+
+                // Else we just exit normally and return SwiftCast
+                return actionID;
+            }
+        }
+
         internal class RDM_CorpsDisplacement : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_CorpsDisplacement;

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -968,7 +968,10 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "Use on Veraero 1/2/3 and Verthunder 1/2/3", "[Choose Jolt or Impact for a one button rotation]\n---------------------------------------------------------------", 4);
 
             if (preset == CustomComboPreset.RDM_LucidDreaming && enabled)
-                ConfigWindowFunctions.DrawSliderInt(0, 10000, RDM.Config.RDM_LucidDreaming_Threshold, "Add Lucid Dreaming when below this MP.", 300, SliderIncrements.Hundreds);
+                ConfigWindowFunctions.DrawSliderInt(0, 10000, RDM.Config.RDM_LucidDreaming_Threshold, "Add Lucid Dreaming when below this MP", 300, SliderIncrements.Hundreds);
+
+            if (preset == CustomComboPreset.RDM_AoE_MeleeCombo && enabled)
+                ConfigWindowFunctions.DrawSliderInt(3, 8, RDM.Config.RDM_MoulinetRange, "Range to use first Moulinet; no range restrictions after first Moulinet", 150, SliderIncrements.Ones);
 
             #endregion
             // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1985,6 +1985,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Lucid Dreaming", "Use Lucid Dreaming on Jolt 1/2, Veraero 1/2/3, Verthunder 1/2/3, and Scatter/Impact when below threshold.", RDM.JobID, 610, "Lucid Dreaming the day away", "OOM? Git gud.")]
         RDM_LucidDreaming = 13610,
 
+        [ReplaceSkill(All.Swiftcast)]
+        [CustomComboInfo("Verraise", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620, "Swifty Verraise", "You're panicing right now, aren't you?")]
+        RDM_Verraise = 13620,
+
         //SECTION_8to9_OTHERS                   
         [ReplaceSkill(RDM.Displacement)]
         [CustomComboInfo("Displacement <> Corps-a-corps", "Replace Displacement with Corps-a-corps when out of range.", RDM.JobID, 810, "I take two steps forward, you take two steps back.", "We come together because opposites attract.")]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1985,10 +1985,6 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Lucid Dreaming", "Use Lucid Dreaming on Jolt 1/2, Veraero 1/2/3, Verthunder 1/2/3, and Scatter/Impact when below threshold.", RDM.JobID, 610, "Lucid Dreaming the day away", "OOM? Git gud.")]
         RDM_LucidDreaming = 13610,
 
-        [ReplaceSkill(All.Swiftcast)]
-        [CustomComboInfo("Verraise", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620, "Swifty Verraise", "You're panicing right now, aren't you?")]
-        RDM_Verraise = 13620,
-
         //SECTION_8to9_OTHERS                   
         [ReplaceSkill(RDM.Displacement)]
         [CustomComboInfo("Displacement <> Corps-a-corps", "Replace Displacement with Corps-a-corps when out of range.", RDM.JobID, 810, "I take two steps forward, you take two steps back.", "We come together because opposites attract.")]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1986,6 +1986,7 @@ namespace XIVSlothComboPlugin
         RDM_LucidDreaming = 13610,
 
         [ReplaceSkill(All.Swiftcast)]
+        [ConflictingCombos(AllCasterRaiseFeature)]
         [CustomComboInfo("Verraise", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620, "Swifty Verraise", "You're panicing right now, aren't you?")]
         RDM_Verraise = 13620,
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1951,6 +1951,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Include Swiftcast", "Add Swiftcast when all Acceleration charges are used or when below level 50", RDM.JobID, 321)]
         RDM_AoE_AccelSwiftCast = 13321,
 
+        [ParentCombo(RDM_AoE_Acceleration)]
+        [CustomComboInfo("Weave Acceleration", "Only use acceleration during weave windows", RDM.JobID, 322)]
+        RDM_AoE_WeaveAcceleration = 13322,
+
         //SECTION_4to5_MELEE
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Riposte)]
         [CustomComboInfo("Single Target Melee Combo", "Stack Reposte Combo on specified action\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 410)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1923,6 +1923,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Engagement", "Use Engagement on above specified action when in melee range", RDM.JobID, 243)]
         RDM_Engagement = 13243,
 
+        [ParentCombo(RDM_Engagement)]
+        [CustomComboInfo("Hold one charge", "Pool one charge of Engagement/Displacement for manual use", RDM.JobID, 246)]
+        RDM_PoolEngage = 13246,
+
         [ParentCombo(RDM_OGCD)]
         [CustomComboInfo("Corps-a-corps", "Use Corps-a-corps on above specified action", RDM.JobID, 244)]
         RDM_Corpsacorps = 13244,
@@ -1930,6 +1934,10 @@ namespace XIVSlothComboPlugin
         [ParentCombo(RDM_Corpsacorps)]
         [CustomComboInfo("Only in Melee Range", "Use Corps-a-corps only when in melee range", RDM.JobID, 245)]
         RDM_Corpsacorps_MeleeRange = 13245,
+
+        [ParentCombo(RDM_Corpsacorps)]
+        [CustomComboInfo("Hold one charge", "Pool one charge of Corp-a-corps for manual use", RDM.JobID, 247)]
+        RDM_PoolCorps = 13247,
 
         [ReplaceSkill(RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("Verthunder II/Veraero II", "Replace Scatter/Impact with Verthunder II or Veraero II", RDM.JobID, 310)]
@@ -1956,7 +1964,6 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Hold for Double Melee Combo [Lv.90]", "Hold both actions until you can perform a double melee combo", RDM.JobID, 412)]
         RDM_ST_DoubleMeleeCombo = 13412,
 
-        //[ReplaceSkill(RDM.Moulinet)]
         [ReplaceSkill(RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("AoE Melee Combo", "Use Moulinet on Scatter/Impact when over 60/60 mana", RDM.JobID, 420)]
         RDM_AoE_MeleeCombo = 13420,
@@ -1968,10 +1975,6 @@ namespace XIVSlothComboPlugin
         [ParentCombo(RDM_ST_MeleeCombo)]
         [CustomComboInfo("Gap close with Corps-a-corps", "Use Corp-a-corps when out of melee range before starting the melee combo", RDM.JobID, 430)]
         RDM_ST_CorpsGapClose = 13430,
-
-        [ParentCombo(RDM_ST_CorpsGapClose)]
-        [CustomComboInfo("Reserve one charge", "Pool one charge of Corp-a-corps for use", RDM.JobID, 431)]
-        RDM_ST_PoolCorps = 13431,
 
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3)]
         [CustomComboInfo("Melee Finisher", "Add Verflare/Verholy and other finishing moves to specified action", RDM.JobID, 510)]


### PR DESCRIPTION
[RDM]
 - Moved option for pooling `Corps-a-corps` to OGCD section
 - Added option for pooling Engagement to allow for a manual displacement
 - Added option for `Acceleration` to only appear during weave windows on AoE
 - Fixed an issue where `Manafication` and `Embolden` may not be used correctly
 - Fixed an issue where `Acceleration` may interfere with Melee combos
 - Fixed an issue where the opener could appear during combat
 - Added `Verraise` conflict warning with `Magical Ranged DPS: Raise Feature`
 - Added range adjustment slider for the first `Moulinet` in the `AoE Melee Combo` feature.
 - Fixed an issue where the option `Acceleration on Single Target` would still function when the parent feature is disabled.