### PR TITLE
[RDM] Fixes and New Option

### DIFF
--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -318,11 +318,19 @@ namespace XIVSlothComboPlugin.Combos
                             && lastComboMove is not Verholy
                             && lastComboMove is not Scorch
                             && System.Math.Max(black, white) <= 50
-                            && System.Math.Max(black, white) >= 42
+                            && (System.Math.Max(black, white) >= 42
+                                || (IsEnabled(CustomComboPreset.RDM_ST_Unbalance) && black == white && black >= 38 && GetCooldown(Acceleration).RemainingCharges > 0))
                             && System.Math.Min(black, white) >= 31
                             && IsOffCooldown(Manafication)
                             && (IsOffCooldown(Embolden) || GetCooldown(Embolden).CooldownRemaining <= 3))
                         {
+                            if (IsEnabled(CustomComboPreset.RDM_ST_Unbalance)
+                                && black == white
+                                && black <= 44
+                                && black >= 38
+                                && GetCooldown(Acceleration).RemainingCharges > 0)
+                                return Acceleration;
+
                             return Manafication;
                         }
                         if (IsEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo)
@@ -368,6 +376,12 @@ namespace XIVSlothComboPlugin.Combos
                             && (IsOffCooldown(Manafication) || level < Levels.Manafication)
                             && IsOffCooldown(Embolden))
                         {
+                            if (IsEnabled(CustomComboPreset.RDM_ST_Unbalance)
+                                && black == white
+                                && black <= 44
+                                && GetCooldown(Acceleration).RemainingCharges > 0)
+                                return Acceleration;
+
                             return Embolden;
                         }
                         if ((IsNotEnabled(CustomComboPreset.RDM_ST_DoubleMeleeCombo) || level < 90) 
@@ -652,6 +666,13 @@ namespace XIVSlothComboPlugin.Combos
                                 && level >= Levels.Corpsacorps && GetCooldown(Corpsacorps).RemainingCharges >= 1 
                                 && distance > 3) 
                                 return Corpsacorps;
+
+                            if (IsEnabled(CustomComboPreset.RDM_ST_Unbalance)
+                                && black == white
+                                && black >= 50
+                                && GetCooldown(Acceleration).RemainingCharges > 0)
+                                return Acceleration;
+
                             if (distance <= 3) 
                                 return OriginalHook(Riposte);
                         }

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -660,7 +660,7 @@ namespace XIVSlothComboPlugin.Combos
                         if (((System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 50 && level >= Levels.Redoublement)
                             || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 35 && level < Levels.Redoublement)
                             || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 20 && level < Levels.Zwerchhau))
-                            && (!HasEffect(Buffs.Dualcast) && !HasEffect(All.Buffs.Swiftcast) && !HasEffect(Buffs.Acceleration))) //Not sure if Swift and Accel are necessary, but better to clear I think.
+                            && !HasEffect(Buffs.Dualcast))
                         {
                             if (IsEnabled(CustomComboPreset.RDM_ST_CorpsGapClose) 
                                 && level >= Levels.Corpsacorps && GetCooldown(Corpsacorps).RemainingCharges >= 1 

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -500,14 +500,14 @@ namespace XIVSlothComboPlugin.Combos
                     if (actionID is Jolt or Jolt2 or Scatter or Impact or Fleche or Riposte or Moulinet)
                     {
                         if (IsEnabled(CustomComboPreset.RDM_Engagement) 
-                            && GetCooldown(Engagement).RemainingCharges > engagementPool 
-                            && (GetCooldown(Engagement).ChargeCooldownRemaining < 3 || IsNotEnabled(CustomComboPreset.RDM_PoolEngage))
+                            && (GetCooldown(Engagement).RemainingCharges > engagementPool
+                                || (HasCharges(Engagement) && GetCooldown(Engagement).ChargeCooldownRemaining < 3))
                             && level >= Levels.Engagement 
                             && distance <= 3) 
                             placeOGCD = Engagement;
                         if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) 
-                            && GetCooldown(Corpsacorps).RemainingCharges > corpsacorpsPool
-                            && (GetCooldown(Corpsacorps).ChargeCooldownRemaining < 3 || IsNotEnabled(CustomComboPreset.RDM_PoolCorps))
+                            && (GetCooldown(Corpsacorps).RemainingCharges > corpsacorpsPool
+                                || (HasCharges(Corpsacorps) && GetCooldown(Corpsacorps).ChargeCooldownRemaining < 3))
                             && ((GetCooldown(Corpsacorps).RemainingCharges >= GetCooldown(Engagement).RemainingCharges) || level < Levels.Engagement) // Try to alternate between Corps-a-corps and Engagement
                             && level >= Levels.Corpsacorps 
                             && distance <= corpacorpsRange) 

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -38,6 +38,7 @@ namespace XIVSlothComboPlugin.Combos
             EnchantedMoulinet = 7530,
             Corpsacorps = 7506,
             Displacement = 7515,
+            MagickBarrier = 25857,
 
             //Buffs
             Acceleration = 7518,
@@ -91,6 +92,7 @@ namespace XIVSlothComboPlugin.Combos
                 Scorch = 80,
                 Veraero3 = 82,
                 Verthunder3 = 82,
+                MagickBarrier = 86,
                 Resolution = 90;
         }
 
