### PR TITLE
Bugfixes Galore + Backend Tweaks

### DIFF
--- a/XIVSlothCombo/Combos/ALL.cs
+++ b/XIVSlothCombo/Combos/ALL.cs
@@ -134,12 +134,12 @@
                 {
                     if (IsOffCooldown(Swiftcast))
                         return Swiftcast;
-                    if (HasEffect(Buffs.Swiftcast))
-                    {
-                        if (actionID == WHM.Raise && IsEnabled(CustomComboPreset.WHMThinAirFeature) && GetRemainingCharges(WHM.ThinAir) > 0 && !HasEffect(WHM.Buffs.ThinAir) && level >= WHM.Levels.ThinAir)
-                            return WHM.ThinAir;
-                        return actionID;
-                    }
+
+                    if (actionID == WHM.Raise && IsEnabled(CustomComboPreset.WHMThinAirFeature) && GetRemainingCharges(WHM.ThinAir) > 0 && !HasEffect(WHM.Buffs.ThinAir) && level >= WHM.Levels.ThinAir)
+                        return WHM.ThinAir;
+
+                    return actionID;
+
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/DRG.cs
+++ b/XIVSlothCombo/Combos/DRG.cs
@@ -589,7 +589,7 @@ namespace XIVSlothComboPlugin.Combos
                             if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
                                 return Stardiver;
 
-                            if (HasEffect(Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) == 2 && canWeave)
+                            if (HasEffect(Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) > 0 && canWeave)
                                 return SpineshatterDive;
                         }
                     }

--- a/XIVSlothCombo/Combos/MCH.cs
+++ b/XIVSlothCombo/Combos/MCH.cs
@@ -131,9 +131,9 @@ namespace XIVSlothComboPlugin.Combos
                     }
                     if (IsEnabled(CustomComboPreset.MachinistRicochetGaussMainCombo))
                     {
-                        if (level >= Levels.Ricochet && ricochetCD.CooldownRemaining <= 30 && GetCooldown(CleanShot).CooldownRemaining > 0.6) //0.6 instead of 0.7 to more easily fit opener. a
+                        if (level >= Levels.Ricochet && ricochetCD.RemainingCharges > 1 && GetCooldown(CleanShot).CooldownRemaining > 0.6) //0.6 instead of 0.7 to more easily fit opener. a
                             return Ricochet;
-                        if (level >= Levels.GaussRound && gaussCD.CooldownRemaining <= 30 && GetCooldown(CleanShot).CooldownRemaining > 0.6)
+                        if (level >= Levels.GaussRound && gaussCD.RemainingCharges > 1 && GetCooldown(CleanShot).CooldownRemaining > 0.6)
                             return GaussRound;
 
                     }

--- a/XIVSlothCombo/Combos/NIN.cs
+++ b/XIVSlothCombo/Combos/NIN.cs
@@ -393,7 +393,7 @@ namespace XIVSlothComboPlugin.Combos
                     var jutsuCharges = jutsuCooldown.RemainingCharges;
                     var gauge = GetJobGauge<NINGauge>();
 
-                    lastUsedJutsu = OriginalHook(Ninjutsu) != Ninjutsu ? OriginalHook(Ninjutsu) : lastUsedJutsu;                    
+                    lastUsedJutsu = OriginalHook(Ninjutsu) != Ninjutsu ? OriginalHook(Ninjutsu) : lastUsedJutsu;
 
                     if (gauge.HutonTimer == 0 && !HasEffect(Buffs.Mudra) && !HasEffect(Buffs.Kassatsu) && level >= Levels.Huraijin)
                         return Huraijin;
@@ -441,8 +441,8 @@ namespace XIVSlothComboPlugin.Combos
                         if (OriginalHook(Ninjutsu) == FumaShuriken)
                             return TenCombo;
 
-                        if (HasEffect(Buffs.Kassatsu))
-                            return OriginalHook(Jin);
+
+                        return OriginalHook(Jin);
                     }
 
                     if (!HasEffect(Buffs.Mudra))
