### PR TITLE
[Framework] TargetExtensions

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -2,6 +2,7 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Objects.Enums;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -159,7 +160,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID is Taurochole or Druochole or Ixochole or Kerachole &&
-                    level >= Levels.Rhizomata &&
+                    Rhizomata.LevelChecked() &&
                     IsOffCooldown(actionID) &&
                     GetJobGauge<SGEGauge>().Addersgall == 0
                    ) return Rhizomata;
@@ -178,7 +179,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauro;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is Druochole && level >= Levels.Taurochole && IsOffCooldown(Taurochole)) return Taurochole;
+                if (actionID is Druochole && Taurochole.LevelChecked() && IsOffCooldown(Taurochole)) return Taurochole;
                 else return actionID;
             }
         }
@@ -190,7 +191,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneuma;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is Pneuma && level >= Levels.Pneuma && IsOffCooldown(Pneuma) && IsOffCooldown(Zoe)) return Zoe;
+                if (actionID is Pneuma && Pneuma.LevelChecked() && IsOffCooldown(Pneuma) && IsOffCooldown(Zoe)) return Zoe;
                 else return actionID;
             }
         }
@@ -215,8 +216,8 @@ namespace XIVSlothCombo.Combos.PvE
                     var NoPhlegmaToxikon  = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoPhlegmaToxikon);
                     var OutOfRangeToxikon = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_OutOfRangeToxikon);
                     if ((NoPhlegmaToxikon || OutOfRangeToxikon) &&
-                        level >= Levels.Toxikon &&
-                        HasBattleTarget() && 
+                        Toxikon.LevelChecked() &&
+                        CurrentTarget.IsEnemy() && 
                         GetJobGauge<SGEGauge>().Addersting > 0)
                     {
                         if ((NoPhlegmaToxikon && GetCooldown(OriginalHook(Phlegma)).RemainingCharges == 0) ||
@@ -226,7 +227,7 @@ namespace XIVSlothCombo.Combos.PvE
                     var NoPhlegmaDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoPhlegmaDyskrasia);
                     var NoTargetDyskrasia  = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoTargetDyskrasia);
                     if ((NoPhlegmaDyskrasia || NoTargetDyskrasia) &&
-                        level >= Levels.Phlegma)
+                        Phlegma.LevelChecked())
                     {
                         if ((NoPhlegmaDyskrasia && GetCooldown(OriginalHook(Phlegma)).RemainingCharges == 0) ||
                             (NoTargetDyskrasia && CurrentTarget is null))
@@ -260,8 +261,8 @@ namespace XIVSlothCombo.Combos.PvE
                     //Eukrasian Dosis.
                     //If we're too low level to use Eukrasia, we can stop here.
                     if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && 
-                        level >= Levels.Eukrasia &&
-                        (CurrentTarget as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy)
+                        Eukrasia.LevelChecked() &&
+                        CurrentTarget.IsEnemy())
                     {
                         //If we're already Eukrasian'd, the whole point of this section is moot
                         if (HasEffect(Buffs.Eukrasia)) return OriginalHook(Dosis1); //OriginalHook will autoselect the correct Dosis for us
@@ -278,15 +279,15 @@ namespace XIVSlothCombo.Combos.PvE
 
                         //Got our Debuff for our level, check for it and procede 
                         if (((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3)) &&
-                            (GetTargetHPPercent() > GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer))
+                            (CurrentTarget.GetHPPercent() > GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer))
                            ) return Eukrasia;
                     }
 
                     //Toxikon
                     if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
-                        level >= Levels.Toxikon &&
-                        HasBattleTarget() &&
-                        ((!GetOptionBool(Config.SGE_ST_Dosis_Toxikon) && this.IsMoving) || GetOptionBool(Config.SGE_ST_Dosis_Toxikon)) &&
+                        Toxikon.LevelChecked() &&
+                        CurrentTarget.IsEnemy() &&
+                        ((!GetOptionBool(Config.SGE_ST_Dosis_Toxikon) && IsMoving) || GetOptionBool(Config.SGE_ST_Dosis_Toxikon)) &&
                         GetJobGauge<SGEGauge>().Addersting > 0
                        ) return OriginalHook(Toxikon);
                 }
