### PR TITLE
Scholar & Sage Code Adjustments

### DIFF
--- a/XIVSlothCombo/Combos/SCH.cs
+++ b/XIVSlothCombo/Combos/SCH.cs
@@ -1,6 +1,7 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Objects.Enums;
+using System.Collections.Generic;
 
 namespace XIVSlothComboPlugin.Combos
 {
@@ -107,9 +108,10 @@ namespace XIVSlothComboPlugin.Combos
         public static class Config
         {
             public const string
-                SCH_ST_Broil_Lucid = "SCH_ST_Broil_Lucid",
-                SCH_ST_Broil_BioHPPer = "SCH_ST_Broil_BioHPPer",
-                SCH_ST_Broil_ChainStratagem = "SCH_ST_Broil_ChainStratagem",
+                SCH_ST_DPS_AltMode = "SCH_ST_DPS_AltMode",
+                SCH_ST_DPS_LucidOption = "SCH_ST_DPS_LucidOption",
+                SCH_ST_DPS_BioOption = "SCH_ST_DPS_BioOption",
+                SCH_ST_DPS_ChainStratagemOption = "SCH_ST_DPS_ChainStratagemOption",
                 SCH_Aetherflow_Display = "SCH_Aetherflow_Display",
                 SCH_Aetherflow_Recite_Excog = "SCH_Aetherflow_Recite_Excog",
                 SCH_Aetherflow_Recite_Indom = "SCH_Aetherflow_Recite_Indom",
@@ -141,37 +143,39 @@ namespace XIVSlothComboPlugin.Combos
                 if (actionID is EnergyDrain or Lustrate or SacredSoil or Indomitability or Excogitation &&
                     level >= Levels.Aetherflow)
                 {
-                    var gauge = GetJobGauge<SCHGauge>().Aetherflow;
+                    var HasAetherFlows = System.Convert.ToBoolean(GetJobGauge<SCHGauge>().Aetherflow); //False if Zero stacks
                     if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite) &&
                         level >= Levels.Recitation &&
                         (IsOffCooldown(Recitation) || HasEffect(Buffs.Recitation)))
                     {
                         //Recitation Indominability and Excogitation, with optional check against AF zero stack count
+                        bool AlwaysShowReciteExcog = GetOptionBool(Config.SCH_Aetherflow_Recite_Excog);
                         if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite_Excog) &&
-                            (GetOptionValue(Config.SCH_Aetherflow_Recite_Excog) == 1 || (GetOptionValue(Config.SCH_Aetherflow_Recite_Excog) == 2 && gauge == 0)) &&
+                            (AlwaysShowReciteExcog || (!AlwaysShowReciteExcog && !HasAetherFlows)) &&
                             actionID is Excogitation)
                         {   //Do not merge this nested if with above. Won't procede with next set
                             if (HasEffect(Buffs.Recitation) && IsOffCooldown(Excogitation)) return Excogitation; else return Recitation;
                         }
 
+                        bool AlwaysShowReciteIndom = GetOptionBool(Config.SCH_Aetherflow_Recite_Indom);
                         if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Recite_Indom) &&
-                            (GetOptionValue(Config.SCH_Aetherflow_Recite_Indom) == 1 || (GetOptionValue(Config.SCH_Aetherflow_Recite_Indom) == 2 && gauge == 0)) &&
+                            (AlwaysShowReciteIndom || (!AlwaysShowReciteIndom && !HasAetherFlows)) &&
                             actionID is Indomitability)
                         {
                             if (HasEffect(Buffs.Recitation) && IsOffCooldown(Excogitation)) return Indomitability; else return Recitation;
                         }
                     }
-                    if (gauge == 0)
+                    if (!HasAetherFlows)
                     {
-                        if ((actionID is EnergyDrain && GetOptionValue(Config.SCH_Aetherflow_Display) == 1)
-                             || GetOptionValue(Config.SCH_Aetherflow_Display) == 2)
+                        bool AetherflowEDOnly = GetOptionBool(Config.SCH_Aetherflow_Display);
+                        if ((actionID is EnergyDrain && AetherflowEDOnly) || !AetherflowEDOnly)
                         {
-                            if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Dissipation)
-                                && level >= Levels.Dissipation
-                                && IsOffCooldown(Dissipation)
-                                && IsOnCooldown(Aetherflow)
+                            if (IsEnabled(CustomComboPreset.SCH_Aetherflow_Dissipation) &&
+                                level >= Levels.Dissipation &&
+                                IsOffCooldown(Dissipation) &&
+                                IsOnCooldown(Aetherflow) &&
                                 //Dissipation requires fairy, can't seem to make it replace dissipation with fairy summon feature *shrug*
-                                && HasPetPresent()) return Dissipation;
+                                HasPetPresent()) return Dissipation;
 
                             else return Aetherflow;
                         }