@@ -525,15 +525,16 @@ namespace XIVSlothComboPlugin.Combos
             {
                 if (actionID == Hide)
                 {
-                    if (HasEffect(Buffs.Suiton) || HasEffect(Buffs.Hidden))
-                    {
-                        return TrickAttack;
-                    }
-
                     if (HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat))
                     {
                         return Mug;
                     }
+
+                    if (HasEffect(Buffs.Hidden))
+                    {
+                        return TrickAttack;
+                    }
+
                 }
 
                 return actionID;
@@ -700,11 +701,11 @@ namespace XIVSlothComboPlugin.Combos
                                     if (HasEffect(Buffs.Kassatsu) && level >= Levels.EnhancedKassatsu)
                                         return JinCombo;
 
-                                    if (level >= Levels.Jin)
-                                        return OriginalHook(JinCombo);
-                                    
                                     if (level >= Levels.Chi)
                                         return OriginalHook(ChiCombo);
+
+                                    if (level >= Levels.Jin)
+                                        return OriginalHook(JinCombo);
                                 }
                             }
 

--- a/XIVSlothCombo/CombosPVP/PVPCommon.cs
+++ b/XIVSlothCombo/CombosPVP/PVPCommon.cs
@@ -75,7 +75,7 @@ namespace XIVSlothComboPlugin
                 var remainingPercentage = (float)LocalPlayer.CurrentHp / (float)maxHPThreshold;
 
 
-
+                if (HasEffect(3180)) return false; //DRG LB buff
                 if (LocalPlayer.CurrentMp < 2500) return false;
                 if (remainingPercentage * 100 > threshold) return false;
 
@@ -116,6 +116,7 @@ namespace XIVSlothComboPlugin
                 var threshold = Service.Configuration.GetCustomIntValue(Config.EmergencyGuardThreshold);
                 var remainingPercentage = (float)LocalPlayer.CurrentHp / (float)jobMaxHp;
 
+                if (HasEffect(3180)) return false; //DRG LB buff
                 if (HasEffectAny(Debuffs.Unguarded) || HasEffect(WARPVP.Buffs.InnerRelease)) return false;
                 if (GetCooldown(Guard).IsCooldown) return false;
                 if (remainingPercentage * 100 > threshold) return false;
@@ -155,6 +156,7 @@ namespace XIVSlothComboPlugin
             {
                 var selectedStatuses = Service.Configuration.GetCustomBoolArrayValue(Config.QuickPurifyStatuses);
 
+                if (HasEffect(3180)) return false; //DRG LB buff
 
                 if (selectedStatuses.Length == 0) return false;
                 if (GetCooldown(Purify).IsCooldown) return false;

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -165,11 +165,16 @@ namespace XIVSlothComboPlugin
                 ImGui.TextUnformatted($"DISTANCE FROM TARGET: {comboClass.GetTargetDistance()}");
                 ImGui.TextUnformatted($"TARGET HP VALUE: {comboClass.EnemyHealthCurrentHp()}");
                 ImGui.TextUnformatted($"LAST ACTION: {ActionWatching.GetActionName(ActionWatching.LastAction)}");
+                ImGui.TextUnformatted($"LAST ACTION COST: {comboClass.GetResourceCost(ActionWatching.LastAction)}");
+                ImGui.TextUnformatted($"LAST ACTION TYPE: {ActionWatching.GetAttackType(ActionWatching.LastAction)}");
                 ImGui.TextUnformatted($"LAST WEAPONSKILL: {ActionWatching.GetActionName(ActionWatching.LastWeaponskill)}");
                 ImGui.TextUnformatted($"LAST SPELL: {ActionWatching.GetActionName(ActionWatching.LastSpell)}");
                 ImGui.TextUnformatted($"LAST ABILITY: {ActionWatching.GetActionName(ActionWatching.LastAbility)}");
                 ImGui.TextUnformatted($"ZONE: {Service.ClientState.TerritoryType}");
-                ImGui.TextUnformatted($"SELECTED BLU SPELLS: {string.Join("\n", Service.Configuration.ActiveBLUSpells.Select(x => ActionWatching.GetActionName(x)).OrderBy(x => x))}");
+                ImGui.BeginChild("BLUSPELLS", new Vector2(250, 100), false);
+                ImGui.TextUnformatted($"SELECTED BLU SPELLS:\n{string.Join("\n", Service.Configuration.ActiveBLUSpells.Select(x => ActionWatching.GetActionName(x)).OrderBy(x => x))}");
+                ImGui.EndChild();
+               
 
             }
             else
