### PR TITLE
Smn decouple summons

### DIFF
--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -423,7 +423,7 @@ namespace XIVSlothComboPlugin.Combos
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.SMNLucidDreamingFeature);
                 var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
                 var summonerPrimalChoice = Service.Configuration.GetCustomIntValue(Config.SummonerPrimalChoice);
-                var swiftcasePhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
+                var swiftcastPhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
                 var demiActive = IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15;
 
                 if (actionID is Tridisaster or Outburst && InCombat())
@@ -513,7 +513,7 @@ namespace XIVSlothComboPlugin.Combos
                     if (IsEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) && level >= All.Levels.Swiftcast)
                     {
                         //Swiftcast Garuda Feature
-                        if (swiftcasePhase is 0 or 1 && level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
+                        if (swiftcastPhase is 0 or 1 && level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
                         {
                             if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned &&
                                 IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcastOption))
@@ -525,7 +525,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                        if (swiftcasePhase == 2)
+                        if (swiftcastPhase == 2)
                         {
                             if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned)
                             {
@@ -539,7 +539,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //SpS Swiftcast
-                        if (swiftcasePhase == 3)
+                        if (swiftcastPhase == 3)
                         {
                             //Swiftcast Garuda Feature
                             if (level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
@@ -565,7 +565,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && (IsNotEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) || swiftcasePhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
+                    if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && (IsNotEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) || swiftcastPhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
                         IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazCata && CanSpellWeave(actionID) || //Titan
                         IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
                         return OriginalHook(AstralFlow);

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -293,9 +293,9 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID) && (gauge.IsBahamutReady || gauge.IsPhoenixReady))
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID) && IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15)
                         {
-                            if (IsOffCooldown(OriginalHook(AstralFlow)) && 
+                            if (IsOffCooldown(Deathflare) && 
                                 level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralImpulse))
                                 return OriginalHook(AstralFlow);
 
@@ -305,7 +305,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //Demi Nuke 2: Electric Boogaloo
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption) && gauge.IsPhoenixReady)
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption) && IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15)
                         {
                             if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire)
                                 return OriginalHook(AstralFlow);
@@ -477,10 +477,9 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID) &&
-                            (gauge.IsBahamutReady || gauge.IsPhoenixReady))
+                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID) && IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15)
                         {
-                            if (IsOffCooldown(OriginalHook(AstralFlow)) &&
+                            if (IsOffCooldown(Deathflare) &&
                                 level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralFlare))
                                 return OriginalHook(AstralFlow);
 
@@ -490,7 +489,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //Demi Nuke 2: Electric Boogaloo
-                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption) && gauge.IsPhoenixReady)
+                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption) && IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15)
                         {
                             if (IsOffCooldown(Rekindle) && lastComboMove is BrandOfPurgatory)
                                 return OriginalHook(AstralFlow);

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -291,18 +291,9 @@ namespace XIVSlothComboPlugin.Combos
                         // Lucid
                         if (IsEnabled(CustomComboPreset.SMNLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
                             return All.LucidDreaming;
-                    }
 
-                    //Demi Features
-                    if (IsEnabled(CustomComboPreset.SummonerDemiSummonsFeature))
-                    {
-                        if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
-                            (level is >= Levels.Aethercharge and < Levels.Bahamut || //Pre Bahamut Phase
-                             gauge.IsBahamutReady && level >= Levels.Bahamut || //Bahamut Phase
-                             gauge.IsPhoenixReady && level >= Levels.Phoenix)) //Phoenix Phase
-                            return OriginalHook(Aethercharge);
-
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID))
+                        //Demi Nuke
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID) && (gauge.IsBahamutReady || gauge.IsPhoenixReady))
                         {
                             if (IsOffCooldown(OriginalHook(AstralFlow)) && 
                                 level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralImpulse))
@@ -313,95 +304,105 @@ namespace XIVSlothComboPlugin.Combos
                                 return OriginalHook(EnkindleBahamut);
                         }
 
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption))
+                        //Demi Nuke 2: Electric Boogaloo
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption) && gauge.IsPhoenixReady)
                         {
                             if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire)
                                 return OriginalHook(AstralFlow);
                         }
                     }
+
+                    //Demi
+                    if (IsEnabled(CustomComboPreset.SummonerDemiSummonsFeature))
+                    {
+                        if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
+                            (level is >= Levels.Aethercharge and < Levels.Bahamut || //Pre Bahamut Phase
+                             gauge.IsBahamutReady && level >= Levels.Bahamut || //Bahamut Phase
+                             gauge.IsPhoenixReady && level >= Levels.Phoenix)) //Phoenix Phase
+                            return OriginalHook(Aethercharge);
+                    }
                     
                     // Egi Features