@@ -198,12 +202,11 @@ namespace XIVSlothComboPlugin.Combos
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_FairyFeature;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is WhisperingDawn or FeyBlessing or FeyBlessing or FeyIllumination or Dissipation or Aetherpact or Dissipation &&
-                    !HasPetPresent() &&
+                if (actionID is WhisperingDawn or FeyBlessing or FeyIllumination or Dissipation or Aetherpact &&
+                    !HasPetPresent() && 
                     GetJobGauge<SCHGauge>().SeraphTimer == 0)
                 {
-                    if ((GetOptionValue(Config.SCH_FairyFeature)) == 2) return SummonSelene; //it's a 1 or 2 option atm.
-                    else return SummonEos;
+                    if (GetOptionBool(Config.SCH_FairyFeature)) return SummonSelene; else return SummonEos;
                 }
                 return actionID;
             }
@@ -212,23 +215,26 @@ namespace XIVSlothComboPlugin.Combos
         //Overwrides main DPS ability family, The Broils (and ruin 1)
         //Implements new Sage features as ToT, and Ruin 2 as the movement option
         //ChainStratagem has overlap protection
-        internal class ScholarBroilFeature : CustomCombo
+        internal class ScholarDPSFeature : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_BroilFeature;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_DPS_Feature;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is Ruin1 or Broil1 or Broil2 or Broil3 or Broil4 && InCombat())
+                bool AlternateMode = GetOptionBool(Config.SCH_ST_DPS_AltMode); //(0 or 1 radio values)
+                if ((!AlternateMode &&  actionID is Ruin1 or Broil1 or Broil2 or Broil3 or Broil4
+                     || (AlternateMode && actionID is Bio1 or Bio2 or Biolysis)) 
+                    && InCombat())
                 {
                     //Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Lucid) &&
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_LucidOption) &&
                         level >= All.Levels.LucidDreaming &&
                         IsOffCooldown(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= GetOptionValue(Config.SCH_ST_Broil_Lucid) &&
+                        LocalPlayer.CurrentMp <= GetOptionValue(Config.SCH_ST_DPS_LucidOption) &&
                         CanSpellWeave(actionID)
                        ) return All.LucidDreaming;
 
                     //Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Aetherflow) &&
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_AetherflowOption) &&
                         level >= Levels.Aetherflow &&
                         GetJobGauge<SCHGauge>().Aetherflow == 0 &&
                         IsOffCooldown(Aetherflow) &&
@@ -236,56 +242,41 @@ namespace XIVSlothComboPlugin.Combos
                        ) return Aetherflow;
 
                     //Chain Stratagem
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_ChainStratagem) &&
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_ChainStratagemOption) &&
                         level >= Levels.ChainStratagem &&
                         IsOffCooldown(ChainStratagem) &&
                         !TargetHasEffectAny(Debuffs.ChainStratagem) && //Overwrite protection
-                        GetTargetHPPercent() > GetOptionValue(Config.SCH_ST_Broil_ChainStratagem) &&
+                        GetTargetHPPercent() > GetOptionValue(Config.SCH_ST_DPS_ChainStratagemOption) &&
                         CanSpellWeave(actionID)
                        ) return ChainStratagem;
 
                     //Ruin 2 Movement 
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Ruin2Movement) &&
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_Ruin2MovementOption) &&
                         level >= Levels.Ruin2 &&
                         HasBattleTarget() &&
                         this.IsMoving
                        ) return OriginalHook(Ruin2); //Who knows in the future
 
                     //Bio/Biolysis