@@ -313,66 +314,66 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Diagnosis)
                 {
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) &&
-                        level >= Levels.Druochole &&
+                        Druochole.LevelChecked() &&
                         IsOffCooldown(Druochole) &&
                         GetJobGauge<SGEGauge>().Addersgall >= 1 &&
-                        GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Druochole)
+                        CurrentTarget.GetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Druochole)
                        ) return Druochole;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) &&
-                        level >= Levels.Taurochole &&
+                        Taurochole.LevelChecked() &&
                         IsOffCooldown(Taurochole) &&
                         GetJobGauge<SGEGauge>().Addersgall >= 1 &&
-                        GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Taurochole)
+                        CurrentTarget.GetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Taurochole)
                        ) return Taurochole;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) &&
-                        level >= Levels.Rhizomata &&
+                        Rhizomata.LevelChecked() &&
                         IsOffCooldown(Rhizomata) &&
                         GetJobGauge<SGEGauge>().Addersgall is 0
                        ) return Rhizomata;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Kardia) &&
-                        level >= Levels.Kardia &&
+                        Kardia.LevelChecked() &&
                         FindEffect(Buffs.Kardia) is null &&
                         FindTargetEffect(Buffs.Kardion) is null
                        ) return Kardia;
 
-                    if (CurrentTarget?.ObjectKind is ObjectKind.Player)
+                    if (CurrentTarget.IsPlayer())
                     {
                         if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) &&
-                            level >= Levels.Soteria &&
+                            Soteria.LevelChecked() &&
                             IsOffCooldown(Soteria) &&
-                            GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Soteria)
+                            CurrentTarget.GetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Soteria)
                            ) return Soteria;
 
                         if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) &&
-                            level >= Levels.Zoe &&
+                            Zoe.LevelChecked() &&
                             IsOffCooldown(Zoe) &&
-                            GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Zoe)
+                            CurrentTarget.GetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Zoe)
                            ) return Zoe;
 
                         if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) &&
-                            level >= Levels.Krasis &&
-                            IsOffCooldown(Krasis) && GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Krasis)
+                            Krasis.LevelChecked() &&
+                            IsOffCooldown(Krasis) && CurrentTarget.GetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Krasis)
                            ) return Krasis;
 
                         if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) &&
-                            level >= Levels.Pepsis &&
-                            IsOffCooldown(Pepsis) && GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Pepsis) &&
+                            Pepsis.LevelChecked() &&
+                            IsOffCooldown(Pepsis) && CurrentTarget.GetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Pepsis) &&
                             FindTargetEffect(Buffs.EukrasianDiagnosis) is not null
                            ) return Pepsis;
 
                         if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) &&
-                            level >= Levels.Haima &&
-                            IsOffCooldown(Haima) && GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Haima)
+                            Haima.LevelChecked() &&
+                            IsOffCooldown(Haima) && CurrentTarget.GetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Haima)
                            ) return Haima;
                     }
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Diagnosis) &&
-                        level >= Levels.Eukrasia &&
+                        Eukrasia.LevelChecked() &&
                         FindTargetEffect(Buffs.EukrasianDiagnosis) is null &&
-                        GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Diagnosis))
+                        CurrentTarget.GetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Diagnosis))
                     {
                         if (!HasEffect(Buffs.Eukrasia))
                             return Eukrasia;
@@ -391,30 +392,30 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Prognosis)
                 {
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) &&
-                        level >= Levels.Rhizomata &&
+                        Rhizomata.LevelChecked() &&
                         IsOffCooldown(Rhizomata) &&
                         GetJobGauge<SGEGauge>().Addersgall is 0
                        ) return Rhizomata;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) &&
