### PR TITLE
[BLMPVP] 6.15 patch removed charges from Paradox.

### DIFF
--- a/XIVSlothCombo/CombosPVP/BLMPVP.cs
+++ b/XIVSlothCombo/CombosPVP/BLMPVP.cs
@@ -63,7 +63,7 @@
                         return OriginalHook(Fire);
 
                     if (FindTargetEffect(Debuffs.AstralWarmth).StackCount < 3 &&
-                        GetRemainingCharges(Paradox) > 0)
+                        IsOffCooldown(Paradox))
                         return Paradox;
 
                     if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_NightWing) &&
@@ -97,7 +97,7 @@
                         return OriginalHook(Blizzard);
 
                     if (FindTargetEffect(Debuffs.UmbralFreeze).StackCount < 3 &&
-                        GetRemainingCharges(Paradox) > 0)
+                        IsOffCooldown(Paradox))
                         return Paradox;
 
                     if (IsEnabled(CustomComboPreset.BLMPvP_BurstMode_NightWing) &&


### PR DESCRIPTION
Paradox no longer has charges since the 6.15 patch.

Pretty much a meaningless PR since i think it would still work even with the charge check but i feel it's better to have it implemented properly.