@@ -880,6 +882,22 @@ namespace XIVSlothComboPlugin.Combos
                     && IsOnCooldown(Embolden) 
                     && IsOffCooldown(Manafication))
                     return Manafication;
+
+                return actionID;
+            }
+        }
+
+        internal class RDM_MagickBarrierAddle : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_MagickBarrierAddle;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is MagickBarrier
+                    && level >= All.Levels.Addle
+                    && (IsOnCooldown(MagickBarrier) || level < Levels.MagickBarrier)
+                    && IsOffCooldown(All.Addle)
+                    && !TargetHasEffectAny(All.Debuffs.Addle))
+                    return All.Addle;
 
                 return actionID;
             }

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -486,13 +486,13 @@ namespace XIVSlothComboPlugin.Combos
                     if (actionID is Jolt or Jolt2 or Scatter or Impact or Fleche or Riposte or Moulinet)
                     {
                         if (IsEnabled(CustomComboPreset.RDM_Engagement) 
-                            && GetCooldown(Engagement).RemainingCharges >= engagementPool 
+                            && GetCooldown(Engagement).RemainingCharges > engagementPool 
                             && (GetCooldown(Engagement).ChargeCooldownRemaining < 3 || IsNotEnabled(CustomComboPreset.RDM_PoolEngage))
                             && level >= Levels.Engagement 
                             && distance <= 3) 
                             placeOGCD = Engagement;
                         if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) 
-                            && GetCooldown(Corpsacorps).RemainingCharges >= corpsacorpsPool
+                            && GetCooldown(Corpsacorps).RemainingCharges > corpsacorpsPool
                             && (GetCooldown(Corpsacorps).ChargeCooldownRemaining < 3 || IsNotEnabled(CustomComboPreset.RDM_PoolCorps))
                             && ((GetCooldown(Corpsacorps).RemainingCharges >= GetCooldown(Engagement).RemainingCharges) || level < Levels.Engagement) // Try to alternate between Corps-a-corps and Engagement
                             && level >= Levels.Corpsacorps 
