### PR TITLE
[Framework] Null Access Exception correction

### DIFF
--- a/XIVSlothCombo/Combos/AST.cs
+++ b/XIVSlothCombo/Combos/AST.cs
@@ -565,7 +565,7 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID == AspectedHelios)
                 {
-                    var heliosBuff = FindEffect(Buffs.AspectedHelios);
+                    var heliosBuff = GetBuffRemainingTime(Buffs.AspectedHelios);
                     var horoscopeCD = GetCooldown(Horoscope);
                     var celestialOppositionCD = GetCooldown(CelestialOpposition);
                     var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
@@ -597,7 +597,7 @@ namespace XIVSlothComboPlugin.Combos
                             return OriginalHook(Horoscope);
                     }
 
-                    if (HasEffect(Buffs.AspectedHelios) && heliosBuff.RemainingTime > 2)
+                    if (HasEffect(Buffs.AspectedHelios) && heliosBuff > 2)
                         return Helios;
                 }
 

--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -1173,7 +1173,7 @@ namespace XIVSlothComboPlugin.Combos
                         // Transpose if F3 is available, or Thundercloud + Xenoglossy is available
                         if (currentMP < MP.AspectFire && lastComboMove != Manafont && IsOnCooldown(Manafont) && GetCooldownRemainingTime(Manafont) <= 118)
                         {
-                            if ((HasEffect(Buffs.LeyLines) && FindEffect(Buffs.LeyLines).RemainingTime >= 15) || HasEffect(Buffs.Firestarter) ||
+                            if ((HasEffect(Buffs.LeyLines) && GetBuffRemainingTime(Buffs.LeyLines) >= 15) || HasEffect(Buffs.Firestarter) ||
                                  lastComboMove == Xenoglossy || lastComboMove == Thunder3 || (IsOffCooldown(All.Swiftcast) && (gauge.PolyglotStacks == 2)))
                             {
                                 if (lastComboMove != Despair && lastComboMove != Fire4)

--- a/XIVSlothCombo/Combos/BRD.cs
+++ b/XIVSlothCombo/Combos/BRD.cs
@@ -733,7 +733,7 @@ namespace XIVSlothComboPlugin.Combos
                         var causticDuration = FindTargetEffect(Debuffs.CausticBite);
                         var stormbiteDuration = FindTargetEffect(Debuffs.Stormbite);
 
-                        var ragingStrikesDuration = FindEffect(Buffs.RagingStrikes);
+                        var ragingStrikesDuration = GetBuffRemainingTime(Buffs.RagingStrikes);
 
                         var ragingJawsRenewTime = Service.Configuration.GetCustomIntValue(Config.RagingJawsRenewTime);
 
@@ -750,7 +750,7 @@ namespace XIVSlothComboPlugin.Combos
                             (level >= Levels.IronJaws && poisonRecast(4)) ||
                             (level >= Levels.IronJaws && windRecast(4)) ||
                             (level >= Levels.IronJaws && IsEnabled(CustomComboPreset.BardSimpleRagingJaws) &&
-                                HasEffect(Buffs.RagingStrikes) && ragingStrikesDuration.RemainingTime < ragingJawsRenewTime &&
+                                HasEffect(Buffs.RagingStrikes) && ragingStrikesDuration < ragingJawsRenewTime &&
                                 poisonRecast(40) && windRecast(40))
                         );
 

--- a/XIVSlothCombo/Combos/DNC.cs
+++ b/XIVSlothCombo/Combos/DNC.cs
@@ -439,15 +439,15 @@ namespace XIVSlothComboPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if (actionID is DNC.Cascade)
+            if (actionID is Cascade)
             {
                 var gauge = GetJobGauge<DNCGauge>();
                 var canWeave = CanWeave(actionID);
                 var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
                 var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
-                var techBurstTimer = FindEffect(Buffs.TechnicalFinish);
+                var techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
                 var techBurst = HasEffect(Buffs.TechnicalFinish);
-                var flourishReady = level >= Levels.Flourish && IsOffCooldown(Flourish);
+                var flourishReady = level >= Levels.Flourish && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
                 var devilmentReady = level >= Levels.Devilment && IsOffCooldown(Devilment);
                 var improvisationReady = level >= Levels.Improvisation && IsOffCooldown(Improvisation);
                 var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
@@ -478,16 +478,16 @@ namespace XIVSlothComboPlugin.Combos
                 // Simple ST Standard (activates dance with no target, or when target is over HP% threshold)
                 if (!HasTarget() || EnemyHealthPercentage() > standardStepBurstThreshold)
                 {
-                    if (level >= DNC.Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) && IsOffCooldown(DNC.StandardStep)
-                        && ((!HasEffect(DNC.Buffs.TechnicalStep) && !techBurst) || techBurstTimer.RemainingTime > 5))
-                        return DNC.StandardStep;
+                    if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleStandardFeature) && IsOffCooldown(StandardStep)
+                        && ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer > 5))
+                        return StandardStep;
                 }
 
                 // Simple ST Tech (activates dance with no target, or when target is over HP% threshold)
                 if (!HasTarget() || EnemyHealthPercentage() > technicalStepBurstThreshold)
                 {
-                    if (level >= DNC.Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) && !HasEffect(DNC.Buffs.StandardStep) && IsOffCooldown(DNC.TechnicalStep))
-                        return DNC.TechnicalStep;
+                    if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleTechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
+                        return TechnicalStep;
                 }
 
                 if (canWeave)