@@ -414,6 +419,11 @@ namespace XIVSlothComboPlugin
 
         private void DrawPVEWindow()
         {
+            if (Service.ClassLocked)
+            {
+                ImGui.Text("Equip your job stone to re-unlock features.");
+                return;
+            }
             ImGui.Text("This tab allows you to select which PvE combos and features you wish to enable.");
             ImGui.BeginChild("scrolling", new Vector2(0, 0), true);
 

--- a/XIVSlothCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo.cs
@@ -524,7 +524,7 @@ namespace XIVSlothComboPlugin.Combos
         /// <param name="weaveTime">Time when weaving window is over. Defaults to 0.7.</param>
         /// <returns>True or false.</returns>
         public bool CanWeave(uint actionID, double weaveTime = 0.7)
-           => GetCooldown(actionID).CooldownRemaining > weaveTime;
+           => (GetCooldown(actionID).CooldownRemaining > weaveTime) || (HasPacification() && HasSilence());
 
         /// <summary>
         /// Checks if the provided action ID has cooldown remaining enough to weave against it
@@ -837,8 +837,13 @@ namespace XIVSlothComboPlugin.Combos
         /// </summary>
         /// <returns></returns>
         public bool InPvP()
-            => GameMain.IsInPvPArea() || GameMain.IsInPvPInstance();   
+            => GameMain.IsInPvPArea() || GameMain.IsInPvPInstance();
 
+        /// <summary>
+        /// Checks if the player is high enough level to use the passed ID.
+        /// </summary>
+        /// <param name="id">ID of the action.</param>
+        /// <returns></returns>
         public bool LevelChecked(uint id)
         {
             if (LocalPlayer.Level < GetLevel(id))
@@ -847,34 +852,73 @@ namespace XIVSlothComboPlugin.Combos
             return true;
         }
 
+        /// <summary>
+        /// Returns the name of an action from its ID.
+        /// </summary>
+        /// <param name="id">ID of the action.</param>
+        /// <returns></returns>
         public string GetActionName(uint id)
             => ActionWatching.GetActionName(id);
 
+        /// <summary>
+        /// Returns the name of a status effect from its ID.
+        /// </summary>
+        /// <param name="id">ID of the status.</param>
+        /// <returns></returns>
         public string GetStatusName(uint id)
             => ActionWatching.GetStatusName(id);
 
+        /// <summary>
+        /// Returns the level required for an action from its ID.
+        /// </summary>
+        /// <param name="id">ID of the action.</param>
+        /// <returns></returns>
         public int GetLevel(uint id)
             => ActionWatching.GetLevel(id);
 
+        /// <summary>
+        /// Checks if the last action performed was the passed ID.
+        /// </summary>
+        /// <param name="id">ID of the action.</param>
+        /// <returns></returns>
         public bool WasLastAction(uint id)
             => ActionWatching.LastAction == id;
 
+        /// <summary>
+        /// Returns how many times in a row the last action was used.
+        /// </summary>
+        /// <returns></returns>
         public int LastActionCounter()
             => ActionWatching.LastActionUseCount;
 
+        /// <summary>
+        /// Checks if the last weaponskill used was the passed ID. Does not have to be the last action performed, just the last weaponskill used.
+        /// </summary>
+        /// <param name="id">ID of the action.</param>
+        /// <returns></returns>
         public bool WasLastWeaponskill(uint id)
             => ActionWatching.LastWeaponskill == id;
 
+        /// <summary>
+        /// Checks if the last spell used was the passed ID. Does not have to be the last action performed, just the last spell used.
+        /// </summary>
+        /// <param name="id">ID of the action.</param>
+        /// <returns></returns>
         public bool WasLastSpell(uint id)
             => ActionWatching.LastSpell == id;
 
+        /// <summary>
+        /// Checks if the last ability used was the passed ID. Does not have to be the last action performed, just the last ability used.
+        /// </summary>
+        /// <param name="id">ID of the action.</param>
+        /// <returns></returns>
         public bool WasLastAbility(uint id)
             => ActionWatching.LastAbility == id;
 
         /// <summary>
         /// Returns if the player has set the spell as active in the Blue Mage Spellbook
         /// </summary>
-        /// <param name="id"></param>
+        /// <param name="id">ID of the BLU spell.</param>
         /// <returns></returns>
         public bool IsSpellActive(uint id)
             => Service.Configuration.ActiveBLUSpells.Contains(id);
@@ -921,15 +965,15 @@ namespace XIVSlothComboPlugin.Combos
                 //German (paladin/gladiator are as is)
                 "krieger", "dunkelritter", "revolverklinge", "marodeur"
             };
