### PR TITLE
[MCH]  Logic Rework for Simple MCH

### DIFF
--- a/XIVSlothCombo/Combos/MCH.cs
+++ b/XIVSlothCombo/Combos/MCH.cs
@@ -414,29 +414,13 @@ namespace XIVSlothComboPlugin.Combos
                         !WasLastWeaponskill(OriginalHook(CleanShot)) && (wildfireCDTime >= 2 && !WasLastAbility(Wildfire) || level < Levels.Wildfire))
                     {
                         //overflow protection
-                        if (gauge.Battery == 100)
+                        if (gauge.Battery == 100 && level >= Levels.RookOverdrive)
                         {
-                            if (level >= Levels.QueenOverdrive)
-                            {
-                                return AutomatonQueen;
-                            }
-
-                            if (level >= Levels.RookOverdrive)
-                            {
-                                return RookAutoturret;
-                            }
+                            return OriginalHook(RookAutoturret);
                         }
-                        else if (gauge.Battery >= 50 && (CombatEngageDuration().Seconds >= 55 || CombatEngageDuration().Seconds <= 05 || CombatEngageDuration().Minutes == 0))
+                        else if (gauge.Battery >= 50 && level >= Levels.RookOverdrive && (CombatEngageDuration().Seconds >= 55 || CombatEngageDuration().Seconds <= 05 || CombatEngageDuration().Minutes == 0))
                         {
-                            if (level >= Levels.QueenOverdrive)
-                            {
-                                return AutomatonQueen;
-                            }
-
-                            if (level >= Levels.RookOverdrive)
-                            {
-                                return RookAutoturret;
-                            }
+                            return OriginalHook(RookAutoturret);
                         } 
 
                     }

--- a/XIVSlothCombo/CustomComboPreset.cs
+++ b/XIVSlothCombo/CustomComboPreset.cs
@@ -1386,7 +1386,7 @@ namespace XIVSlothComboPlugin
 
         [ParentCombo(MCH_ST_Simple_Assembling)]
         [CustomComboInfo("Chain Saw", "Use Reassemble with Chain Saw when available.", MCH.JobID, 0, "", "")]
-        MCH_Simple_Assembling_ChainSaw = 8031,
+        MCH_ST_Simple_Assembling_ChainSaw = 8031,
 
         [ParentCombo(MCH_ST_Simple_Assembling_Drill)]
         [CustomComboInfo("Only use Drill...", "...when you have max charges of reassemble.", MCH.JobID, 0, "", "")]
@@ -1396,9 +1396,13 @@ namespace XIVSlothComboPlugin
         [CustomComboInfo("Only use Air Anchor...", "...when you have max charges of reassemble.", MCH.JobID, 0, "", "")]
         MCH_ST_Simple_Assembling_AirAnchor_MaxCharges = 8033,
 
-        [ParentCombo(MCH_Simple_Assembling_ChainSaw)]
+        [ParentCombo(MCH_ST_Simple_Assembling_ChainSaw)]
         [CustomComboInfo("Only use Chain Saw...", "...when you have max charges of reassemble.", MCH.JobID, 0, "", "")]
         MCH_ST_Simple_Assembling_ChainSaw_MaxCharges = 8034,
+
+        [ParentCombo(MCH_ST_Simple_Stabilizer)]
+        [CustomComboInfo("Wildfire Only", "Only use it to prepare for Wildfire use.", MCH.JobID, 0, "", "")]
+        MCH_ST_Simple_Stabilizer_Wildfire_Only = 8035,
 
         #endregion
         // ====================================================================================


### PR DESCRIPTION
### MCH

- PVE
   - Added an option to `Stabilizer` to ensure that its only used to prep for `Wildfire` burst windows, avoiding desyncs and misalign of bursts, purposefully or not; 
   - Reworked the `Simple Machinist` internal logic to be more responsive to CD desyncs, reopeners and openers with saved resources (looking at you dungeons and alliance raids :P) 
      - 2m Burst windows should feel tighter, ensuring correct use.
      - It will try to automatically minimize the effects of desync, being that occurring from death or starting the fight with some CDs off, because of that `Drill`, `Air Anchor` and `ChainSaw` can and will drift a little, but that should not negatively effect you that much.
         - Note that a desync/misalign of burst is almost impossible to realign during the course of a fight unless you restart it, if you don't die you should never misalign though , so don't die! xD
      - Note that on the opener if you have saved resources it will waste some on purpose until the full opener is done, that is to prevent desyncing with raid buffs ,etc.