-                    if (IsEnabled(CustomComboPreset.SCH_ST_Broil_Bio) && level >= Levels.Bio1 && CurrentTarget is not null)
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_BioOption) && 
+                        level >= Levels.Bio1 && 
+                        (CurrentTarget as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy)
                     {
-                        var OurTarget = CurrentTarget;
-                        //Check if our Target is there and not an enemy
-                        if ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy)
-                        {
-                            //If ToT is enabled, Check if ToT is not null
-                            if ((IsEnabled(CustomComboPreset.SCH_ST_Broil_BioToT)) &&
-                                (CurrentTarget.TargetObject is not null) &&
-                                ((CurrentTarget.TargetObject as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy))
-                                //Set Ourtarget as the Target of Target
-                                OurTarget = CurrentTarget.TargetObject;
-                            //Our Target of Target wasn't hostile, our target isn't hostile, time to exit, nothing to check debuff on, fuck this shit we're out
-                            else return actionID;
-                        }
-
                         //Determine which Bio debuff to check
                         var BioDebuffID = level switch
                         {
                             //Using FindEffect b/c we have a custom Target variable
-                            >= Levels.Biolysis => FindEffect(Debuffs.Biolysis, OurTarget, LocalPlayer?.ObjectId),
-                            >= Levels.Bio2 => FindEffect(Debuffs.Bio2, OurTarget, LocalPlayer?.ObjectId),
+                            >= Levels.Biolysis => FindTargetEffect(Debuffs.Biolysis),
+                            >= Levels.Bio2 => FindTargetEffect(Debuffs.Bio2),
                             //Bio 1 checked at the start, fine for default
-                            _ => FindEffect(Debuffs.Bio1, OurTarget, LocalPlayer?.ObjectId),
+                            _ => FindTargetEffect(Debuffs.Bio1),
                         };
-                        if ((BioDebuffID is null) || (BioDebuffID?.RemainingTime <= 3))
-                        {
-                            //Advanced Options Enabled to procede with auto-bio
-                            if (IsEnabled(CustomComboPreset.SCH_ST_Broil_BioHPPer))
-                            {
-                                if (GetTargetHPPercent(OurTarget) > GetOptionValue(Config.SCH_ST_Broil_BioHPPer)) return OriginalHook(Bio1);
-                            }
-                            else return OriginalHook(Bio1);
-                        }
+                        if ((BioDebuffID is null) || (BioDebuffID?.RemainingTime <= 3) &&
+                            (GetTargetHPPercent() > GetOptionValue(Config.SCH_ST_DPS_BioOption))
+                           ) return OriginalHook(Bio1);
+
+                        //AlterateMode idles as Ruin/Broil
+                        if (AlternateMode) return OriginalHook(Ruin1);
                     }
                 }
                 return actionID;

--- a/XIVSlothCombo/Combos/SCH.cs
+++ b/XIVSlothCombo/Combos/SCH.cs
@@ -1,7 +1,6 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Objects.Enums;
-using System.Collections.Generic;
 
 namespace XIVSlothComboPlugin.Combos
 {

--- a/XIVSlothCombo/Combos/SGE.cs
+++ b/XIVSlothCombo/Combos/SGE.cs
@@ -253,53 +253,34 @@ namespace XIVSlothComboPlugin.Combos
 
                     //Eukrasian Dosis.
                     //If we're too low level to use Eukrasia, we can stop here.
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && (level >= Levels.Eukrasia) && CurrentTarget is not null)
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && 
+                        level >= Levels.Eukrasia &&
+                        (CurrentTarget as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy)
                     {
-
                         //If we're already Eukrasian'd, the whole point of this section is moot
                         if (HasEffect(Buffs.Eukrasia)) return OriginalHook(Dosis1); //OriginalHook will autoselect the correct Dosis for us
-
-                        var OurTarget = CurrentTarget;
-                        //Check if our Target is there and not an enemy
-                        if ((CurrentTarget as BattleNpc)?.BattleNpcKind is not BattleNpcSubKind.Enemy)
-                        {
-                            //If ToT is enabled, Check if ToT is not null
-                            if ((IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosisToT)) &&
-                                (CurrentTarget.TargetObject is not null) &&
-                                ((CurrentTarget.TargetObject as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy))
-                                //Set Ourtarget as the Target of Target
-                                OurTarget = CurrentTarget.TargetObject;
-                            //Our Target of Target wasn't hostile, our target isn't hostile, time to exit, nothing to check debuff on, fuck this shit we're out
-                            else return actionID;
-                        }
 
                         //Determine which Dosis debuff to check
                         var DosisDebuffID = level switch
                         {
                             //Using FindEffect b/c we have a custom Target variable
-                            >= Levels.Dosis3 => FindEffect(Debuffs.EukrasianDosis3, OurTarget, LocalPlayer?.ObjectId),
-                            >= Levels.Dosis2 => FindEffect(Debuffs.EukrasianDosis2, OurTarget, LocalPlayer?.ObjectId),
+                            >= Levels.Dosis3 => FindTargetEffect(Debuffs.EukrasianDosis3),
+                            >= Levels.Dosis2 => FindTargetEffect(Debuffs.EukrasianDosis2),
                             //Ekrasia Dosis unlocks with Eukrasia, checked at the start
-                            _ => FindEffect(Debuffs.EukrasianDosis1, OurTarget, LocalPlayer?.ObjectId),
+                            _ => FindTargetEffect(Debuffs.EukrasianDosis1),
                         };
 
                         //Got our Debuff for our level, check for it and procede 
-                        if ((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3))
-                        {
-                            //Advanced Options Enabled to procede with auto-Eukrasia
-                            if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosisHPPer))
-                            {
-                                if (GetTargetHPPercent(OurTarget) > GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer)) return Eukrasia;
-                            }
-                            else return Eukrasia;
-                        }
+                        if (((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3)) &&
+                            (GetTargetHPPercent() > GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer))
+                           ) return Eukrasia;
                     }
 
                     //Toxikon
                     if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
                         level >= Levels.Toxikon &&
                         HasBattleTarget() &&