@@ -593,19 +593,21 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             if (black >= white && level >= Levels.Verholy)
                             {
-                                if (HasEffect(Buffs.VerstoneReady) 
-                                    && (!HasEffect(Buffs.VerfireReady) || HasEffect(Buffs.Embolden)) 
-                                    && (black - white <= 9))
+                                if ((!HasEffect(Buffs.Embolden) || GetBuffRemainingTime(Buffs.Embolden) < 10)
+                                    && !HasEffect(Buffs.VerfireReady)
+                                    && (HasEffect(Buffs.VerstoneReady) && GetBuffRemainingTime(Buffs.VerstoneReady) >= 10)
+                                    && (black - white <= 18))
                                     return Verflare;
 
                                 return Verholy;
                             }
                             else if (level >= Levels.Verflare)
                             {
-                                if (!HasEffect(Buffs.VerstoneReady) 
-                                    && (HasEffect(Buffs.VerfireReady) || HasEffect(Buffs.Embolden)) 
+                                if ((!HasEffect(Buffs.Embolden) || GetBuffRemainingTime(Buffs.Embolden) < 10)
+                                    && (HasEffect(Buffs.VerfireReady) && GetBuffRemainingTime(Buffs.VerfireReady) >= 10)
+                                    && !HasEffect(Buffs.VerstoneReady)
                                     && level >= Levels.Verholy 
-                                    && (white - black <= 9))
+                                    && (white - black <= 18))
                                     return Verholy;
 
                                 return Verflare;

--- a/XIVSlothCombo/Combos/RDM.cs
+++ b/XIVSlothCombo/Combos/RDM.cs
@@ -501,13 +501,13 @@ namespace XIVSlothComboPlugin.Combos
                     {
                         if (IsEnabled(CustomComboPreset.RDM_Engagement) 
                             && (GetCooldown(Engagement).RemainingCharges > engagementPool
-                                || (HasCharges(Engagement) && GetCooldown(Engagement).ChargeCooldownRemaining < 3))
+                                || (GetCooldown(Engagement).RemainingCharges == 1 && GetCooldown(Engagement).CooldownRemaining < 3))
                             && level >= Levels.Engagement 
                             && distance <= 3) 
                             placeOGCD = Engagement;
                         if (IsEnabled(CustomComboPreset.RDM_Corpsacorps) 
                             && (GetCooldown(Corpsacorps).RemainingCharges > corpsacorpsPool
-                                || (HasCharges(Corpsacorps) && GetCooldown(Corpsacorps).ChargeCooldownRemaining < 3))
+                                || (GetCooldown(Corpsacorps).RemainingCharges == 1 && GetCooldown(Corpsacorps).CooldownRemaining < 3))
                             && ((GetCooldown(Corpsacorps).RemainingCharges >= GetCooldown(Engagement).RemainingCharges) || level < Levels.Engagement) // Try to alternate between Corps-a-corps and Engagement
                             && level >= Levels.Corpsacorps 
                             && distance <= corpacorpsRange) 
@@ -668,10 +668,21 @@ namespace XIVSlothComboPlugin.Combos
                                 return Corpsacorps;
 
                             if (IsEnabled(CustomComboPreset.RDM_ST_Unbalance)
+                                && level >= Levels.Acceleration
                                 && black == white
-                                && black >= 50
-                                && GetCooldown(Acceleration).RemainingCharges > 0)
-                                return Acceleration;
+                                && black >= 50)
+                            {
+                                if (HasEffect(Buffs.Acceleration) || WasLastAction(Buffs.Acceleration))
+                                {
+                                    if (useAero && level >= Levels.Veraero3) return Veraero3;
+                                    if (useThunder && level >= Levels.Verthunder3) return Verthunder3;
+                                    if (useAero && level < Levels.Veraero3) return Veraero;
+                                    if (useThunder && level < Levels.Verthunder3) return Verthunder;
+                                }
+
+                                if (GetCooldown(Acceleration).RemainingCharges > 0)
+                                    return Acceleration;
+                            }
 
                             if (distance <= 3) 
                                 return OriginalHook(Riposte);

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2021,10 +2021,6 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Hold for Double Melee Combo [Lv.90]", "Hold both actions until you can perform a double melee combo", RDM.JobID, 412)]
         RDM_ST_DoubleMeleeCombo = 13412,
 
