### PR TITLE
BLU QoL Overhaul

### DIFF
--- a/XIVSlothCombo/ActionWatching.cs
+++ b/XIVSlothCombo/ActionWatching.cs
@@ -16,9 +16,6 @@ namespace XIVSlothComboPlugin
         private static Dictionary<uint, Lumina.Excel.GeneratedSheets.Status>? StatusSheet = Service.DataManager?.GetExcelSheet<Lumina.Excel.GeneratedSheets.Status>()?
             .ToDictionary(i => i.RowId, i => i);
 
-        private static Dictionary<uint, Lumina.Excel.GeneratedSheets.TerritoryType>? TerritorySheet = Service.DataManager?.GetExcelSheet<Lumina.Excel.GeneratedSheets.TerritoryType>()?
-            .ToDictionary(i => i.RowId, i => i);
-
         private delegate void ReceiveActionEffectDelegate(int sourceObjectId, IntPtr sourceActor, IntPtr position, IntPtr effectHeader, IntPtr effectArray, IntPtr effectTrail);
         private readonly static Hook<ReceiveActionEffectDelegate>? ReceiveActionEffectHook;
         private static void ReceiveActionEffectDetour(int sourceObjectId, IntPtr sourceActor, IntPtr position, IntPtr effectHeader, IntPtr effectArray, IntPtr effectTrail)

--- a/XIVSlothCombo/ActionWatching.cs
+++ b/XIVSlothCombo/ActionWatching.cs
@@ -14,7 +14,10 @@ namespace XIVSlothComboPlugin
             .ToDictionary(i => i.RowId, i => i);
 
         private static Dictionary<uint, Lumina.Excel.GeneratedSheets.Status>? StatusSheet = Service.DataManager?.GetExcelSheet<Lumina.Excel.GeneratedSheets.Status>()?
-    .ToDictionary(i => i.RowId, i => i);
+            .ToDictionary(i => i.RowId, i => i);
+
+        private static Dictionary<uint, Lumina.Excel.GeneratedSheets.TerritoryType>? TerritorySheet = Service.DataManager?.GetExcelSheet<Lumina.Excel.GeneratedSheets.TerritoryType>()?
+            .ToDictionary(i => i.RowId, i => i);
 
         private delegate void ReceiveActionEffectDelegate(int sourceObjectId, IntPtr sourceActor, IntPtr position, IntPtr effectHeader, IntPtr effectArray, IntPtr effectTrail);
         private readonly static Hook<ReceiveActionEffectDelegate>? ReceiveActionEffectHook;

--- a/XIVSlothCombo/Attributes/BlueInactiveAttribute.cs
+++ b/XIVSlothCombo/Attributes/BlueInactiveAttribute.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XIVSlothComboPlugin;
+
+namespace XIVSlothComboPlugin
+{
+    /// <summary>
+    /// Attribute documenting which skill the feature uses the user does not have active currently.
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Field)]
+    public class BlueInactiveAttribute : Attribute
+    {
+        /// <summary>
+        /// List of each action the feature uses the user does not have active. Initializes a new instance of the <see cref="BlueInactiveAttribute"/> class.
+        /// </summary>
+        /// <param name="actionIDs">List of actions the preset replaces</param>
+        internal BlueInactiveAttribute(params uint[] actionIDs)
+        {
+            if (Service.Configuration is null) return;
+
+            foreach(uint id in actionIDs)
+            {
+                if (Service.Configuration.ActiveBLUSpells.Contains(id)) continue;
+
+                Actions.Add(id);
+            }
+
+        }
+
+        internal List<uint> Actions { get; set; } = new();
+
+    }
+}