@@ -503,10 +503,6 @@ namespace XIVSlothComboPlugin.Combos
                     if (IsEnabled(CustomComboPreset.DancerSimpleFlourishFeature) && flourishReady)
                         return Flourish;
                 }
-                
-                // Simple ST Saber Dance
-                if (level >= Levels.SaberDance && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
-                    return SaberDance;
 
                 // Occurring within weave windows
                 if (canWeave)
@@ -529,7 +525,7 @@ namespace XIVSlothComboPlugin.Combos
                     // Simple ST FD4 
                     if (HasEffect(Buffs.FourFoldFanDance))
                         return FanDance4;
-                    
+
                     // Simple ST Panic Heals
                     if (IsEnabled(CustomComboPreset.DancerSimplePanicHealsFeature))
                     {
@@ -539,14 +535,20 @@ namespace XIVSlothComboPlugin.Combos
                         if (PlayerHealthPercentageHp() < secondWindThreshold && secondWindReady)
                             return All.SecondWind;
                     }
-                    
+
                     // Simple ST Improvisation
                     if (IsEnabled(CustomComboPreset.DancerSimpleImprovFeature) && improvisationReady)
                         return Improvisation;
                 }
 
+                // Simple ST Saber Dance
+                if (level >= Levels.SaberDance && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
+                return SaberDance;
+
+
+
                 // Simple ST Combos and burst attacks
-                if (level >= Levels.Fountain && lastComboMove is DNC.Cascade && comboTime < 2 && comboTime > 0)
+                if (level >= Levels.Fountain && lastComboMove is Cascade && comboTime < 2 && comboTime > 0)
                     return Fountain;
 
                 // Tillana
@@ -563,7 +565,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (level >= Levels.ReverseCascade && symmetry)
                     return ReverseCascade;
                 
-                if (level >= Levels.Fountain && lastComboMove is DNC.Cascade && comboTime > 0)
+                if (level >= Levels.Fountain && lastComboMove is Cascade && comboTime > 0)
                     return Fountain;
 
                 return Cascade;
@@ -579,13 +581,13 @@ namespace XIVSlothComboPlugin.Combos
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is DNC.Windmill)
+                if (actionID is Windmill)
                 {
                     var gauge = GetJobGauge<DNCGauge>();
                     var canWeave = CanWeave(actionID);
                     var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
                     var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
-                    var techBurstTimer = FindEffect(Buffs.TechnicalFinish);
+                    var techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
                     var techBurst = HasEffect(Buffs.TechnicalFinish);
                     var flourishReady = level >= Levels.Flourish && IsOffCooldown(Flourish);
                     var devilmentReady = level >= Levels.Devilment && IsOffCooldown(Devilment);
@@ -617,16 +619,16 @@ namespace XIVSlothComboPlugin.Combos
                     // Simple AoE Standard (activates dance with no target, or when target is over HP% threshold)
                     if (!HasTarget() || EnemyHealthPercentage() > standardStepBurstThreshold)
                     {
-                        if (level >= DNC.Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) && IsOffCooldown(DNC.StandardStep)
-                            && ((!HasEffect(DNC.Buffs.TechnicalStep) && !techBurst) || techBurstTimer.RemainingTime > 5))
-                            return DNC.StandardStep;
+                        if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DancerSimpleAoEStandardFeature) && IsOffCooldown(StandardStep)
+                            && ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer > 5))
+                            return StandardStep;
                     }
 
                     // Simple AoE Tech (activates dance with no target, or when target is over HP% threshold)
                     if (!HasTarget() || EnemyHealthPercentage() > technicalStepBurstThreshold)
                     {
-                        if (level >= DNC.Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) && !HasEffect(DNC.Buffs.StandardStep) && IsOffCooldown(DNC.TechnicalStep))
-                            return DNC.TechnicalStep;
+                        if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DancerSimpleAoETechnicalFeature) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
+                            return TechnicalStep;
                     }
 
                     if (canWeave)