-                    if (IsEnabled(CustomComboPreset.EgisOnRuinFeature))
+                    if (IsEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) && level >= All.Levels.Swiftcast)
                     {
-                        if (IsEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) && level >= All.Levels.Swiftcast)
+                        //Swiftcast Garuda Feature
+                        if (swiftcastPhase is 0 or 1 && level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
+                        {
+                            if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned)
+                                return All.Swiftcast;
+                            if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
+                                ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
+                                 (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
+                                return OriginalHook(AstralFlow);
+                        }
+
+                        //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
+                        if (swiftcastPhase == 2)
+                        {
+                            if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned)
+                            {
+                                if (IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
+                                    (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && gauge.Attunement >= 1))
+                                    return All.Swiftcast;
+                            }
+
+                        }
+
+                        //SpS Swiftcast
+                        if (swiftcastPhase == 3)
                         {
                             //Swiftcast Garuda Feature
-                            if (swiftcastPhase is 0 or 1 && level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
+                            if (level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
                             {
-                                if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned)
+                                if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
                                     return All.Swiftcast;
                                 if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
                                     ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
-                                    (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
+                                     (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
                                     return OriginalHook(AstralFlow);
                             }
 
                             //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                            if (swiftcastPhase == 2)
+                            if (gauge.IsIfritAttuned && IsOffCooldown(All.Swiftcast))
                             {
-                                if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned)
-                                {
-                                    if (IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
-                                        (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && gauge.Attunement >= 1))
-                                        return All.Swiftcast;
-                                }
-
-                            }
-
-                            //SpS Swiftcast
-                            if (swiftcastPhase == 3)
-                            {
-                                //Swiftcast Garuda Feature
-                                if (level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
-                                {
-                                    if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
-                                        return All.Swiftcast;
-                                    if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
-                                        ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
-                                        (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
-                                        return OriginalHook(AstralFlow);
-                                }
-
-                                //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                                if (gauge.IsIfritAttuned && IsOffCooldown(All.Swiftcast))
-                                {
-                                    if (IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
-                                        (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && gauge.Attunement >= 1))
-                                        return All.Swiftcast;
-                                }
-                            }
-                        }
-
-                        if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && (IsNotEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) || swiftcastPhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
-                            IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazRite && CanSpellWeave(actionID) || //Titan
-                            IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
-                            return OriginalHook(AstralFlow);
-
-                        if (IsEnabled(CustomComboPreset.SummonerEgiAttacksFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
-                            return OriginalHook(Gemshine);
-
-                        if (IsEnabled(CustomComboPreset.SummonerEgiOrderFeature) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
-                        {
-                            if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && level >= Levels.SummonRuby)
-                                return OriginalHook(SummonRuby);
-
-                            if (summonerPrimalChoice is 0 or 1)
-                            {
-                                if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
-                                    return OriginalHook(SummonTopaz);
-                                if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
-                                    return OriginalHook(SummonEmerald);
-                            }
-
-                            if (summonerPrimalChoice == 2)
-                            {
-                                if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
-                                    return OriginalHook(SummonEmerald);
-                                if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
-                                    return OriginalHook(SummonTopaz);
+                                if (IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
+                                    (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && gauge.Attunement >= 1))
+                                    return All.Swiftcast;
                             }
                         }
                     }
+
+                    if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && (IsNotEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) || swiftcastPhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
+                        IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazRite && CanSpellWeave(actionID) || //Titan
+                        IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
+                        return OriginalHook(AstralFlow);
+
+                    // Gemshine
+                    if (IsEnabled(CustomComboPreset.SummonerEgiAttacksFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
+                        return OriginalHook(Gemshine);
+
+                    if (IsEnabled(CustomComboPreset.SummonerEgiOrderFeature) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                    {
+                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && level >= Levels.SummonRuby)
+                            return OriginalHook(SummonRuby);
+
+                        if (summonerPrimalChoice is 0 or 1)
+                        {
+                            if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
+                                return OriginalHook(SummonTopaz);
+                            if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
+                                return OriginalHook(SummonEmerald);
+                        }
+
+                        if (summonerPrimalChoice == 2)
+                        {
+                            if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
+                                return OriginalHook(SummonEmerald);
+                            if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
+                                return OriginalHook(SummonTopaz);
+                        }
+                    }
+                    
 
                     if (IsEnabled(CustomComboPreset.SummonerRuin4ToRuin3Feature) && level >= Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
                         return Ruin4;
@@ -423,176 +424,183 @@ namespace XIVSlothComboPlugin.Combos
                 var summonerPrimalChoice = Service.Configuration.GetCustomIntValue(Config.SummonerPrimalChoice);
                 var swiftcasePhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
 
-                if (actionID is Tridisaster or Outburst)
+                if (actionID is Tridisaster or Outburst && InCombat())
                 {
-                    if (InCombat())
+                    if (CanSpellWeave(actionID))
                     {
-                        if (CanSpellWeave(actionID))
+                        // Searing Light
+                        if (IsEnabled(CustomComboPreset.SearingLightFeature) &&
+                            IsNotEnabled(CustomComboPreset.SearingLightSTOnlyOption) && IsOffCooldown(SearingLight) &&
+                            level >= Levels.SearingLight)
                         {
-                            // Searing Light
-                            if (IsEnabled(CustomComboPreset.SearingLightFeature) && IsNotEnabled(CustomComboPreset.SearingLightSTOnlyOption) && IsOffCooldown(SearingLight) && level >= Levels.SearingLight)
+                            if (IsEnabled(CustomComboPreset.SummonerSearingLightBurstOption))
                             {
-                                if (IsEnabled(CustomComboPreset.SummonerSearingLightBurstOption))
+                                if ((SummonerBurstPhase is 0 or 1 && OriginalHook(Tridisaster) == AstralFlare) ||
+                                    (SummonerBurstPhase == 2 && OriginalHook(Tridisaster) == BrandOfPurgatory) ||
+                                    (SummonerBurstPhase == 3 && OriginalHook(Tridisaster) is AstralFlare or BrandOfPurgatory) ||
+                                    (SummonerBurstPhase == 4))
+                                    return SearingLight;
+                            }
+
+                            else return SearingLight;
+                        }
+
+
+                        // ED & Fester
+                        if (IsEnabled(CustomComboPreset.SummonerESAOEFeature))
+                        {
+                            if (gauge.HasAetherflowStacks && level >= Levels.Painflare)
+                            {
+                                if (IsNotEnabled(CustomComboPreset.SummonerOGCDPoolFeature))
+                                    return Painflare;
+                                if (IsEnabled(CustomComboPreset.SummonerOGCDPoolFeature) && IsNotEnabled(CustomComboPreset.SummonerSTPoolOnlyOption))
                                 {
+                                    if (level < Levels.SearingLight)
+                                        return Painflare;
                                     if ((SummonerBurstPhase is 0 or 1 && OriginalHook(Tridisaster) == AstralFlare) ||
                                         (SummonerBurstPhase == 2 && OriginalHook(Tridisaster) == BrandOfPurgatory) ||
-                                        (SummonerBurstPhase == 3 && OriginalHook(Tridisaster) is AstralFlare or BrandOfPurgatory) ||
-                                        (SummonerBurstPhase == 4))
-                                        return SearingLight;
-                                }
-
-                                else return SearingLight;
-                            }
-
-
-                            // ED & Fester
-                            if (IsEnabled(CustomComboPreset.SummonerESAOEFeature))
-                            {
-                                if (gauge.HasAetherflowStacks && level >= Levels.Painflare)
-                                {
-                                    if (IsNotEnabled(CustomComboPreset.SummonerOGCDPoolFeature))
+                                        (SummonerBurstPhase == 3 && (GetCooldownRemainingTime(SearingLight) < 30 || GetCooldownRemainingTime(SearingLight) > 100) && OriginalHook(Tridisaster) is AstralFlare or BrandOfPurgatory) ||
+                                        (SummonerBurstPhase == 4 && HasEffectAny(Buffs.SearingLight) &&
+                                         !HasEffect(Buffs.TitansFavor)) || IsNotEnabled(CustomComboPreset.SummonerPrimalBurstChoice))
                                         return Painflare;
-                                    if (IsEnabled(CustomComboPreset.SummonerOGCDPoolFeature) && IsNotEnabled(CustomComboPreset.SummonerSTPoolOnlyOption))
-                                    {
-                                        if (level < Levels.SearingLight)
-                                            return Painflare;
-                                        if ((SummonerBurstPhase is 0 or 1 && OriginalHook(Tridisaster) == AstralFlare) ||
-                                            (SummonerBurstPhase == 2 && OriginalHook(Tridisaster) == BrandOfPurgatory) ||
-                                            (SummonerBurstPhase == 3 && (GetCooldownRemainingTime(SearingLight) < 30 || GetCooldownRemainingTime(SearingLight) > 100) && OriginalHook(Tridisaster) is AstralFlare or BrandOfPurgatory) ||
-                                            (SummonerBurstPhase == 4 && HasEffectAny(Buffs.SearingLight) && !HasEffect(Buffs.TitansFavor)) ||
-                                            IsNotEnabled(CustomComboPreset.SummonerPrimalBurstChoice))
-                                            return Painflare;
-                                    }
                                 }
-
-                                if (level >= Levels.EnergySiphon && !gauge.HasAetherflowStacks && IsOffCooldown(EnergySiphon))
-                                    return EnergySiphon;
                             }
 
-                            // Lucid
-                            if (IsEnabled(CustomComboPreset.SMNLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
-                                return All.LucidDreaming;
-
-                            //Demi Nuke
-                            if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID))
-                            {
-                                if (IsOffCooldown(OriginalHook(AstralFlow)) && 
-                                    level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralFlare))
-                                    return OriginalHook(AstralFlow);
-
-                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && 
-                                    level >= Levels.Bahamut && lastComboMove is AstralFlare or BrandOfPurgatory)
-                                    return OriginalHook(EnkindleBahamut);
-                            }
-
-                            //Demi Nuke 2: Electric Boogaloo
-                            if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption))
-                            {
-                                if (IsOffCooldown(OriginalHook(AstralFlow)) && lastComboMove is BrandOfPurgatory)
-                                    return OriginalHook(AstralFlow);
-                            }
+                            if (level >= Levels.EnergySiphon && !gauge.HasAetherflowStacks &&
+                                IsOffCooldown(EnergySiphon))
+                                return EnergySiphon;
                         }
 
-                        //Demi
-                        if (IsEnabled(CustomComboPreset.SummonerDemiAoESummonsFeature))
+                        // Lucid
+                        if (IsEnabled(CustomComboPreset.SMNLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) &&
+                            LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
+                            return All.LucidDreaming;
+
+                        //Demi Nuke
+                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID) &&
+                            (gauge.IsBahamutReady || gauge.IsPhoenixReady))
                         {
-                            if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
-                                (level is >= Levels.Aethercharge and < Levels.Bahamut || //Pre Bahamut Phase
-                                 gauge.IsBahamutReady && level >= Levels.Bahamut || //Bahamut Phase
-                                 gauge.IsPhoenixReady && level >= Levels.Phoenix)) //Phoenix Phase
-                                return OriginalHook(Aethercharge);
+                            if (IsOffCooldown(OriginalHook(AstralFlow)) &&
+                                level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralFlare))
+                                return OriginalHook(AstralFlow);
+
+                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) &&
+                                level >= Levels.Bahamut && lastComboMove is AstralFlare or BrandOfPurgatory)
+                                return OriginalHook(EnkindleBahamut);
+                        }
+
+                        //Demi Nuke 2: Electric Boogaloo
+                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption) && gauge.IsPhoenixReady)
+                        {
+                            if (IsOffCooldown(Rekindle) && lastComboMove is BrandOfPurgatory)
+                                return OriginalHook(AstralFlow);
+                        }
+                    }
+
+                    //Demi
+                    if (IsEnabled(CustomComboPreset.SummonerDemiAoESummonsFeature))
+                    {
+                        if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 &&
+                            IsOffCooldown(OriginalHook(Aethercharge)) &&
+                            (level is >= Levels.Aethercharge and < Levels.Bahamut || //Pre Bahamut Phase
+                             gauge.IsBahamutReady && level >= Levels.Bahamut || //Bahamut Phase
+                             gauge.IsPhoenixReady && level >= Levels.Phoenix)) //Phoenix Phase
+                            return OriginalHook(Aethercharge);
+                    }
+
+                    // Egi Features
+                    if (IsEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) && level >= All.Levels.Swiftcast)
+                    {
+                        //Swiftcast Garuda Feature
+                        if (swiftcasePhase is 0 or 1 && level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
+                        {
+                            if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned &&
+                                IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
+                                return All.Swiftcast;
+                            if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
+                                ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
+                                 (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
+                                return OriginalHook(AstralFlow);
+                        }
+
+                        //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
+                        if (swiftcasePhase == 2)
+                        {
+                            if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned)
+                            {
+                                if ((IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
+                                     (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) &&
+                                      gauge.Attunement >= 1)) &&
+                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
+                                    return All.Swiftcast;
+                            }
 
                         }
 
-
-                        // Egi Features
-                    if (IsEnabled(CustomComboPreset.EgisOnAOEFeature))
-                    {
-                        if (IsEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) && level >= All.Levels.Swiftcast)
+                        //SpS Swiftcast
+                        if (swiftcasePhase == 3)
                         {
                             //Swiftcast Garuda Feature
-                            if (swiftcasePhase is 0 or 1 && level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
+                            if (level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
                             {
-                                if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned && IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
+                                if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast) &&
+                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
                                     return All.Swiftcast;
                                 if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
                                     ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
-                                    (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
+                                     (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
                                     return OriginalHook(AstralFlow);
                             }
 
                             //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                            if (swiftcasePhase == 2)
+                            if (gauge.IsIfritAttuned && IsOffCooldown(All.Swiftcast))
                             {
-                                if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned)
-                                {
-                                    if ((IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
-                                        (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && gauge.Attunement >= 1)) && IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
-                                        return All.Swiftcast;
-                                }
-
-                            }
-
-                            //SpS Swiftcast
-                            if (swiftcasePhase == 3)
-                            {
-                                //Swiftcast Garuda Feature
-                                if (level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
-                                {
-                                    if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast) && IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
-                                        return All.Swiftcast;
-                                    if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
-                                        ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
-                                        (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
-                                        return OriginalHook(AstralFlow);
-                                }
-
-                                //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                                if (gauge.IsIfritAttuned && IsOffCooldown(All.Swiftcast))
-                                {
-                                    if ((IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
-                                        (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && gauge.Attunement >= 1)) && IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
-                                        return All.Swiftcast;
-                                }
+                                if ((IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
+                                     (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) &&
+                                      gauge.Attunement >= 1)) &&
+                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
+                                    return All.Swiftcast;
                             }
                         }
+                    }
 
-                        if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && (IsNotEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) || swiftcasePhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
-                            IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazCata && CanSpellWeave(actionID) || //Titan
-                            IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
-                            return OriginalHook(AstralFlow);
+                    if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && (IsNotEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) || swiftcasePhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
+                        IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazCata && CanSpellWeave(actionID) || //Titan
+                        IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
+                        return OriginalHook(AstralFlow);
 
-                        //Precious Brilliance
-                        if (IsEnabled(CustomComboPreset.SummonerEgiAttacksAOEFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
-                            return OriginalHook(PreciousBrilliance);
+                    //Precious Brilliance
+                    if (IsEnabled(CustomComboPreset.SummonerEgiAttacksAOEFeature) &&
+                        (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
+                        return OriginalHook(PreciousBrilliance);
 
-                        if (IsEnabled(CustomComboPreset.SummonerEgiOrderFeature) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                    if (IsEnabled(CustomComboPreset.SummonerEgiOrderFeature) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                    {
+                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady &&
+                            level >= Levels.SummonRuby)
+                            return OriginalHook(SummonRuby);
+
+                        if (summonerPrimalChoice is 0 or 1)
                         {
-                            if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && level >= Levels.SummonRuby)
-                                return OriginalHook(SummonRuby);
+                            if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
+                                return OriginalHook(SummonTopaz);
+                            if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
+                                return OriginalHook(SummonEmerald);
+                        }
 
-                            if (summonerPrimalChoice is 0 or 1)
-                            {
-                                if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
-                                    return OriginalHook(SummonTopaz);
-                                if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
-                                    return OriginalHook(SummonEmerald);
-                            }
-
-                            if (summonerPrimalChoice == 2)
-                            {
-                                if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
-                                    return OriginalHook(SummonEmerald);
-                                if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
-                                    return OriginalHook(SummonTopaz);
-                            }
+                        if (summonerPrimalChoice == 2)
+                        {
+                            if (gauge.IsGarudaReady && level >= Levels.SummonEmerald)
+                                return OriginalHook(SummonEmerald);
+                            if (gauge.IsTitanReady && level >= Levels.SummonTopaz)
+                                return OriginalHook(SummonTopaz);
                         }
                     }
-                        if (IsEnabled(CustomComboPreset.SummonerRuin4ToTridisasterFeature) && level >= Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
-                            return Ruin4;
-                    }
-                }
 
+                    if (IsEnabled(CustomComboPreset.SummonerRuin4ToTridisasterFeature) && level >= Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                        return Ruin4;
+                }
+                
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -163,9 +163,9 @@ namespace XIVSlothComboPlugin.Combos
                 SummonerSwiftcastPhase = "SummonerSwiftcastPhase";
         }
 
-        internal class SummonerRaiseFeature : CustomCombo
+        internal class SMN_Raise : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerRaiseFeature;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_Raise;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -178,9 +178,9 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
-        internal class SummonerSpecialRuinFeature : CustomCombo
+        internal class SMN_RuinMobility : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerSpecialRuinFeature;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_RuinMobility;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -194,16 +194,16 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
-        internal class SummonerEDFesterCombo : CustomCombo
+        internal class SMN_EDFester : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerEDFesterCombo;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_EDFester;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID == Fester)
                 {
                     var gauge = GetJobGauge<SMNGauge>();
-                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SummonerFesterPainflareRuinFeature))
+                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_EDFester_PainflareRuin4))
                         return Ruin4;
                     if (level >= Levels.EnergyDrain && !gauge.HasAetherflowStacks)
                         return EnergyDrain;
@@ -213,16 +213,16 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
-        internal class SummonerESPainflareCombo : CustomCombo
+        internal class SMN_ESPainflare : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerESPainflareCombo;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_ESPainflare;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID == Painflare)
                 {
                     var gauge = GetJobGauge<SMNGauge>();
-                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SummonerFesterPainflareRuinFeature))
+                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_EDFester_PainflareRuin4))
                         return Ruin4;
                     if (level >= Levels.EnergySiphon && !gauge.HasAetherflowStacks)
                         return EnergySiphon;