-        [ParentCombo(RDM_ST_ManaficationEmbolden)]
-        [CustomComboInfo("Unbalance Mana", "Use Acceleration to unbalance mana prior to starting melee combo", RDM.JobID, 413)]
-        RDM_ST_Unbalance = 13413,
-
         [ReplaceSkill(RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("AoE Melee Combo", "Use Moulinet on Scatter/Impact when over 60/60 mana", RDM.JobID, 420)]
         RDM_AoE_MeleeCombo = 13420,
@@ -2036,6 +2032,10 @@ namespace XIVSlothComboPlugin
         [ParentCombo(RDM_ST_MeleeCombo)]
         [CustomComboInfo("Gap close with Corps-a-corps", "Use Corp-a-corps when out of melee range and you have enough mana to start the melee combo", RDM.JobID, 430)]
         RDM_ST_CorpsGapClose = 13430,
+
+        [ParentCombo(RDM_ST_MeleeCombo)]
+        [CustomComboInfo("Unbalance Mana", "Use Acceleration to unbalance mana prior to starting melee combo", RDM.JobID, 410)]
+        RDM_ST_Unbalance = 13440,
 
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3)]
         [CustomComboInfo("Melee Finisher", "Add Verflare/Verholy and other finishing moves to specified action(s)", RDM.JobID, 510)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2021,6 +2021,10 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Hold for Double Melee Combo [Lv.90]", "Hold both actions until you can perform a double melee combo", RDM.JobID, 412)]
         RDM_ST_DoubleMeleeCombo = 13412,
 
+        [ParentCombo(RDM_ST_ManaficationEmbolden)]
+        [CustomComboInfo("Unbalance Mana", "Use Acceleration to unbalance mana prior to starting melee combo", RDM.JobID, 413)]
+        RDM_ST_Unbalance = 13413,
+
         [ReplaceSkill(RDM.Scatter, RDM.Impact)]
         [CustomComboInfo("AoE Melee Combo", "Use Moulinet on Scatter/Impact when over 60/60 mana", RDM.JobID, 420)]
         RDM_AoE_MeleeCombo = 13420,

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2057,9 +2057,12 @@ namespace XIVSlothComboPlugin
         RDM_CorpsDisplacement = 13810,
 
         [ReplaceSkill(RDM.Embolden)]
-        //[ConflictingCombos(RDM_ST_ManaficationEmbolden)]
         [CustomComboInfo("Embolden to Manafication", "Changes Embolden to Manafication when on cooldown.", RDM.JobID, 820, "You're approaching me?", "do do do do do do do do do")]
         RDM_EmboldenManafication = 13820,
+
+        [ReplaceSkill(RDM.MagickBarrier)]
+        [CustomComboInfo("Magick Barrier to Addle", "Changes Magick Barrier to Addle when on cooldown.", RDM.JobID, 820, "Shields up, Red Alert", "Bewooo bewooo bewoo...")]
+        RDM_MagickBarrierAddle = 13821,
 
         #endregion
         // ====================================================================================
@@ -2070,10 +2073,10 @@ namespace XIVSlothComboPlugin
         //Example: 14110 (Feature Number 1, Option 1, no suboption)
         //New features should be added to the appropriate sections.
 
-            #region SAGE DPS
+        #region SAGE DPS
 
-                #region Single Target DPS Feature
-                [ReplaceSkill(SGE.Dosis1, SGE.Dosis2, SGE.Dosis3)]
+        #region Single Target DPS Feature
+        [ReplaceSkill(SGE.Dosis1, SGE.Dosis2, SGE.Dosis3)]
                 [CustomComboInfo("Single Target DPS Feature", "Replaces Dosis with options below", SGE.JobID, 100)]
                 SGE_ST_DosisFeature = 14100,
                 

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1936,132 +1936,132 @@ namespace XIVSlothComboPlugin
 
         //SECTION_1_OPENERS
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
-        [CustomComboInfo("Balance Opener [Lv.90]", "Replaces Jolt with the Balance opener ending with Resolution\n**Must move into melee range before melee combo**", RDM.JobID, 110)]
+        [CustomComboInfo("Balance Opener Feature [Lv.90]", "Replaces Jolt with the Balance opener ending with Resolution\n**Must move into melee range before melee combo**", RDM.JobID, 110)]
         RDM_Balance_Opener = 13110,
 
         [ParentCombo(RDM_Balance_Opener)]
-        [CustomComboInfo("Use Opener at any Mana", "Removes 0/0 Mana reqirement to reset opener\n**All other actions must be off cooldown**", RDM.JobID, 111)]
+        [CustomComboInfo("Use Opener at any Mana Option", "Removes 0/0 Mana reqirement to reset opener\n**All other actions must be off cooldown**", RDM.JobID, 111)]
         RDM_Opener_Any_Mana = 13111,
 
         //SECTION_2to3_ROTATION
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
-        [CustomComboInfo("Verthunder/Veraero", "Replace Jolt with Verthunder and Veraero", RDM.JobID, 210)]
+        [CustomComboInfo("Verthunder/Veraero Feature", "Replace Jolt with Verthunder and Veraero", RDM.JobID, 210)]
         RDM_VerthunderVeraero = 13210,
 
         [ParentCombo(RDM_VerthunderVeraero)]
-        [CustomComboInfo("Single Target Acceleration", "Add Acceleration when no Verfire/Verstone proc is available", RDM.JobID, 211)]
+        [CustomComboInfo("Single Target Acceleration Option", "Add Acceleration when no Verfire/Verstone proc is available", RDM.JobID, 211)]
         RDM_ST_Acceleration = 13211,
 
         [ParentCombo(RDM_ST_Acceleration)]
-        [CustomComboInfo("Include Swiftcast", "Add Swiftcast when all Acceleration charges are used", RDM.JobID, 212)]
+        [CustomComboInfo("Include Swiftcast Option", "Add Swiftcast when all Acceleration charges are used", RDM.JobID, 212)]
         RDM_ST_AccelSwiftCast = 13212,
 
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
-        [CustomComboInfo("Verfire/Verstone", "Replace Jolt with Verfire and Verstone", RDM.JobID,220)]
+        [CustomComboInfo("Verfire/Verstone Feature", "Replace Jolt with Verfire and Verstone", RDM.JobID,220)]
         RDM_VerfireVerstone = 13220,
 
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Fleche, RDM.Riposte, RDM.Moulinet)]
-        [CustomComboInfo("Weave OGCD Damage", "Use oGCD actions on specified action(s)", RDM.JobID, 240)]
+        [CustomComboInfo("Weave oGCD Damage Feature", "Use oGCD actions on specified action(s)", RDM.JobID, 240)]
         RDM_OGCD = 13240,
 
         [ParentCombo(RDM_OGCD)]