--- a/XIVSlothCombo/BlueMageService.cs
+++ b/XIVSlothCombo/BlueMageService.cs
@@ -1,0 +1,59 @@
+﻿using Dalamud.Game.Gui;
+using FFXIVClientStructs.FFXIV.Client.System.Framework;
+using FFXIVClientStructs.FFXIV.Client.UI;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using static FFXIVClientStructs.FFXIV.Client.UI.AddonAOZNotebook;
+
+namespace XIVSlothComboPlugin
+{
+    internal unsafe static class BlueMageService
+    {
+        public static void PopulateBLUSpells()
+        {
+            IntPtr notebookPtr = Service.GameGui.GetAddonByName("AOZNotebook", 1);
+            if (notebookPtr == IntPtr.Zero)
+                return;
+
+            List<uint> prevList = Service.Configuration.ActiveBLUSpells.ToList();
+
+            Service.Configuration.ActiveBLUSpells.Clear();
+            var notebook = Marshal.PtrToStructure<AddonAOZNotebook>(notebookPtr);
+
+            if (notebook.ActiveActions01.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions01.ActionID);
+            if (notebook.ActiveActions02.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions02.ActionID);
+            if (notebook.ActiveActions03.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions03.ActionID);
+            if (notebook.ActiveActions04.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions04.ActionID);
+            if (notebook.ActiveActions05.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions05.ActionID);
+            if (notebook.ActiveActions06.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions06.ActionID);
+
+            if (notebook.ActiveActions07.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions07.ActionID);
+            if (notebook.ActiveActions08.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions08.ActionID);
+            if (notebook.ActiveActions09.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions09.ActionID);
+            if (notebook.ActiveActions10.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions10.ActionID);
+            if (notebook.ActiveActions11.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions11.ActionID);
+            if (notebook.ActiveActions12.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions12.ActionID);
+
+            if (notebook.ActiveActions13.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions13.ActionID);
+            if (notebook.ActiveActions14.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions14.ActionID);
+            if (notebook.ActiveActions15.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions15.ActionID);
+            if (notebook.ActiveActions16.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions16.ActionID);
+            if (notebook.ActiveActions17.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions17.ActionID);
+            if (notebook.ActiveActions18.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions18.ActionID);
+
+            if (notebook.ActiveActions19.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions19.ActionID);
+            if (notebook.ActiveActions20.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions20.ActionID);
+            if (notebook.ActiveActions21.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions21.ActionID);
+            if (notebook.ActiveActions22.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions22.ActionID);
+            if (notebook.ActiveActions23.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions23.ActionID);
+            if (notebook.ActiveActions24.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions24.ActionID);
+
+            if (Service.Configuration.ActiveBLUSpells.Except(prevList).Any())
+            Service.Configuration.Save();
+
+        }
+
+    }
+}

--- a/XIVSlothCombo/Combos/BLU.cs
+++ b/XIVSlothCombo/Combos/BLU.cs
@@ -75,8 +75,10 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID == SongOfTorment)
                 {
-                    if (!HasEffect(Buffs.Bristle))
+                    if (!HasEffect(Buffs.Bristle) && IsSpellActive(Bristle))
                         return Bristle;
+
+                    if (IsSpellActive(SongOfTorment))
                     return SongOfTorment;
                 }
 