-                        ((GetOptionValue(Config.SGE_ST_Dosis_Toxikon) == 1 && this.IsMoving) || (GetOptionValue(Config.SGE_ST_Dosis_Toxikon) == 2)) &&
+                        ((!GetOptionBool(Config.SGE_ST_Dosis_Toxikon) && this.IsMoving) || GetOptionBool(Config.SGE_ST_Dosis_Toxikon)) &&
                         GetJobGauge<SGEGauge>().Addersting > 0
                        ) return OriginalHook(Toxikon);
                 }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -1040,16 +1040,16 @@ namespace XIVSlothComboPlugin
             // ====================================================================================
             #region SAGE
 
-            if (preset is CustomComboPreset.SGE_ST_Dosis_EDosisHPPer)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Dosis_EDosisHPPer, "Enemy HP % Threshold");
+            if (preset is CustomComboPreset.SGE_ST_Dosis_EDosis)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Dosis_EDosisHPPer, "Stop using at Enemy HP %. Set to Zero to disable this check");
 
             if (preset is CustomComboPreset.SGE_ST_Dosis_Lucid)
                 ConfigWindowFunctions.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_Dosis_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
 
             if (preset is CustomComboPreset.SGE_ST_Dosis_Toxikon)
             {
-                ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show when moving only", "", 1);
-                ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show at all times", "", 2);
+                ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show when moving only", "", 0);
+                ConfigWindowFunctions.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show at all times", "", 1);
             }
 
             if (preset is CustomComboPreset.SGE_AoE_Phlegma_Lucid)
@@ -1100,31 +1100,36 @@ namespace XIVSlothComboPlugin
             #endregion
             // ====================================================================================
             #region SCHOLAR