-        [CustomComboInfo("Fleche", "Use Fleche on above specified action(s)", RDM.JobID, 241)]
+        [CustomComboInfo("Fleche Option", "Use Fleche on above specified action(s)", RDM.JobID, 241)]
         RDM_Fleche = 13241,
 
         [ParentCombo(RDM_OGCD)]
-        [CustomComboInfo("Contra Sixte", "Use Contre Sixte on above specified action(s)", RDM.JobID, 242)]
+        [CustomComboInfo("Contra Sixte Option", "Use Contre Sixte on above specified action(s)", RDM.JobID, 242)]
         RDM_ContraSixte = 13242,
 
         [ParentCombo(RDM_OGCD)]
-        [CustomComboInfo("Engagement", "Use Engagement on above specified action(s) when in melee range", RDM.JobID, 243)]
+        [CustomComboInfo("Engagement Option", "Use Engagement on above specified action(s) when in melee range", RDM.JobID, 243)]
         RDM_Engagement = 13243,
 
         [ParentCombo(RDM_Engagement)]
-        [CustomComboInfo("Hold one charge", "Pool one charge of Engagement/Displacement for manual use", RDM.JobID, 246)]
+        [CustomComboInfo("Hold one charge Option", "Pool one charge of Engagement/Displacement for manual use", RDM.JobID, 246)]
         RDM_PoolEngage = 13246,
 
         [ParentCombo(RDM_OGCD)]
-        [CustomComboInfo("Corps-a-corps", "Use Corps-a-corps on above specified action(s)", RDM.JobID, 244)]
+        [CustomComboInfo("Corps-a-corps Option", "Use Corps-a-corps on above specified action(s)", RDM.JobID, 244)]
         RDM_Corpsacorps = 13244,
 
         [ParentCombo(RDM_Corpsacorps)]
-        [CustomComboInfo("Only in Melee Range", "Use Corps-a-corps only when in melee range", RDM.JobID, 245)]
+        [CustomComboInfo("Only in Melee Range Option", "Use Corps-a-corps only when in melee range", RDM.JobID, 245)]
         RDM_Corpsacorps_MeleeRange = 13245,
 
         [ParentCombo(RDM_Corpsacorps)]
-        [CustomComboInfo("Hold one charge", "Pool one charge of Corp-a-corps for manual use", RDM.JobID, 247)]
+        [CustomComboInfo("Hold one charge Option", "Pool one charge of Corp-a-corps for manual use", RDM.JobID, 247)]
         RDM_PoolCorps = 13247,
 
         [ReplaceSkill(RDM.Scatter, RDM.Impact)]
