### PR TITLE
[MCH] Cleanup

### DIFF
--- a/XIVSlothCombo/Combos/MCH.cs
+++ b/XIVSlothCombo/Combos/MCH.cs
@@ -414,29 +414,13 @@ namespace XIVSlothComboPlugin.Combos
                         !WasLastWeaponskill(OriginalHook(CleanShot)) && (wildfireCDTime >= 2 && !WasLastAbility(Wildfire) || level < Levels.Wildfire))
                     {
                         //overflow protection
-                        if (gauge.Battery == 100)
+                        if (gauge.Battery == 100 && level >= Levels.RookOverdrive)
                         {
-                            if (level >= Levels.QueenOverdrive)
-                            {
-                                return AutomatonQueen;
-                            }
-
-                            if (level >= Levels.RookOverdrive)
-                            {
-                                return RookAutoturret;
-                            }
+                            return OriginalHook(RookAutoturret);
                         }
-                        else if (gauge.Battery >= 50 && (CombatEngageDuration().Seconds >= 55 || CombatEngageDuration().Seconds <= 05 || CombatEngageDuration().Minutes == 0))
+                        else if (gauge.Battery >= 50 && level >= Levels.RookOverdrive && (CombatEngageDuration().Seconds >= 55 || CombatEngageDuration().Seconds <= 05 || CombatEngageDuration().Minutes == 0))
                         {
-                            if (level >= Levels.QueenOverdrive)
-                            {
-                                return AutomatonQueen;
-                            }
-
-                            if (level >= Levels.RookOverdrive)
-                            {
-                                return RookAutoturret;
-                            }
+                            return OriginalHook(RookAutoturret);
                         } 
 
                     }

--- a/XIVSlothCombo/ConfigWindow.cs
+++ b/XIVSlothCombo/ConfigWindow.cs
@@ -892,6 +892,9 @@ namespace XIVSlothComboPlugin
             // ====================================================================================
             #region MACHINIST
 
+            if (preset is CustomComboPreset.MCH_ST_MainCombo_RicochetGaussCharges)
+                ConfigWindowFunctions.DrawSliderInt(0, 1, MCH.Config.MCH_ST_MainCombo_RicochetGaussCharges_ChargesToKeep, "Amount of Charges of Ricochet and Gauss to Save");
+
             #endregion
             // ====================================================================================
             #region MONK

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1386,7 +1386,7 @@ namespace XIVSlothComboPlugin
 
         [ParentCombo(MCH_ST_Simple_Assembling)]
         [CustomComboInfo("Chain Saw", "Use Reassemble with Chain Saw when available.", MCH.JobID, 0, "", "")]
-        MCH_Simple_Assembling_ChainSaw = 8031,
+        MCH_ST_Simple_Assembling_ChainSaw = 8031,
 
         [ParentCombo(MCH_ST_Simple_Assembling_Drill)]
         [CustomComboInfo("Only use Drill...", "...when you have max charges of reassemble.", MCH.JobID, 0, "", "")]
@@ -1396,9 +1396,13 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Only use Air Anchor...", "...when you have max charges of reassemble.", MCH.JobID, 0, "", "")]
         MCH_ST_Simple_Assembling_AirAnchor_MaxCharges = 8033,
 
-        [ParentCombo(MCH_Simple_Assembling_ChainSaw)]
+        [ParentCombo(MCH_ST_Simple_Assembling_ChainSaw)]
         [CustomComboInfo("Only use Chain Saw...", "...when you have max charges of reassemble.", MCH.JobID, 0, "", "")]
         MCH_ST_Simple_Assembling_ChainSaw_MaxCharges = 8034,
+
+        [ParentCombo(MCH_ST_Simple_Stabilizer)]
+        [CustomComboInfo("Wildfire Only", "Only use it to prepare for Wildfire use.", MCH.JobID, 0, "", "")]
+        MCH_ST_Simple_Stabilizer_Wildfire_Only = 8035,
 
         #endregion
         // ====================================================================================

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1314,15 +1314,9 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Always Gauss Round/Ricochet on AoE Option", "Adds Gauss Round/Ricochet to the AoE combo outside of Hypercharge windows.", MCH.JobID, 0, "", "")]
         MCH_AoE_Gauss = 8012,
 
-        [ConflictingCombos(MCH_ST_MainCombo_RicochetGauss)]
         [ParentCombo(MCH_ST_MainCombo)]
-        [CustomComboInfo("Ricochet & Gauss Round Feature", "Adds Ricochet and Gauss Round to main combo. Will use all charges.", MCH.JobID, 0, "", "")]
+        [CustomComboInfo("Ricochet & Gauss Round Feature", "Adds Ricochet and Gauss Round to main combo.", MCH.JobID, 0, "", "")]
         MCH_ST_MainCombo_RicochetGaussCharges = 8017,
-
-        [ConflictingCombos(MCH_ST_MainCombo_RicochetGaussCharges)]
-        [ParentCombo(MCH_ST_MainCombo)]
-        [CustomComboInfo("Ricochet & Gauss Round overcap protection option", "Adds Ricochet and Gauss Round to main combo. Will leave 1 charge of each.", MCH.JobID, 0, "", "")]
-        MCH_ST_MainCombo_RicochetGauss = 8013,
 
         [ParentCombo(MCH_ST_MainCombo)]
         [CustomComboInfo("Barrel Stabilizer drift protection feature", "Adds Barrel Stabilizer onto the main combo if heat is between 5-20.", MCH.JobID, 0, "", "")]


### PR DESCRIPTION
*Note* Hold till after Aug's commit is accepted. Then re-review*
MCH_ST_MainCombo: No need to check for all cooldowns at the start. Using GetCoolDownRemainingTime as needed. Hard level check for Ricochet corrected
-MCH_ST_MainCombo_Cooldowns: switch code
-MCH_ST_MainCombo_RicochetGaussCharges Merged Overcap protection as a slider (0/1)
-MCH_ST_MainComboAlternate: Simplified, based on option's description
-MCH_ST_MainCombo_OverCharge: OriginalHooking of RookAutoTurret instead of level checks for Queen
MCH_HeatblastGaussRicochet: Cooldown cleanup
MCH_GaussRoundRicochet: Hard level check corrected. Cooldown code cleanup
MCH_AoE_SimpleMode: Originalhooking of RookAutoTurret instead of level checks for Queen
-MCH_AoE_Simple_Hypercharge: combined if checks
MCH_Overdrive: Simplified into single if
MachinistHotShotDrillChainsawFeature: changed to MCH_HotShotDrillChainSaw. Switch checking
MCH_AutoCrossbowGaussRicochet: Simplified cooldowns, switch level checking of ricochet and gauss
MCH_ST_SimpleMode: Simplified battery overflow protection.