@@ -689,7 +691,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
 
                     // Simple AoE Combos and burst attacks
-                    if (level >= Levels.Bladeshower && lastComboMove is DNC.Windmill && comboTime < 2 && comboTime > 0)
+                    if (level >= Levels.Bladeshower && lastComboMove is Windmill && comboTime < 2 && comboTime > 0)
                         return Bladeshower;
 
                     // Tillana
@@ -706,7 +708,7 @@ namespace XIVSlothComboPlugin.Combos
                     if (level >= Levels.RisingWindmill && symmetry)
                         return RisingWindmill;
 
-                    if (level >= Levels.Bladeshower && lastComboMove is DNC.Windmill && comboTime > 0)
+                    if (level >= Levels.Bladeshower && lastComboMove is Windmill && comboTime > 0)
                         return Bladeshower;
                 }
 

--- a/XIVSlothCombo/Combos/DRG.cs
+++ b/XIVSlothCombo/Combos/DRG.cs
@@ -307,7 +307,7 @@ namespace XIVSlothComboPlugin.Combos
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var Disembowel = FindEffect(Buffs.PowerSurge);
+                var Disembowel = GetBuffRemainingTime(Buffs.PowerSurge);
                 var gauge = GetJobGauge<DRGGauge>();
 
                 if (actionID is DRG.FullThrust)
@@ -658,7 +658,7 @@ namespace XIVSlothComboPlugin.Combos
 
                     if (comboTime > 0)
                     {
-                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.Disembowel && (Disembowel is null || (Disembowel.RemainingTime < 10)))
+                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.Disembowel && Disembowel < 10)
                             return DRG.Disembowel;
 
                         if (lastComboMove is DRG.Disembowel && level >= Levels.ChaoticSpring)