-        [CustomComboInfo("Verthunder II/Veraero II", "Replace Scatter/Impact with Verthunder II or Veraero II", RDM.JobID, 310)]
+        [CustomComboInfo("Verthunder II/Veraero II Feature", "Replace Scatter/Impact with Verthunder II or Veraero II", RDM.JobID, 310)]
         RDM_VerthunderIIVeraeroII = 13310,
 
         [ReplaceSkill(RDM.Scatter, RDM.Impact)]
-        [CustomComboInfo("AoE Acceleration", "Use Acceleration on Scatter/Impact for increased damage", RDM.JobID, 320)]
+        [CustomComboInfo("AoE Acceleration Feature", "Use Acceleration on Scatter/Impact for increased damage", RDM.JobID, 320)]
         RDM_AoE_Acceleration = 13320,
 
         [ParentCombo(RDM_AoE_Acceleration)]
-        [CustomComboInfo("Include Swiftcast", "Add Swiftcast when all Acceleration charges are used or when below level 50", RDM.JobID, 321)]
+        [CustomComboInfo("Include Swiftcast Option", "Add Swiftcast when all Acceleration charges are used or when below level 50", RDM.JobID, 321)]
         RDM_AoE_AccelSwiftCast = 13321,
 
         [ParentCombo(RDM_AoE_Acceleration)]