@@ -92,44 +94,46 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID == MoonFlute || actionID == Whistle)
                 {
-                    if (GetCooldown(TripleTrident).CooldownRemaining < 3)
+                    if (GetCooldown(TripleTrident).CooldownRemaining < 3 && IsSpellActive(TripleTrident))
                     {
-                        if (!HasEffect(Buffs.Whistle))
+                        if (!HasEffect(Buffs.Whistle) && IsSpellActive(Whistle))
                             return Whistle;
-                        if (!HasEffect(Buffs.Tingle))
+                        if (!HasEffect(Buffs.Tingle) && IsSpellActive(Tingle))
                             return Tingle;
-                        if (!HasEffect(Buffs.MoonFlute))
+                        if (!HasEffect(Buffs.MoonFlute) && IsSpellActive(MoonFlute))
                             return MoonFlute;
-                        if (!GetCooldown(JKick).IsCooldown)
+                        if (!GetCooldown(JKick).IsCooldown && IsSpellActive(JKick))
                             return JKick;
                         if (!GetCooldown(TripleTrident).IsCooldown)
                             return TripleTrident;
                     }
 
-                    if (!HasEffect(Buffs.Whistle) && !GetCooldown(JKick).IsCooldown)
+                    if (!HasEffect(Buffs.Whistle) && !GetCooldown(JKick).IsCooldown && IsSpellActive(Whistle))
                         return Whistle;
-                    if (!HasEffect(Buffs.MoonFlute))
+                    if (!HasEffect(Buffs.MoonFlute) && IsSpellActive(MoonFlute))
                         return MoonFlute;
-                    if (!GetCooldown(JKick).IsCooldown)
+                    if (!GetCooldown(JKick).IsCooldown && IsSpellActive(JKick))
                         return JKick;
-                    if (!GetCooldown(Nightbloom).IsCooldown)
+                    if (!GetCooldown(Nightbloom).IsCooldown && IsSpellActive(Nightbloom))
                         return Nightbloom;
-                    if (!GetCooldown(RoseOfDestruction).IsCooldown)
+                    if (!GetCooldown(RoseOfDestruction).IsCooldown && IsSpellActive(RoseOfDestruction))
                         return RoseOfDestruction;
-                    if (!GetCooldown(FeatherRain).IsCooldown)
+                    if (!GetCooldown(FeatherRain).IsCooldown && IsSpellActive(FeatherRain))
                         return FeatherRain;
-                    if (!HasEffect(Buffs.Bristle) && !GetCooldown(All.Swiftcast).IsCooldown)
+                    if (!HasEffect(Buffs.Bristle) && !GetCooldown(All.Swiftcast).IsCooldown && IsSpellActive(Bristle))
                         return Bristle;
                     if (!GetCooldown(All.Swiftcast).IsCooldown)
                         return All.Swiftcast;
-                    if (!GetCooldown(GlassDance).IsCooldown)
+                    if (!GetCooldown(GlassDance).IsCooldown && IsSpellActive(GlassDance))
                         return GlassDance;
-                    if (GetCooldown(Surpanakha).CooldownRemaining < 95)
+                    if (GetCooldown(Surpanakha).CooldownRemaining < 95 && IsSpellActive(Surpanakha))
                         return Surpanakha;
-                    if (!GetCooldown(MatraMagic).IsCooldown && HasEffect(Buffs.DPSMimicry))
+                    if (!GetCooldown(MatraMagic).IsCooldown && HasEffect(Buffs.DPSMimicry) && IsSpellActive(MatraMagic))
                         return MatraMagic;
-                    if (!GetCooldown(ShockStrike).IsCooldown)
+                    if (!GetCooldown(ShockStrike).IsCooldown && IsSpellActive(ShockStrike))
                         return ShockStrike;
+
+                    if (IsSpellActive(PhantomFlurry))
                     return PhantomFlurry;
                 }
 
@@ -146,29 +150,30 @@ namespace XIVSlothComboPlugin.Combos
                 if (actionID == FinalSting)
                 {
 
-                    if (!HasEffect(Buffs.MoonFlute))
+                    if (!HasEffect(Buffs.MoonFlute) && IsSpellActive(MoonFlute))
                         return MoonFlute;
                     if (IsEnabled(CustomComboPreset.BluPrimals))
                     {
-
-                        if (!GetCooldown(RoseOfDestruction).IsCooldown)
+                        if (!GetCooldown(RoseOfDestruction).IsCooldown && IsSpellActive(RoseOfDestruction))
                             return RoseOfDestruction;
-                        if (!GetCooldown(FeatherRain).IsCooldown)
+                        if (!GetCooldown(FeatherRain).IsCooldown && IsSpellActive(FeatherRain))
                             return FeatherRain;
-                        if (!GetCooldown(GlassDance).IsCooldown)
+                        if (!GetCooldown(GlassDance).IsCooldown && IsSpellActive(GlassDance))
                             return GlassDance;
-                        if (!GetCooldown(JKick).IsCooldown)
+                        if (!GetCooldown(JKick).IsCooldown && IsSpellActive(JKick))
                             return JKick;
                     }
 
-                    if (!HasEffect(Buffs.Tingle))
+                    if (!HasEffect(Buffs.Tingle) && IsSpellActive(Tingle))
                         return Tingle;
-                    if (!GetCooldown(ShockStrike).IsCooldown && IsEnabled(CustomComboPreset.BluPrimals))
+                    if (!GetCooldown(ShockStrike).IsCooldown && IsEnabled(CustomComboPreset.BluPrimals) && IsSpellActive(ShockStrike))
                         return ShockStrike;
-                    if (!HasEffect(Buffs.Whistle))
+                    if (!HasEffect(Buffs.Whistle) && IsSpellActive(Whistle))
                         return Whistle;
                     if (!GetCooldown(All.Swiftcast).IsCooldown)
                         return All.Swiftcast;
+
+                    if(IsSpellActive(FinalSting))
                     return FinalSting;
                 }
 