-                        level >= Levels.Kerachole &&
+                        Kerachole.LevelChecked() &&
                         IsOffCooldown(Kerachole) &&
                         GetJobGauge<SGEGauge>().Addersgall >= 1
                        ) return Kerachole;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) &&
-                        level >= Levels.Ixochole &&
+                        Ixochole.LevelChecked() &&
                         IsOffCooldown(Ixochole) &&
                         GetJobGauge<SGEGauge>().Addersgall >= 1
                        ) return Ixochole;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) &&
-                        level >= Levels.Physis &&
+                        Physis.LevelChecked() &&
                         IsOffCooldown(OriginalHook(Physis))
                        ) return OriginalHook(Physis);
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) &&
-                        level >= Levels.Eukrasia &&
+                        Eukrasia.LevelChecked() &&
                         FindEffect(Buffs.EukrasianPrognosis) is null)
                     {
                         if (!HasEffect(Buffs.Eukrasia))
@@ -424,17 +425,17 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) &&
-                        level >= Levels.Holos &&
+                        Holos.LevelChecked() &&
                         IsOffCooldown(Holos)
                        ) return Holos;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) &&
-                        level >= Levels.Panhaima &&
+                        Panhaima.LevelChecked() &&
                         IsOffCooldown(Panhaima)
                        ) return Panhaima;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) &&
-                        level >= Levels.Pepsis &&
+                        Pepsis.LevelChecked() &&
                         IsOffCooldown(Pepsis) &&
                         FindEffect(Buffs.EukrasianPrognosis) is not null
                        ) return Pepsis;