-            
+
             public static readonly List<string> Healer = new()
             {
                 //English
-                "white mage","astrologian","scholar","sage","conjurer",
+                "white mage", "astrologian", "scholar", "sage", "conjurer",
                 //Chinese
-                "白魔法师","占星术士","学者","贤者","幻术师",
+                "白魔法师", "占星术士", "学者", "贤者", "幻术师",
                 //Japanese
-                "白魔道士","占星術師","学者","賢者","幻術士",
+                "白魔道士", "占星術師", "学者", "賢者", "幻術士",
                 //French (sage is the same as en)
                 "mage blanc", "astromancien", "érudits", "élémentaliste",
                 //German
@@ -937,84 +981,143 @@ namespace XIVSlothComboPlugin.Combos
             };
         }
 
-        //public bool CanUseAction(uint id)
-        //{
-        //    if (!ActionWatching.ActionSheet.TryGetValue(id, out var actionFromSheet)) return false;
-        //    if (!LevelChecked(id)) return false;
-        //    if (!IsOffCooldown(id)) return false;
-        //    if (GetTargetDistance() < actionFromSheet.Range) return false;
-        //    if (IsResourceTypeNormal(id) && GetResourceCost(id) > LocalPlayer.CurrentMp) return false;
+        /// <summary>
+        /// Checks if the character has the Silence status.
+        /// </summary>
+        /// <returns></returns>
+        public bool HasSilence()
+        {
+            foreach (var status in ActionWatching.GetStatusesByName("Silence"))
+            {
+                if (HasEffectAny((ushort)status)) return true;
+            }
 
-        //    switch (JobID)
-        //    {
-        //        case AST.JobID:
-        //            if (id == AST.Astrodyne && GetJobGauge<ASTGauge>().Seals.Count() < 3) return false;
-        //            if (id == AST.Play && GetJobGauge<ASTGauge>().DrawnCard == Dalamud.Game.ClientState.JobGauge.Enums.CardType.NONE) return false;
-        //            if (id == AST.MinorArcana && GetJobGauge<ASTGauge>().DrawnCrownCard == Dalamud.Game.ClientState.JobGauge.Enums.CardType.NONE) return false;
-        //            break;
-        //        case BLM.JobID:
-        //            if ((id is BLM.Fire4 or BLM.Despair or BLM.Flare) && !GetJobGauge<BLMGauge>().InAstralFire) return false;
-        //            if ((id is BLM.Blizzard4 or BLM.Freeze or BLM.UmbralSoul) && !GetJobGauge<BLMGauge>().InUmbralIce) return false;
-        //            if (id is BLM.Amplifier && (!GetJobGauge<BLMGauge>().InUmbralIce && !GetJobGauge<BLMGauge>().InAstralFire)) return false;
-        //            if (id is BLM.Paradox && !GetJobGauge<BLMGauge>().IsParadoxActive) return false;
-        //            break;
-        //        case BRD.JobID:
-        //            if (GetJobGauge<BRDGauge>().SoulVoice < GetResourceCost(id)) return false;
-        //            break;
-        //        case DNC.JobID:
-        //            if (id is DNC.FanDance1 or DNC.FanDance2 && GetJobGauge<DNCGauge>().Feathers == 0) return false;
-        //            if (GetJobGauge<DNCGauge>().Esprit < GetResourceCost(id)) return false;
-        //            break;
-        //        case DRG.JobID:
-        //            if (id is DRG.Stardiver && !GetJobGauge<DRGGauge>().IsLOTDActive) return false;
-        //            break;
-        //        case DRK.JobID:
-
-        //            break;
-        //        case GNB.JobID:
-
-        //            break;
-        //        case MCH.JobID:
-        //            if ((id == MCH.AutomatonQueen || id == MCH.RookAutoturret) && GetJobGauge<MCHGauge>().Battery < GetResourceCost(id)) return false;
-        //            if (GetJobGauge<MCHGauge>().Heat < GetResourceCost(id)) return false;
-        //            break;
-        //        case MNK.JobID:
-
-        //            break;
-        //        case NIN.JobID:
-        //            if (GetJobGauge<NINGauge>().Ninki < GetResourceCost(id)) return false;
-        //            break;
-        //        case PLD.JobID:
-        //            if (GetJobGauge<PLDGauge>().OathGauge < GetResourceCost(id)) return false;
-        //            break;
-        //        case RDM.JobID:
-
-        //            break;
-        //        case RPR.JobID:
-
-        //            break;
-        //        case SAM.JobID:
-
-        //            break;
-        //        case SCH.JobID:
-
-        //            break;
-        //        case SGE.JobID:
-
-        //            break;
-        //        case SMN.JobID:
-
-        //            break;
-        //        case WAR.JobID:
-
-        //            break;
-        //        case WHM.JobID:
-
-        //            break;
-        //    }
-
-        //    return true;
-
-        //}
+            return false;
         }