@@ -188,12 +193,13 @@ namespace XIVSlothComboPlugin.Combos
                     var swiftCD = GetCooldown(All.Swiftcast);
                     var ultraCD = GetCooldown(Ultravibration);
 
-                    if (freezeDebuff is null && !ultraCD.IsCooldown)
+                    if (freezeDebuff is null && !ultraCD.IsCooldown && IsSpellActive(RamsVoice))
                         return RamsVoice;
                     if (freezeDebuff is not null)
                     {
                         if (!swiftCD.IsCooldown)
                             return All.Swiftcast;
+                        if (IsSpellActive(Ultravibration))
                         return Ultravibration;
                     }
                 }
@@ -215,11 +221,11 @@ namespace XIVSlothComboPlugin.Combos
                     var offguardCD = GetCooldown(Offguard);
                     var lucidCD = GetCooldown(All.LucidDreaming);
 
-                    if (offguardDebuff is null && !offguardCD.IsCooldown)
+                    if (offguardDebuff is null && !offguardCD.IsCooldown && IsSpellActive(Offguard))
                         return Offguard;
-                    if (TargetHasEffect(Debuffs.Malodorous) && HasEffect(Buffs.TankMimicry))
+                    if (TargetHasEffect(Debuffs.Malodorous) && HasEffect(Buffs.TankMimicry) && IsSpellActive(BadBreath))
                         return BadBreath;
-                    if (!devourCD.IsCooldown && HasEffect(Buffs.TankMimicry))
+                    if (!devourCD.IsCooldown && HasEffect(Buffs.TankMimicry) && IsSpellActive(Devour))
                         return Devour;
                     if (!lucidCD.IsCooldown && LocalPlayer.CurrentMp <= 9000 & level >= All.Levels.LucidDreaming)
                         return All.LucidDreaming;
@@ -262,15 +268,15 @@ namespace XIVSlothComboPlugin.Combos
                     var kickCD = GetCooldown(JKick);
                     var roseCD = GetCooldown(RoseOfDestruction);
 
-                    if (!rainCD.IsCooldown)
+                    if (!rainCD.IsCooldown && IsSpellActive(FeatherRain))
                         return FeatherRain;
-                    if (!shockCD.IsCooldown)
+                    if (!shockCD.IsCooldown && IsSpellActive(ShockStrike))
                         return ShockStrike;
-                    if (!roseCD.IsCooldown)
+                    if (!roseCD.IsCooldown && IsSpellActive(RoseOfDestruction))
                         return RoseOfDestruction;
-                    if (!glassCD.IsCooldown)
+                    if (!glassCD.IsCooldown && IsSpellActive(GlassDance))
                         return GlassDance;
-                    if (!kickCD.IsCooldown)
+                    if (!kickCD.IsCooldown && IsSpellActive(JKick))
                         return JKick;
                 }
 
@@ -286,9 +292,9 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID == WhiteKnightsTour || actionID == BlackKnightsTour)
                 {
-                    if (TargetHasEffect(Debuffs.Slow))
+                    if (TargetHasEffect(Debuffs.Slow) && IsSpellActive(BlackKnightsTour))
                         return BlackKnightsTour;
-                    if (TargetHasEffect(Debuffs.Bind))
+                    if (TargetHasEffect(Debuffs.Bind) && IsSpellActive(WhiteKnightsTour))
                         return WhiteKnightsTour;
                 }
 
@@ -303,9 +309,9 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID == PeripheralSynthesis)
                 {
-                    if (!TargetHasEffect(Debuffs.Lightheaded))
+                    if (!TargetHasEffect(Debuffs.Lightheaded) && IsSpellActive(PeripheralSynthesis))
                         return PeripheralSynthesis;
-                    if (TargetHasEffect(Debuffs.Lightheaded))
+                    if (TargetHasEffect(Debuffs.Lightheaded) && IsSpellActive(MustardBomb))
                         return MustardBomb;
                 }
 

--- a/XIVSlothCombo/Combos/BLU.cs
+++ b/XIVSlothCombo/Combos/BLU.cs
@@ -34,6 +34,7 @@ namespace XIVSlothComboPlugin.Combos
             WhiteKnightsTour = 18310,
             BlackKnightsTour = 18311,
             PeripheralSynthesis = 23286,
