### PR TITLE
RDM Embolden Feature, Embolden checks and WHM Feature

### DIFF
--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -335,7 +335,7 @@ namespace XIVSlothComboPlugin.Combos
                         if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) && level >= 90 && (gauge.ManaStacks == 0 || gauge.ManaStacks == 3)
                             && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                             && System.Math.Max(black, white) <= 50
-                            && HasEffect(Buffs.Embolden)
+                            && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden))
                             && IsOffCooldown(Manafication))
                         {
                             return Manafication;
@@ -352,7 +352,7 @@ namespace XIVSlothComboPlugin.Combos
                         if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) && level >= Levels.Manafication && (gauge.ManaStacks == 0 || gauge.ManaStacks == 3)
                             && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                             && System.Math.Max(black, white) <= 50
-                            && HasEffect(Buffs.Embolden)
+                            && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden))
                             && IsOffCooldown(Manafication))
                         {
                             return Manafication;
@@ -383,13 +383,13 @@ namespace XIVSlothComboPlugin.Combos
                     if (level >= Levels.Manafication && ((gauge.ManaStacks == 3 && System.Math.Min(black, white) >= 2) || (gauge.ManaStacks == 0 && System.Math.Min(black, white) >= 10))
                         && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                         && System.Math.Max(black, white) <= 50
-                        && HasEffect(Buffs.Embolden)
+                        && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden))
                         && IsOffCooldown(Manafication))
                     {
                         return Manafication;
                     }
 
-                    //Situation 2: Manafication first (Single)
+                    //Situation 2: Embolden First (Single)
                     if (level >= Levels.Manafication && gauge.ManaStacks == 0
                         && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                         && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
@@ -400,7 +400,7 @@ namespace XIVSlothComboPlugin.Combos
                     if (level >= Levels.Manafication && gauge.ManaStacks == 0 
                         && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
                         && System.Math.Max(black, white) <= 50 && System.Math.Min(black, white) >= 10
-                        && HasEffect(Buffs.Embolden)
+                        && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden))
                         && IsOffCooldown(Manafication))
                     {
                         return Manafication;
@@ -575,8 +575,8 @@ namespace XIVSlothComboPlugin.Combos
                 //RDM_AOE_MELEECOMBO
                 if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo) && level >= Levels.Moulinet && actionID is Scatter or Impact && LocalPlayer.IsCasting == false
                     && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration)
-                    && ((System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60) || (level < Levels.Manafication && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
-                    && ((GetTargetDistance() <= moulinetRange && gauge.ManaStacks == 0) || gauge.ManaStacks > 0))
+                    && ((System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60) || (level < Levels.Verflare && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
+                    && ((GetTargetDistance() <= moulinetRange && gauge.ManaStacks == 0) || gauge.ManaStacks >= 1))
                     return OriginalHook(EnchantedMoulinet);
                 //END_RDM_AOE_MELEECOMBO
 
@@ -594,7 +594,7 @@ namespace XIVSlothComboPlugin.Combos
 
                 //RDM_AoE_ACCELERATION
                 if (IsEnabled(CustomComboPreset.RDM_AoE_Acceleration) && actionID is Scatter or Impact && LocalPlayer.IsCasting == false && gauge.ManaStacks == 0
-                    && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch
+                    && lastComboMove is not Verflare && lastComboMove is not Verholy && lastComboMove is not Scorch && !WasLastAction(Embolden)
                     && (IsNotEnabled(CustomComboPreset.RDM_AoE_WeaveAcceleration) || CanSpellWeave(actionID))
                     && !HasEffect(Buffs.Acceleration) && !HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast))
                 {
@@ -704,5 +704,14 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
+        internal class RDM_EmboldenManafication : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_EmboldenManafication;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Embolden && level >= Levels.Manafication && IsOnCooldown(Embolden) && IsOffCooldown(Manafication)) { return Manafication; }
+                return actionID;
+            }
+        }
     }
 }

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -436,7 +436,7 @@ namespace XIVSlothComboPlugin.Combos
                     if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) && IsEnabled(CustomComboPreset.RDM_PoolCorps)) corpsacorpsPool = 1;
                     if (IsEnabled(CustomComboPreset.RDM_Engagement) && IsEnabled(CustomComboPreset.RDM_PoolEngage)) engagementPool = 1;
 