-            if (preset is CustomComboPreset.SCH_ST_Broil_Lucid)
-                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SCH.Config.SCH_ST_Broil_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
-            if (preset is CustomComboPreset.SCH_ST_Broil_BioHPPer)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SCH.Config.SCH_ST_Broil_BioHPPer, "Enemy HP % Threshold");
-            if (preset is CustomComboPreset.SCH_ST_Broil_ChainStratagem)
-                ConfigWindowFunctions.DrawSliderInt(0, 100, SCH.Config.SCH_ST_Broil_ChainStratagem, "Enemy HP% Threshold");
+            if (preset is CustomComboPreset.SCH_DPS_Feature)
+            {
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_ST_DPS_AltMode, "On Ruin I / Broils", "", 0);
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_ST_DPS_AltMode, "On Bio", "Alternative DPS Mode. Leaves Ruin I / Broil alone for pure DPS, becomes Ruin I / Broil when features are on cooldown", 1);
+            }
+            if (preset is CustomComboPreset.SCH_DPS_LucidOption)
+                ConfigWindowFunctions.DrawSliderInt(4000, 9500, SCH.Config.SCH_ST_DPS_LucidOption, "MP Threshold", 150, SliderIncrements.Hundreds);
+            if (preset is CustomComboPreset.SCH_DPS_BioOption)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SCH.Config.SCH_ST_DPS_BioOption, "Stop using at Enemy HP %. Set to Zero to disable this check");
+            if (preset is CustomComboPreset.SCH_DPS_ChainStratagemOption)
+                ConfigWindowFunctions.DrawSliderInt(0, 100, SCH.Config.SCH_ST_DPS_ChainStratagemOption, "Stop using at Enemy HP %. Set to Zero to disable this check");
             if (preset is CustomComboPreset.SCH_FairyFeature)
             {
-                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Eos", "", 1);
-                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Selene", "", 2);
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Eos", "", 0);
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Selene", "", 1);
             }
             if (preset is CustomComboPreset.SCH_AetherflowFeature)
             {
-                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Display, "Show Aetherflow On Energy Drain Only","", 1);
-                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Display, "Show Aetherflow On All Aetherflow Skills", "", 2);
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Display, "Show Aetherflow On Energy Drain Only","", 0);
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Display, "Show Aetherflow On All Aetherflow Skills", "", 1);
             }
             if (preset is CustomComboPreset.SCH_Aetherflow_Recite_Excog)
             {
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Excog, "Only when out of Aetherflow Stacks", "", 0);
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Excog, "Always when available", "", 1);
-                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Excog, "Only when out of Aetherflow Stacks", "", 2);
             }
             if (preset is CustomComboPreset.SCH_Aetherflow_Recite_Indom)
             {
+                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Indom, "Only when out of Aetherflow Stacks", "", 0);
                 ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Indom, "Always when available", "", 1);
-                ConfigWindowFunctions.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Indom, "Only when out of Aetherflow Stacks", "", 2);
             }
             #endregion
             // ====================================================================================

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -1,4 +1,4 @@
-using Dalamud.Game.ClientState.Conditions;
+﻿using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
@@ -751,10 +751,9 @@ namespace XIVSlothComboPlugin.Combos
 
         }
 
-        public int GetOptionValue(string SliderID)
-        {
-            return Service.Configuration.GetCustomIntValue(SliderID);
-        }
+        public static int GetOptionValue(string SliderID) => Service.Configuration.GetCustomIntValue(SliderID);
+
+        public static bool GetOptionBool(string SliderID) => Convert.ToBoolean(GetOptionValue(SliderID));
 
         protected unsafe static FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject* GetTarget(TargetType target)
         {
@@ -959,5 +958,5 @@ namespace XIVSlothComboPlugin.Combos
         //    return true;
 
         //}
+        }
     }
-}

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2082,14 +2082,6 @@ namespace XIVSlothComboPlugin
                     [CustomComboInfo("Eukrasian Dosis Option", "Automatic DoT Uptime", SGE.JobID, 120)]
                     SGE_ST_Dosis_EDosis = 14120,
 
-                        [ParentCombo(SGE_ST_Dosis_EDosis)]
-                        [CustomComboInfo("Enemy HP Limiter Options", "Stop using Eukrasian Dosis when Enemy HP values match\nEnable to see input boxes", SGE.JobID, 121)]
-                        SGE_ST_Dosis_EDosisHPPer = 14121,
-
-                        [ParentCombo(SGE_ST_Dosis_EDosis)]
-                        [CustomComboInfo("Target of Target Checking", "Performs additional checking for Target of Target\nThis will not help you apply DoT onto your Target of Target", SGE.JobID, 122)]
-                        SGE_ST_Dosis_EDosisToT = 14122,
-
                     [ParentCombo(SGE_ST_DosisFeature)]
                     [CustomComboInfo("Toxikon Movement Option", "Use Toxikon when you have Addersting charges and are moving", SGE.JobID, 130)]
                     SGE_ST_Dosis_Toxikon = 14130,
@@ -2445,39 +2437,30 @@ namespace XIVSlothComboPlugin
 
             #region SCHOLAR_DPS
 