+            BasicInstinct = 23276,
             MustardBomb = 23279;
 
         public static class Buffs
@@ -44,7 +45,8 @@ namespace XIVSlothComboPlugin.Combos
                 Tingle = 2492,
                 Whistle = 2118,
                 TankMimicry = 2124,
-                DPSMimicry = 2125;
+                DPSMimicry = 2125,
+                BasicInstinct = 2498;
         }
 
         public static class Debuffs
@@ -149,7 +151,8 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID == FinalSting)
                 {
-
+                    if (IsEnabled(CustomComboPreset.BluSoloMode) && HasCondition(ConditionFlag.BoundByDuty) && !HasEffect(Buffs.BasicInstinct) && GetPartyMembers().Length == 0 && IsSpellActive(BasicInstinct))
+                        return BasicInstinct;
                     if (!HasEffect(Buffs.MoonFlute) && IsSpellActive(MoonFlute))
                         return MoonFlute;
                     if (IsEnabled(CustomComboPreset.BluPrimals))

--- a/XIVSlothCombo/Combos/BLU.cs
+++ b/XIVSlothCombo/Combos/BLU.cs
@@ -35,6 +35,7 @@ namespace XIVSlothComboPlugin.Combos
             BlackKnightsTour = 18311,
             PeripheralSynthesis = 23286,
             BasicInstinct = 23276,
+            HydroPull = 23282,
             MustardBomb = 23279;
 
         public static class Buffs
@@ -196,6 +197,8 @@ namespace XIVSlothComboPlugin.Combos
                     var swiftCD = GetCooldown(All.Swiftcast);
                     var ultraCD = GetCooldown(Ultravibration);
 
+                    if (IsEnabled(CustomComboPreset.BluHydroPull) && !InMeleeRange() && IsSpellActive(HydroPull))
+                        return HydroPull;
                     if (freezeDebuff is null && !ultraCD.IsCooldown && IsSpellActive(RamsVoice))
                         return RamsVoice;
                     if (freezeDebuff is not null)

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -169,7 +169,7 @@ namespace XIVSlothComboPlugin
                 ImGui.TextUnformatted($"LAST SPELL: {ActionWatching.GetActionName(ActionWatching.LastSpell)}");
                 ImGui.TextUnformatted($"LAST ABILITY: {ActionWatching.GetActionName(ActionWatching.LastAbility)}");
                 ImGui.TextUnformatted($"ZONE: {Service.ClientState.TerritoryType}");
-                ImGui.TextUnformatted($"SELECTED BLU SPELLS: {string.Join(", ", Service.Configuration.ActiveBLUSpells.Select(x => ActionWatching.GetActionName(x)).OrderBy(x => x))}");
+                ImGui.TextUnformatted($"SELECTED BLU SPELLS: {string.Join("\n", Service.Configuration.ActiveBLUSpells.Select(x => ActionWatching.GetActionName(x)).OrderBy(x => x))}");
 
             }
             else

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -118,7 +118,6 @@ namespace XIVSlothComboPlugin.Combos
         public bool TryInvoke(uint actionID, byte level, uint lastComboMove, float comboTime, out uint newActionID)
         {
             newActionID = 0;
-
             // Movement
             if (this.MovingCounter == 0)
             {
@@ -132,6 +131,7 @@ namespace XIVSlothComboPlugin.Combos
 
             if (this.MovingCounter > 0)
                 this.MovingCounter--;
+
 
             if (!IsEnabled(this.Preset))
                 return false;
@@ -845,6 +845,14 @@ namespace XIVSlothComboPlugin.Combos
 
         public bool WasLastAbility(uint id)
             => ActionWatching.LastAbility == id;
+
+        /// <summary>
+        /// Returns if the player has set the spell as active in the Blue Mage Spellbook
+        /// </summary>
+        /// <param name="id"></param>
+        /// <returns></returns>
+        public bool IsSpellActive(uint id)
+            => Service.Configuration.ActiveBLUSpells.Contains(id);
 
     }
 }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -450,6 +450,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Peripheral Synthesis into Mustard Bomb", "Turns Peripheral Synthesis into Mustard Bomb when target is under the effect of Lightheaded. \nSpells Required: Peripheral Synthesis, Mustard Bomb.", BLU.JobID)]
         BluLightheadedCombo = 70010,
 
