### PR TITLE
Revert of DrawRadioButton commit

### DIFF
--- a/XIVSlothCombo/ConfigWindowFunctions.cs
+++ b/XIVSlothCombo/ConfigWindowFunctions.cs
@@ -85,7 +85,7 @@ namespace XIVSlothComboPlugin.ConfigFunctions
         {
             ImGui.Indent();
             if (descriptionColor == new Vector4()) descriptionColor = ImGuiColors.DalamudYellow;
-            var output = Service.Configuration.GetCustomIntValue(config, outputValue);
+            var output = Service.Configuration.GetCustomIntValue(config);
             ImGui.PushItemWidth(itemWidth);
             var enabled = output == outputValue;
 


### PR DESCRIPTION
After testing, ImGUI Radio buttons default (regardless of GUI showing no checkboxes or both) to the lowest number.  However, if you want to use a true default (checked in gui on show), start with Zero, not a One. Test results here: https://media.discordapp.net/attachments/977323921277849600/977358185272864778/unknown.png (0&1 and 1&2 on the first example, not 0&2)