--- a/XIVSlothCombo/Combos/MNK.cs
+++ b/XIVSlothCombo/Combos/MNK.cs
@@ -144,7 +144,7 @@ namespace XIVSlothComboPlugin.Combos
                                 if (((GetRemainingCharges(PerfectBalance) == 2) ||
                                     (GetRemainingCharges(PerfectBalance) == 1 && GetCooldownChargeRemainingTime(PerfectBalance) < 4) ||
                                     (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.Brotherhood)) ||
-                                    (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.RiddleOfFire) && FindEffect(Buffs.RiddleOfFire).RemainingTime < 10) ||
+                                    (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.RiddleOfFire) && GetBuffRemainingTime(Buffs.RiddleOfFire) < 10) ||
                                     (GetRemainingCharges(PerfectBalance) >= 1 && GetCooldownRemainingTime(RiddleOfFire) < 4 && GetCooldownRemainingTime(Brotherhood) < 8)))
                                 {
                                     return PerfectBalance;
@@ -249,11 +249,11 @@ namespace XIVSlothComboPlugin.Combos
                 if (actionID == TrueStrike)
                 {
                     var disciplinedFistBuff = HasEffect(Buffs.DisciplinedFist);
-                    var disciplinedFistDuration = FindEffect(Buffs.DisciplinedFist);
+                    var disciplinedFistDuration = GetBuffRemainingTime(Buffs.DisciplinedFist);
 
                     if (level >= Levels.TrueStrike)
                     {
-                        if ((!disciplinedFistBuff && level >= Levels.TwinSnakes) || (disciplinedFistDuration.RemainingTime < 6 && level >= Levels.TwinSnakes))
+                        if ((!disciplinedFistBuff && level >= Levels.TwinSnakes) || (disciplinedFistDuration < 6 && level >= Levels.TwinSnakes))
                             return TwinSnakes;
                         return TrueStrike;
                     }
@@ -327,8 +327,8 @@ namespace XIVSlothComboPlugin.Combos
                     var canWeave = CanWeave(actionID, 0.5);
                     var canDelayedWeave = CanWeave(actionID, 0.0) && GetCooldown(actionID).CooldownRemaining < 0.7;
 
-                    var twinsnakeDuration = FindEffect(Buffs.DisciplinedFist);
-                    var demolishDuration = FindTargetEffect(Debuffs.Demolish);
+                    var twinsnakeDuration = GetBuffRemainingTime(Buffs.DisciplinedFist);
+                    var demolishDuration = GetDebuffRemainingTime(Debuffs.Demolish);
 
                     var pbStacks = FindEffectAny(Buffs.PerfectBalance);
                     var lunarNadi = gauge.Nadi == Nadi.LUNAR;
@@ -453,7 +453,7 @@ namespace XIVSlothComboPlugin.Combos
                                         (GetRemainingCharges(PerfectBalance) == 1 && GetCooldownChargeRemainingTime(PerfectBalance) < 4) ||
                                         (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.Brotherhood)) ||
                                         (GetRemainingCharges(PerfectBalance) >= 1 && GetCooldownRemainingTime(RiddleOfFire) < 3 && GetCooldownRemainingTime(Brotherhood) > 40) ||
-                                        (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.RiddleOfFire) && FindEffect(Buffs.RiddleOfFire).RemainingTime > 6) ||
+                                        (GetRemainingCharges(PerfectBalance) >= 1 && HasEffect(Buffs.RiddleOfFire) && GetBuffRemainingTime(Buffs.RiddleOfFire) > 6) ||
                                         (GetRemainingCharges(PerfectBalance) >= 1 && GetCooldownRemainingTime(RiddleOfFire) < 3 && GetCooldownRemainingTime(Brotherhood) < 10)))
                                     {
                                         return PerfectBalance;
@@ -525,18 +525,18 @@ namespace XIVSlothComboPlugin.Combos
                                 bool demolishFirst = !TargetHasEffect(Debuffs.Demolish);
                                 if (!demolishFirst && HasEffect(Buffs.DisciplinedFist))
                                 {
-                                    demolishFirst = twinsnakeDuration.RemainingTime >= demolishDuration.RemainingTime;
+                                    demolishFirst = twinsnakeDuration >= demolishDuration;
                                 }
                                 return demolishFirst ? Demolish : TwinSnakes;
                             }
                         }
                         if (canSolar && (lunarNadi || !solarNadi))
                         {
-                            if (!raptorChakra && (!HasEffect(Buffs.DisciplinedFist) || twinsnakeDuration.RemainingTime <= 2.5))
+                            if (!raptorChakra && (!HasEffect(Buffs.DisciplinedFist) || twinsnakeDuration <= 2.5))
                             {
                                 return TwinSnakes;
                             }
-                            if (!coeurlChakra && (demolishDuration.RemainingTime <= 2.5 || !TargetHasEffect(Debuffs.Demolish)))
+                            if (!coeurlChakra && (demolishDuration <= 2.5 || !TargetHasEffect(Debuffs.Demolish)))
                             {
                                 return Demolish;
                             }
@@ -552,7 +552,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
                     if (level >= Levels.TrueStrike && HasEffect(Buffs.RaptorForm))
                     {
-                        if (level >= Levels.TwinSnakes && (!HasEffect(Buffs.DisciplinedFist) || twinsnakeDuration.RemainingTime <= Service.Configuration.GetCustomIntValue(Config.MnkDisciplinedFistApply)))
+                        if (level >= Levels.TwinSnakes && (!HasEffect(Buffs.DisciplinedFist) || twinsnakeDuration <= Service.Configuration.GetCustomIntValue(Config.MnkDisciplinedFistApply)))
                         {
                             return TwinSnakes;
                         }
@@ -560,7 +560,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
                     if (level >= Levels.SnapPunch && HasEffect(Buffs.CoerlForm))
                     {
-                        if (level >= Levels.Demolish && HasEffect(Buffs.DisciplinedFist) && (!TargetHasEffect(Debuffs.Demolish) || demolishDuration.RemainingTime <= Service.Configuration.GetCustomIntValue(Config.MnkDemolishApply)))
+                        if (level >= Levels.Demolish && HasEffect(Buffs.DisciplinedFist) && (!TargetHasEffect(Debuffs.Demolish) || demolishDuration <= Service.Configuration.GetCustomIntValue(Config.MnkDemolishApply)))
                         {
                             return Demolish;
                         }

--- a/XIVSlothCombo/Combos/PLD.cs
+++ b/XIVSlothCombo/Combos/PLD.cs
@@ -307,11 +307,12 @@
                 {
                     if (HasEffect(Buffs.Requiescat) && level >= Levels.HolySpirit)
                     {
-                        var requiescat = FindEffect(Buffs.Requiescat);
+                        var requiescatTime = GetBuffRemainingTime(Buffs.Requiescat);
+                        var requiescatStacks = GetBuffStacks(Buffs.Requiescat);
 
                         if (level >= Levels.Confiteor &&
-                                ((IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && requiescat.RemainingTime <= 3 && requiescat.RemainingTime > 0) ||
-                                requiescat.StackCount is 1 || LocalPlayer.CurrentMp <= 2000))
+                                ((IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && requiescatTime <= 3 && requiescatTime > 0) ||
+                                requiescatStacks is 1 || LocalPlayer.CurrentMp <= 2000))
                             return Confiteor;
 
                         return HolySpirit;
@@ -334,10 +335,11 @@
                 {
                     if (HasEffect(Buffs.Requiescat) && level >= Levels.HolyCircle)
                     {
-                        var requiescat = FindEffect(Buffs.Requiescat);
+                        var requiescatTime = GetBuffRemainingTime(Buffs.Requiescat);
+                        var requiescatStacks = GetBuffStacks(Buffs.Requiescat);
 
-                        if (level >= Levels.Confiteor && ((IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && requiescat.RemainingTime <= 3 && requiescat.RemainingTime > 0) ||
-                                requiescat.StackCount is 1 || LocalPlayer.CurrentMp <= 2000))
+                        if (level >= Levels.Confiteor && ((IsEnabled(CustomComboPreset.PaladinConfiteorFeature) && requiescatTime <= 3 && requiescatTime > 0) ||
+                                requiescatStacks is 1 || LocalPlayer.CurrentMp <= 2000))
                             return Confiteor;
 
                         return HolyCircle;

--- a/XIVSlothCombo/Combos/WHM.cs
+++ b/XIVSlothCombo/Combos/WHM.cs
@@ -278,14 +278,14 @@ namespace XIVSlothComboPlugin.Combos
                     if (actionID == Medica2)
                     {
                         var gauge = GetJobGauge<WHMGauge>();
-                        var medica2Buff = FindEffect(Buffs.Medica2);
+                        var medica2Buff = GetBuffRemainingTime(Buffs.Medica2);
                         if (level < Levels.Medica2)
                             return Medica1;
                         if (IsEnabled(CustomComboPreset.WhiteMageAfflatusMiseryMedicaFeature) && gauge.BloodLily == 3)
                             return AfflatusMisery;
-                        if (IsEnabled(CustomComboPreset.WhiteMageAfflatusRaptureMedicaFeature) && level >= Levels.AfflatusRapture && gauge.Lily > 0 && medica2Buff.RemainingTime > 2)
+                        if (IsEnabled(CustomComboPreset.WhiteMageAfflatusRaptureMedicaFeature) && level >= Levels.AfflatusRapture && gauge.Lily > 0 && medica2Buff > 2)
                             return AfflatusRapture;
-                        if (HasEffect(Buffs.Medica2) && medica2Buff.RemainingTime > 2)
+                        if (HasEffect(Buffs.Medica2) && medica2Buff > 2)
                             return Medica1;
                     }
 


### PR DESCRIPTION
### Framework
- Changed the potencially hazzard effects of `FindEffect` to `GetBuffRemaingTime` to avoid `Null Access Exceptions` in many jobs.
   - 3 helper functions should be used to avoid those situations:
      - `GetBuffRemaingTime`, `GetBuffStacks` and `GetDebuffRemaingTime`.