+        [BlueInactive(BLU.BasicInstinct)]
+        [ParentCombo(BluFinalSting)]
+        [CustomComboInfo("Solo Mode", "Uses Basic Instinct if you're in an instance and on your own.", BLU.JobID)]
+        BluSoloMode = 70011,
+
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -400,42 +400,52 @@ namespace XIVSlothComboPlugin
         // ====================================================================================
         #region BLUE MAGE
 
+        [BlueInactive(BLU.SongOfTorment, BLU.Bristle)]
         [ReplaceSkill(BLU.SongOfTorment)]
         [CustomComboInfo("Buffed Song of Torment", "Turns Song of Torment into Bristle so SoT is buffed. \nSpells Required: Song of Torment.", BLU.JobID)]
         BluBuffedSoT = 70000,
 
+        [BlueInactive(BLU.Whistle, BLU.Tingle, BLU.MoonFlute, BLU.JKick, BLU.TripleTrident, BLU.Nightbloom, BLU.RoseOfDestruction, BLU.FeatherRain, BLU.Bristle, BLU.GlassDance, BLU.Surpanakha, BLU.MatraMagic, BLU.ShockStrike, BLU.PhantomFlurry)]
         [ReplaceSkill(BLU.MoonFlute)]
         [CustomComboInfo("Moon Flute Opener", "Puts the Full Moon Flute Opener on Moon Flute or Whistle. \nSpells Required: Whistle, Tingle, Moon Flute, J Kick, Triple Trident, Nightbloom, Rose of Destruction, Feather Rain, Bristle, Glass Dance, Surpanakha, Matra Magic, Shock Strike, Phantom Flurry.", BLU.JobID)]
         BluOpener = 70001,
 
+        [BlueInactive(BLU.MoonFlute, BLU.Tingle, BLU.ShockStrike, BLU.Whistle, BLU.FinalSting)]
         [ReplaceSkill(BLU.FinalSting)]
         [CustomComboInfo("Final Sting Combo", "Turns Final Sting into the buff combo of: Moon Flute, Tingle, Whistle, Final Sting. Will use any primals off CD before casting Final Sting. \nSpells Required: Moon Flute, Tingle, Whistle, Final Sting", BLU.JobID)]
         BluFinalSting = 70002,
 
+        [BlueInactive(BLU.RoseOfDestruction, BLU.FeatherRain, BLU.GlassDance, BLU.JKick)]
         [ParentCombo(BluFinalSting)]
         [CustomComboInfo("Off CD Primal Additions", "Adds any Primals that are off CD to the Final Sting Combo. \nPrimals Used: Feather Rain, Shock Strike, Glass Dance, J Kick, Rose of Destruction. ", BLU.JobID)]
         BluPrimals = 70003,
 
+        [BlueInactive(BLU.RamsVoice, BLU.Ultravibration)]
         [ReplaceSkill(BLU.Ultravibration)]
         [CustomComboInfo("Ram's Voice into Ultravibration", "Turns Ultravibration into Ram's Voice if Deep Freeze isn't on the target. Will swiftcast Ultravibration if available. \nSpells Required: Ram's Voice, Ultravibration. ", BLU.JobID)]
         BluUltravibrate = 70005,
 
+        [BlueInactive(BLU.Offguard, BLU.BadBreath, BLU.Devour)]
         [ReplaceSkill(BLU.Devour, BLU.Offguard, BLU.BadBreath)]
         [CustomComboInfo("Tank Debuff Feature", "Puts Devour, Off-Guard, Lucid Dreaming, and Bad Breath into one button when under Tank Mimicry. \nSpells Required: Devour, Off-Guard, Bad Breath.", BLU.JobID)]
         BluDebuffCombo = 70006,
 
+        [BlueInactive(BLU.MagicHammer)]
         [ReplaceSkill(BLU.MagicHammer)]
         [CustomComboInfo("Addle/Magic Hammer Debuff Feature", "Turns Magic Hammer into Addle when off CD. \nSpells Required: Magic Hammer.", BLU.JobID)]
         BluAddleFeature = 70007,
 
