### PR TITLE
RPR AOE Fix

### DIFF
--- a/XIVSlothCombo/Combos/RPR.cs
+++ b/XIVSlothCombo/Combos/RPR.cs
@@ -310,11 +310,12 @@ namespace XIVSlothComboPlugin.Combos
 
                     if (deathsDesign)
                     {
-                        if (IsEnabled(CustomComboPreset.ReapearEnshroudonAOEFeature))
+
+                        if (IsEnabled(CustomComboPreset.ReaperEnshroudonAOEFeature) && !enshrouded && !soulReaver && level >= Levels.Enshroud && IsOffCooldown(Enshroud) && CanWeave(actionID) && gauge.Shroud >= 50)
+                            return Enshroud;
+                        if (enshrouded)
                         {
-                            if (!enshrouded && !soulReaver && level >= Levels.Enshroud && IsOffCooldown(Enshroud) && CanWeave(actionID) && gauge.Shroud >= 50)
-                                return Enshroud;
-                            if (enshrouded)
+                            if (IsEnabled(CustomComboPreset.ReaperGuillotineFeature))
                             {
                                 if (IsEnabled(CustomComboPreset.ReaperComboCommunioAOEFeature) && gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && level >= Levels.Communio)
                                     return Communio;

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1840,13 +1840,13 @@ namespace XIVSlothComboPlugin
 
         [ParentCombo(ReaperScytheCombo)]
         [CustomComboInfo("Enshroud Option", "Adds Enshroud to the AoE combo when at 50 Shroud and greater and when current target is afflicted with Death's Design.", RPR.JobID, 0, "", "")]
-        ReapearEnshroudonAOEFeature = 12026,
+        ReaperEnshroudonAOEFeature = 12026,
 
-        [ParentCombo(ReapearEnshroudonAOEFeature)]
+        [ParentCombo(ReaperGuillotineFeature)]
         [CustomComboInfo("Lemure's Slice Option", "Adds Lemure's Slice to the AoE combo when there are 2 Void Shrouds.", RPR.JobID, 0, "", "")]
         ReaperLemureAOEFeature = 12027,
 
-        [ParentCombo(ReapearEnshroudonAOEFeature)]
+        [ParentCombo(ReaperGuillotineFeature)]
         [CustomComboInfo("Communio Finisher Option", "Adds Communio to the AoE combo when there is 1 Lemure Shroud left.", RPR.JobID, 0, "", "")]
         ReaperComboCommunioAOEFeature = 12028,
 


### PR DESCRIPTION
Moved `Communio` and `Lemure's Scythe` options from `Enshroud` to `Guillotine`
Made `Guillotine` use `Grim Reaping` without the `Enshroud Option` enabled