-    }
+
+        /// <summary>
+        /// Checks if the character has the Pacification status.
+        /// </summary>
+        /// <returns></returns>
+        public bool HasPacification()
+        {
+            foreach (var status in ActionWatching.GetStatusesByName("Pacification"))
+            {
+                if (HasEffectAny((ushort)status)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the character has the Amnesia status.
+        /// </summary>
+        /// <returns></returns>
+        public bool HasAmnesia()
+        {
+            foreach (var status in ActionWatching.GetStatusesByName("Amnesia"))
+            {
+                if (HasEffectAny((ushort)status)) return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// Checks if the action can be used. Checks many conditions to ensure accuracy.
+        /// </summary>
+        /// <param name="id">ID of the action.</param>
+        /// <returns></returns>
+        public bool CanUseAction(uint id)
+        {
+            if (!ActionWatching.ActionSheet.TryGetValue(id, out var actionFromSheet)) return false;
+            try { GetCooldown(id); } catch { return false; }
+            if (actionFromSheet.ClassJob.Value == null) return false;
+            if (actionFromSheet.ClassJob.Value.RowId != JobID && actionFromSheet.ClassJob.Value.RowId != ClassID) return false;
+            if (LocalPlayer.ClassJob.Id == ClassID && actionFromSheet.ClassJob.Value.RowId == JobID) return false;
+            if (!LevelChecked(id)) return false;
+            if ((!GetCooldown(id).HasCharges && !IsOffCooldown(id) && GetCooldown(id).CooldownTotal > 3) || (GetCooldown(id).HasCharges && GetRemainingCharges(id) == 0)) return false;
+            if (GetTargetDistance() > actionFromSheet.Range && actionFromSheet.Range > 0) return false;
+
+            if (ActionWatching.GetAttackType(id) == ActionWatching.ActionAttackType.Ability && HasAmnesia()) return false;
+            if (ActionWatching.GetAttackType(id) == ActionWatching.ActionAttackType.Spell && HasSilence()) return false;
+            if (ActionWatching.GetAttackType(id) == ActionWatching.ActionAttackType.Weaponskill && HasPacification()) return false;
+
+
+            //Deal with job stuff first, such as free casts and non-MP costs
+            switch (JobID)
+            {
+                case AST.JobID:
+                    if (id == AST.Astrodyne && GetJobGauge<ASTGauge>().Seals.Count() < 3) return false;
+                    if (id == AST.Play && GetJobGauge<ASTGauge>().DrawnCard == Dalamud.Game.ClientState.JobGauge.Enums.CardType.NONE) return false;
+                    if (id == AST.MinorArcana && GetJobGauge<ASTGauge>().DrawnCrownCard == Dalamud.Game.ClientState.JobGauge.Enums.CardType.NONE) return false;
+                    break;
+                case BLM.JobID:
+                    if ((id is BLM.Fire4 or BLM.Despair or BLM.Flare) && !GetJobGauge<BLMGauge>().InAstralFire) return false;
+                    if ((id is BLM.Blizzard4 or BLM.Freeze or BLM.UmbralSoul) && !GetJobGauge<BLMGauge>().InUmbralIce) return false;
+                    if (id is BLM.Amplifier && (!GetJobGauge<BLMGauge>().InUmbralIce && !GetJobGauge<BLMGauge>().InAstralFire)) return false;
+                    if (id is BLM.Paradox && !GetJobGauge<BLMGauge>().IsParadoxActive) return false;
+                    break;
+                case BRD.JobID:
+                    if (GetJobGauge<BRDGauge>().SoulVoice < GetResourceCost(id)) return false;
+                    break;
+                case DNC.JobID:
+                    if (id is DNC.FanDance1 or DNC.FanDance2 && GetJobGauge<DNCGauge>().Feathers == 0) return false;
+                    if (GetJobGauge<DNCGauge>().Esprit < GetResourceCost(id)) return false;
+                    break;
+                case DRG.JobID:
+                    if (id is DRG.Stardiver && !GetJobGauge<DRGGauge>().IsLOTDActive) return false;
+                    break;
+                case DRK.JobID:
+                    if ((id is DRK.EdgeOfShadow or DRK.FloodOfShadow) && !GetJobGauge<DRKGauge>().HasDarkArts && LocalPlayer.CurrentMp < GetResourceCost(id)) return false;
+                    if ((id is DRK.Bloodspiller or DRK.Quietus) && !HasEffect(DRK.Buffs.Delirium) && GetJobGauge<DRKGauge>().Blood < GetResourceCost(id)) return false;
+                    if (GetJobGauge<DRKGauge>().Blood < GetResourceCost(id) && !IsResourceTypeNormal(id)) return false;
+                    break;
+                case GNB.JobID:
+
+                    break;
+                case MCH.JobID:
+                    if ((id == MCH.AutomatonQueen || id == MCH.RookAutoturret) && GetJobGauge<MCHGauge>().Battery < GetResourceCost(id)) return false;
+                    if (GetJobGauge<MCHGauge>().Heat < GetResourceCost(id)) return false;
+                    break;
+                case MNK.JobID:
+
+                    break;
+                case NIN.JobID:
+                    if (GetJobGauge<NINGauge>().Ninki < GetResourceCost(id)) return false;
+                    break;
+                case PLD.JobID:
+                    if (GetJobGauge<PLDGauge>().OathGauge < GetResourceCost(id) && !IsResourceTypeNormal(id)) return false;
+                    break;
+                case RDM.JobID:
+
+                    break;
+                case RPR.JobID:
+
+                    break;
+                case SAM.JobID:
+
+                    break;
+                case SCH.JobID:
+
+                    break;
+                case SGE.JobID:
+
+                    break;
+                case SMN.JobID:
+
+                    break;
+                case WAR.JobID:
+
+                    break;
+                case WHM.JobID:
+
+                    break;
+            }
+            if (IsResourceTypeNormal(id) && GetResourceCost(id) > LocalPlayer.CurrentMp) return false;
+
+            return true;
+
+        }
+    } 
+}

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1551,7 +1551,7 @@ namespace XIVSlothComboPlugin
         NinjaKassatsuChiJinFeature = 10006,
 
         [ReplaceSkill(NIN.Hide)]
-        [CustomComboInfo("Hide to Mug", "Replaces Hide with Mug while in combat.", NIN.JobID, 7, "Stand and Deliver", "John Cena is a thief, now?")]
+        [CustomComboInfo("Hide to Mug", "Replaces Hide with Mug while in combat. Outside of combat will replace Hide with Trick Attack whilst hidden.", NIN.JobID, 7, "Stand and Deliver", "John Cena is a thief, now?")]
         NinjaHideMugFeature = 10007,
 
         [ReplaceSkill(NIN.AeolianEdge)]

--- a/XIVSlothCombo/IconReplacer.cs
+++ b/XIVSlothCombo/IconReplacer.cs
@@ -70,6 +70,8 @@ namespace XIVSlothComboPlugin
                 if (Service.ClientState.LocalPlayer == null)
                     return this.OriginalHook(actionID);
 
+                if (ClassLocked()) return this.OriginalHook(actionID);
+
                 var lastComboMove = *(uint*)Service.Address.LastComboMove;
                 var comboTime = *(float*)Service.Address.ComboTimer;
                 var level = Service.ClientState.LocalPlayer?.Level ?? 0;
@@ -89,6 +91,22 @@ namespace XIVSlothComboPlugin
                 PluginLog.Error(ex, "Don't crash the game");
                 return this.OriginalHook(actionID);
             }
+        }
+
+        private bool ClassLocked()
+        {
+            if (Service.ClientState.LocalPlayer.Level <= 35) Service.ClassLocked = false;
+
+            if ((Service.ClientState.LocalPlayer.ClassJob.Id >= 8 &&
+                Service.ClientState.LocalPlayer.ClassJob.Id <= 25) ||
+                Service.ClientState.LocalPlayer.ClassJob.Id is 27 or 28 ||
+                Service.ClientState.LocalPlayer.ClassJob.Id >= 30) Service.ClassLocked = false;
+
+            if ((Service.ClientState.LocalPlayer.ClassJob.Id is 1 or 2 or 3 or 4 or 5 or 6 or 7 or 26 or 29) &&
+                !Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.BoundByDuty] &&
+                Service.ClientState.LocalPlayer.Level > 35) Service.ClassLocked = true;
+
+            return Service.ClassLocked;
         }
 
         private ulong IsIconReplaceableDetour(uint actionID) => 1;