+        [BlueInactive(BLU.FeatherRain, BLU.ShockStrike, BLU.RoseOfDestruction, BLU.GlassDance, BLU.JKick)]
         [ReplaceSkill(BLU.FeatherRain)]
         [CustomComboInfo("Primal Feature", "Turns Feather Rain into any Primals that are off CD. \nSpells Required: Feather Rain, Shock Strike, The Rose of Destruction, Glass Dance, J Kick. \nWill cause primals to desync from Moon Flute burst phases if used on CD.", BLU.JobID)]
         BluPrimalFeature = 70008,
 
+        [BlueInactive(BLU.BlackKnightsTour, BLU.WhiteKnightsTour)]
         [ReplaceSkill(BLU.BlackKnightsTour, BLU.WhiteKnightsTour)]
         [CustomComboInfo("Knight's Tour Feature", "Turns Black Knight's Tour or White Knight's Tour into its counterpart when the enemy is under the effect of the spell's debuff. \nSpells Required: White Knight's Tour, Black Knight's Tour", BLU.JobID)]
         BluKnightFeature = 70009,
 
+        [BlueInactive(BLU.PeripheralSynthesis, BLU.MustardBomb)]
         [ReplaceSkill(BLU.PeripheralSynthesis)]
         [CustomComboInfo("Peripheral Synthesis into Mustard Bomb", "Turns Peripheral Synthesis into Mustard Bomb when target is under the effect of Lightheaded. \nSpells Required: Peripheral Synthesis, Mustard Bomb.", BLU.JobID)]
         BluLightheadedCombo = 70010,

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -455,6 +455,11 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Solo Mode", "Uses Basic Instinct if you're in an instance and on your own.", BLU.JobID)]
         BluSoloMode = 70011,
 
+        [BlueInactive(BLU.HydroPull)]
+        [ParentCombo(BluUltravibrate)]
+        [CustomComboInfo("Hydro Pull Setup", "Uses Hydro Pull before using Ram's Voice.", BLU.JobID)]
+        BluHydroPull = 70012,
+
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/IconReplacer.cs
+++ b/XIVSlothCombo/IconReplacer.cs
@@ -74,6 +74,8 @@ namespace XIVSlothComboPlugin
                 var comboTime = *(float*)Service.Address.ComboTimer;
                 var level = Service.ClientState.LocalPlayer?.Level ?? 0;
 
+                BlueMageService.PopulateBLUSpells();
+
                 foreach (var combo in this.customCombos)
                 {
                     if (combo.TryInvoke(actionID, level, lastComboMove, comboTime, out var newActionID))

--- a/XIVSlothCombo/PluginConfiguration.cs
+++ b/XIVSlothCombo/PluginConfiguration.cs
@@ -62,7 +62,7 @@ namespace XIVSlothComboPlugin
         public HashSet<CustomComboPreset> EnabledActions4 { get; set; } = new();
 
         /// <summary>
-        /// Gets or sets a value indicating whether to allow and display secret combos.
+        /// Gets or sets a value indicating whether to output combat log to the chatbox.
         /// </summary>
         public bool EnabledOutputLog { get; set; } = false;
 
@@ -312,6 +312,8 @@ namespace XIVSlothComboPlugin
             if (array == Array.Empty<bool>()) return false;
             return array[index];
         }
+
+        public List<uint> ActiveBLUSpells { get; set; } = new List<uint>();
 
         private static int RoleIDToArrayIndex(byte key)
         {

--- a/XIVSlothCombo/Service.cs
+++ b/XIVSlothCombo/Service.cs
@@ -131,5 +131,8 @@ namespace XIVSlothComboPlugin
         [PluginService]
         internal static PartyList PartyList { get; private set; } = null!;
 
+        [PluginService]
+        internal static GameGui GameGui { get; private set; } = null!;
+
     }
 }


### PR DESCRIPTION
[BLU]
- New tracking of active spells. Requires the player to open the Blue Magic Spellbook to register any existing active spells.
- Features will skip over spells if the player does not have them active. Huzzah for all us non-Matra Magic having folks.
- Config window now displays which spells you still have to activate to meet the feature's quota of spells.
- `Solo Mode` feature added to `Final Sting Combo`. Checks if able to use Basic Instinct to increase damage for maximum one shot damage.
- `Hydro Pull Setup` feature added to `Ram's Voice into Ultravibration`. If the target is not in melee range, uses Hydro Pull to grab them into range for vibe checking.