### PR TITLE
Config Tweaks & 6.11a BLM Update

### DIFF
--- a/XIVSlothCombo/CombosPVP/BLMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/BLMPVP.cs
@@ -66,7 +66,7 @@
                         return OriginalHook(Fire);
 
                     if (FindTargetEffect(Debuffs.AstralWarmth).StackCount < 3 &&
-                        IsOffCooldown(Paradox))
+                        GetRemainingCharges(Paradox) > 0)
                         return Paradox;
 
 
@@ -101,7 +101,7 @@
                         return OriginalHook(Blizzard);
 
                     if (FindTargetEffect(Debuffs.UmbralFreeze).StackCount < 3 &&
-                        IsOffCooldown(Paradox))
+                        GetRemainingCharges(Paradox) > 0)
                         return Paradox;
 
 

--- a/XIVSlothCombo/ConfigWindowFunctions.cs
+++ b/XIVSlothCombo/ConfigWindowFunctions.cs
@@ -85,7 +85,7 @@ namespace XIVSlothComboPlugin.ConfigFunctions
         {
             ImGui.Indent();
             if (descriptionColor == new Vector4()) descriptionColor = ImGuiColors.DalamudYellow;
-            var output = Service.Configuration.GetCustomIntValue(config);
+            var output = Service.Configuration.GetCustomIntValue(config, outputValue);
             ImGui.PushItemWidth(itemWidth);
             var enabled = output == outputValue;
 

--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -123,18 +123,6 @@ namespace XIVSlothComboPlugin
 
             switch (argumentsParts[0].ToLower())
             {
-                case "setall":
-                    {
-                        foreach (var preset in Enum.GetValues<CustomComboPreset>())
-                        {
-                            Service.Configuration.EnabledActions.Add(preset);
-                        }
-
-                        Service.ChatGui.Print("All SET");
-                        Service.Configuration.Save();
-                        break;
-                    }
-
                 case "unsetall":
                     {
                         foreach (var preset in Enum.GetValues<CustomComboPreset>())
@@ -149,57 +137,80 @@ namespace XIVSlothComboPlugin
 
                 case "set":
                     {
-                        var targetPreset = argumentsParts[1].ToLowerInvariant();
-                        foreach (var preset in Enum.GetValues<CustomComboPreset>())
+                        if (!Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat])
                         {
-                            if (preset.ToString().ToLowerInvariant() != targetPreset)
-                                continue;
+                            var targetPreset = argumentsParts[1].ToLowerInvariant();
+                            foreach (var preset in Enum.GetValues<CustomComboPreset>())
+                            {
+                                if (preset.ToString().ToLowerInvariant() != targetPreset)
+                                    continue;
 
-                            Service.Configuration.EnabledActions.Add(preset);
-                            Service.ChatGui.Print($"{preset} SET");
+                                Service.Configuration.EnabledActions.Add(preset);
+                                Service.ChatGui.Print($"{preset} SET");
+                            }
+
+                            Service.Configuration.Save();
                         }
-
-                        Service.Configuration.Save();
+                        else
+                        {
+                            Service.ChatGui.PrintError("Features cannot be set in combat.");
+                        }
                         break;
                     }
 
                 case "toggle":
                     {
-                        var targetPreset = argumentsParts[1].ToLowerInvariant();
-                        foreach (var preset in Enum.GetValues<CustomComboPreset>())
+                        if (!Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat])
                         {
-                            if (preset.ToString().ToLowerInvariant() != targetPreset)
-                                continue;
 
-                            if (Service.Configuration.EnabledActions.Contains(preset))
+
+                            var targetPreset = argumentsParts[1].ToLowerInvariant();
+                            foreach (var preset in Enum.GetValues<CustomComboPreset>())
                             {
-                                Service.Configuration.EnabledActions.Remove(preset);
-                                Service.ChatGui.Print($"{preset} UNSET");
+                                if (preset.ToString().ToLowerInvariant() != targetPreset)
+                                    continue;
+
+                                if (Service.Configuration.EnabledActions.Contains(preset))
+                                {
+                                    Service.Configuration.EnabledActions.Remove(preset);
+                                    Service.ChatGui.Print($"{preset} UNSET");
+                                }
+                                else
+                                {
+                                    Service.Configuration.EnabledActions.Add(preset);
+                                    Service.ChatGui.Print($"{preset} SET");
+                                }
                             }
-                            else
-                            {
-                                Service.Configuration.EnabledActions.Add(preset);
-                                Service.ChatGui.Print($"{preset} SET");
-                            }
+
+                            Service.Configuration.Save();
                         }
-
-                        Service.Configuration.Save();
+                        else
+                        {
+                            Service.ChatGui.PrintError("Features cannot be toggled in combat.");
+                        }
                         break;
                     }
 
                 case "unset":
                     {
-                        var targetPreset = argumentsParts[1].ToLowerInvariant();
-                        foreach (var preset in Enum.GetValues<CustomComboPreset>())
+                        if (!Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat])
                         {
-                            if (preset.ToString().ToLowerInvariant() != targetPreset)
-                                continue;
+                            var targetPreset = argumentsParts[1].ToLowerInvariant();
+                            foreach (var preset in Enum.GetValues<CustomComboPreset>())
+                            {
+                                if (preset.ToString().ToLowerInvariant() != targetPreset)
+                                    continue;
 
-                            Service.Configuration.EnabledActions.Remove(preset);
-                            Service.ChatGui.Print($"{preset} UNSET");
+                                Service.Configuration.EnabledActions.Remove(preset);
+                                Service.ChatGui.Print($"{preset} UNSET");
+                            }
+
+                            Service.Configuration.Save();
                         }
-
-                        Service.Configuration.Save();
+                        else
+                        {
+                            Service.ChatGui.PrintError("Features cannot be unset in combat.");
+                        }
                         break;
                     }
 


### PR DESCRIPTION
[Framework]
- Stopped situations where the default value wasn't being set to a config properly.

[PVP]
- BLM Burst Mode now takes into account stacks of Paradox due to recent 6.11a update changing the action.