-            [ReplaceSkill(SCH.Ruin1, SCH.Broil1, SCH.Broil2, SCH.Broil3, SCH.Broil4)]
-            [CustomComboInfo("Single Target DPS Feature", "Replace Ruin I / Broils with options below", SCH.JobID, 100)]
-            SCH_ST_BroilFeature = 16100,
+            [ReplaceSkill(SCH.Ruin1, SCH.Broil1, SCH.Broil2, SCH.Broil3, SCH.Broil4, SCH.Bio1, SCH.Bio2, SCH.Biolysis)]
+            [CustomComboInfo("Single Target DPS Feature", "Replace Ruin I / Broils or Bios with options below", SCH.JobID, 100)]
+            SCH_DPS_Feature = 16100,
 
-                    [ParentCombo(SCH_ST_BroilFeature)]
+                    [ParentCombo(SCH_DPS_Feature)]
                     [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID, 110)]
-                    SCH_ST_Broil_Lucid = 16110,
+                    SCH_DPS_LucidOption = 16110,
 
-                    [ParentCombo(SCH_ST_BroilFeature)]
-                    [ConflictingCombos(SCH_ST_Broil_BioToT)]
+                    [ParentCombo(SCH_DPS_Feature)]
                     [CustomComboInfo("Chain Stratagem Weave Option", "Adds Chain Stratagem on Cooldown with overlap protection", SCH.JobID, 120)]
-                    SCH_ST_Broil_ChainStratagem = 16120,
+                    SCH_DPS_ChainStratagemOption = 16120,
 
-                    [ParentCombo(SCH_ST_BroilFeature)]
-                    [CustomComboInfo("Aetherflow Weave Feature", "Use Aetherflow when out of aetherflow stacks", SCH.JobID, 130)]
-                    SCH_ST_Broil_Aetherflow = 16130,
+                    [ParentCombo(SCH_DPS_Feature)]
+                    [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of aetherflow stacks", SCH.JobID, 130)]
+                    SCH_DPS_AetherflowOption = 16130,
 
-                    [ParentCombo(SCH_ST_BroilFeature)]
-                    [CustomComboInfo("Ruin II Moving Feature", "Use Ruin 2 when you have to move", SCH.JobID, 140)]
-                    SCH_ST_Broil_Ruin2Movement = 16140,
+                    [ParentCombo(SCH_DPS_Feature)]
+                    [CustomComboInfo("Ruin II Moving Option", "Use Ruin 2 when you have to move", SCH.JobID, 140)]
+                    SCH_DPS_Ruin2MovementOption = 16140,
 
-                    [ParentCombo(SCH_ST_BroilFeature)]
+                    [ParentCombo(SCH_DPS_Feature)]
                     [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT Uptime", SCH.JobID, 150)]
-                    SCH_ST_Broil_Bio = 16150,
-
-                        [ParentCombo(SCH_ST_Broil_Bio)]
-                        [CustomComboInfo("Enemy HP Limiter Options", "Stop using Bio when Enemy HP values match below:", SCH.JobID, 151)]
-                        SCH_ST_Broil_BioHPPer = 16151,
-
-                        [ParentCombo(SCH_ST_Broil_Bio)]
-                        [ConflictingCombos(SCH_ST_Broil_ChainStratagem)]
-                        [CustomComboInfo("Target of Target Checking", "Performs additional checking for Target of Target\nThis will not help you apply DoT onto your Target of Target", SCH.JobID, 152)]
-                        SCH_ST_Broil_BioToT = 16152,
+                    SCH_DPS_BioOption = 16150,
+                        
             #endregion
 
             #region SCHOLAR HEALING


### PR DESCRIPTION
CustomCombo - GetOptionBool: Since Zero has been identified as the default checked value for ImGui radiobuttons, if there are only 2 radio buttons for an option, this will return a bool value (0/1).
Scholar: ScholarBroilFeature is now ScholarDPSFeature
ScholarDPSFeature: ToT removed. Alternate mode restored (DPS features on Bio) by radio button option. Bio's HP% limiter is now part of the Bio Option, it instead of being a sub option.
ScholarAetherflowFeature & ScholarFairyFeature: Various option radio button values 1 and 2 have been changed to 0 and 1 (to allow for GUI checked defaults instead of blank selections, and easier bool checking).
Sage_ST_DosisFeature: HP% limiter is now part of the EDosis Option, it instead of being a sub option. ToT removed. Toxikon radio buttons fixed for default (0/1).