-        [CustomComboInfo("Weave Acceleration", "Only use acceleration during weave windows", RDM.JobID, 322)]
+        [CustomComboInfo("Weave Acceleration Option", "Only use acceleration during weave windows", RDM.JobID, 322)]
         RDM_AoE_WeaveAcceleration = 13322,
 
         //SECTION_4to5_MELEE
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Riposte)]
-        [CustomComboInfo("Single Target Melee Combo", "Stack Reposte Combo on specified action(s)\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 410)]
+        [CustomComboInfo("Single Target Melee Combo Feature", "Stack Reposte Combo on specified action(s)\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 410)]
         RDM_ST_MeleeCombo = 13410,
 
         [ParentCombo(RDM_ST_MeleeCombo)]
-        [CustomComboInfo("Use Manafication and Embolden", "Add Manafication and Embolden on specified action(s)\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 411)]
+        [CustomComboInfo("Use Manafication and Embolden Option", "Add Manafication and Embolden on specified action(s)\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 411)]
         RDM_ST_ManaficationEmbolden = 13411,
 
         [ParentCombo(RDM_ST_ManaficationEmbolden)]
-        [CustomComboInfo("Hold for Double Melee Combo [Lv.90]", "Hold both actions until you can perform a double melee combo", RDM.JobID, 412)]
+        [CustomComboInfo("Hold for Double Melee Combo Option [Lv.90]", "Hold both actions until you can perform a double melee combo", RDM.JobID, 412)]
         RDM_ST_DoubleMeleeCombo = 13412,
 
         [ReplaceSkill(RDM.Scatter, RDM.Impact)]
-        [CustomComboInfo("AoE Melee Combo", "Use Moulinet on Scatter/Impact when over 60/60 mana", RDM.JobID, 420)]
+        [CustomComboInfo("AoE Melee Combo Feature", "Use Moulinet on Scatter/Impact when over 60/60 mana", RDM.JobID, 420)]
         RDM_AoE_MeleeCombo = 13420,
 
         [ParentCombo(RDM_AoE_MeleeCombo)]
-        [CustomComboInfo("Use Manafication and Embolden", "Add Manafication and Embolden to Scatter/Impact\n**Must be in range of Moulinet**", RDM.JobID, 411)]
+        [CustomComboInfo("Use Manafication and Embolden Option", "Add Manafication and Embolden to Scatter/Impact\n**Must be in range of Moulinet**", RDM.JobID, 411)]
         RDM_AoE_ManaficationEmbolden = 13421,
 
         [ParentCombo(RDM_ST_MeleeCombo)]
-        [CustomComboInfo("Gap close with Corps-a-corps", "Use Corp-a-corps when out of melee range and you have enough mana to start the melee combo", RDM.JobID, 430)]
+        [CustomComboInfo("Gap close with Corps-a-corps Option", "Use Corp-a-corps when out of melee range and you have enough mana to start the melee combo", RDM.JobID, 430)]
         RDM_ST_CorpsGapClose = 13430,
 
         [ParentCombo(RDM_ST_MeleeCombo)]
-        [CustomComboInfo("Unbalance Mana", "Use Acceleration to unbalance mana prior to starting melee combo", RDM.JobID, 410)]
+        [CustomComboInfo("Unbalance Mana Option", "Use Acceleration to unbalance mana prior to starting melee combo", RDM.JobID, 410)]
         RDM_ST_Unbalance = 13440,
 
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3)]
-        [CustomComboInfo("Melee Finisher", "Add Verflare/Verholy and other finishing moves to specified action(s)", RDM.JobID, 510)]
+        [CustomComboInfo("Melee Finisher Feature", "Add Verflare/Verholy and other finishing moves to specified action(s)", RDM.JobID, 510)]
         RDM_MeleeFinisher = 13510,
 
         //SECTION_6to7_QOL
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3, RDM.Scatter, RDM.Impact)]
-        [CustomComboInfo("Lucid Dreaming", "Use Lucid Dreaming on Jolt 1/2, Veraero 1/2/3, Verthunder 1/2/3, and Scatter/Impact when below threshold.", RDM.JobID, 610, "Lucid Dreaming the day away", "OOM? Git gud.")]
+        [CustomComboInfo("Lucid Dreaming Feature", "Use Lucid Dreaming on Jolt 1/2, Veraero 1/2/3, Verthunder 1/2/3, and Scatter/Impact when below threshold.", RDM.JobID, 610, "Lucid Dreaming the day away", "OOM? Git gud.")]
         RDM_LucidDreaming = 13610,
 
         [ReplaceSkill(All.Swiftcast)]
         [ConflictingCombos(ALL_Caster_Raise)]
-        [CustomComboInfo("Verraise", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620, "Swifty Verraise", "You're panicing right now, aren't you?")]
+        [CustomComboInfo("Verraise Feature", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620, "Swifty Verraise", "You're panicing right now, aren't you?")]
         RDM_Verraise = 13620,
 
         //SECTION_8to9_OTHERS                   
         [ReplaceSkill(RDM.Displacement)]
-        [CustomComboInfo("Displacement <> Corps-a-corps", "Replace Displacement with Corps-a-corps when out of range.", RDM.JobID, 810, "I take two steps forward, you take two steps back.", "We come together because opposites attract.")]
+        [CustomComboInfo("Displacement <> Corps-a-corps Feature", "Replace Displacement with Corps-a-corps when out of range.", RDM.JobID, 810, "I take two steps forward, you take two steps back.", "We come together because opposites attract.")]
         RDM_CorpsDisplacement = 13810,
 
         [ReplaceSkill(RDM.Embolden)]
-        [CustomComboInfo("Embolden to Manafication", "Changes Embolden to Manafication when on cooldown.", RDM.JobID, 820, "You're approaching me?", "do do do do do do do do do")]
+        [CustomComboInfo("Embolden to Manafication Feature", "Changes Embolden to Manafication when on cooldown.", RDM.JobID, 820, "You're approaching me?", "do do do do do do do do do")]
         RDM_EmboldenManafication = 13820,
 
         [ReplaceSkill(RDM.MagickBarrier)]
-        [CustomComboInfo("Magick Barrier to Addle", "Changes Magick Barrier to Addle when on cooldown.", RDM.JobID, 820, "Shields up, Red Alert", "Bewooo bewooo bewoo...")]
+        [CustomComboInfo("Magick Barrier to Addle Feature", "Changes Magick Barrier to Addle when on cooldown.", RDM.JobID, 820, "Shields up, Red Alert", "Bewooo bewooo bewoo...")]
         RDM_MagickBarrierAddle = 13821,
 
         #endregion


### PR DESCRIPTION
[RDM]
`Weave OGCD Damage` Feature
 - Fixed an issue where `Corps-a-corps` and `Engagement` would be shown while they had 0 charges remaining
 - Fixed an issue where `Corps-a-corps` and `Engagement` wouldn't appear just prior to reaching 2 stacks when pooling

`Single Target Melee Combo` Feature
 - Added new option `Unbalance Mana`: Uses an `Acceleration` charge to unbalance mana prior to the melee combo (Note: Will not activate between 45 and 49 mana as it would overcap after `Manafication`)

`Magick Barrier to Addle` Feature (New)
 - Replaces `Magick Barrier` with `Addle` when on cooldown.  Includes double `Addle` protection.