--- a/XIVSlothCombo/Extensions/TargetExtensions.cs
+++ b/XIVSlothCombo/Extensions/TargetExtensions.cs
@@ -1,0 +1,102 @@
+﻿using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Game.ClientState.Objects.Enums;
+using System;
+using System.Numerics;
+using System.Linq;
+using XIVSlothCombo.CustomComboNS.Functions; //Needed for LocalPlayer for Distance Mathematics
+using XIVSlothCombo.Services;
+
+
+namespace XIVSlothCombo.Extensions
+{
+    internal static class TargetExtensions
+    {
+        /*
+         * Example useage
+         * CurrentTarget.GetHPPercent
+         * CurrentTarget.IsEnemy
+         * etc
+        */
+        
+        /// <summary> Gets a value indicating a specified target's HP Percent</summary>
+        /// <returns> Double representing percentage. </returns>
+        internal static double GetHPPercent(this GameObject? target) => target is not BattleChara chara ? 0 : chara.CurrentHp / chara.MaxHp * 100;
+        
+        /// <summary> Gets a specified target's Maximum HP</summary>
+        /// <returns> uint representing Max HP value </returns>
+        internal static uint GetMaxHP(this GameObject? target) => target is not BattleChara chara ? 0 : chara.MaxHp;
+
+        /// <summary> Gets a specified target's Current HP</summary>
+        /// <returns> uint representing a HP value </returns>
+        internal static uint GetHP(this GameObject? target) => target is not BattleChara chara ? 0 : chara.CurrentHp;
+
+        /// <summary> Determines if the current target is an Enemy</summary>
+        /// <returns> bool indicating if the current target is an Enemy</returns>
+        internal static bool IsEnemy(this GameObject? target) => (target as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy;
+
+        internal static bool IsPlayer(this GameObject? target) => (target?.ObjectKind is ObjectKind.Player);
+
+        /// <summary> Determines if the enemy can be interrupted if they are currently casting. </summary>
+        /// <returns> Bool indicating whether they can be interrupted or not. </returns>
+        internal static bool CanInterupt(this GameObject? target) => ((target as BattleChara)?.IsCastInterruptible is true);
+
+        /// <summary> Gets distance from player to target </summary>
+        /// <returns> Double representing distance</returns>
+        internal static double GetDistance(this GameObject? target)
+        {
+            if (target is null || CustomComboFunctions.LocalPlayer is null)
+                return 0;
+
+            if (target is not BattleChara chara)
+                return 0;
+
+            if (target.ObjectId == CustomComboFunctions.LocalPlayer.ObjectId)
+                return 0;
+
+            var position = new Vector2(chara.Position.X, chara.Position.Z);
+            var selfPosition = new Vector2(CustomComboFunctions.LocalPlayer.Position.X, CustomComboFunctions.LocalPlayer.Position.Z);
+
+            return Math.Max(0, (Vector2.Distance(position, selfPosition) - chara.HitboxRadius) - CustomComboFunctions.LocalPlayer.HitboxRadius);
+        }
+
+        /// <summary> Gets a value indicating whether you are in melee range from the current target. </summary>
+        /// <returns> Bool indicating whether you are in melee range. </returns>
+        internal static bool InMeleeRange(this GameObject? target)
+        {
+            if (CustomComboFunctions.LocalPlayer.TargetObject == null) return false;
+            var distance = target.GetDistance();
+
+            if (distance == 0)
+                return true;
+
+            if (distance > 3 + Service.Configuration.MeleeOffset)
+                return false;
+
+            return true;
+        }
+
+        /// <summary> Checks if target is in appropriate range for targeting </summary>
+        internal static bool IsInRange(this GameObject? target) => target.YalmDistanceX < 30;
+
+        /// <summary> Attempts to target the given party member </summary>
+        /// <param name="target"></param>
+        /*internal static unsafe void SetAsTarget(CustomComboFunctions.TargetType target)
+        {
+            //CustomComboFunctions.GetTarget is protected. Extension commented out until wiser ones can fix?
+            var t = CustomComboFunctions.GetTarget(target);
+            if (t == null) return;
+            var o = PartyTargetingService.GetObjectID(t);
+            var p = Service.ObjectTable.Where(x => x.ObjectId == o).First();
+
+            if (IsInRange(p)) Service.TargetManager.Target = p;
+        }*/
+
+        internal static void SetAsTarget(this GameObject? target)
+        {
+            if (target.IsInRange()) Service.TargetManager.Target = target;
+        }
+    }
+
+
+
+}

--- a/XIVSlothCombo/Extensions/TargetExtensions.cs
+++ b/XIVSlothCombo/Extensions/TargetExtensions.cs
@@ -17,10 +17,10 @@ namespace XIVSlothCombo.Extensions
          * CurrentTarget.IsEnemy
          * etc
         */
-        
+
         /// <summary> Gets a value indicating a specified target's HP Percent</summary>
-        /// <returns> Double representing percentage. </returns>
-        internal static double GetHPPercent(this GameObject? target) => target is not BattleChara chara ? 0 : chara.CurrentHp / chara.MaxHp * 100;
+        /// <returns> float representing percentage. </returns>
+        internal static float GetHPPercent(this GameObject? target) => target is not BattleChara chara ? 0 : (float)chara.CurrentHp / chara.MaxHp * 100;
         
         /// <summary> Gets a specified target's Maximum HP</summary>
         /// <returns> uint representing Max HP value </returns>
@@ -42,7 +42,7 @@ namespace XIVSlothCombo.Extensions
 
         /// <summary> Gets distance from player to target </summary>
         /// <returns> Double representing distance</returns>
-        internal static double GetDistance(this GameObject? target)
+        internal static float GetDistance(this GameObject? target)
         {
             if (target is null || CustomComboFunctions.LocalPlayer is null)
                 return 0;


### PR DESCRIPTION
Taurenkey "Now make them extension methods"
and lo, I was bored enough to do so
90% of Target related functions from Target.cs have been converted to extension methods
SGE has the proof of concept + Taurenkey's LevelChecked() extension
Party SetAsTarget not added due to protected status my brain has yet to comprehend.