@@ -233,9 +233,9 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
-        internal class SummonerMainComboFeature : CustomCombo
+        internal class SMN_ST_MainCombo : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerMainComboFeature;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_ST_MainCombo;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -250,9 +250,9 @@ namespace XIVSlothComboPlugin.Combos
                     if (CanSpellWeave(actionID))
                     {
                         // Searing Light
-                        if (IsEnabled(CustomComboPreset.SearingLightFeature) && IsOffCooldown(SearingLight) && level >= Levels.SearingLight)
+                        if (IsEnabled(CustomComboPreset.SMN_SearingLight) && IsOffCooldown(SearingLight) && level >= Levels.SearingLight)
                         {
-                            if (IsEnabled(CustomComboPreset.SummonerSearingLightBurstOption))
+                            if (IsEnabled(CustomComboPreset.SMN_SearingLight_Burst))
                             {
                                 if ((SummonerBurstPhase is 0 or 1 && OriginalHook(Ruin) == AstralImpulse) ||
                                     (SummonerBurstPhase == 2 && OriginalHook(Ruin) == FountainOfFire) ||
@@ -265,13 +265,13 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         // ED & Fester
-                        if (IsEnabled(CustomComboPreset.SummonerEDMainComboFeature))
+                        if (IsEnabled(CustomComboPreset.SMN_ST_MainCombo_EDFester))
                         {
                             if (gauge.HasAetherflowStacks)
                             {
-                                if (IsNotEnabled(CustomComboPreset.SummonerOGCDPoolFeature))
+                                if (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling))
                                     return Fester;
-                                if (IsEnabled(CustomComboPreset.SummonerOGCDPoolFeature))
+                                if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling))
                                 {
                                     if (level < Levels.SearingLight)
                                         return Fester;
@@ -279,7 +279,7 @@ namespace XIVSlothComboPlugin.Combos
                                         (SummonerBurstPhase == 2 && OriginalHook(Ruin) == FountainOfFire) ||
                                         (SummonerBurstPhase == 3 && (GetCooldownRemainingTime(SearingLight) < 30 || GetCooldownRemainingTime(SearingLight) > 100) && OriginalHook(Ruin) is AstralImpulse or FountainOfFire) ||
                                         (SummonerBurstPhase == 4 && HasEffectAny(Buffs.SearingLight) && !HasEffect(Buffs.TitansFavor)) ||
-                                        IsNotEnabled(CustomComboPreset.SummonerPrimalBurstChoice))
+                                        IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_BurstChoice))
                                         return Fester;
                                 }
                             }
@@ -289,13 +289,13 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         // Lucid
-                        if (IsEnabled(CustomComboPreset.SMNLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
+                        if (IsEnabled(CustomComboPreset.SMN_Lucid) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
                             return All.LucidDreaming;
 
                         //Demi Nuke
                         if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
                         {
-                            if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature))
+                            if (IsEnabled(CustomComboPreset.SMN_ST_MainCombo_DemiSummons_Attacks))
                             {
                                 if (IsOffCooldown(Deathflare) && level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralImpulse))
                                     return OriginalHook(AstralFlow);
@@ -305,7 +305,7 @@ namespace XIVSlothComboPlugin.Combos
                             }
 
                             //Demi Nuke 2: Electric Boogaloo
-                            if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption))
+                            if (IsEnabled(CustomComboPreset.SMN_ST_MainCombo_DemiSummons_Rekindle))
                             {
                                 if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire)
                                     return OriginalHook(AstralFlow);
@@ -314,7 +314,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
 
                     //Demi
-                    if (IsEnabled(CustomComboPreset.SummonerDemiSummonsFeature))
+                    if (IsEnabled(CustomComboPreset.SMN_ST_MainCombo_DemiSummons))
                     {
                         if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
                             (level is >= Levels.Aethercharge and < Levels.Bahamut || //Pre Bahamut Phase
@@ -324,14 +324,14 @@ namespace XIVSlothComboPlugin.Combos
                     }
                     
                     // Egi Features
-                    if (IsEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) && level >= All.Levels.Swiftcast)
+                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) && level >= All.Levels.Swiftcast)
                     {
                         //Swiftcast Garuda Feature
                         if (swiftcastPhase is 0 or 1 && level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
                         {
                             if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned)
                                 return All.Swiftcast;
-                            if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
+                            if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) &&
                                 ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
                                  (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
                                 return OriginalHook(AstralFlow);
@@ -342,8 +342,8 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned)
                             {
-                                if (IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
-                                    (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && gauge.Attunement >= 1))
+                                if (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) ||
+                                    (IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && gauge.Attunement >= 1))
                                     return All.Swiftcast;
                             }
 
@@ -357,7 +357,7 @@ namespace XIVSlothComboPlugin.Combos
                             {
                                 if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
                                     return All.Swiftcast;
-                                if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
+                                if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) &&
                                     ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
                                      (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
                                     return OriginalHook(AstralFlow);
@@ -366,23 +366,23 @@ namespace XIVSlothComboPlugin.Combos
                             //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
                             if (gauge.IsIfritAttuned && IsOffCooldown(All.Swiftcast))
                             {
-                                if (IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
-                                    (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && gauge.Attunement >= 1))
+                                if (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) ||
+                                    (IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && gauge.Attunement >= 1))
                                     return All.Swiftcast;
                             }
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && (IsNotEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) || swiftcastPhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
-                        IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazRite && CanSpellWeave(actionID) || //Titan
-                        IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
+                    if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
+                        IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazRite && CanSpellWeave(actionID) || //Titan
+                        IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
                         return OriginalHook(AstralFlow);
 
                     // Gemshine
-                    if (IsEnabled(CustomComboPreset.SummonerEgiAttacksFeature) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
+                    if (IsEnabled(CustomComboPreset.SMN_ST_MainCombo_EgiSummons_Attacks) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
                         return OriginalHook(Gemshine);
 
-                    if (IsEnabled(CustomComboPreset.SummonerEgiOrderFeature) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
                     {
                         if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && level >= Levels.SummonRuby)
                             return OriginalHook(SummonRuby);
@@ -405,7 +405,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
                     
 
-                    if (IsEnabled(CustomComboPreset.SummonerRuin4ToRuin3Feature) && level >= Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                    if (IsEnabled(CustomComboPreset.SMN_ST_MainCombo_Ruin4) && level >= Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
                         return Ruin4;
                 }
 
@@ -413,9 +413,9 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
-        internal class SummonerAOEComboFeature : CustomCombo
+        internal class SMN_AoE_MainCombo : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SummonerAOEComboFeature;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SMN_AoE_MainCombo;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -430,11 +430,11 @@ namespace XIVSlothComboPlugin.Combos
                     if (CanSpellWeave(actionID))
                     {
                         // Searing Light
-                        if (IsEnabled(CustomComboPreset.SearingLightFeature) &&
-                            IsNotEnabled(CustomComboPreset.SearingLightSTOnlyOption) && IsOffCooldown(SearingLight) &&
+                        if (IsEnabled(CustomComboPreset.SMN_SearingLight) &&
+                            IsNotEnabled(CustomComboPreset.SMN_SearingLight_STOnly) && IsOffCooldown(SearingLight) &&
                             level >= Levels.SearingLight)
                         {
-                            if (IsEnabled(CustomComboPreset.SummonerSearingLightBurstOption))
+                            if (IsEnabled(CustomComboPreset.SMN_SearingLight_Burst))
                             {
                                 if ((SummonerBurstPhase is 0 or 1 && OriginalHook(Tridisaster) == AstralFlare) ||
                                     (SummonerBurstPhase == 2 && OriginalHook(Tridisaster) == BrandOfPurgatory) ||
@@ -448,13 +448,13 @@ namespace XIVSlothComboPlugin.Combos
 
 
                         // ES & Painflare
-                        if (IsEnabled(CustomComboPreset.SummonerESAOEFeature))
+                        if (IsEnabled(CustomComboPreset.SMN_AoE_MainCombo_ESPainflare))
                         {
                             if (gauge.HasAetherflowStacks && level >= Levels.Painflare)
                             {
-                                if (IsNotEnabled(CustomComboPreset.SummonerOGCDPoolFeature))
+                                if (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling))
                                     return Painflare;
-                                if (IsEnabled(CustomComboPreset.SummonerOGCDPoolFeature) && IsNotEnabled(CustomComboPreset.SummonerSTOnlyPoolOption))
+                                if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling) && IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_Only))
                                 {
                                     if (level < Levels.SearingLight)
                                         return Painflare;
@@ -462,7 +462,7 @@ namespace XIVSlothComboPlugin.Combos
                                         (SummonerBurstPhase == 2 && OriginalHook(Tridisaster) == BrandOfPurgatory) ||
                                         (SummonerBurstPhase == 3 && (GetCooldownRemainingTime(SearingLight) < 30 || GetCooldownRemainingTime(SearingLight) > 100) && OriginalHook(Tridisaster) is AstralFlare or BrandOfPurgatory) ||
                                         (SummonerBurstPhase == 4 && HasEffectAny(Buffs.SearingLight) &&
-                                         !HasEffect(Buffs.TitansFavor)) || IsNotEnabled(CustomComboPreset.SummonerPrimalBurstChoice))
+                                         !HasEffect(Buffs.TitansFavor)) || IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_BurstChoice))
                                         return Painflare;
                                 }
                             }
@@ -473,14 +473,14 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         // Lucid
-                        if (IsEnabled(CustomComboPreset.SMNLucidDreamingFeature) && IsOffCooldown(All.LucidDreaming) &&
+                        if (IsEnabled(CustomComboPreset.SMN_Lucid) && IsOffCooldown(All.LucidDreaming) &&
                             LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
                             return All.LucidDreaming;
 
                         //Demi Nuke
                         if (OriginalHook(Tridisaster) is AstralFlare or BrandOfPurgatory)
                         {
-                            if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature))
+                            if (IsEnabled(CustomComboPreset.SMN_AoE_MainCombo_Demis))
                             {
                                 if (IsOffCooldown(Deathflare) && level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralFlare))
                                     return OriginalHook(AstralFlow);
@@ -490,7 +490,7 @@ namespace XIVSlothComboPlugin.Combos
                             }
                             
                             //Demi Nuke 2: Electric Boogaloo
-                            if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption))
+                            if (IsEnabled(CustomComboPreset.SMN_AoE_MainCombo_Rekindle))
                             {
                                 if (IsOffCooldown(Rekindle) && lastComboMove is BrandOfPurgatory)
                                     return OriginalHook(AstralFlow);
@@ -499,7 +499,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
 
                     //Demi
-                    if (IsEnabled(CustomComboPreset.SummonerDemiAOESummonsFeature))
+                    if (IsEnabled(CustomComboPreset.SMN_AoE_MainCombo_DemiSummons))
                     {
                         if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 &&
                             IsOffCooldown(OriginalHook(Aethercharge)) &&
@@ -510,15 +510,15 @@ namespace XIVSlothComboPlugin.Combos
                     }
 
                     // Egi Features
-                    if (IsEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) && level >= All.Levels.Swiftcast)
+                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) && level >= All.Levels.Swiftcast)
                     {
                         //Swiftcast Garuda Feature
                         if (swiftcastPhase is 0 or 1 && level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
                         {
                             if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned &&
-                                IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcastOption))
+                                IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi_Only))
                                 return All.Swiftcast;
-                            if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
+                            if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) &&
                                 ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
                                  (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
                                 return OriginalHook(AstralFlow);
@@ -529,10 +529,10 @@ namespace XIVSlothComboPlugin.Combos
                         {
                             if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned)
                             {
-                                if ((IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
-                                     (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) &&
+                                if ((IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) ||
+                                     (IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) &&
                                       gauge.Attunement >= 1)) &&
-                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcastOption))
+                                    IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi_Only))
                                     return All.Swiftcast;
                             }
 
@@ -545,9 +545,9 @@ namespace XIVSlothComboPlugin.Combos
                             if (level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
                             {
                                 if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast) &&
-                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcastOption))
+                                    IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi_Only))
                                     return All.Swiftcast;
