### PR TITLE
Added level for Inner Release, and added level check for the melee onslaught option.

### DIFF
--- a/XIVSlothCombo/Combos/WAR.cs
+++ b/XIVSlothCombo/Combos/WAR.cs
@@ -62,6 +62,7 @@ namespace XIVSlothComboPlugin.Combos
                 Decimate = 60,
                 Onslaught = 62,
                 Upheaval = 64,
+                InnerRelease = 70,
                 ChaoticCyclone = 72,
                 MythrilTempestTrait = 74,
                 NascentFlash = 76,
@@ -115,7 +116,7 @@ namespace XIVSlothComboPlugin.Combos
                             if (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_Onslaught) && level >= Levels.Onslaught && GetRemainingCharges(Onslaught) > onslaughtChargesRemaining)
                             {
                                 if (IsNotEnabled(CustomComboPreset.WAR_ST_StormsPath_Onslaught_MeleeSpender) ||
-                                    (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_Onslaught_MeleeSpender) && GetTargetDistance() <= 1 && GetCooldownRemainingTime(InnerRelease) > 40))
+                                    (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_Onslaught_MeleeSpender) && GetTargetDistance() <= 1 && (GetCooldownRemainingTime(InnerRelease) > 40 || level < Levels.InnerRelease)))
                                     return Onslaught;
                             }
                         }


### PR DESCRIPTION
Melee onslaught option checks for `Inner Release` cooldown, meaning it would cause you to not use onslaught at all until level 70.
Added level check to resolve.