-                    if (actionID is Jolt or Jolt2 or Scatter or Impact or Fleche)
+                    if (actionID is Jolt or Jolt2 or Scatter or Impact or Fleche or Riposte or Moulinet)
                     {
                         if (IsEnabled(CustomComboPreset.RDM_Engagement) && GetCooldown(Engagement).RemainingCharges >= engagementPool 
                             && (GetCooldown(Engagement).ChargeCooldownRemaining < 3 || IsNotEnabled(CustomComboPreset.RDM_PoolEngage))
@@ -450,7 +450,8 @@ namespace XIVSlothComboPlugin.Combos
 
                         if ((actionID is Jolt or Jolt2) && (radioButton is 2 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
                         if ((actionID is Scatter or Impact) && (radioButton is 3 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
-                        if (actionID is Fleche && radioButton == 1 && placeOGCD == 0) // All actions are on cooldown, determine the lowest CD to display on Fleche.
+                        if ((actionID is Riposte or Moulinet) && (radioButton is 5 or 6) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
+                        if (actionID is Fleche && radioButton is 1 or 6 && placeOGCD == 0) // All actions are on cooldown, determine the lowest CD to display on Fleche.
                         {
                             placeOGCD = Fleche;
                             if (IsEnabled(CustomComboPreset.RDM_ContraSixte) && level >= Levels.ContreSixte

--- a/XIVSlothCombo/Combos/WHM.cs
+++ b/XIVSlothCombo/Combos/WHM.cs
@@ -28,6 +28,8 @@ namespace XIVSlothComboPlugin.Combos
             Stone3 = 3568,
             Stone4 = 7431,
             Assize = 3571,
+            Holy = 139,
+            Holy3 = 25860,
 
             // DoT
             Dia = 16532,
@@ -81,6 +83,7 @@ namespace XIVSlothComboPlugin.Combos
         {
             public const string
                 WHMLucidDreamingFeature = "WHMLucidDreamingFeature",
+                WHM_AoE_Lucid = "WHM_AoE_Lucid",
                 WHMogcdHealsShieldsFeature = "WHMogcdHealsShieldsFeature";
         }
 
@@ -321,6 +324,34 @@ namespace XIVSlothComboPlugin.Combos
                 return actionID;
             }
         }
+        internal class WHM_AoE_DPS_Feature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHM_AoE_DPS_Feature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Holy or Holy3)
+                {
+                    var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.WHM_AoE_Lucid);
+                    var gauge = GetJobGauge<WHMGauge>();
+
+                    if (CanSpellWeave(actionID) && IsEnabled(CustomComboPreset.WHM_AoE_Lucid) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
+                        return All.LucidDreaming;
+
+                    if (CanSpellWeave(actionID) && IsEnabled(CustomComboPreset.WHM_AoE_Assize) && level >= Levels.Assize && IsOffCooldown(Assize))
+                        return Assize;
+
+                    if (IsEnabled(CustomComboPreset.WHM_AoE_LilyOvercap) && level >= Levels.AfflatusRapture && ((gauge.Lily == 3 && gauge.BloodLily < 3) || (gauge.Lily == 2 && gauge.LilyTimer >= 17000)))
+                        return AfflatusRapture;
+
+                    if (IsEnabled(CustomComboPreset.WHM_AoE_AfflatusMisery) && level >= Levels.AfflatusMisery && gauge.BloodLily >= 3 && CurrentTarget is Dalamud.Game.ClientState.Objects.Types.BattleNpc)
+                        return AfflatusMisery;
+                }
+
+                return actionID;
+            }
+        }
+
     }
 
 }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -1163,6 +1163,9 @@ namespace XIVSlothComboPlugin
             if (preset == CustomComboPreset.WHMLucidDreamingFeature)
                 ConfigWindowFunctions.DrawSliderInt(4000, 9500, WHM.Config.WHMLucidDreamingFeature, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);
 
+            if (preset == CustomComboPreset.WHM_AoE_Lucid)
+                ConfigWindowFunctions.DrawSliderInt(4000, 9500, WHM.Config.WHM_AoE_Lucid, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);
+
             if (preset == CustomComboPreset.WHMogcdHealsShieldsFeature)
                 ConfigWindowFunctions.DrawSliderInt(0, 100, WHM.Config.WHMogcdHealsShieldsFeature, "Set HP% of target to use Tetragrammaton");
 

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -988,7 +988,7 @@ namespace XIVSlothComboPlugin
             #region RED MAGE
 
             if (preset == CustomComboPreset.RDM_OGCD)
-                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_OGCD_OnAction, "Use on Fleche", "", 1);
+                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_OGCD_OnAction, "Use on Fleche only", "", 1);
 
             if (preset == CustomComboPreset.RDM_OGCD)
                 ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_OGCD_OnAction, "Use on Jolt/Jolt II only", "", 2);