-                                if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
+                                if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) &&
                                     ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
                                      (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
                                     return OriginalHook(AstralFlow);
@@ -556,26 +556,26 @@ namespace XIVSlothComboPlugin.Combos
                             //Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
                             if (gauge.IsIfritAttuned && IsOffCooldown(All.Swiftcast))
                             {
-                                if ((IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
-                                     (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) &&
+                                if ((IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) ||
+                                     (IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) &&
                                       gauge.Attunement >= 1)) &&
-                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcastOption))
+                                    IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi_Only))
                                     return All.Swiftcast;
                             }
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) && (IsNotEnabled(CustomComboPreset.SummonerSwiftcastEgiFeature) || swiftcastPhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
-                        IsEnabled(CustomComboPreset.SummonerTitanUniqueFeature) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazCata && CanSpellWeave(actionID) || //Titan
-                        IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
+                    if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
+                        IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove == TopazCata && CanSpellWeave(actionID) || //Titan
+                        IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
                         return OriginalHook(AstralFlow);
 
                     //Precious Brilliance
-                    if (IsEnabled(CustomComboPreset.SummonerEgiAttacksAOEFeature) &&
+                    if (IsEnabled(CustomComboPreset.SMN_AoE_MainCombo_EgiAttacks) &&
                         (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
                         return OriginalHook(PreciousBrilliance);
 
-                    if (IsEnabled(CustomComboPreset.SummonerEgiOrderFeature) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
                     {
                         if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady &&
                             level >= Levels.SummonRuby)
@@ -598,7 +598,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.SummonerRuin4ToTridisasterFeature) && level >= Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                    if (IsEnabled(CustomComboPreset.SMN_AoE_MainCombo_Ruin4) && level >= Levels.Ruin4 && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
                         return Ruin4;
                 }
                 
@@ -606,9 +606,9 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
-        internal class SummonerCarbuncleSummonFeature : CustomCombo
+        internal class SMN_CarbuncleReminder : CustomCombo
         {
-            protected internal override CustomComboPreset Preset => CustomComboPreset.SummonerCarbuncleSummonFeature;
+            protected internal override CustomComboPreset Preset => CustomComboPreset.SMN_CarbuncleReminder;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -623,9 +623,9 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
-        internal class SummonerAstralFlowonSummonsFeature : CustomCombo
+        internal class SMN_Egi_AstralFlow : CustomCombo
         {
-            protected internal override CustomComboPreset Preset => CustomComboPreset.SummonerAstralFlowonSummonsFeature;
+            protected internal override CustomComboPreset Preset => CustomComboPreset.SMN_Egi_AstralFlow;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -637,9 +637,9 @@ namespace XIVSlothComboPlugin.Combos
             }
         }
 
-        internal class SummonerPrimalAbilitiesFeature : CustomCombo
+        internal class SMN_DemiAbilities : CustomCombo
         {
-            protected internal override CustomComboPreset Preset => CustomComboPreset.SummonerPrimalAbilitiesFeature;
+            protected internal override CustomComboPreset Preset => CustomComboPreset.SMN_DemiAbilities;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -244,7 +244,7 @@ namespace XIVSlothComboPlugin.Combos
                 var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.SMNLucidDreamingFeature);
                 var swiftcastPhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
-                var demiActive = IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15;
+                var demiActive = GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed is <= 15 or > 0;
 
                 if (actionID is Ruin or Ruin2 && InCombat())
                 {
@@ -294,22 +294,23 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID) && demiActive)
+                        if (demiActive)
                         {
-                            if (IsOffCooldown(Deathflare) && 
-                                level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralImpulse))
-                                return OriginalHook(AstralFlow);
+                            if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature))
+                            {
+                                if (IsOffCooldown(Deathflare) && level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralImpulse))
+                                    return OriginalHook(AstralFlow);
 
-                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && 
-                                level >= Levels.Bahamut && lastComboMove is AstralImpulse or FountainOfFire)
-                                return OriginalHook(EnkindleBahamut);
-                        }
+                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && level >= Levels.Bahamut && lastComboMove is AstralImpulse or FountainOfFire)
+                                    return OriginalHook(EnkindleBahamut);
+                            }
 
-                        //Demi Nuke 2: Electric Boogaloo
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption) && demiActive)
-                        {
-                            if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire)
-                                return OriginalHook(AstralFlow);
+                            //Demi Nuke 2: Electric Boogaloo
+                            if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption))
+                            {
+                                if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire)
+                                    return OriginalHook(AstralFlow);
+                            }
                         }
                     }
 
@@ -424,7 +425,7 @@ namespace XIVSlothComboPlugin.Combos
                 var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
                 var summonerPrimalChoice = Service.Configuration.GetCustomIntValue(Config.SummonerPrimalChoice);
                 var swiftcastPhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
-                var demiActive = IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15;
+                var demiActive = GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed is <= 15 or > 0;
 
                 if (actionID is Tridisaster or Outburst && InCombat())
                 {
@@ -448,7 +449,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
 
-                        // ED & Fester
+                        // ES & Painflare
                         if (IsEnabled(CustomComboPreset.SummonerESAOEFeature))
                         {
                             if (gauge.HasAetherflowStacks && level >= Levels.Painflare)
@@ -479,22 +480,23 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID) && demiActive)
+                        if (demiActive)
                         {
-                            if (IsOffCooldown(Deathflare) &&
-                                level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralFlare))
-                                return OriginalHook(AstralFlow);
+                            if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature))
+                            {
+                                if (IsOffCooldown(Deathflare) && level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralFlare))
+                                    return OriginalHook(AstralFlow);
 
-                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) &&
-                                level >= Levels.Bahamut && lastComboMove is AstralFlare or BrandOfPurgatory)
-                                return OriginalHook(EnkindleBahamut);
-                        }
-
-                        //Demi Nuke 2: Electric Boogaloo
-                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption) && demiActive)
-                        {
-                            if (IsOffCooldown(Rekindle) && lastComboMove is BrandOfPurgatory)
-                                return OriginalHook(AstralFlow);
+                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && level >= Levels.Bahamut && lastComboMove is AstralFlare or BrandOfPurgatory)
+                                    return OriginalHook(EnkindleBahamut);
+                            }
+                            
+                            //Demi Nuke 2: Electric Boogaloo
+                            if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption))
+                            {
+                                if (IsOffCooldown(Rekindle) && lastComboMove is BrandOfPurgatory)
+                                    return OriginalHook(AstralFlow);
+                            }
                         }
                     }
 

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -244,7 +244,7 @@ namespace XIVSlothComboPlugin.Combos
                 var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.SMNLucidDreamingFeature);
                 var swiftcastPhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
-                var demiActive = GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15;
+                var demiActive = IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15;
 
                 if (actionID is Ruin or Ruin2 && InCombat())
                 {
@@ -294,7 +294,7 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID) && IsOnCooldown(OriginalHook(SummonBahamut)) && demiActive)
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID) && demiActive)
                         {
                             if (IsOffCooldown(Deathflare) && 
                                 level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralImpulse))
@@ -306,7 +306,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //Demi Nuke 2: Electric Boogaloo
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption) && IsOnCooldown(OriginalHook(SummonBahamut)) && demiActive)
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption) && demiActive)
                         {
                             if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire)
                                 return OriginalHook(AstralFlow);
@@ -424,7 +424,7 @@ namespace XIVSlothComboPlugin.Combos
                 var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
                 var summonerPrimalChoice = Service.Configuration.GetCustomIntValue(Config.SummonerPrimalChoice);
                 var swiftcasePhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
-                var demiActive = GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15;
+                var demiActive = IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15;
 
                 if (actionID is Tridisaster or Outburst && InCombat())
                 {
@@ -479,7 +479,7 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID) && IsOnCooldown(OriginalHook(SummonBahamut)) && demiActive)
+                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID) && demiActive)
                         {
                             if (IsOffCooldown(Deathflare) &&
                                 level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralFlare))
@@ -491,7 +491,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //Demi Nuke 2: Electric Boogaloo
-                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption) && IsOnCooldown(OriginalHook(SummonBahamut)) && demiActive)
+                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption) && demiActive)
                         {
                             if (IsOffCooldown(Rekindle) && lastComboMove is BrandOfPurgatory)
                                 return OriginalHook(AstralFlow);

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -203,7 +203,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (actionID == Fester)
                 {
                     var gauge = GetJobGauge<SMNGauge>();
-                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_EDFester_PainflareRuin4))
+                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_EDFester_Ruin4))
                         return Ruin4;
                     if (level >= Levels.EnergyDrain && !gauge.HasAetherflowStacks)
                         return EnergyDrain;
@@ -222,7 +222,7 @@ namespace XIVSlothComboPlugin.Combos
                 if (actionID == Painflare)
                 {
                     var gauge = GetJobGauge<SMNGauge>();
-                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_EDFester_PainflareRuin4))
+                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
                         return Ruin4;
                     if (level >= Levels.EnergySiphon && !gauge.HasAetherflowStacks)
                         return EnergySiphon;

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -453,7 +453,7 @@ namespace XIVSlothComboPlugin.Combos
                             {
                                 if (IsNotEnabled(CustomComboPreset.SummonerOGCDPoolFeature))
                                     return Painflare;
-                                if (IsEnabled(CustomComboPreset.SummonerOGCDPoolFeature) && IsNotEnabled(CustomComboPreset.SummonerSTPoolOnlyOption))
+                                if (IsEnabled(CustomComboPreset.SummonerOGCDPoolFeature) && IsNotEnabled(CustomComboPreset.SummonerSTOnlyPoolOption))
                                 {
                                     if (level < Levels.SearingLight)
                                         return Painflare;
@@ -497,7 +497,7 @@ namespace XIVSlothComboPlugin.Combos
                     }
 
                     //Demi
-                    if (IsEnabled(CustomComboPreset.SummonerDemiAoESummonsFeature))
+                    if (IsEnabled(CustomComboPreset.SummonerDemiAOESummonsFeature))
                     {
                         if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 &&
                             IsOffCooldown(OriginalHook(Aethercharge)) &&
@@ -514,7 +514,7 @@ namespace XIVSlothComboPlugin.Combos
                         if (swiftcasePhase is 0 or 1 && level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
                         {
                             if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned &&
-                                IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
+                                IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcastOption))
                                 return All.Swiftcast;
                             if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
                                 ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
@@ -530,7 +530,7 @@ namespace XIVSlothComboPlugin.Combos
                                 if ((IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
                                      (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) &&
                                       gauge.Attunement >= 1)) &&
-                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
+                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcastOption))
                                     return All.Swiftcast;
                             }
 
@@ -543,7 +543,7 @@ namespace XIVSlothComboPlugin.Combos
                             if (level >= Levels.Slipstream && HasEffect(Buffs.GarudasFavor))
                             {
                                 if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast) &&
-                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
+                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcastOption))
                                     return All.Swiftcast;
                                 if (IsEnabled(CustomComboPreset.SummonerGarudaUniqueFeature) &&
                                     ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
@@ -557,7 +557,7 @@ namespace XIVSlothComboPlugin.Combos
                                 if ((IsNotEnabled(CustomComboPreset.SummonerIfritUniqueFeature) ||
                                      (IsEnabled(CustomComboPreset.SummonerIfritUniqueFeature) &&
                                       gauge.Attunement >= 1)) &&
-                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcast))
+                                    IsNotEnabled(CustomComboPreset.SummonerSTOnlySwiftcastOption))
                                     return All.Swiftcast;
                             }
                         }

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -244,7 +244,6 @@ namespace XIVSlothComboPlugin.Combos
                 var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.SMNLucidDreamingFeature);
                 var swiftcastPhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