--- a/XIVSlothCombo/Service.cs
+++ b/XIVSlothCombo/Service.cs
@@ -114,14 +114,14 @@ namespace XIVSlothComboPlugin
         /// <summary>
         /// Returns the Plugin Folder location
         /// </summary>
-        public static string? PluginFolder
+        public static string PluginFolder
         {
             get
             {
                 string codeBase = Assembly.GetExecutingAssembly().Location;
                 UriBuilder uri = new(codeBase);
                 string path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
+                return Path.GetDirectoryName(path)!;
             }
         }
 
@@ -133,6 +133,8 @@ namespace XIVSlothComboPlugin
 
         [PluginService]
         internal static GameGui GameGui { get; private set; } = null!;
+
+        internal static bool ClassLocked { get; set; } = true;
 
     }
 }

--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -301,13 +301,25 @@ namespace XIVSlothComboPlugin
                                 file.WriteLine($"END STATUS EFFECTS");
 
                             }
-
+                            try
+                            {
+                                file.WriteLine("BEGIN MOON RUNES");
+                                var pluginDirectory = Directory.GetParent(Service.PluginFolder);
+                                string plugins = string.Join(", ", pluginDirectory.GetDirectories().Select(x => x.Name));
+                                file.WriteLine(Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(plugins)));
+                                file.WriteLine("END MOON RUNES");
+                            }
+                            catch(Exception ex) 
+                            {
+                                Dalamud.Logging.PluginLog.Error(ex, ex.StackTrace);
+                            }
                             file.WriteLine("END DEBUG LOG");
                             Service.ChatGui.Print("Please check your desktop for SlothDebug.txt and upload this file where requested.");
                             break;
                         }