@@ -997,7 +997,13 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_OGCD_OnAction, "Use on Scatter/Impact only", "", 3);
 
             if (preset == CustomComboPreset.RDM_OGCD)
-                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_OGCD_OnAction, "Use on Jolt/Jolt II & Scatter/Impact", "[Choose Jolt or Impact for a one button rotation]\n---------------------------------------------------------------", 4);
+                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_OGCD_OnAction, "Use on Jolt/Jolt II & Scatter/Impact", "", 4);
+
+            if (preset == CustomComboPreset.RDM_OGCD)
+                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_OGCD_OnAction, "Use on Riposte/Moulinet only", "", 5);
+
+            if (preset == CustomComboPreset.RDM_OGCD)
+                ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_OGCD_OnAction, "Use on Fleche & Riposte/Moulinet", "[Choose Jolt or Impact for a one button rotation]\n---------------------------------------------------------------", 6);
 
             if (preset == CustomComboPreset.RDM_ST_MeleeCombo)
                 ConfigWindowFunctions.DrawRadioButton(RDM.Config.RDM_ST_MeleeCombo_OnAction, "Use on Riposte", "", 1);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2007,7 +2007,7 @@ namespace XIVSlothComboPlugin
         RDM_AoE_ManaficationEmbolden = 13421,
 
         [ParentCombo(RDM_ST_MeleeCombo)]
-        [CustomComboInfo("Gap close with Corps-a-corps", "Use Corp-a-corps when out of melee range before starting the melee combo", RDM.JobID, 430)]
+        [CustomComboInfo("Gap close with Corps-a-corps", "Use Corp-a-corps when out of melee range when you have enough mana to start the melee combo", RDM.JobID, 430)]
         RDM_ST_CorpsGapClose = 13430,
 
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2007,7 +2007,7 @@ namespace XIVSlothComboPlugin
         RDM_AoE_ManaficationEmbolden = 13421,
 
         [ParentCombo(RDM_ST_MeleeCombo)]
-        [CustomComboInfo("Gap close with Corps-a-corps", "Use Corp-a-corps when out of melee range when you have enough mana to start the melee combo", RDM.JobID, 430)]
+        [CustomComboInfo("Gap close with Corps-a-corps", "Use Corp-a-corps when out of melee range and you have enough mana to start the melee combo", RDM.JobID, 430)]
         RDM_ST_CorpsGapClose = 13430,
 
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2029,19 +2029,24 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Displacement <> Corps-a-corps", "Replace Displacement with Corps-a-corps when out of range.", RDM.JobID, 810, "I take two steps forward, you take two steps back.", "We come together because opposites attract.")]
         RDM_CorpsDisplacement = 13810,
 