-                var demiActive = GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed is <= 15 or > 0;
 
                 if (actionID is Ruin or Ruin2 && InCombat())
                 {
@@ -294,7 +293,7 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (demiActive)
+                        if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
                         {
                             if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature))
                             {
@@ -425,7 +424,6 @@ namespace XIVSlothComboPlugin.Combos
                 var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
                 var summonerPrimalChoice = Service.Configuration.GetCustomIntValue(Config.SummonerPrimalChoice);
                 var swiftcastPhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
-                var demiActive = GetCooldown(OriginalHook(Aethercharge)).CooldownElapsed is <= 15 or > 0;
 
                 if (actionID is Tridisaster or Outburst && InCombat())
                 {
@@ -480,7 +478,7 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (demiActive)
+                        if (OriginalHook(Tridisaster) is AstralFlare or BrandOfPurgatory)
                         {
                             if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature))
                             {

--- a/XIVSlothCombo/Combos/SMN.cs
+++ b/XIVSlothCombo/Combos/SMN.cs
@@ -244,6 +244,7 @@ namespace XIVSlothComboPlugin.Combos
                 var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
                 var lucidThreshold = Service.Configuration.GetCustomIntValue(Config.SMNLucidDreamingFeature);
                 var swiftcastPhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
+                var demiActive = GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15;
 
                 if (actionID is Ruin or Ruin2 && InCombat())
                 {
@@ -293,7 +294,7 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID) && IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15)
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetDemiFeature) && CanSpellWeave(actionID) && IsOnCooldown(OriginalHook(SummonBahamut)) && demiActive)
                         {
                             if (IsOffCooldown(Deathflare) && 
                                 level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralImpulse))
@@ -305,7 +306,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //Demi Nuke 2: Electric Boogaloo
-                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption) && IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15)
+                        if (IsEnabled(CustomComboPreset.SummonerSingleTargetRekindleOption) && IsOnCooldown(OriginalHook(SummonBahamut)) && demiActive)
                         {
                             if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire)
                                 return OriginalHook(AstralFlow);
@@ -423,6 +424,7 @@ namespace XIVSlothComboPlugin.Combos
                 var SummonerBurstPhase = Service.Configuration.GetCustomIntValue(Config.SummonerBurstPhase);
                 var summonerPrimalChoice = Service.Configuration.GetCustomIntValue(Config.SummonerPrimalChoice);
                 var swiftcasePhase = Service.Configuration.GetCustomIntValue(Config.SummonerSwiftcastPhase);
+                var demiActive = GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15;
 
                 if (actionID is Tridisaster or Outburst && InCombat())
                 {
@@ -477,7 +479,7 @@ namespace XIVSlothComboPlugin.Combos
                             return All.LucidDreaming;
 
                         //Demi Nuke
-                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID) && IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15)
+                        if (IsEnabled(CustomComboPreset.SummonerAOEDemiFeature) && CanSpellWeave(actionID) && IsOnCooldown(OriginalHook(SummonBahamut)) && demiActive)
                         {
                             if (IsOffCooldown(Deathflare) &&
                                 level >= Levels.AstralFlow && (level < Levels.Bahamut || lastComboMove is AstralFlare))
@@ -489,7 +491,7 @@ namespace XIVSlothComboPlugin.Combos
                         }
 
                         //Demi Nuke 2: Electric Boogaloo
-                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption) && IsOnCooldown(OriginalHook(SummonBahamut)) && GetCooldown(OriginalHook(SummonBahamut)).CooldownElapsed <= 15)
+                        if (IsEnabled(CustomComboPreset.SummonerAOETargetRekindleOption) && IsOnCooldown(OriginalHook(SummonBahamut)) && demiActive)
                         {
                             if (IsOffCooldown(Rekindle) && lastComboMove is BrandOfPurgatory)
                                 return OriginalHook(AstralFlow);

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -1137,14 +1137,14 @@ namespace XIVSlothComboPlugin
             // ====================================================================================
             #region SUMMONER
 
-            if (preset == CustomComboPreset.SummonerEgiOrderFeature)
+            if (preset == CustomComboPreset.SMN_DemiEgiMenu_EgiOrder)
             {
                 ConfigWindowFunctions.DrawHorizontalRadioButton(SMN.Config.SummonerPrimalChoice, "Titan first", "Summons Titan first, Garuda second, Ifrit third", 1);
                 ConfigWindowFunctions.DrawHorizontalRadioButton(SMN.Config.SummonerPrimalChoice, "Garuda first", "Summons Garuda first, Titan second, Ifrit third", 2);
             }
 
             
-            if (preset == CustomComboPreset.SummonerPrimalBurstChoice)
+            if (preset == CustomComboPreset.SMN_DemiEgiMenu_BurstChoice)
             {
                 ConfigWindowFunctions.DrawHorizontalRadioButton(SMN.Config.SummonerBurstPhase, "Bahamut", "Burst during Bahamut Phase", 1);
                 ConfigWindowFunctions.DrawHorizontalRadioButton(SMN.Config.SummonerBurstPhase, "Phoenix", "Burst during Phoenix Phase", 2);
@@ -1152,14 +1152,14 @@ namespace XIVSlothComboPlugin
                 ConfigWindowFunctions.DrawHorizontalRadioButton(SMN.Config.SummonerBurstPhase, "SpS Friendly Option", "Bursts when Searing Light is ready regardless of Phase", 4);
             }
 
-            if (preset == CustomComboPreset.SummonerSwiftcastEgiFeature)
+            if (preset == CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi)
             {
                 ConfigWindowFunctions.DrawHorizontalRadioButton(SMN.Config.SummonerSwiftcastPhase, "Garuda", "Swiftcast Slipstream", 1);
                 ConfigWindowFunctions.DrawHorizontalRadioButton(SMN.Config.SummonerSwiftcastPhase, "Ifrit", "Swiftcast Ruby Ruin/Rite", 2);
                 ConfigWindowFunctions.DrawHorizontalRadioButton(SMN.Config.SummonerSwiftcastPhase, "SpS Friendly Option", "Swiftcasts whichever Primal is available when Swiftcast is ready", 3);
             }
 
-            if (preset == CustomComboPreset.SMNLucidDreamingFeature)
+            if (preset == CustomComboPreset.SMN_Lucid)
                 ConfigWindowFunctions.DrawSliderInt(4000, 9500, SMN.Config.SMNLucidDreamingFeature, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);
 
             #endregion

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2558,7 +2558,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Ifrit Cyclone Feature", "Adds Crimson Cyclone/Crimson Strike on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 4, "Fists of Fury", "Show MNK how it's done, will ya?")]
         SMN_Ifrit_Cyclone = 17006,
 