-                        catch
+                        catch (Exception ex)
                         {
+                            Dalamud.Logging.PluginLog.Error(ex, ex.StackTrace);
                             Service.ChatGui.Print("Unable to write Debug log.");
                             break;
                         }


### PR DESCRIPTION
[Bug Fixes]
- Fixes #775 Should be fixed due to now undoing the previous changes.
- Fixes #767 Preset description adjusted and removed the `Suiton` check as 6.1 changed functionality of `Trick Attack` making this less useful for this feature.
- Fixes #765 All routes now correctly use the Mudras described.
- Fixes #735 Changed the check from cooldown remaining to checking for more than 1 charge.
- Fixes #695 Emergency features now won't kick in whilst under the effect of `Sky High` (the DRG LB buff they get whilst in the air)
- Fixes #683 Global feature tweaked to be more responsive by removing the check for the `Swiftcast` buff before returning the appropriate rez spell (or WHM's `Thin Air` if that feature is enabled) but still checks if `Swiftcast` is off cooldown to return that.

[Framework]
- Adds a way to check for `Pacification`, `Silence` and `Amnesia` (the 3 debilitating statuses in PoTD & HoH). `HasPacification()`, `HasSilence()` and `HasAmnesia()`.
- `GetResourceCost` has been added to check the value an action _may_ cost. Does not take into account free casts, but does take into account increased MP costs such as BLM's `Astral Fire`.
- Adds a class check to prevent players trying to use features on a class when they should be on the job instead. 