### PR TITLE
PLD: Expiacion and Circle of Scorn option

### DIFF
--- a/XIVSlothCombo/Combos/PLD.cs
+++ b/XIVSlothCombo/Combos/PLD.cs
@@ -148,12 +148,17 @@
                     // oGCD features
                     if (CanWeave(actionID))
                     {
-                        if (IsEnabled(CustomComboPreset.PaladinExpiacionScornFeature) && incombat && lastComboMove != FastBlade && lastComboMove != RiotBlade)
+                        if (IsEnabled(CustomComboPreset.PaladinExpiacionScornFeature) && incombat && IsOffCooldown(OriginalHook(SpiritsWithin)) && level >= Levels.SpiritsWithin)
                         {
-                            if (level >= Levels.SpiritsWithin && IsOffCooldown(SpiritsWithin))
+                            if (IsNotEnabled(CustomComboPreset.PaladinExpiacionScornOption) ||
+                                (IsEnabled(CustomComboPreset.PaladinExpiacionScornOption) && HasEffect(Buffs.FightOrFlight) || IsOnCooldown(FightOrFlight)))
                                 return OriginalHook(SpiritsWithin);
-
-                            if (level >= Levels.CircleOfScorn && IsOffCooldown(CircleOfScorn))
+                        }
+                        
+                        if (IsEnabled(CustomComboPreset.PaladinExpiacionScornFeature) && incombat && IsOffCooldown(CircleOfScorn) && level >= Levels.CircleOfScorn)
+                        {
+                            if (IsNotEnabled(CustomComboPreset.PaladinExpiacionScornOption) ||
+                                (IsEnabled(CustomComboPreset.PaladinExpiacionScornOption) && HasEffect(Buffs.FightOrFlight) || IsOnCooldown(FightOrFlight)))
                                 return CircleOfScorn;
                         }
 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1708,6 +1708,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Melee Intervene Option", "Uses Intervene when under Fight or Flight and in the target ring (1 yalm).\nWill use as many stacks as selected in the above slider.", PLD.JobID, 4, "", "")]
         PaladinMeleeInterveneOption = 11026,
 
+        [ParentCombo(PaladinExpiacionScornFeature)]
+        [CustomComboInfo("Expiacion and Circle of Scorn Option", "Uses Circle of Scorn and Expiacion when under Fight or Flight or when Fight or Flight is on cooldown", PLD.JobID, 4, "", "")]
+        PaladinExpiacionScornOption = 11027,
+
         #endregion
         // ====================================================================================
         #region REAPER


### PR DESCRIPTION
[PLD]
Added `Expiacion and Circle of Scorn option` to only use during FoF windows, or when FoF is on cooldown.
Normal `Expiacion and Circle of Scorn feature` now uses it on cooldown.