-        [CustomComboInfo("Titan Mountain Buster Feature", "Adds Mountain Buster on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 5, "Mountain, BUSTA", "Bring the mountain to Mohammed, as they say")]
+        [CustomComboInfo("Titan Mountain Buster Feature", "Adds Mountain Buster on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 3, "Mountain, BUSTA", "Bring the mountain to Mohammed, as they say")]
         SMN_Titan_MountainBuster = 17007,
 
         [ReplaceSkill(SMN.Fester)]
@@ -2582,8 +2582,8 @@ namespace XIVSlothComboPlugin
         SMN_AoE_MainCombo_Ruin4 = 17012,
 
         [ParentCombo(SMN_EDFester)]
-        [CustomComboInfo("Ruin IV Fester/PainFlare Feature", "Change Fester/PainFlare into Ruin4 when out of Aetherflow stacks, ED/ES is on cooldown, and Ruin IV is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
-        SMN_EDFester_PainflareRuin4 = 17013,
+        [CustomComboInfo("Ruin 4 Fester Feature", "Changes Fester to Ruin 4 when out of Aetherflow stacks, Energy Drain is on cooldown, and Ruin 4 is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
+        SMN_EDFester_Ruin4 = 17013,
 
         [ParentCombo(SMN_ST_MainCombo)]
         [CustomComboInfo("Energy Drain/Fester on Main Combo", "Adds ED/Fester to the Main Combo. Will use on cooldown.", SMN.JobID, 1)]
@@ -2617,7 +2617,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 1, "", "")]
         SMN_DemiEgiMenu_SwiftcastEgi = 17023,
 
-        [CustomComboInfo("Astral Flow/Enkindle on Bahamut/Phoenix", "Adds Astral Flow and Enkindle to Bahamut/Phoenix.", SMN.JobID, 3, "", "")]
+        [CustomComboInfo("Astral Flow/Enkindle on Bahamut/Phoenix", "Adds Astral Flow and Enkindle to Bahamut/Phoenix.", SMN.JobID, 10, "", "")]
         SMN_DemiAbilities = 17024,
 
         [ParentCombo(SMN_DemiEgiMenu)]
@@ -2669,6 +2669,10 @@ namespace XIVSlothComboPlugin
         [ParentCombo(SMN_DemiEgiMenu_SwiftcastEgi)]
         [CustomComboInfo("Single target only Swiftcast Egis Option", "Only use Swiftcast on single target combo.", SMN.JobID, 2, "", "")]
         SMN_DemiEgiMenu_SwiftcastEgi_Only = 17038,
+        
+        [ParentCombo(SMN_ESPainflare)]
+        [CustomComboInfo("Ruin 4 Painflare Feature", "Changes Painflare to Ruin 4 when out of Aetherflow stacks, Energy Siphon is on cooldown, and Ruin 4 is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
+        SMN_ESPainflare_Ruin4 = 17039,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2527,7 +2527,7 @@ namespace XIVSlothComboPlugin
         SummonerMainComboFeature = 17000,
 
         [ReplaceSkill(SMN.Tridisaster)]
-        [CustomComboInfo("Enable AOE Combo Features", "Enables features tied to Tridisaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple AOE)", SMN.JobID, 1, "", "Can't deal with dungeons on your own? Fear not.")]
+        [CustomComboInfo("Enable AoE Combo Features", "Enables features tied to Tridisaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple A0E)", SMN.JobID, 1, "", "Can't deal with dungeons on your own? Fear not.")]
         SummonerAOEComboFeature = 17001,
 
         [ParentCombo(SummonerMainComboFeature)]
@@ -2568,7 +2568,7 @@ namespace XIVSlothComboPlugin
         SummonerRuin4ToRuin3Feature = 17011,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Ruin 4 On Tri-disaster Feature", "Adds Ruin 4 to the AOE Combo when there are currently no summons active.", SMN.JobID, 0, "", "More Ruin this, more ruin that! Now in sharing size!")]
+        [CustomComboInfo("Ruin 4 On Tri-disaster Feature", "Adds Ruin 4 to the AoE Combo when there are currently no summons active.", SMN.JobID, 0, "", "More Ruin this, more ruin that! Now in sharing size!")]
         SummonerRuin4ToTridisasterFeature = 17012,
 
         [ParentCombo(SummonerEDFesterCombo)]
@@ -2588,7 +2588,7 @@ namespace XIVSlothComboPlugin
         SummonerESAOEFeature = 17017,
 
         [ParentCombo(SummonerDemiEgiOrder)]
-        [CustomComboInfo("Searing Light on Single target/Aoe combo", "Adds Searing Light to the Single target, and Aoe combos and will be used on cooldown.", SMN.JobID, 2, "My eyes!", "I can't see!")]
+        [CustomComboInfo("Searing Light on Single target/AoE combo", "Adds Searing Light to the Single target, and AoE combos and will be used on cooldown.", SMN.JobID, 2, "My eyes!", "I can't see!")]
         SearingLightFeature = 17018,
 
         [ParentCombo(SearingLightFeature)]
@@ -2600,8 +2600,8 @@ namespace XIVSlothComboPlugin
         SummonerDemiSummonsFeature = 17020,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Demi Summons AOE Combo", "Adds Demi Summons to the AOE Combo.", SMN.JobID, 3, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
-        SummonerDemiAoESummonsFeature = 17021,
+        [CustomComboInfo("Demi Summons AoE Combo", "Adds Demi Summons to the AoE Combo.", SMN.JobID, 3, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
+        SummonerDemiAOESummonsFeature = 17021,
 
         [ParentCombo(SummonerDemiEgiOrder)]
         [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 1, "", "")]
@@ -2615,7 +2615,7 @@ namespace XIVSlothComboPlugin
         SummonerOGCDPoolFeature = 17025,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Precious Brilliance on AOE Combo", "Adds Egi attacks (Precious Brilliance) to the AoE Combo.", SMN.JobID, 2)]
+        [CustomComboInfo("Precious Brilliance on AoE Combo", "Adds Egi attacks (Precious Brilliance) to the AoE Combo.", SMN.JobID, 2)]
         SummonerEgiAttacksAOEFeature = 17026,
 
         [ConflictingCombos(ALL_Caster_Raise)]
@@ -2627,7 +2627,7 @@ namespace XIVSlothComboPlugin
         SummonerSingleTargetRekindleOption = 17028,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Rekindle on AOE Combo option", "Adds Rekindle to the AOE Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        [CustomComboInfo("Rekindle on AoE Combo option", "Adds Rekindle to the AoE Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
         SummonerAOETargetRekindleOption = 17029,
 
         [ReplaceSkill(SMN.Ruin4)]
@@ -2654,11 +2654,11 @@ namespace XIVSlothComboPlugin
         
         [ParentCombo(SummonerOGCDPoolFeature)]
         [CustomComboInfo("Single target only Pooled OGCD Option", "Only use damage OGCDs on single target combo.", SMN.JobID, 2, "", "")]
-        SummonerSTPoolOnlyOption = 17037,
+        SummonerSTOnlyPoolOption = 17037,
         
         [ParentCombo(SummonerSwiftcastEgiFeature)]
         [CustomComboInfo("Single target only Swiftcast Egis Option", "Only use Swiftcast on single target combo.", SMN.JobID, 2, "", "")]
-        SummonerSTOnlySwiftcast = 17038,
+        SummonerSTOnlySwiftcastOption = 17038,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2530,16 +2530,16 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Enable AOE Combo Features", "Enables features tied to Tridisaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple AOE)", SMN.JobID, 1, "", "Can't deal with dungeons on your own? Fear not.")]
         SummonerAOEComboFeature = 17001,
 
-        [ParentCombo(SummonerDemiSummonsFeature)]
-        [CustomComboInfo("Demi Attacks on Main Combo", "Adds Astral Flow to the Main Combo.", SMN.JobID, 0, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
+        [ParentCombo(SummonerMainComboFeature)]
+        [CustomComboInfo("Demi Attacks on Main Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main Combo.", SMN.JobID, 4, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
         SummonerSingleTargetDemiFeature = 17002,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("AOE Demi Attacks on AOE Combo", "Adds Astral Flare/Brand of Purgatory to the AOE Combo.", SMN.JobID, 4, "BRRRR", "Upgrade!")]
+        [CustomComboInfo("Demi Attacks on AoE Combo", "Adds Deathflare/Ahk Morn/Revelation to the AoE Combo.", SMN.JobID, 4, "BRRRR", "Upgrade!")]
         SummonerAOEDemiFeature = 17003,
 
-        [ParentCombo(EgisOnRuinFeature)]
-        [CustomComboInfo("Gemshine on Main Combo", "Adds Egi Attacks (Gemshine) to Main Combo.", SMN.JobID, 1, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
+        [ParentCombo(SummonerMainComboFeature)]
+        [CustomComboInfo("Gemshine on Main Combo", "Adds Egi Attacks (Gemshine) to the Main Combo.", SMN.JobID, 2, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
         SummonerEgiAttacksFeature = 17004,
 
         [CustomComboInfo("Garuda Slipstream Feature", "Adds Slipstream on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 4, "Slipstream", "2 Fast 2 Furious")]
@@ -2564,11 +2564,11 @@ namespace XIVSlothComboPlugin
         SummonerCarbuncleSummonFeature = 17010,
 
         [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Ruin 4 on Main Combo", "Adds Ruin4 on Main Combo when there are currently no summons active.", SMN.JobID, 1, "Ruin -> Ruin -> Ruin", "Ruin this, ruin that. Can't you see I'm busy ruining the plugin?!")]
+        [CustomComboInfo("Ruin 4 on Main Combo", "Adds Ruin 4 to the Main Combo when there are currently no summons active.", SMN.JobID, 0, "Ruin -> Ruin -> Ruin", "Ruin this, ruin that. Can't you see I'm busy ruining the plugin?!")]
         SummonerRuin4ToRuin3Feature = 17011,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Ruin 4 On Tri-disaster Feature", "Adds Ruin4 on AOE Combo when there are currently no summons active.", SMN.JobID, 0, "", "More Ruin this, more ruin that! Now in sharing size!")]
+        [CustomComboInfo("Ruin 4 On Tri-disaster Feature", "Adds Ruin 4 to the AOE Combo when there are currently no summons active.", SMN.JobID, 0, "", "More Ruin this, more ruin that! Now in sharing size!")]
         SummonerRuin4ToTridisasterFeature = 17012,
 
         [ParentCombo(SummonerEDFesterCombo)]
@@ -2576,19 +2576,15 @@ namespace XIVSlothComboPlugin
         SummonerFesterPainflareRuinFeature = 17013,
 
         [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Energy Drain/Fester on Main Combo", "Adds ED/Fester to Ruin. Will use on cooldown.", SMN.JobID, 1)]
+        [CustomComboInfo("Energy Drain/Fester on Main Combo", "Adds ED/Fester to the Main Combo. Will use on cooldown.", SMN.JobID, 1)]
         SummonerEDMainComboFeature = 17014,
 
-        [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Egi Summons combo Features", "Various options for egis.", SMN.JobID, 1)]
-        EgisOnRuinFeature = 17015,
-        
         [ParentCombo(SummonerDemiEgiOrder)]
         [CustomComboInfo("Egi Summon order", "Sets the order you summon egis.", SMN.JobID, 0)]
         SummonerEgiOrderFeature = 17016,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Energy Siphon/Painflare on AOE Combo", "Adds Energy Siphon/Painflare to AOE Combo", SMN.JobID, 1, "", "We'll play the game for you. Shush, now")]
+        [CustomComboInfo("Energy Siphon/Painflare on AoE Combo", "Adds Energy Siphon/Painflare to the AoE Combo", SMN.JobID, 1, "", "We'll play the game for you. Shush, now")]
         SummonerESAOEFeature = 17017,
 
         [ParentCombo(SummonerDemiEgiOrder)]
@@ -2600,17 +2596,13 @@ namespace XIVSlothComboPlugin
         SummonerSearingLightBurstOption = 170181,
 
         [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Demi Summons on Main Combo", "Adds Demi Summons to the Main Combo.", SMN.JobID, 1, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
+        [CustomComboInfo("Demi Summons on Main Combo", "Adds Demi Summons to the Main Combo.", SMN.JobID, 3, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
         SummonerDemiSummonsFeature = 17020,
 
         [ParentCombo(SummonerAOEComboFeature)]
         [CustomComboInfo("Demi Summons AOE Combo", "Adds Demi Summons to the AOE Combo.", SMN.JobID, 3, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
         SummonerDemiAoESummonsFeature = 17021,
 
-        [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Egi Summons on AOE Combo", "Adds Egi Summons to AOE Combo", SMN.JobID, 5, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
-        EgisOnAOEFeature = 17022,
-        
         [ParentCombo(SummonerDemiEgiOrder)]
         [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 1, "", "")]
         SummonerSwiftcastEgiFeature = 17023,
@@ -2623,19 +2615,19 @@ namespace XIVSlothComboPlugin
         SummonerOGCDPoolFeature = 17025,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Precious Brilliance on AOE Combo", "Adds Egi attacks (Precious Brilliance) to AOE Combo.", SMN.JobID, 6)]
+        [CustomComboInfo("Precious Brilliance on AOE Combo", "Adds Egi attacks (Precious Brilliance) to the AoE Combo.", SMN.JobID, 2)]
         SummonerEgiAttacksAOEFeature = 17026,
 
         [ConflictingCombos(ALL_Caster_Raise)]
         [CustomComboInfo("SMN Alternative Raise Feature", "Changes Swiftcast to Raise when on cooldown", SMN.JobID, 8, "Shittier RezMage", "Just play RDM oh my gawwddddddddddddd")]
         SummonerRaiseFeature = 17027,
 
-        [ParentCombo(SummonerDemiSummonsFeature)]
-        [CustomComboInfo("Rekindle on Main Combo option", "Adds Rekindle to the Main Combo.", SMN.JobID, 0, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        [ParentCombo(SummonerMainComboFeature)]
+        [CustomComboInfo("Rekindle on Main Combo option", "Adds Rekindle to the Main Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
         SummonerSingleTargetRekindleOption = 17028,
 
         [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Rekindle on AOE Combo option", "Adds Rekindle to the AOE Combo.", SMN.JobID, 6, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        [CustomComboInfo("Rekindle on AOE Combo option", "Adds Rekindle to the AOE Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
         SummonerAOETargetRekindleOption = 17029,
 
         [ReplaceSkill(SMN.Ruin4)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2582,7 +2582,7 @@ namespace XIVSlothComboPlugin
         SMN_AoE_MainCombo_Ruin4 = 17012,
 
         [ParentCombo(SMN_EDFester)]
-        [CustomComboInfo("Ruin 4 Fester Feature", "Changes Fester to Ruin 4 when out of Aetherflow stacks, Energy Drain is on cooldown, and Ruin 4 is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
+        [CustomComboInfo("Ruin 4 Fester Option", "Changes Fester to Ruin 4 when out of Aetherflow stacks, Energy Drain is on cooldown, and Ruin 4 is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
         SMN_EDFester_Ruin4 = 17013,
 
         [ParentCombo(SMN_ST_MainCombo)]
@@ -2671,7 +2671,7 @@ namespace XIVSlothComboPlugin
         SMN_DemiEgiMenu_SwiftcastEgi_Only = 17038,
         
         [ParentCombo(SMN_ESPainflare)]
-        [CustomComboInfo("Ruin 4 Painflare Feature", "Changes Painflare to Ruin 4 when out of Aetherflow stacks, Energy Siphon is on cooldown, and Ruin 4 is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
+        [CustomComboInfo("Ruin 4 Painflare Option", "Changes Painflare to Ruin 4 when out of Aetherflow stacks, Energy Siphon is on cooldown, and Ruin 4 is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
         SMN_ESPainflare_Ruin4 = 17039,
 
         #endregion

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2617,7 +2617,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 1, "", "")]
         SMN_DemiEgiMenu_SwiftcastEgi = 17023,
 
-        [CustomComboInfo("Astral Flow/Enkindle on Bahamut/Phoenix", "Adds Astral Flow and Enkindle to Bahamut/Phoenix.", SMN.JobID, 10, "", "")]
+        [CustomComboInfo("Astral Flow/Enkindle on Bahamut/Phoenix", "Adds Astral Flow and Enkindle to Bahamut/Phoenix.", SMN.JobID, 11, "", "")]
         SMN_DemiAbilities = 17024,
 
         [ParentCombo(SMN_DemiEgiMenu)]
@@ -2652,7 +2652,7 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Fester and Searing Light will only be used during Bahamut/Phoenix windows.", SMN.JobID, 3, "", "")]
         SMN_DemiEgiMenu_BurstChoice = 17032,
 
-        [CustomComboInfo("Egi Abilities on Egi Summons", "Adds Egi Abilities (Astral Flow) to Egi Summons when ready.\nEgi Abilities will appear on their respective Egi Summon Ability, as well as, Titan.", SMN.JobID, 11, "", "")]
+        [CustomComboInfo("Egi Abilities on Egi Summons", "Adds Egi Abilities (Astral Flow) to Egi Summons when ready.\nEgi Abilities will appear on their respective Egi Summon Ability, as well as, Titan.", SMN.JobID, 12, "", "")]
         SMN_Egi_AstralFlow = 17034,
         
         [CustomComboInfo("Egi and Demi Summon features", "Features related to changing Egi and Demi summons.\nCollapsing this category does NOT disable the features inside.", SMN.JobID, 2, "", "")]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -2540,16 +2540,16 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Enable AoE Combo Features", "Enables features tied to Tridisaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple AOE)", SMN.JobID, 1, "", "Can't deal with dungeons on your own? Fear not.")]
         SMN_AoE_MainCombo = 17001,
 
-        [ParentCombo(SMN_ST_MainCombo_DemiSummons)]
-        [CustomComboInfo("Demi Attacks on Main Combo", "Adds Astral Flow to the Main Combo.", SMN.JobID, 0, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Demi Attacks on Main Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main Combo.", SMN.JobID, 4, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
         SMN_ST_MainCombo_DemiSummons_Attacks = 17002,
 
         [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("AoE Demi Attacks on AoE Combo", "Adds Astral Flare/Brand of Purgatory to the AOE Combo.", SMN.JobID, 4, "BRRRR", "Upgrade!")]
+        [CustomComboInfo("AoE Demi Attacks on AoE Combo", "Adds Deathflare/Ahk Morn/Revelation to the AOE Combo.", SMN.JobID, 4, "BRRRR", "Upgrade!")]
         SMN_AoE_MainCombo_Demis = 17003,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Gemshine on Main Combo", "Adds Egi Attacks (Gemshine) to Main Combo.", SMN.JobID, 1, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
+        [CustomComboInfo("Gemshine on Main Combo", "Adds Egi Attacks (Gemshine) to the Main Combo.", SMN.JobID, 2, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
         SMN_ST_MainCombo_EgiSummons_Attacks = 17004,
 
         [CustomComboInfo("Garuda Slipstream Feature", "Adds Slipstream on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 4, "Slipstream", "2 Fast 2 Furious")]
@@ -2574,7 +2574,7 @@ namespace XIVSlothComboPlugin
         SMN_CarbuncleReminder = 17010,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Ruin 4 on Main Combo", "Adds Ruin4 on Main Combo when there are currently no summons active.", SMN.JobID, 1, "Ruin -> Ruin -> Ruin", "Ruin this, ruin that. Can't you see I'm busy ruining the plugin?!")]
+        [CustomComboInfo("Ruin 4 on Main Combo", "Adds Ruin 4 to the Main Combo when there are currently no summons active.", SMN.JobID, 0, "Ruin -> Ruin -> Ruin", "Ruin this, ruin that. Can't you see I'm busy ruining the plugin?!")]
         SMN_ST_MainCombo_Ruin4 = 17011,
 
         [ParentCombo(SMN_AoE_MainCombo)]
@@ -2586,7 +2586,7 @@ namespace XIVSlothComboPlugin
         SMN_EDFester_PainflareRuin4 = 17013,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Energy Drain/Fester on Main Combo", "Adds ED/Fester to Ruin. Will use on cooldown.", SMN.JobID, 1)]
+        [CustomComboInfo("Energy Drain/Fester on Main Combo", "Adds ED/Fester to the Main Combo. Will use on cooldown.", SMN.JobID, 1)]
         SMN_ST_MainCombo_EDFester = 17014,
 
         [ParentCombo(SMN_DemiEgiMenu)]
@@ -2594,7 +2594,7 @@ namespace XIVSlothComboPlugin
         SMN_DemiEgiMenu_EgiOrder = 17016,
 
         [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("Energy Siphon/Painflare on AoE Combo", "Adds Energy Siphon/Painflare to AoE Combo", SMN.JobID, 1, "", "We'll play the game for you. Shush, now")]
+        [CustomComboInfo("Energy Siphon/Painflare on AoE Combo", "Adds Energy Siphon/Painflare to the AoE Combo", SMN.JobID, 1, "", "We'll play the game for you. Shush, now")]
         SMN_AoE_MainCombo_ESPainflare = 17017,
 
         [ParentCombo(SMN_DemiEgiMenu)]
@@ -2606,7 +2606,7 @@ namespace XIVSlothComboPlugin
         SMN_SearingLight_Burst = 170181,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Demi Summons on Main Combo", "Adds Demi Summons to the Main Combo.", SMN.JobID, 1, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
+        [CustomComboInfo("Demi Summons on Main Combo", "Adds Demi Summons to the Main Combo.", SMN.JobID, 3, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
         SMN_ST_MainCombo_DemiSummons = 17020,
 
         [ParentCombo(SMN_AoE_MainCombo)]
@@ -2625,19 +2625,19 @@ namespace XIVSlothComboPlugin
         SMN_DemiEgiMenu_oGCDPooling = 17025,
 
         [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("Precious Brilliance on AoE Combo", "Adds Egi attacks (Precious Brilliance) to AoE Combo.", SMN.JobID, 6)]
+        [CustomComboInfo("Precious Brilliance on AoE Combo", "Adds Egi attacks (Precious Brilliance) to the AoE Combo.", SMN.JobID, 2)]
         SMN_AoE_MainCombo_EgiAttacks = 17026,
 
         [ConflictingCombos(ALL_Caster_Raise)]
         [CustomComboInfo("Alternative Raise Feature", "Changes Swiftcast to Raise when on cooldown", SMN.JobID, 8, "Shittier RezMage", "Just play RDM oh my gawwddddddddddddd")]
         SMN_Raise = 17027,
 
-        [ParentCombo(SMN_ST_MainCombo_DemiSummons)]
-        [CustomComboInfo("Rekindle on Main Combo option", "Adds Rekindle to the Main Combo.", SMN.JobID, 0, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Rekindle on Main Combo option", "Adds Rekindle to the Main Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
         SMN_ST_MainCombo_DemiSummons_Rekindle = 17028,
 
         [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("Rekindle on AoE Combo option", "Adds Rekindle to the AoE Combo.", SMN.JobID, 6, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        [CustomComboInfo("Rekindle on AoE Combo option", "Adds Rekindle to the AoE Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
         SMN_AoE_MainCombo_Rekindle = 17029,
 
         [ReplaceSkill(SMN.Ruin4)]

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -119,8 +119,8 @@ namespace XIVSlothComboPlugin
             [CustomComboInfo("Magical Ranged DPS: Double Addle Protection", "Prevents the use of Addle when target already has the effect by replacing it with Fell Cleave.", ADV.JobID)]
             ALL_Caster_Addle = 100020,
 
-        //            [ConflictingCombos(SummonerRaiseFeature, RedMageSwiftVerraise)]
-            [ConflictingCombos(SummonerRaiseFeature, RDM_Verraise)]
+        //  [ConflictingCombos(SummonerRaiseFeature, RedMageSwiftVerraise)]
+            [ConflictingCombos(SMN_Raise, RDM_Verraise)]
             [ParentCombo(AllCasterFeatures)]
             [CustomComboInfo("Magical Ranged DPS: Raise Feature", "Changes the class' Raise Ability into Swiftcast or Dualcast in the case of RDM.", ADV.JobID)]
             ALL_Caster_Raise = 100021,
@@ -2534,141 +2534,141 @@ namespace XIVSlothComboPlugin
 
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2)]
         [CustomComboInfo("Enable Single Target Combo Features", "Enables features tied to Ruin, or Ruin II.\nIf all sub options are toggled will turn into a full one button rotation (Simple Summoner)\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
-        SummonerMainComboFeature = 17000,
+        SMN_ST_MainCombo = 17000,
 
         [ReplaceSkill(SMN.Tridisaster)]
-        [CustomComboInfo("Enable AoE Combo Features", "Enables features tied to Tridisaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple A0E)", SMN.JobID, 1, "", "Can't deal with dungeons on your own? Fear not.")]
-        SummonerAOEComboFeature = 17001,
+        [CustomComboInfo("Enable AoE Combo Features", "Enables features tied to Tridisaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple AOE)", SMN.JobID, 1, "", "Can't deal with dungeons on your own? Fear not.")]
+        SMN_AoE_MainCombo = 17001,
 
-        [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Demi Attacks on Main Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main Combo.", SMN.JobID, 4, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
-        SummonerSingleTargetDemiFeature = 17002,
+        [ParentCombo(SMN_ST_MainCombo_DemiSummons)]
+        [CustomComboInfo("Demi Attacks on Main Combo", "Adds Astral Flow to the Main Combo.", SMN.JobID, 0, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
+        SMN_ST_MainCombo_DemiSummons_Attacks = 17002,
 
-        [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Demi Attacks on AoE Combo", "Adds Deathflare/Ahk Morn/Revelation to the AoE Combo.", SMN.JobID, 4, "BRRRR", "Upgrade!")]
-        SummonerAOEDemiFeature = 17003,
+        [ParentCombo(SMN_AoE_MainCombo)]
+        [CustomComboInfo("AoE Demi Attacks on AoE Combo", "Adds Astral Flare/Brand of Purgatory to the AOE Combo.", SMN.JobID, 4, "BRRRR", "Upgrade!")]
+        SMN_AoE_MainCombo_Demis = 17003,
 
-        [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Gemshine on Main Combo", "Adds Egi Attacks (Gemshine) to the Main Combo.", SMN.JobID, 2, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
-        SummonerEgiAttacksFeature = 17004,
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Gemshine on Main Combo", "Adds Egi Attacks (Gemshine) to Main Combo.", SMN.JobID, 1, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
+        SMN_ST_MainCombo_EgiSummons_Attacks = 17004,
 
         [CustomComboInfo("Garuda Slipstream Feature", "Adds Slipstream on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 4, "Slipstream", "2 Fast 2 Furious")]
-        SummonerGarudaUniqueFeature = 17005,
+        SMN_Garuda_Slipstream = 17005,
 
         [CustomComboInfo("Ifrit Cyclone Feature", "Adds Crimson Cyclone/Crimson Strike on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 4, "Fists of Fury", "Show MNK how it's done, will ya?")]
-        SummonerIfritUniqueFeature = 17006,
+        SMN_Ifrit_Cyclone = 17006,
 
         [CustomComboInfo("Titan Mountain Buster Feature", "Adds Mountain Buster on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 5, "Mountain, BUSTA", "Bring the mountain to Mohammed, as they say")]
-        SummonerTitanUniqueFeature = 17007,
+        SMN_Titan_MountainBuster = 17007,
 
         [ReplaceSkill(SMN.Fester)]
         [CustomComboInfo("ED Fester", "Change Fester into Energy Drain when out of Aetherflow stacks.", SMN.JobID, 6, "Festering", "Festering? Go take a shower, bro")]
-        SummonerEDFesterCombo = 17008,
+        SMN_EDFester = 17008,
 
         [ReplaceSkill(SMN.Painflare)]
         [CustomComboInfo("ES Painflare", "Change Painflare into Energy Siphon when out of Aetherflow stacks.", SMN.JobID, 7, "Old age", "I sometimes get a painflare in my middle-back, too.")]
-        SummonerESPainflareCombo = 17009,
+        SMN_ESPainflare = 17009,
 
         // BONUS TWEAKS
         [CustomComboInfo("Carbuncle Reminder Feature", "Reminds you to summon Carbuncle by replacing most actions with Summon Carbuncle.", SMN.JobID, 8)]
-        SummonerCarbuncleSummonFeature = 17010,
+        SMN_CarbuncleReminder = 17010,
 
-        [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Ruin 4 on Main Combo", "Adds Ruin 4 to the Main Combo when there are currently no summons active.", SMN.JobID, 0, "Ruin -> Ruin -> Ruin", "Ruin this, ruin that. Can't you see I'm busy ruining the plugin?!")]
-        SummonerRuin4ToRuin3Feature = 17011,
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Ruin 4 on Main Combo", "Adds Ruin4 on Main Combo when there are currently no summons active.", SMN.JobID, 1, "Ruin -> Ruin -> Ruin", "Ruin this, ruin that. Can't you see I'm busy ruining the plugin?!")]
+        SMN_ST_MainCombo_Ruin4 = 17011,
 
-        [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Ruin 4 On Tri-disaster Feature", "Adds Ruin 4 to the AoE Combo when there are currently no summons active.", SMN.JobID, 0, "", "More Ruin this, more ruin that! Now in sharing size!")]
-        SummonerRuin4ToTridisasterFeature = 17012,
+        [ParentCombo(SMN_AoE_MainCombo)]
+        [CustomComboInfo("Ruin 4 On Tri-disaster Feature", "Adds Ruin4 on AoE Combo when there are currently no summons active.", SMN.JobID, 0, "", "More Ruin this, more ruin that! Now in sharing size!")]
+        SMN_AoE_MainCombo_Ruin4 = 17012,
 
-        [ParentCombo(SummonerEDFesterCombo)]
+        [ParentCombo(SMN_EDFester)]
         [CustomComboInfo("Ruin IV Fester/PainFlare Feature", "Change Fester/PainFlare into Ruin4 when out of Aetherflow stacks, ED/ES is on cooldown, and Ruin IV is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
-        SummonerFesterPainflareRuinFeature = 17013,
+        SMN_EDFester_PainflareRuin4 = 17013,
 
-        [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Energy Drain/Fester on Main Combo", "Adds ED/Fester to the Main Combo. Will use on cooldown.", SMN.JobID, 1)]
-        SummonerEDMainComboFeature = 17014,
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Energy Drain/Fester on Main Combo", "Adds ED/Fester to Ruin. Will use on cooldown.", SMN.JobID, 1)]
+        SMN_ST_MainCombo_EDFester = 17014,
 
-        [ParentCombo(SummonerDemiEgiOrder)]
-        [CustomComboInfo("Egi Summon order", "Sets the order you summon egis.", SMN.JobID, 0)]
-        SummonerEgiOrderFeature = 17016,
+        [ParentCombo(SMN_DemiEgiMenu)]
+        [CustomComboInfo("Egi Summon Order", "Sets the order you summon egis.", SMN.JobID, 0)]
+        SMN_DemiEgiMenu_EgiOrder = 17016,
 
-        [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Energy Siphon/Painflare on AoE Combo", "Adds Energy Siphon/Painflare to the AoE Combo", SMN.JobID, 1, "", "We'll play the game for you. Shush, now")]
-        SummonerESAOEFeature = 17017,
+        [ParentCombo(SMN_AoE_MainCombo)]
+        [CustomComboInfo("Energy Siphon/Painflare on AoE Combo", "Adds Energy Siphon/Painflare to AoE Combo", SMN.JobID, 1, "", "We'll play the game for you. Shush, now")]
+        SMN_AoE_MainCombo_ESPainflare = 17017,
 
-        [ParentCombo(SummonerDemiEgiOrder)]
-        [CustomComboInfo("Searing Light on Single target/AoE combo", "Adds Searing Light to the Single target, and AoE combos and will be used on cooldown.", SMN.JobID, 2, "My eyes!", "I can't see!")]
-        SearingLightFeature = 17018,
+        [ParentCombo(SMN_DemiEgiMenu)]
+        [CustomComboInfo("Searing Light on Single Target/AoE combo", "Adds Searing Light to the Single target, and AoE combos. Will be used on cooldown.", SMN.JobID, 2, "My eyes!", "I can't see!")]
+        SMN_SearingLight = 17018,
 
-        [ParentCombo(SearingLightFeature)]
+        [ParentCombo(SMN_SearingLight)]
         [CustomComboInfo("Searing Light Burst Option", "Casts Searing Light only during Bahamut/Phoenix Phase.\nChoose which phase to burst in under 'Burst Phase Choice' option.\nNot recommended for SpS Builds.", SMN.JobID, 0, "My eyes!", "I can't see!")]
-        SummonerSearingLightBurstOption = 170181,
+        SMN_SearingLight_Burst = 170181,
 
-        [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Demi Summons on Main Combo", "Adds Demi Summons to the Main Combo.", SMN.JobID, 3, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
-        SummonerDemiSummonsFeature = 17020,
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Demi Summons on Main Combo", "Adds Demi Summons to the Main Combo.", SMN.JobID, 1, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
+        SMN_ST_MainCombo_DemiSummons = 17020,
 
-        [ParentCombo(SummonerAOEComboFeature)]
+        [ParentCombo(SMN_AoE_MainCombo)]
         [CustomComboInfo("Demi Summons AoE Combo", "Adds Demi Summons to the AoE Combo.", SMN.JobID, 3, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
-        SummonerDemiAOESummonsFeature = 17021,
-
-        [ParentCombo(SummonerDemiEgiOrder)]
+        SMN_AoE_MainCombo_DemiSummons = 17021,
+        
+        [ParentCombo(SMN_DemiEgiMenu)]
         [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 1, "", "")]
-        SummonerSwiftcastEgiFeature = 17023,
+        SMN_DemiEgiMenu_SwiftcastEgi = 17023,
 
         [CustomComboInfo("Astral Flow/Enkindle on Bahamut/Phoenix", "Adds Astral Flow and Enkindle to Bahamut/Phoenix.", SMN.JobID, 3, "", "")]
-        SummonerPrimalAbilitiesFeature = 17024,
+        SMN_DemiAbilities = 17024,
 
-        [ParentCombo(SummonerDemiEgiOrder)]
-        [CustomComboInfo("Pooled OGCDs Feature", "Pools damage OGCDs to use under Searing Light and in Bahamut/Phoenix Phase.\nChoose which phase to burst in under 'Burst Phase Choice' option.", SMN.JobID, 1)]
-        SummonerOGCDPoolFeature = 17025,
+        [ParentCombo(SMN_DemiEgiMenu)]
+        [CustomComboInfo("Pooled oGCDs Feature", "Pools damage OGCDs to use under Searing Light and in Bahamut/Phoenix Phase.\nChoose which phase to burst in under 'Burst Phase Choice' option.", SMN.JobID, 1)]
+        SMN_DemiEgiMenu_oGCDPooling = 17025,
 
-        [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Precious Brilliance on AoE Combo", "Adds Egi attacks (Precious Brilliance) to the AoE Combo.", SMN.JobID, 2)]
-        SummonerEgiAttacksAOEFeature = 17026,
+        [ParentCombo(SMN_AoE_MainCombo)]
+        [CustomComboInfo("Precious Brilliance on AoE Combo", "Adds Egi attacks (Precious Brilliance) to AoE Combo.", SMN.JobID, 6)]
+        SMN_AoE_MainCombo_EgiAttacks = 17026,
 
         [ConflictingCombos(ALL_Caster_Raise)]
-        [CustomComboInfo("SMN Alternative Raise Feature", "Changes Swiftcast to Raise when on cooldown", SMN.JobID, 8, "Shittier RezMage", "Just play RDM oh my gawwddddddddddddd")]
-        SummonerRaiseFeature = 17027,
+        [CustomComboInfo("Alternative Raise Feature", "Changes Swiftcast to Raise when on cooldown", SMN.JobID, 8, "Shittier RezMage", "Just play RDM oh my gawwddddddddddddd")]
+        SMN_Raise = 17027,
 
-        [ParentCombo(SummonerMainComboFeature)]
-        [CustomComboInfo("Rekindle on Main Combo option", "Adds Rekindle to the Main Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
-        SummonerSingleTargetRekindleOption = 17028,
+        [ParentCombo(SMN_ST_MainCombo_DemiSummons)]
+        [CustomComboInfo("Rekindle on Main Combo option", "Adds Rekindle to the Main Combo.", SMN.JobID, 0, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        SMN_ST_MainCombo_DemiSummons_Rekindle = 17028,
 
-        [ParentCombo(SummonerAOEComboFeature)]
-        [CustomComboInfo("Rekindle on AoE Combo option", "Adds Rekindle to the AoE Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
-        SummonerAOETargetRekindleOption = 17029,
+        [ParentCombo(SMN_AoE_MainCombo)]
+        [CustomComboInfo("Rekindle on AoE Combo option", "Adds Rekindle to the AoE Combo.", SMN.JobID, 6, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        SMN_AoE_MainCombo_Rekindle = 17029,
 
         [ReplaceSkill(SMN.Ruin4)]
         [CustomComboInfo("Ruin III Mobility Feature", "Puts Ruin III on Ruin IV when you don't have Further Ruin.", SMN.JobID, 9, "Yo Dawg I Heard You Like Ruin Feature", "Ruin while you Ruin")]
-        SummonerSpecialRuinFeature = 17030,
+        SMN_RuinMobility = 17030,
 
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2)]
         [CustomComboInfo("Lucid Dreaming Feature", "Adds Lucid dreaming to the Main Combo when below set MP value.", SMN.JobID, 10, "", "")]
-        SMNLucidDreamingFeature = 17031,
+        SMN_Lucid = 17031,
         
-        [ParentCombo(SummonerDemiEgiOrder)]
-        [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Festers and Searing Lights will only be used during Bahamut/Phoenix windows.", SMN.JobID, 3, "", "")]
-        SummonerPrimalBurstChoice = 17032,
+        [ParentCombo(SMN_DemiEgiMenu)]
+        [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Fester and Searing Light will only be used during Bahamut/Phoenix windows.", SMN.JobID, 3, "", "")]
+        SMN_DemiEgiMenu_BurstChoice = 17032,
 
         [CustomComboInfo("Egi Abilities on Egi Summons", "Adds Egi Abilities (Astral Flow) to Egi Summons when ready.\nEgi Abilities will appear on their respective Egi Summon Ability, as well as, Titan.", SMN.JobID, 11, "", "")]
-        SummonerAstralFlowonSummonsFeature = 17034,
+        SMN_Egi_AstralFlow = 17034,
         
-        [CustomComboInfo("Egi and Demi summon features", "Features related to changing egi and demi summons.\nCollapsing this category does NOT disable the features inside.", SMN.JobID, 2, "", "")]
-        SummonerDemiEgiOrder = 17035,
+        [CustomComboInfo("Egi and Demi Summon features", "Features related to changing Egi and Demi summons.\nCollapsing this category does NOT disable the features inside.", SMN.JobID, 2, "", "")]
+        SMN_DemiEgiMenu = 17035,
         
-        [ParentCombo(SearingLightFeature)]
-        [CustomComboInfo("Single target only Searing Light Option", "Only use Searing Light on single target combo.", SMN.JobID, 2, "", "")]
-        SearingLightSTOnlyOption = 17036,
+        [ParentCombo(SMN_SearingLight)]
+        [CustomComboInfo("Single target only Searing Light Option", "Only use Searing Light on Single Target combo.", SMN.JobID, 2, "", "")]
+        SMN_SearingLight_STOnly = 17036,
         
-        [ParentCombo(SummonerOGCDPoolFeature)]
-        [CustomComboInfo("Single target only Pooled OGCD Option", "Only use damage OGCDs on single target combo.", SMN.JobID, 2, "", "")]
-        SummonerSTOnlyPoolOption = 17037,
+        [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
+        [CustomComboInfo("Single target only Pooled oGCD Option", "Only use damage oGCDs on single target combo.", SMN.JobID, 2, "", "")]
+        SMN_DemiEgiMenu_oGCDPooling_Only = 17037,
         
-        [ParentCombo(SummonerSwiftcastEgiFeature)]
+        [ParentCombo(SMN_DemiEgiMenu_SwiftcastEgi)]
         [CustomComboInfo("Single target only Swiftcast Egis Option", "Only use Swiftcast on single target combo.", SMN.JobID, 2, "", "")]
-        SummonerSTOnlySwiftcastOption = 17038,
+        SMN_DemiEgiMenu_SwiftcastEgi_Only = 17038,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
## SMN
- Decouples Demi/Egi attacks from their `Summons on Main/AoE Combo` features.
- Removed "top level" features `EgisOnRuinFeature` and `EgisOnAOEFeature` as they didn't actually do anything.
- Moved single target Demi attacks into the `canSpellWeave` block as they are in AoE version (bugfix)
- Changes `AoE Rekindle (Astral Flow) Feature` to check `Rekindle` specifically instead of `Astral Flow` to match single target.
    - Changes `Single Target Deathflare (Astral Flow)` to check its ability specifically to fall in line with the above change.
    - Changes `AoE Deathflare (Astral Flow)` to check its ability specifically to fall in line with the above change.
- Renamed `SummonerSTPoolOnlyOption` to `SummonerSTOnlyPoolOption` to fall in line with other single target features.
- Renamed `SummonerSTOnlySwiftcast` to `SummonerSTOnlySwiftcastOption` to signify that its an option.
- Added demi detection for demi attacks - thanks Cupcake!
- Fix typo `swiftcasePhase` > `swiftcastPhase` for aoe combo.
- Split up `Ruin IV on Fester/Painflare Feature` to be on `ED Fester` and `ES Painflare` separately.
- Small tweaks and case changes in feature descriptions, and order changes.