+        [ReplaceSkill(RDM.Embolden)]
+        //[ConflictingCombos(RDM_ST_ManaficationEmbolden)]
+        [CustomComboInfo("Embolden to Manafication", "Changes Embolden to Manafication when on cooldown.", RDM.JobID, 820, "You're approaching me?", "do do do do do do do do do")]
+        RDM_EmboldenManafication = 13820,
+
         #endregion
         // ====================================================================================
         #region SAGE
 
-            //SAGE_FEATURE_NUMBERING
+        //SAGE_FEATURE_NUMBERING
         //Numbering Scheme: 14[Feature][Option][Sub-Option]
         //Example: 14110 (Feature Number 1, Option 1, no suboption)
         //New features should be added to the appropriate sections.
 
-            #region SAGE DPS
+        #region SAGE DPS
 
-                #region Single Target DPS Feature
-                [ReplaceSkill(SGE.Dosis1, SGE.Dosis2, SGE.Dosis3)]
+        #region Single Target DPS Feature
+        [ReplaceSkill(SGE.Dosis1, SGE.Dosis2, SGE.Dosis3)]
                 [CustomComboInfo("Single Target DPS Feature", "Replaces Dosis with options below", SGE.JobID, 100)]
                 SGE_ST_DosisFeature = 14100,
                 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2815,6 +2815,26 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Prioritize oGCD Heals/Shields on Cure II when available.", "Displays oGCD Heals/Shields over Afflatus.\n(Only applies to GCD options for Tetragrammaton and Divine Benison)", WHM.JobID, 0, "That, not this.", "Shields over flowers.")]
         WHMPrioritizeoGCDHealsShields = 19024,
 
+        [ReplaceSkill(WHM.Holy, WHM.Holy3)]
+        [CustomComboInfo("CDs on Holy/Holy3", "Collection of CDs and spell features on Holy/Holy3.", WHM.JobID, 0, "Weak", "WHM DPS rotation too much?")]
+        WHM_AoE_DPS_Feature = 19190,
+
+        [ParentCombo(WHM_AoE_DPS_Feature)]
+        [CustomComboInfo("Lucid Dreaming Feature", "Adds Lucid dreaming to the AoE DPS feature when below set MP value.", WHM.JobID, 0, "Dream within a Dream", "Awake, yet wholly asleep")]
+        WHM_AoE_Lucid = 19191,
+
+        [ParentCombo(WHM_AoE_DPS_Feature)]
+        [CustomComboInfo("Assize Feature", "Adds Assize as oGCD to Holy/Holy3", WHM.JobID, 0, "", "Size 'em up, knock 'em down")]
+        WHM_AoE_Assize = 19192,
+
+        [ParentCombo(WHM_AoE_DPS_Feature)]
+        [CustomComboInfo("Lily Overcap Protection", "Adds Afflatus Rapture (AoE Heal) to Holy/Holy3 when at 3 lilies.", WHM.JobID, 0, "Feed the blood lily!", "Burn out the bad! Burn out the bad!")]
+        WHM_AoE_LilyOvercap = 19193,
+
+        [ParentCombo(WHM_AoE_DPS_Feature)]
+        [CustomComboInfo("Adds Afflatus Misery to Holy/Holy3", "Adds Afflatus Misery to Holy/Holy3 when Blood Lily is in full bloom.", WHM.JobID, 0, "Take this!", "**Throws Blood**")]
+        WHM_AoE_AfflatusMisery = 19194,
+
         #endregion
         // ====================================================================================
         #region DOH


### PR DESCRIPTION
[RDM]
 - Added `Embolden to Manafication` feature. (https://github.com/Nik-Potokar/XIVSlothCombo/issues/355)
 - Improved checks for `Embolden` before `Manafication` is used
 - Added `Riposte and Moulinet` and `Fleche, Riposte and Moulinet` to `Weave OGCD Damage` feature
 - Updated the description for `Gap close with Corps-a-corps` to specify that you need the required mana to start the melee combo

[WHM]
 - Added `AoE DPS Feature` including `Lucid Dreaming`, `Assize`, `Lily Overcap Protection` and `Afflatus Misery` when targeting an NPC. (https://github.com/Nik-Potokar/XIVSlothCombo/issues/355)