### PR TITLE
[SMN] Rework, added Simple Summoner combo.

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2531,15 +2531,15 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
         [CustomComboInfo("Enable Combo Features", "Enables features tied to Ruin, Ruin II, Outburst, or Tri-Disaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple Summoner)\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
-        SMN_ST_MainCombo = 17000,
+        SMN_Advanced_Combo = 17000,
 
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Demi Attacks on Main/AOE Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main/AoE Combos.", SMN.JobID, 7, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
-        SMN_ST_MainCombo_DemiSummons_Attacks = 17002,
+        SMN_Advanced_Combo_DemiSummons_Attacks = 17002,
 
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Gemshine/Precious Brilliance on Main/AoE Combo", "Adds Egi Attacks (Gemshine/Precious Brilliance) to the Main/AoE Combos.", SMN.JobID, 3, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
-        SMN_ST_MainCombo_EgiSummons_Attacks = 17004,
+        SMN_Advanced_Combo_EgiSummons_Attacks = 17004,
 
         [CustomComboInfo("Garuda Slipstream Feature", "Adds Slipstream on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 4, "Slipstream", "2 Fast 2 Furious")]
         SMN_Garuda_Slipstream = 17005,
@@ -2562,23 +2562,23 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Carbuncle Reminder Feature", "Reminds you to summon Carbuncle by replacing most actions with Summon Carbuncle.", SMN.JobID, 8)]
         SMN_CarbuncleReminder = 17010,
 
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Ruin 4 on Main/AoE Combo", "Adds Ruin 4 to the Main/AoE Combos when there are currently no summons active.", SMN.JobID, 0, "Ruin -> Ruin -> Ruin", "Ruin this, ruin that. Can't you see I'm busy ruining the plugin?!")]
-        SMN_ST_MainCombo_Ruin4 = 17011,
+        SMN_Advanced_Combo_Ruin4 = 17011,
 
         [ParentCombo(SMN_EDFester)]
         [CustomComboInfo("Ruin 4 Fester Option", "Changes Fester to Ruin 4 when out of Aetherflow stacks, Energy Drain is on cooldown, and Ruin 4 is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
         SMN_EDFester_Ruin4 = 17013,
 
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Energy Drain/Siphon and Fester/Painflare on Main/AoE Combos", "Adds ED/Fester and ES/Painflare to the Main/AoE Combo. Will use on cooldown.", SMN.JobID, 1)]
-        SMN_ST_MainCombo_EDFester = 17014,
+        SMN_Advanced_Combo_EDFester = 17014,
 
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Egis on Main/Aoe Combo", "Adds Egi summons to your Main/AoE Combos.\nIf no option is selected below, it will default to Titan first.", SMN.JobID, 2)]
         SMN_DemiEgiMenu_EgiOrder = 17016,
 
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Searing Light on Single Target/AoE combo", "Adds Searing Light to the Single target, and AoE combos. Will be used on cooldown.", SMN.JobID, 6, "My eyes!", "I can't see!")]
         SMN_SearingLight = 17018,
 
@@ -2586,18 +2586,18 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Searing Light Burst Option", "Casts Searing Light only during Bahamut/Phoenix Phase.\nChoose which phase to burst in under 'Burst Phase Choice' option.\nNot recommended for SpS Builds.", SMN.JobID, 0, "My eyes!", "I can't see!")]
         SMN_SearingLight_Burst = 170181,
 
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Demi Summons on Main/AoE Combo", "Adds Demi Summons to the Main/AoE Combos.", SMN.JobID, 5, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
-        SMN_ST_MainCombo_DemiSummons = 17020,
+        SMN_Advanced_Combo_DemiSummons = 17020,
 
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 4, "", "")]
         SMN_DemiEgiMenu_SwiftcastEgi = 17023,
 
         [CustomComboInfo("Astral Flow/Enkindle on Bahamut/Phoenix", "Adds Astral Flow and Enkindle to Bahamut/Phoenix.", SMN.JobID, 11, "", "")]
         SMN_DemiAbilities = 17024,
 
-        [ParentCombo(SMN_ST_MainCombo_EDFester)]
+        [ParentCombo(SMN_Advanced_Combo_EDFester)]
         [CustomComboInfo("Pooled oGCDs Feature", "Pools damage OGCDs to use under Searing Light and in Bahamut/Phoenix Phase.\nChoose which phase to burst in under 'Burst Phase Choice' option.", SMN.JobID, 1)]
         SMN_DemiEgiMenu_oGCDPooling = 17025,
 
@@ -2605,9 +2605,9 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Alternative Raise Feature", "Changes Swiftcast to Raise when on cooldown", SMN.JobID, 8, "Shittier RezMage", "Just play RDM oh my gawwddddddddddddd")]
         SMN_Raise = 17027,
 
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Rekindle on Main/AoE Combo option", "Adds Rekindle to the Main/Aoe Combos.", SMN.JobID, 9, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
-        SMN_ST_MainCombo_DemiSummons_Rekindle = 17028,
+        SMN_Advanced_Combo_DemiSummons_Rekindle = 17028,
 
         [ReplaceSkill(SMN.Ruin4)]
         [CustomComboInfo("Ruin III Mobility Feature", "Puts Ruin III on Ruin IV when you don't have Further Ruin.", SMN.JobID, 9, "Yo Dawg I Heard You Like Ruin Feature", "Ruin while you Ruin")]
@@ -2617,7 +2617,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Lucid Dreaming Feature", "Adds Lucid dreaming to the Main Combo when below set MP value.", SMN.JobID, 10, "", "")]
         SMN_Lucid = 17031,
         
-        [ParentCombo(SMN_ST_MainCombo)]
+        [ParentCombo(SMN_Advanced_Combo)]
         [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Fester and Searing Light will only be used during Bahamut/Phoenix windows.", SMN.JobID, 8, "", "")]
         SMN_DemiEgiMenu_BurstChoice = 17032,
 
@@ -2644,6 +2644,11 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Crimson Cyclone Option", "Changes Crimson Cyclone to only be used after all Ifrit Attunement charges have been used, or if moving.", SMN.JobID, 0, "", "")]
         SMN_Ifrit_Cyclone_Option = 17040,
 
+        [ConflictingCombos(SMN_Advanced_Combo)]
+        [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
+        [CustomComboInfo("Summoner Simple Combo", "Summoner simple one button combo.", SMN.JobID, -1, "", "")]
+        SMN_Simple_Combo = 17041,
+        
         #endregion
 
         #region WARRIOR

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2530,24 +2530,28 @@ namespace XIVSlothCombo.Combos
         #region SUMMONER
 
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
-        [CustomComboInfo("Enable Combo Features", "Enables features tied to Ruin, Ruin II, Outburst, or Tri-Disaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple Summoner)\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
+        [ConflictingCombos(SMN_Simple_Combo)]
+        [CustomComboInfo("Summoner Advanced Combo", "Advanced Combo features tied to Ruin, Ruin II, Outburst, or Tri-Disaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple Summoner)\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
         SMN_Advanced_Combo = 17000,
-
+        
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Demi Attacks on Main/AOE Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main/AoE Combos.", SMN.JobID, 7, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
+        [CustomComboInfo("Demi Attacks on Main/AOE Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main/AoE Combos.", SMN.JobID, 11, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
         SMN_Advanced_Combo_DemiSummons_Attacks = 17002,
 
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Gemshine/Precious Brilliance on Main/AoE Combo", "Adds Egi Attacks (Gemshine/Precious Brilliance) to the Main/AoE Combos.", SMN.JobID, 3, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
+        [CustomComboInfo("Gemshine/Precious Brilliance on Main/AoE Combo", "Adds Egi Attacks (Gemshine/Precious Brilliance) to the Main/AoE Combos.", SMN.JobID, 4, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
         SMN_Advanced_Combo_EgiSummons_Attacks = 17004,
-
-        [CustomComboInfo("Garuda Slipstream Feature", "Adds Slipstream on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 4, "Slipstream", "2 Fast 2 Furious")]
+        
+        [ParentCombo(SMN_Advanced_Combo)]
+        [CustomComboInfo("Garuda Slipstream Feature", "Adds Slipstream on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 6, "Slipstream", "2 Fast 2 Furious")]
         SMN_Garuda_Slipstream = 17005,
-
-        [CustomComboInfo("Ifrit Cyclone Feature", "Adds Crimson Cyclone/Crimson Strike on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 4, "Fists of Fury", "Show MNK how it's done, will ya?")]
+        
+        [ParentCombo(SMN_Advanced_Combo)]
+        [CustomComboInfo("Ifrit Cyclone Feature", "Adds Crimson Cyclone/Crimson Strike on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 7, "Fists of Fury", "Show MNK how it's done, will ya?")]
         SMN_Ifrit_Cyclone = 17006,
-
-        [CustomComboInfo("Titan Mountain Buster Feature", "Adds Mountain Buster on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 3, "Mountain, BUSTA", "Bring the mountain to Mohammed, as they say")]
+        
+        [ParentCombo(SMN_Advanced_Combo)]
+        [CustomComboInfo("Titan Mountain Buster Feature", "Adds Mountain Buster on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 5, "Mountain, BUSTA", "Bring the mountain to Mohammed, as they say")]
         SMN_Titan_MountainBuster = 17007,
 
         [ReplaceSkill(SMN.Fester)]
@@ -2575,11 +2579,11 @@ namespace XIVSlothCombo.Combos
         SMN_Advanced_Combo_EDFester = 17014,
 
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Egis on Main/Aoe Combo", "Adds Egi summons to your Main/AoE Combos.\nIf no option is selected below, it will default to Titan first.", SMN.JobID, 2)]
+        [CustomComboInfo("Egis on Main/Aoe Combo", "Adds Egi summons to your Main/AoE Combos.\nIf no option is selected below, it will default to Titan first.", SMN.JobID, 3)]
         SMN_DemiEgiMenu_EgiOrder = 17016,
 
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Searing Light on Single Target/AoE combo", "Adds Searing Light to the Single target, and AoE combos. Will be used on cooldown.", SMN.JobID, 6, "My eyes!", "I can't see!")]
+        [CustomComboInfo("Searing Light on Single Target/AoE combo", "Adds Searing Light to the Single target, and AoE combos. Will be used on cooldown.", SMN.JobID, 9, "My eyes!", "I can't see!")]
         SMN_SearingLight = 17018,
 
         [ParentCombo(SMN_SearingLight)]
@@ -2587,11 +2591,11 @@ namespace XIVSlothCombo.Combos
         SMN_SearingLight_Burst = 170181,
 
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Demi Summons on Main/AoE Combo", "Adds Demi Summons to the Main/AoE Combos.", SMN.JobID, 5, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
+        [CustomComboInfo("Demi Summons on Main/AoE Combo", "Adds Demi Summons to the Main/AoE Combos.", SMN.JobID, 10, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
         SMN_Advanced_Combo_DemiSummons = 17020,
 
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 4, "", "")]
+        [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 8, "", "")]
         SMN_DemiEgiMenu_SwiftcastEgi = 17023,
 
         [CustomComboInfo("Astral Flow/Enkindle on Bahamut/Phoenix", "Adds Astral Flow and Enkindle to Bahamut/Phoenix.", SMN.JobID, 11, "", "")]
@@ -2606,19 +2610,19 @@ namespace XIVSlothCombo.Combos
         SMN_Raise = 17027,
 
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Rekindle on Main/AoE Combo option", "Adds Rekindle to the Main/Aoe Combos.", SMN.JobID, 9, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        [CustomComboInfo("Rekindle on Main/AoE Combo option", "Adds Rekindle to the Main/Aoe Combos.", SMN.JobID, 13, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
         SMN_Advanced_Combo_DemiSummons_Rekindle = 17028,
 
         [ReplaceSkill(SMN.Ruin4)]
         [CustomComboInfo("Ruin III Mobility Feature", "Puts Ruin III on Ruin IV when you don't have Further Ruin.", SMN.JobID, 9, "Yo Dawg I Heard You Like Ruin Feature", "Ruin while you Ruin")]
         SMN_RuinMobility = 17030,
 
-        [ReplaceSkill(SMN.Ruin, SMN.Ruin2)]
-        [CustomComboInfo("Lucid Dreaming Feature", "Adds Lucid dreaming to the Main Combo when below set MP value.", SMN.JobID, 10, "", "")]
+        [ParentCombo(SMN_Advanced_Combo)]
+        [CustomComboInfo("Lucid Dreaming Feature", "Adds Lucid dreaming to the Main Combo when below set MP value.", SMN.JobID, 2, "", "")]
         SMN_Lucid = 17031,
         
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Fester and Searing Light will only be used during Bahamut/Phoenix windows.", SMN.JobID, 8, "", "")]
+        [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Fester and Searing Light will only be used during Bahamut/Phoenix windows.", SMN.JobID, 12, "", "")]
         SMN_DemiEgiMenu_BurstChoice = 17032,
 
         [CustomComboInfo("Egi Abilities on Egi Summons", "Adds Egi Abilities (Astral Flow) to Egi Summons when ready.\nEgi Abilities will appear on their respective Egi Summon Ability, as well as, Titan.", SMN.JobID, 12, "", "")]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2653,6 +2653,10 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Summoner Simple Combo", "Summoner simple one button combo.", SMN.JobID, -1, "", "")]
         SMN_Simple_Combo = 17041,
         
+        [ParentCombo(SMN_Simple_Combo)]
+        [CustomComboInfo("Ifrit Swiftcast Option", "Use Swiftcast only for Ruby Rite/Catastrophe.", SMN.JobID, 0, "", "")]
+        SMN_Simple_Swiftcast_Option = 17042,
+        
         #endregion
 
         #region WARRIOR

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2531,7 +2531,7 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
         [ConflictingCombos(SMN_Simple_Combo)]
-        [CustomComboInfo("Summoner Advanced Combo", "Advanced Combo features tied to Ruin, Ruin II, Outburst, or Tri-Disaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple Summoner)\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
+        [CustomComboInfo("Summoner Advanced Combo", "Advanced Combo features tied to Ruin, Ruin II, Outburst, and Tri-Disaster.\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
         SMN_Advanced_Combo = 17000,
         
         [ParentCombo(SMN_Advanced_Combo)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2531,7 +2531,7 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
         [ConflictingCombos(SMN_Simple_Combo)]
-        [CustomComboInfo("Summoner Advanced Combo", "Advanced Combo features tied to Ruin, Ruin II, Outburst, and Tri-Disaster.\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
+        [CustomComboInfo("Advanced Summoner", "Advanced Combo features tied to Ruin, Ruin II, Outburst, and Tri-Disaster.\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
         SMN_Advanced_Combo = 17000,
         
         [ParentCombo(SMN_Advanced_Combo)]
@@ -2650,7 +2650,7 @@ namespace XIVSlothCombo.Combos
 
         [ConflictingCombos(SMN_Advanced_Combo)]
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
-        [CustomComboInfo("Summoner Simple Combo", "Summoner simple one button combo.", SMN.JobID, -1, "", "")]
+        [CustomComboInfo("Simple Summoner", "Summoner simple one button combo.", SMN.JobID, -1, "", "")]
         SMN_Simple_Combo = 17041,
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2529,24 +2529,16 @@ namespace XIVSlothCombo.Combos
 
         #region SUMMONER
 
-        [ReplaceSkill(SMN.Ruin, SMN.Ruin2)]
-        [CustomComboInfo("Enable Single Target Combo Features", "Enables features tied to Ruin, or Ruin II.\nIf all sub options are toggled will turn into a full one button rotation (Simple Summoner)\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
+        [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
+        [CustomComboInfo("Enable Combo Features", "Enables features tied to Ruin, Ruin II, Outburst, or Tri-Disaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple Summoner)\nRuin III is kept untouched for mobility.", SMN.JobID, 0, "Ruin 7 Feature", "Ruination is come... again?")]
         SMN_ST_MainCombo = 17000,
 
-        [ReplaceSkill(SMN.Tridisaster)]
-        [CustomComboInfo("Enable AoE Combo Features", "Enables features tied to Tridisaster.\nIf all sub options are toggled will turn into a full one button rotation (Simple AOE)", SMN.JobID, 1, "", "Can't deal with dungeons on your own? Fear not.")]
-        SMN_AoE_MainCombo = 17001,
-
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Demi Attacks on Main Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main Combo.", SMN.JobID, 4, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
+        [CustomComboInfo("Demi Attacks on Main/AOE Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main/AoE Combos.", SMN.JobID, 17, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
         SMN_ST_MainCombo_DemiSummons_Attacks = 17002,
 
-        [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("AoE Demi Attacks on AoE Combo", "Adds Deathflare/Ahk Morn/Revelation to the AOE Combo.", SMN.JobID, 4, "BRRRR", "Upgrade!")]
-        SMN_AoE_MainCombo_Demis = 17003,
-
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Gemshine on Main Combo", "Adds Egi Attacks (Gemshine) to the Main Combo.", SMN.JobID, 2, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
+        [CustomComboInfo("Gemshine/Precious Brilliance on Main/AoE Combo", "Adds Egi Attacks (Gemshine/Precious Brilliance) to the Main/AoE Combos.", SMN.JobID, 3, "Eggy-bread", "No idea when you're in burst phase?\nHint: It's all the time, really")]
         SMN_ST_MainCombo_EgiSummons_Attacks = 17004,
 
         [CustomComboInfo("Garuda Slipstream Feature", "Adds Slipstream on RuinI/Ruin II/Tri-disaster.", SMN.JobID, 4, "Slipstream", "2 Fast 2 Furious")]
@@ -2571,31 +2563,23 @@ namespace XIVSlothCombo.Combos
         SMN_CarbuncleReminder = 17010,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Ruin 4 on Main Combo", "Adds Ruin 4 to the Main Combo when there are currently no summons active.", SMN.JobID, 0, "Ruin -> Ruin -> Ruin", "Ruin this, ruin that. Can't you see I'm busy ruining the plugin?!")]
+        [CustomComboInfo("Ruin 4 on Main/AoE Combo", "Adds Ruin 4 to the Main/AoE Combos when there are currently no summons active.", SMN.JobID, 0, "Ruin -> Ruin -> Ruin", "Ruin this, ruin that. Can't you see I'm busy ruining the plugin?!")]
         SMN_ST_MainCombo_Ruin4 = 17011,
-
-        [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("Ruin 4 On Tri-disaster Feature", "Adds Ruin4 on AoE Combo when there are currently no summons active.", SMN.JobID, 0, "", "More Ruin this, more ruin that! Now in sharing size!")]
-        SMN_AoE_MainCombo_Ruin4 = 17012,
 
         [ParentCombo(SMN_EDFester)]
         [CustomComboInfo("Ruin 4 Fester Option", "Changes Fester to Ruin 4 when out of Aetherflow stacks, Energy Drain is on cooldown, and Ruin 4 is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
         SMN_EDFester_Ruin4 = 17013,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Energy Drain/Fester on Main Combo", "Adds ED/Fester to the Main Combo. Will use on cooldown.", SMN.JobID, 1)]
+        [CustomComboInfo("Energy Drain/Siphon and Fester/Painflare on Main/AoE Combos", "Adds ED/Fester and ES/Painflare to the Main/AoE Combo. Will use on cooldown.", SMN.JobID, 1)]
         SMN_ST_MainCombo_EDFester = 17014,
 
-        [ParentCombo(SMN_DemiEgiMenu)]
-        [CustomComboInfo("Egi Summon Order", "Sets the order you summon egis.", SMN.JobID, 0)]
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Egis on Main/Aoe Combo", "Adds Egi summons to your Main/AoE Combos.\nIf no option is selected below, it will default to Titan first.", SMN.JobID, 2)]
         SMN_DemiEgiMenu_EgiOrder = 17016,
 
-        [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("Energy Siphon/Painflare on AoE Combo", "Adds Energy Siphon/Painflare to the AoE Combo", SMN.JobID, 1, "", "We'll play the game for you. Shush, now")]
-        SMN_AoE_MainCombo_ESPainflare = 17017,
-
-        [ParentCombo(SMN_DemiEgiMenu)]
-        [CustomComboInfo("Searing Light on Single Target/AoE combo", "Adds Searing Light to the Single target, and AoE combos. Will be used on cooldown.", SMN.JobID, 2, "My eyes!", "I can't see!")]
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Searing Light on Single Target/AoE combo", "Adds Searing Light to the Single target, and AoE combos. Will be used on cooldown.", SMN.JobID, 16, "My eyes!", "I can't see!")]
         SMN_SearingLight = 17018,
 
         [ParentCombo(SMN_SearingLight)]
@@ -2603,39 +2587,27 @@ namespace XIVSlothCombo.Combos
         SMN_SearingLight_Burst = 170181,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Demi Summons on Main Combo", "Adds Demi Summons to the Main Combo.", SMN.JobID, 3, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
+        [CustomComboInfo("Demi Summons on Main/AoE Combo", "Adds Demi Summons to the Main/AoE Combos.", SMN.JobID, 15, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
         SMN_ST_MainCombo_DemiSummons = 17020,
 
-        [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("Demi Summons AoE Combo", "Adds Demi Summons to the AoE Combo.", SMN.JobID, 3, "Nickelback Demi Feature", "Oh fuck, the whole band is here! Run!")]
-        SMN_AoE_MainCombo_DemiSummons = 17021,
-        
-        [ParentCombo(SMN_DemiEgiMenu)]
-        [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 1, "", "")]
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Swiftcast Egi Ability Option", "Swiftcasts during the selected Primal Summon.", SMN.JobID, 4, "", "")]
         SMN_DemiEgiMenu_SwiftcastEgi = 17023,
 
         [CustomComboInfo("Astral Flow/Enkindle on Bahamut/Phoenix", "Adds Astral Flow and Enkindle to Bahamut/Phoenix.", SMN.JobID, 11, "", "")]
         SMN_DemiAbilities = 17024,
 
-        [ParentCombo(SMN_DemiEgiMenu)]
+        [ParentCombo(SMN_ST_MainCombo_EDFester)]
         [CustomComboInfo("Pooled oGCDs Feature", "Pools damage OGCDs to use under Searing Light and in Bahamut/Phoenix Phase.\nChoose which phase to burst in under 'Burst Phase Choice' option.", SMN.JobID, 1)]
         SMN_DemiEgiMenu_oGCDPooling = 17025,
-
-        [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("Precious Brilliance on AoE Combo", "Adds Egi attacks (Precious Brilliance) to the AoE Combo.", SMN.JobID, 2)]
-        SMN_AoE_MainCombo_EgiAttacks = 17026,
 
         [ConflictingCombos(ALL_Caster_Raise)]
         [CustomComboInfo("Alternative Raise Feature", "Changes Swiftcast to Raise when on cooldown", SMN.JobID, 8, "Shittier RezMage", "Just play RDM oh my gawwddddddddddddd")]
         SMN_Raise = 17027,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Rekindle on Main Combo option", "Adds Rekindle to the Main Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        [CustomComboInfo("Rekindle on Main/AoE Combo option", "Adds Rekindle to the Main/Aoe Combos.", SMN.JobID, 19, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
         SMN_ST_MainCombo_DemiSummons_Rekindle = 17028,
-
-        [ParentCombo(SMN_AoE_MainCombo)]
-        [CustomComboInfo("Rekindle on AoE Combo option", "Adds Rekindle to the AoE Combo.", SMN.JobID, 5, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
-        SMN_AoE_MainCombo_Rekindle = 17029,
 
         [ReplaceSkill(SMN.Ruin4)]
         [CustomComboInfo("Ruin III Mobility Feature", "Puts Ruin III on Ruin IV when you don't have Further Ruin.", SMN.JobID, 9, "Yo Dawg I Heard You Like Ruin Feature", "Ruin while you Ruin")]
@@ -2645,16 +2617,13 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Lucid Dreaming Feature", "Adds Lucid dreaming to the Main Combo when below set MP value.", SMN.JobID, 10, "", "")]
         SMN_Lucid = 17031,
         
-        [ParentCombo(SMN_DemiEgiMenu)]
-        [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Fester and Searing Light will only be used during Bahamut/Phoenix windows.", SMN.JobID, 3, "", "")]
+        [ParentCombo(SMN_ST_MainCombo)]
+        [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Fester and Searing Light will only be used during Bahamut/Phoenix windows.", SMN.JobID, 18, "", "")]
         SMN_DemiEgiMenu_BurstChoice = 17032,
 
         [CustomComboInfo("Egi Abilities on Egi Summons", "Adds Egi Abilities (Astral Flow) to Egi Summons when ready.\nEgi Abilities will appear on their respective Egi Summon Ability, as well as, Titan.", SMN.JobID, 12, "", "")]
         SMN_Egi_AstralFlow = 17034,
-        
-        [CustomComboInfo("Egi and Demi Summon features", "Features related to changing Egi and Demi summons.\nCollapsing this category does NOT disable the features inside.", SMN.JobID, 2, "", "")]
-        SMN_DemiEgiMenu = 17035,
-        
+
         [ParentCombo(SMN_SearingLight)]
         [CustomComboInfo("Single target only Searing Light Option", "Only use Searing Light on Single Target combo.", SMN.JobID, 2, "", "")]
         SMN_SearingLight_STOnly = 17036,

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2639,6 +2639,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(SMN_ESPainflare)]
         [CustomComboInfo("Ruin 4 Painflare Option", "Changes Painflare to Ruin 4 when out of Aetherflow stacks, Energy Siphon is on cooldown, and Ruin 4 is up.", SMN.JobID, 0, "Festering Painflare", "Just take some Advil for that, or see the doc?")]
         SMN_ESPainflare_Ruin4 = 17039,
+        
+        [ParentCombo(SMN_Ifrit_Cyclone)]
+        [CustomComboInfo("Crimson Cyclone Option", "Changes Crimson Cyclone to only be used after all Ifrit Attunement charges have been used, or if moving.", SMN.JobID, 0, "", "")]
+        SMN_Ifrit_Cyclone_Option = 17040,
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2652,11 +2652,6 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
         [CustomComboInfo("Summoner Simple Combo", "Summoner simple one button combo.", SMN.JobID, -1, "", "")]
         SMN_Simple_Combo = 17041,
-        
-        [ParentCombo(SMN_Simple_Combo)]
-        [CustomComboInfo("Ifrit Swiftcast Option", "Use Swiftcast only for Ruby Rite/Catastrophe.", SMN.JobID, 0, "", "")]
-        SMN_Simple_Swiftcast_Option = 17042,
-        
         #endregion
 
         #region WARRIOR

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2534,7 +2534,7 @@ namespace XIVSlothCombo.Combos
         SMN_ST_MainCombo = 17000,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Demi Attacks on Main/AOE Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main/AoE Combos.", SMN.JobID, 17, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
+        [CustomComboInfo("Demi Attacks on Main/AOE Combo", "Adds Deathflare/Ahk Morn/Revelation to the Main/AoE Combos.", SMN.JobID, 7, "Demi Dingus Feature", "Can't tell the difference between a Bahamut and a Phoenix?\nWe know.")]
         SMN_ST_MainCombo_DemiSummons_Attacks = 17002,
 
         [ParentCombo(SMN_ST_MainCombo)]
@@ -2579,7 +2579,7 @@ namespace XIVSlothCombo.Combos
         SMN_DemiEgiMenu_EgiOrder = 17016,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Searing Light on Single Target/AoE combo", "Adds Searing Light to the Single target, and AoE combos. Will be used on cooldown.", SMN.JobID, 16, "My eyes!", "I can't see!")]
+        [CustomComboInfo("Searing Light on Single Target/AoE combo", "Adds Searing Light to the Single target, and AoE combos. Will be used on cooldown.", SMN.JobID, 6, "My eyes!", "I can't see!")]
         SMN_SearingLight = 17018,
 
         [ParentCombo(SMN_SearingLight)]
@@ -2587,7 +2587,7 @@ namespace XIVSlothCombo.Combos
         SMN_SearingLight_Burst = 170181,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Demi Summons on Main/AoE Combo", "Adds Demi Summons to the Main/AoE Combos.", SMN.JobID, 15, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
+        [CustomComboInfo("Demi Summons on Main/AoE Combo", "Adds Demi Summons to the Main/AoE Combos.", SMN.JobID, 5, "Chad Kroeger Demi Feature", "This is how, you remind me, of what I really am")]
         SMN_ST_MainCombo_DemiSummons = 17020,
 
         [ParentCombo(SMN_ST_MainCombo)]
@@ -2606,7 +2606,7 @@ namespace XIVSlothCombo.Combos
         SMN_Raise = 17027,
 
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Rekindle on Main/AoE Combo option", "Adds Rekindle to the Main/Aoe Combos.", SMN.JobID, 19, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
+        [CustomComboInfo("Rekindle on Main/AoE Combo option", "Adds Rekindle to the Main/Aoe Combos.", SMN.JobID, 9, "Phoenix Dingus Feature", "You only need to worry about healing yourself.\nIts okay.")]
         SMN_ST_MainCombo_DemiSummons_Rekindle = 17028,
 
         [ReplaceSkill(SMN.Ruin4)]
@@ -2618,7 +2618,7 @@ namespace XIVSlothCombo.Combos
         SMN_Lucid = 17031,
         
         [ParentCombo(SMN_ST_MainCombo)]
-        [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Fester and Searing Light will only be used during Bahamut/Phoenix windows.", SMN.JobID, 18, "", "")]
+        [CustomComboInfo("Burst Phase Choice", "Chooses which phase to burst in for all relevant burst features. Fester and Searing Light will only be used during Bahamut/Phoenix windows.", SMN.JobID, 8, "", "")]
         SMN_DemiEgiMenu_BurstChoice = 17032,
 
         [CustomComboInfo("Egi Abilities on Egi Summons", "Adds Egi Abilities (Astral Flow) to Egi Summons when ready.\nEgi Abilities will appear on their respective Egi Summon Ability, as well as, Titan.", SMN.JobID, 12, "", "")]

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -279,9 +279,8 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(AstralFlow);
                         }
                         
-                        if (gauge.IsIfritAttuned && IsOffCooldown(All.Swiftcast))
-                            if (gauge.Attunement >= 1)
-                                return All.Swiftcast;
+                        if (gauge.IsIfritAttuned && gauge.Attunement >= 1 && IsOffCooldown(All.Swiftcast))
+                            return All.Swiftcast;
                     }
 
                     if (gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) ||

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -497,11 +497,12 @@ namespace XIVSlothCombo.Combos.PvE
                         IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && ((HasEffect(Buffs.IfritsFavor) && (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone_Option) || (IsMoving || gauge.Attunement == 0))) || lastComboMove == CrimsonCyclone)) //Ifrit
                         return OriginalHook(AstralFlow);
 
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && gauge.IsIfritAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
+                        return Ruin4;
+                    
                     // Gemshine
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
                     {
-                        if (gauge.IsIfritAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
-                            return Ruin4;
                         if (STCombo)
                             return OriginalHook(Gemshine);
                         if (AoECombo && PreciousBrilliance.LevelChecked())

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -245,6 +245,9 @@ namespace XIVSlothCombo.Combos.PvE
                                 return EnergySiphon;
                         }
                         
+                        if (IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= 4000 && level >= All.Levels.LucidDreaming)
+                            return All.LucidDreaming;
+                        
                         if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
                         {
                             if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && (!SummonBahamut.LevelChecked() || lastComboMove is AstralImpulse or AstralFlare))

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -379,12 +379,14 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
                         IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove is TopazRite or TopazCata && CanSpellWeave(actionID) || //Titan
-                        IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && (gauge.IsIfritAttuned && HasEffect(Buffs.IfritsFavor) || gauge.IsIfritAttuned && lastComboMove == CrimsonCyclone)) //Ifrit
+                        IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && ((HasEffect(Buffs.IfritsFavor) && (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone_Option) || (IsMoving || gauge.Attunement == 0))) || lastComboMove == CrimsonCyclone)) //Ifrit
                         return OriginalHook(AstralFlow);
 
                     // Gemshine
                     if (IsEnabled(CustomComboPreset.SMN_ST_MainCombo_EgiSummons_Attacks) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
                     {
+                        if (gauge.IsIfritAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
+                            return Ruin4;
                         if (STCombo)
                             return OriginalHook(Gemshine);
                         if (AoECombo && PreciousBrilliance.LevelChecked())

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -272,7 +272,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (Slipstream.LevelChecked() && HasEffect(Buffs.GarudasFavor))
                         {
-                            if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast) && IsNotEnabled(CustomComboPreset.SMN_Simple_Swiftcast_Option))
+                            if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
                                 return All.Swiftcast;
 
                             if ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)))

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -262,7 +262,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
                     
-                    if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
+                    if (gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
                         (Aethercharge.LevelChecked() && !SummonBahamut.LevelChecked() ||
                          gauge.IsBahamutReady && SummonBahamut.LevelChecked() ||
                          gauge.IsPhoenixReady && SummonPhoenix.LevelChecked()))
@@ -272,10 +272,10 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (Slipstream.LevelChecked() && HasEffect(Buffs.GarudasFavor))
                         {
-                            if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
+                            if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast) && IsNotEnabled(CustomComboPreset.SMN_Simple_Swiftcast_Option))
                                 return All.Swiftcast;
 
-                            if ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) || gauge.Attunement == 0)
+                            if ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)))
                                 return OriginalHook(AstralFlow);
                         }
                         
@@ -283,7 +283,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return All.Swiftcast;
                     }
 
-                    if (gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) ||
+                    if (HasEffect(Buffs.GarudasFavor) && gauge.Attunement is 0 ||
                         HasEffect(Buffs.TitansFavor) && lastComboMove is TopazRite or TopazCata && CanSpellWeave(actionID) ||
                         HasEffect(Buffs.IfritsFavor) && (IsMoving || gauge.Attunement is 0) || lastComboMove == CrimsonCyclone)
                         return OriginalHook(AstralFlow);
@@ -424,7 +424,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Demi
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons))
                     {
-                        if (gauge.AttunmentTimerRemaining == 0 && gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
+                        if (gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
                             (Aethercharge.LevelChecked() && !SummonBahamut.LevelChecked() || //Pre Bahamut Phase
                              gauge.IsBahamutReady && SummonBahamut.LevelChecked() || //Bahamut Phase
                              gauge.IsPhoenixReady && SummonPhoenix.LevelChecked())) //Phoenix Phase
@@ -474,7 +474,7 @@ namespace XIVSlothCombo.Combos.PvE
                                         return All.Swiftcast;
                                 }
                                 if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) &&
-                                    ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) ||
+                                    ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)) ||
                                      (gauge.Attunement == 0))) //Astral Flow if Swiftcast is not ready throughout Garuda
                                     return OriginalHook(AstralFlow);
                             }
@@ -492,7 +492,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) && gauge.IsGarudaAttuned && HasEffect(Buffs.GarudasFavor) || //Garuda
+                    if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) && HasEffect(Buffs.GarudasFavor) || //Garuda
                         IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove is TopazRite or TopazCata && CanSpellWeave(actionID) || //Titan
                         IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && ((HasEffect(Buffs.IfritsFavor) && (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone_Option) || (IsMoving || gauge.Attunement == 0))) || lastComboMove == CrimsonCyclone)) //Ifrit
                         return OriginalHook(AstralFlow);


### PR DESCRIPTION
## SMN
- Removed `SMN AoE Combo` and rolled that into the single target version, renamed to `Advanced Summoner`.
- Added `Simple Summoner` feature as a no fuss single checkbox for Summoner.
   - `Searing Light` during Bahamut. 
   - Titan > Garuda > Ifrit egi order, `Swiftcast` during Garuda or Ifrit to account for drift if you have enough spell speed.
   - `Ruin 4` when no summons are up (or if moving during ifrit phase),
- Added `Crimson Cyclone Option` to use Crimson Cyclone if at 0 attunement, or moving instead of using it immediately.
- Logic tweaks for `Slipstream` and `Crimson Cyclone` (Don't need attunement to use those, just Garuda/Ifrit's Favor)
- Logic Tweak for Summoning Demis.
