### PR TITLE
[BLM/PLD] Fixes

### DIFF
--- a/XIVSlothCombo/Combos/BLM.cs
+++ b/XIVSlothCombo/Combos/BLM.cs
@@ -664,7 +664,7 @@ namespace XIVSlothComboPlugin.Combos
                                 {
                                     return All.Swiftcast;
                                 }
-                                if (GetRemainingCharges(Triplecast) >= 1)
+                                if (level >= Levels.Triplecast && GetRemainingCharges(Triplecast) >= 1)
                                 {
                                     return Triplecast;
                                 }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1764,7 +1764,7 @@ namespace XIVSlothComboPlugin
         PaladinExpiacionScornOption = 11027,
 
         [ParentCombo(PaladinRoyalAuthorityCombo)]
-        [CustomComboInfo("FoF Opener Feature", "Adds the FoF opener to the main combo. Requires level 68.", PLD.JobID, 0, "", "")]
+        [CustomComboInfo("FoF Opener Feature", "Adds the FoF opener to the main combo. Will execute the full FoF opener by default, but if FoF is activated 18s pre-pull, the 18s pre-pull opener will be executed. Requires level 68.", PLD.JobID, 0, "", "")]
         PaladinFoFOpenerFeature = 11028,
 
         [ParentCombo(PaladinFoFOpenerFeature)]


### PR DESCRIPTION
- Level check for triplecast usage in BLM movement feature
- Updated PLD opener description to include information about the 18s pre-pull FoF opener execution.