### PR TITLE
[ALL] Bugfix for Global Raise & SCH/SMN

### DIFF
--- a/XIVSlothCombo/Combos/PvE/ALL.cs
+++ b/XIVSlothCombo/Combos/PvE/ALL.cs
@@ -132,7 +132,8 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is WHM.Raise or SCH.Resurrection or AST.Ascend or SGE.Egeiro)
+                if ((actionID is WHM.Raise or AST.Ascend or SGE.Egeiro) 
+                    || (actionID is SCH.Resurrection && LocalPlayer.ClassJob.Id is SCH.JobID))
                 {
                     if (IsOffCooldown(Swiftcast))
                         return Swiftcast;
@@ -170,7 +171,8 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is BLU.AngelWhisper or RDM.Verraise or SMN.Resurrection)
+                if ((actionID is BLU.AngelWhisper or RDM.Verraise) 
+                    || (actionID is SMN.Resurrection && LocalPlayer.ClassJob.Id is SMN.JobID))
                 {
                     if (HasEffect(Buffs.Swiftcast) || HasEffect(RDM.Buffs.Dualcast))
                         return actionID;


### PR DESCRIPTION
ALL_Healer_Raise was affecting Summoner & ALL_Caster_Raise was affecting Scholar due to both classes having the same Resurrection ID. This has been fixed by this PR, _**BUT**_ needs a review. LocalPlayer.ClassJob.Id works as something to check but if there is a better item to check against SCH/SMN.JobID, please let me know