### PR TITLE
[MCH] Simple MCH improvements;

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1343,7 +1343,7 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(MCH.SplitShot, MCH.HeatedSplitShot)]
         [ConflictingCombos(MCH_ST_MainCombo, MCH_HeatblastGaussRicochet)]
-        [CustomComboInfo("Simple Machinist", "Single button single target machinist, including buffs and overprotections.\nConflicts with other single target toggles!!\nMade to work optimally with a 2.5 GCD.\nThe use of NoClippy or XIVAlexander is highly recommended because of SE does not like networks outside Japan.", MCH.JobID, 0, "", "")]
+        [CustomComboInfo("Simple Machinist", "Single button single target machinist, including buffs and overcap protections.\nConflicts with other single target toggles!\nMade to work optimally with a 2.5 GCD.\nThe use of latency mitigation tools is recommended due to XIV's network handling.", MCH.JobID, 0, "", "")]
         MCH_ST_SimpleMode = 8020,
 
         [ParentCombo(MCH_ST_SimpleMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1343,7 +1343,7 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(MCH.SplitShot, MCH.HeatedSplitShot)]
         [ConflictingCombos(MCH_ST_MainCombo, MCH_HeatblastGaussRicochet)]
-        [CustomComboInfo("Simple Machinist", "Single button single target machinist, including buffs and overprotections.\nConflicts with other single target toggles!!\nMade to work optimally with a 2.5 GCD.", MCH.JobID, 0, "", "")]
+        [CustomComboInfo("Simple Machinist", "Single button single target machinist, including buffs and overprotections.\nConflicts with other single target toggles!!\nMade to work optimally with a 2.5 GCD.\nThe use of NoClippy or XIVAlexander is highly recommended because of SE does not like networks outside Japan.", MCH.JobID, 0, "", "")]
         MCH_ST_SimpleMode = 8020,
 
         [ParentCombo(MCH_ST_SimpleMode)]
@@ -1405,6 +1405,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(MCH_ST_Simple_Stabilizer)]
         [CustomComboInfo("Wildfire Only", "Only use it to prepare for Wildfire use.", MCH.JobID, 0, "", "")]
         MCH_ST_Simple_Stabilizer_Wildfire_Only = 8035,
+
+        [ParentCombo(MCH_ST_SimpleMode)]
+        [CustomComboInfo("High Ping Mode", "A high ping friendly mode.\nIt limits the uses of Gauss/Ricochet inside Hypercharge windows.\nThere will be a little dps loss.", MCH.JobID, 0, "", "")]
+        MCH_ST_Simple_High_Latency_Mode = 8036,
 
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/MCH.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH.cs
@@ -552,10 +552,11 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.MCH_ST_Simple_GaussRicochet) && CanWeave(actionID))
                     {
                         var gaussCharges = GetRemainingCharges(GaussRound);
+                        var gaussMaxCharges = GetMaxCharges(GaussRound);
+
                         var ricochetCharges = GetRemainingCharges(Ricochet);
 
-                        if ((gaussCharges >= ricochetCharges || level < Levels.Ricochet) && gaussCharges > 0 &&
-                        level >= Levels.GaussRound)
+                        if (gaussCharges > ricochetCharges || gaussCharges == gaussMaxCharges || level < Levels.Ricochet)
                             return GaussRound;
                         else if (ricochetCharges > 0 && level >= Levels.Ricochet)
                             return Ricochet;


### PR DESCRIPTION
### PVE

- Simple MCH `Reassemble` casts bug fix;
- `Wildfire` a bit more intelligent for levels below max level;
- Implementation of a `High Latency Mode` feature for Simple MCH;
   - With this a disclaimer in the description of Simple MCH was added to advice for the use of `NoClippy` or `XIVAlexander` to avoid the "But it works on our basement servers from our office" mentality that plagues some jobs in the game.
      - If someone don't want to run either, HLM is the way to go for it to function properly.