### PR TITLE
Smn burst optimizations

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2624,7 +2624,7 @@ namespace XIVSlothCombo.Combos
         SMN_SearingLight_STOnly = 17036,
         
         [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
-        [CustomComboInfo("Use only on Single Target combo", "Prevent this feature from applying to the AoE combo.", SMN.JobID, 2, "", "")]
+        [CustomComboInfo("Use only on Single Target combo", "Prevent this feature from applying to the AoE combo.", SMN.JobID, 3, "", "")]
         SMN_DemiEgiMenu_oGCDPooling_Only = 17037,
         
         [ParentCombo(SMN_DemiEgiMenu_SwiftcastEgi)]
@@ -2647,6 +2647,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
         [CustomComboInfo("Energy Drain/Siphon Delay Option", "Makes Energy Drain/Siphon follow the same oGCD delay as Fester/Painflare.", SMN.JobID, 1, "", "")]
         SMN_Advanced_ED_ES_Option = 17042,
+        
+        [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
+        [CustomComboInfo("Burst Delay Only During Opener", "Only follows Burst Delay settings for initial burst phase.", SMN.JobID, 2, "", "")]
+        SMN_Advanced_Burst_Delay_Option = 17043,
         #endregion
 
         #region WARRIOR

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2643,13 +2643,9 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
         [CustomComboInfo("Simple Summoner Feature", "General purpose one-button combo.\nBursts on Bahamut phase.\nSummons Titan, Garuda, then Ifrit.\nSwiftcasts on Slipstream unless drifted.", SMN.JobID, -1, "", "")]
         SMN_Simple_Combo = 17041,
-        
+
         [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
-        [CustomComboInfo("Energy oGCDs Delay Option", "Makes Energy Drain/Siphon follow the same oGCD delay as Fester/Painflare.\nOnly applies to opener burst.", SMN.JobID, 1, "", "")]
-        SMN_Advanced_ED_ES_Option = 17042,
-        
-        [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
-        [CustomComboInfo("Burst Delay Option", "Only follows Burst Delay settings for the opener burst.", SMN.JobID, 2, "", "")]
+        [CustomComboInfo("Burst Delay Option", "Only follows Burst Delay settings for the opener burst.\nThis Option is for high SPS builds.", SMN.JobID, 2, "", "")]
         SMN_Advanced_Burst_Delay_Option = 17043,
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2645,11 +2645,11 @@ namespace XIVSlothCombo.Combos
         SMN_Simple_Combo = 17041,
         
         [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
-        [CustomComboInfo("Energy oGCDs Delay Option", "Makes Energy Drain/Siphon follow the same oGCD delay as Fester/Painflare.", SMN.JobID, 1, "", "")]
+        [CustomComboInfo("Energy oGCDs Delay Option", "Makes Energy Drain/Siphon follow the same oGCD delay as Fester/Painflare.\nOnly applies to opener burst.", SMN.JobID, 1, "", "")]
         SMN_Advanced_ED_ES_Option = 17042,
         
         [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
-        [CustomComboInfo("Burst Delay Option", "Only follows Burst Delay settings for initial burst phase.", SMN.JobID, 2, "", "")]
+        [CustomComboInfo("Burst Delay Option", "Only follows Burst Delay settings for the opener burst.", SMN.JobID, 2, "", "")]
         SMN_Advanced_Burst_Delay_Option = 17043,
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2643,6 +2643,10 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(SMN.Ruin, SMN.Ruin2, SMN.Outburst, SMN.Tridisaster)]
         [CustomComboInfo("Simple Summoner Feature", "General purpose one-button combo.\nBursts on Bahamut phase.\nSummons Titan, Garuda, then Ifrit.\nSwiftcasts on Slipstream unless drifted.", SMN.JobID, -1, "", "")]
         SMN_Simple_Combo = 17041,
+        
+        [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
+        [CustomComboInfo("Energy Drain/Siphon Delay Option", "Makes Energy Drain/Siphon follow the same oGCD delay as Fester/Painflare.", SMN.JobID, 1, "", "")]
+        SMN_Advanced_ED_ES_Option = 17042,
         #endregion
 
         #region WARRIOR

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2645,11 +2645,11 @@ namespace XIVSlothCombo.Combos
         SMN_Simple_Combo = 17041,
         
         [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
-        [CustomComboInfo("Energy Drain/Siphon Delay Option", "Makes Energy Drain/Siphon follow the same oGCD delay as Fester/Painflare.", SMN.JobID, 1, "", "")]
+        [CustomComboInfo("Energy oGCDs Delay Option", "Makes Energy Drain/Siphon follow the same oGCD delay as Fester/Painflare.", SMN.JobID, 1, "", "")]
         SMN_Advanced_ED_ES_Option = 17042,
         
         [ParentCombo(SMN_DemiEgiMenu_oGCDPooling)]
-        [CustomComboInfo("Burst Delay Only During Opener", "Only follows Burst Delay settings for initial burst phase.", SMN.JobID, 2, "", "")]
+        [CustomComboInfo("Burst Delay Option", "Only follows Burst Delay settings for initial burst phase.", SMN.JobID, 2, "", "")]
         SMN_Advanced_Burst_Delay_Option = 17043,
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -388,7 +388,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         
                         // ED/ES
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks)
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && DemiAttackCount >= burstDelay)
                         {
                             if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
                                 return EnergyDrain;

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -405,7 +405,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Non-Opener first set Fester/Painfalre
                         if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling) && gauge.HasAetherflowStacks && !inOpener)
                         {
-                            if (GetCooldown(EnergyDrain).CooldownRemaining <= 2.85)
+                            if (GetCooldown(EnergyDrain).CooldownRemaining <= 3.2)
                             {
                                 if (HasEffect(Buffs.SearingLight) &&
                                     (SummonerBurstPhase is 0 or 1 or 2 ||

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -393,7 +393,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         
                         // ED/ES
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && (IsNotEnabled(CustomComboPreset.SMN_Advanced_ED_ES_Option) || DemiAttackCount >= burstDelay))
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && (IsNotEnabled(CustomComboPreset.SMN_Advanced_ED_ES_Option) || (!inOpener || DemiAttackCount >= burstDelay)))
                         {
                             if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
                                 return EnergyDrain;

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -241,7 +241,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
                                 return OriginalHook(EnkindleBahamut);
 
-                            if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire or BrandOfPurgatory)
+                            if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
                                 return OriginalHook(AstralFlow);
                         }
                         
@@ -411,7 +411,7 @@ namespace XIVSlothCombo.Combos.PvE
                             // Demi Nuke 2: Electric Boogaloo
                             if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle))
                             {
-                                if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire or BrandOfPurgatory)
+                                if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
                                     return OriginalHook(AstralFlow);
                             }
                         }

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -555,6 +555,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
+                    // Gemshine/Precious Brilliance if has Swiftcast
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) && gauge.IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && lastComboMove is not CrimsonCyclone)
                     {
                         if (STCombo)
@@ -569,6 +570,7 @@ namespace XIVSlothCombo.Combos.PvE
                         IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && ((HasEffect(Buffs.IfritsFavor) && (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone_Option) || (IsMoving || gauge.Attunement == 0))) || lastComboMove == CrimsonCyclone)) // Ifrit
                         return OriginalHook(AstralFlow);
 
+                    // Movement Ruin4 in Ifrit Phase
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && gauge.IsIfritAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
                         return Ruin4;
                     
@@ -582,6 +584,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(PreciousBrilliance);
                     }
 
+                    // Egi Order
                     if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
                     {
                         if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
@@ -606,6 +609,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
+                    // Ruin 4
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
                         return Ruin4;
                 }

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -387,7 +387,8 @@ namespace XIVSlothCombo.Combos.PvE
                             else return SearingLight;
                         }
                         
-                        if (!gauge.HasAetherflowStacks)
+                        // ED/ES
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks)
                         {
                             if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
                                 return EnergyDrain;
@@ -416,7 +417,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
                         
-                        // ED & Fester
+                        // Fester/Painflare
                         if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester))
                         {
                             if (gauge.HasAetherflowStacks)

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -224,6 +224,15 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsOffCooldown(SearingLight) && LevelChecked(SearingLight) && OriginalHook(Ruin) == AstralImpulse)
                             return SearingLight;
 
+                        if (!gauge.HasAetherflowStacks)
+                        {
+                            if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
+                                return EnergyDrain;
+
+                            if (AoECombo && EnergySiphon.LevelChecked() && IsOffCooldown(EnergySiphon))
+                                return EnergySiphon;
+                        }
+                        
                         if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
                         {
                             if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && Deathflare.LevelChecked())
@@ -257,15 +266,6 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        if (!gauge.HasAetherflowStacks)
-                        {
-                            if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
-                                return EnergyDrain;
-
-                            if (AoECombo && EnergySiphon.LevelChecked() && IsOffCooldown(EnergySiphon))
-                                return EnergySiphon;
-                        }
-                        
                         if (IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= 4000 && level >= All.Levels.LucidDreaming)
                             return All.LucidDreaming;
                     }
@@ -386,6 +386,15 @@ namespace XIVSlothCombo.Combos.PvE
 
                             else return SearingLight;
                         }
+                        
+                        if (!gauge.HasAetherflowStacks)
+                        {
+                            if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
+                                return EnergyDrain;
+
+                            if (AoECombo && EnergySiphon.LevelChecked() && IsOffCooldown(EnergySiphon))
+                                return EnergySiphon;
+                        }
 
                         // Demi Nuke
                         if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
@@ -444,15 +453,6 @@ namespace XIVSlothCombo.Combos.PvE
                                             return Painflare;
                                     }
                                 }
-                            }
-
-                            if (!gauge.HasAetherflowStacks)
-                            {
-                                if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
-                                    return EnergyDrain;
-
-                                if (AoECombo && EnergySiphon.LevelChecked() && IsOffCooldown(EnergySiphon))
-                                    return EnergySiphon;
                             }
                         }
 

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -350,23 +350,28 @@ namespace XIVSlothCombo.Combos.PvE
                 var lucidThreshold = PluginConfiguration.GetCustomIntValue(Config.SMN_Lucid);
                 var swiftcastPhase = PluginConfiguration.GetCustomIntValue(Config.SMN_SwiftcastPhase);
                 var burstDelay = PluginConfiguration.GetCustomIntValue(Config.SMN_Burst_Delay);
+                var inOpener = CombatEngageDuration().TotalSeconds < 30;
                 var STCombo = actionID is Ruin or Ruin2;
                 var AoECombo = actionID is Outburst or Tridisaster;
 
+                if (WasLastAction(OriginalHook(Aethercharge))) DemiAttackCount = 0;    // Resets counter
+
+                if (IsEnabled(CustomComboPreset.SMN_Advanced_Burst_Delay_Option) && !inOpener) DemiAttackCount = 6; // If SMN_Advanced_Burst_Delay_Option is active and outside opener window, set DemiAttackCount to 6 to ignore delayed oGCDs 
+
+                if (gauge.SummonTimerRemaining == 0 && !InCombat()) DemiAttackCount = 0;
+                
+                //CHECK_DEMIATTACK_USE
+                if (UsedDemiAttack == false && lastComboMove is AstralImpulse or FountainOfFire or AstralFlare or BrandOfPurgatory && DemiAttackCount is not 6 && GetCooldownRemainingTime(AstralImpulse) > 1)
+                {
+                    UsedDemiAttack = true;      // Registers that a Demi Attack was used and blocks further incrementation of DemiAttackCountCount
+                    DemiAttackCount++;          // Increments DemiAttack counter
+                }
+
+                //CHECK_DEMIATTACK_USE_RESET
+                if (UsedDemiAttack && GetCooldownRemainingTime(AstralImpulse) < 1) UsedDemiAttack = false;  // Resets block to allow CHECK_DEMIATTACK_USE
+
                 if (actionID is Ruin or Ruin2 or Outburst or Tridisaster && InCombat())
                 {
-                    if (WasLastAction(OriginalHook(Aethercharge))) DemiAttackCount = 0;    // Resets counter
-
-                    //CHECK_DEMIATTACK_USE
-                    if (UsedDemiAttack == false && lastComboMove is AstralImpulse or FountainOfFire or AstralFlare or BrandOfPurgatory && DemiAttackCount is not 6 && GetCooldownRemainingTime(AstralImpulse) > 1)
-                    {
-                        UsedDemiAttack = true;      // Registers that a Demi Attack was used and blocks further incrementation of DemiAttackCountCount
-                        DemiAttackCount++;          // Increments DemiAttack counter
-                    }
-
-                    //CHECK_DEMIATTACK_USE_RESET
-                    if (UsedDemiAttack && GetCooldownRemainingTime(AstralImpulse) < 1) UsedDemiAttack = false;  // Resets block to allow CHECK_DEMIATTACK_USE
-                    
                     if (CanSpellWeave(actionID))
                     {
                         // Searing Light

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -388,7 +388,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         
                         // ED/ES
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && DemiAttackCount >= burstDelay)
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && (IsNotEnabled(CustomComboPreset.SMN_Advanced_ED_ES_Option) || DemiAttackCount >= burstDelay))
                         {
                             if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
                                 return EnergyDrain;

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -226,16 +226,14 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
                         {
-                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
-                                return OriginalHook(EnkindleBahamut);
-                            
                             if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && Deathflare.LevelChecked())
                                 return OriginalHook(AstralFlow);
+                            
+                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
+                                return OriginalHook(EnkindleBahamut);
 
                             if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire or BrandOfPurgatory)
                                 return OriginalHook(AstralFlow);
-
-                            return actionID;
                         }
                         
                         if (gauge.HasAetherflowStacks)
@@ -394,11 +392,11 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && DemiAttackCount >= burstDelay)
                             {
-                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
-                                    return OriginalHook(EnkindleBahamut);
-                                
                                 if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && Deathflare.LevelChecked())
                                     return OriginalHook(AstralFlow);
+                                
+                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
+                                    return OriginalHook(EnkindleBahamut);
                             }
 
                             // Demi Nuke 2: Electric Boogaloo

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -235,7 +235,7 @@ namespace XIVSlothCombo.Combos.PvE
                         
                         if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
                         {
-                            if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && Deathflare.LevelChecked())
+                            if (IsOffCooldown(Deathflare) && Deathflare.LevelChecked())
                                 return OriginalHook(AstralFlow);
                             
                             if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -223,6 +223,20 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (IsOffCooldown(SearingLight) && LevelChecked(SearingLight) && OriginalHook(Ruin) == AstralImpulse)
                             return SearingLight;
+
+                        if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
+                        {
+                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
+                                return OriginalHook(EnkindleBahamut);
+                            
+                            if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && Deathflare.LevelChecked())
+                                return OriginalHook(AstralFlow);
+
+                            if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire or BrandOfPurgatory)
+                                return OriginalHook(AstralFlow);
+
+                            return actionID;
+                        }
                         
                         if (gauge.HasAetherflowStacks)
                         {
@@ -235,7 +249,7 @@ namespace XIVSlothCombo.Combos.PvE
                                     return Painflare;
                             }
 
-                            if (OriginalHook(Ruin) == AstralImpulse && HasEffect(Buffs.SearingLight))
+                            if (HasEffect(Buffs.SearingLight))
                             {
                                 if (STCombo)
                                     return Fester;
@@ -256,20 +270,6 @@ namespace XIVSlothCombo.Combos.PvE
                         
                         if (IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= 4000 && level >= All.Levels.LucidDreaming)
                             return All.LucidDreaming;
-                        
-                        if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
-                        {
-                            if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && (!SummonBahamut.LevelChecked() || lastComboMove is AstralImpulse or AstralFlare))
-                                return OriginalHook(AstralFlow);
-
-                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked() && lastComboMove is AstralImpulse or AstralFlare or FountainOfFire or BrandOfPurgatory)
-                                return OriginalHook(EnkindleBahamut);
-                            
-                            if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire or BrandOfPurgatory)
-                                return OriginalHook(AstralFlow);
-
-                            return actionID;
-                        }
                     }
                     
                     if (gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
@@ -357,10 +357,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is Ruin or Ruin2 or Outburst or Tridisaster && InCombat())
                 {
-                    if (OriginalHook(Ruin) is not (AstralImpulse or FountainOfFire) || gauge.SummonTimerRemaining == 0) DemiAttackCount = 0;    // Resets counter
+                    if (WasLastAction(OriginalHook(Aethercharge))) DemiAttackCount = 0;    // Resets counter
 
                     //CHECK_DEMIATTACK_USE
-                    if (UsedDemiAttack == false && lastComboMove is AstralImpulse or FountainOfFire or AstralFlare or BrandOfPurgatory && GetCooldownRemainingTime(AstralImpulse) > 1)
+                    if (UsedDemiAttack == false && lastComboMove is AstralImpulse or FountainOfFire or AstralFlare or BrandOfPurgatory && DemiAttackCount is not 6 && GetCooldownRemainingTime(AstralImpulse) > 1)
                     {
                         UsedDemiAttack = true;      // Registers that a Demi Attack was used and blocks further incrementation of DemiAttackCountCount
                         DemiAttackCount++;          // Increments DemiAttack counter
@@ -389,6 +389,26 @@ namespace XIVSlothCombo.Combos.PvE
                             else return SearingLight;
                         }
 
+                        // Demi Nuke
+                        if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
+                        {
+                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && DemiAttackCount >= burstDelay)
+                            {
+                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
+                                    return OriginalHook(EnkindleBahamut);
+                                
+                                if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && Deathflare.LevelChecked())
+                                    return OriginalHook(AstralFlow);
+                            }
+
+                            // Demi Nuke 2: Electric Boogaloo
+                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle))
+                            {
+                                if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire or BrandOfPurgatory)
+                                    return OriginalHook(AstralFlow);
+                            }
+                        }
+                        
                         // ED & Fester
                         if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester))
                         {
@@ -415,10 +435,9 @@ namespace XIVSlothCombo.Combos.PvE
                                     }
 
                                     if (HasEffect(Buffs.SearingLight) && 
-                                        SummonerBurstPhase is 0 or 1 && DemiAttackCount >= burstDelay && OriginalHook(Ruin) == AstralImpulse ||
-                                        (SummonerBurstPhase == 2 && DemiAttackCount >= burstDelay && OriginalHook(Ruin) == FountainOfFire) ||
-                                        (SummonerBurstPhase == 3 && DemiAttackCount >= burstDelay && (GetCooldownRemainingTime(SearingLight) < 30 || GetCooldownRemainingTime(SearingLight) > 100) && OriginalHook(Ruin) is AstralImpulse or FountainOfFire) ||
-                                        (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
+                                        (SummonerBurstPhase is 0 or 1 or 2 && DemiAttackCount >= burstDelay ||
+                                        (SummonerBurstPhase == 3 && DemiAttackCount >= burstDelay && (GetCooldownRemainingTime(SearingLight) < 30 || GetCooldownRemainingTime(SearingLight) > 100)) ||
+                                        (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor))))
                                     {
                                         if (STCombo)
                                             return Fester;
@@ -442,28 +461,6 @@ namespace XIVSlothCombo.Combos.PvE
                         // Lucid Dreaming
                         if (IsEnabled(CustomComboPreset.SMN_Lucid) && IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold && level >= All.Levels.LucidDreaming)
                             return All.LucidDreaming;
-
-                        // Demi Nuke
-                        if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
-                        {
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && DemiAttackCount >= burstDelay)
-                            {
-                                if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && (!SummonBahamut.LevelChecked() ||
-                                    lastComboMove is AstralImpulse or AstralFlare))
-                                    return OriginalHook(AstralFlow);
-
-                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked() &&
-                                    lastComboMove is AstralImpulse or AstralFlare or FountainOfFire or BrandOfPurgatory)
-                                    return OriginalHook(EnkindleBahamut);
-                            }
-
-                            // Demi Nuke 2: Electric Boogaloo
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Rekindle))
-                            {
-                                if (IsOffCooldown(Rekindle) && lastComboMove is FountainOfFire or BrandOfPurgatory)
-                                    return OriginalHook(AstralFlow);
-                            }
-                        }
                     }
 
                     // Demi

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -177,7 +177,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergyDrain) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_EDFester_Ruin4))
                         return Ruin4;
 
-                    if (EnergyDrain.LevelChecked() && !gauge.HasAetherflowStacks)
+                    if (LevelChecked(EnergyDrain) && !gauge.HasAetherflowStacks)
                         return EnergyDrain;
                 }
 
@@ -198,7 +198,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
                         return Ruin4;
 
-                    if (EnergySiphon.LevelChecked() && !gauge.HasAetherflowStacks)
+                    if (LevelChecked(EnergySiphon) && !gauge.HasAetherflowStacks)
                         return EnergySiphon;
 
                 }
@@ -226,33 +226,33 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (!gauge.HasAetherflowStacks)
                         {
-                            if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
+                            if (STCombo && LevelChecked(EnergyDrain) && IsOffCooldown(EnergyDrain))
                                 return EnergyDrain;
 
-                            if (AoECombo && EnergySiphon.LevelChecked() && IsOffCooldown(EnergySiphon))
+                            if (AoECombo && LevelChecked(EnergySiphon) && IsOffCooldown(EnergySiphon))
                                 return EnergySiphon;
                         }
                         
                         if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
                         {
-                            if (IsOffCooldown(Deathflare) && Deathflare.LevelChecked() && OriginalHook(Ruin) is AstralImpulse)
-                                return OriginalHook(AstralFlow);
-                            
-                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
+                            if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
                                 return OriginalHook(EnkindleBahamut);
 
+                            if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
+                                return OriginalHook(AstralFlow);
+                            
                             if (IsOffCooldown(Rekindle) && OriginalHook(Ruin) is FountainOfFire)
                                 return OriginalHook(AstralFlow);
                         }
                         
                         if (gauge.HasAetherflowStacks)
                         {
-                            if (!SearingLight.LevelChecked())
+                            if (!LevelChecked(SearingLight))
                             {
                                 if (STCombo)
                                     return Fester;
 
-                                if (AoECombo && Painflare.LevelChecked())
+                                if (AoECombo && LevelChecked(Painflare))
                                     return Painflare;
                             }
 
@@ -261,7 +261,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (STCombo)
                                     return Fester;
 
-                                if (AoECombo && Painflare.LevelChecked())
+                                if (AoECombo && LevelChecked(Painflare))
                                     return Painflare;
                             }
                         }
@@ -271,14 +271,14 @@ namespace XIVSlothCombo.Combos.PvE
                     }
                     
                     if (gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
-                        (Aethercharge.LevelChecked() && !SummonBahamut.LevelChecked() ||
-                         gauge.IsBahamutReady && SummonBahamut.LevelChecked() ||
-                         gauge.IsPhoenixReady && SummonPhoenix.LevelChecked()))
+                        (LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut) ||
+                         gauge.IsBahamutReady && LevelChecked(SummonBahamut) ||
+                         gauge.IsPhoenixReady && LevelChecked(SummonPhoenix)))
                         return OriginalHook(Aethercharge);
                     
                     if (level >= All.Levels.Swiftcast)
                     {
-                        if (Slipstream.LevelChecked() && HasEffect(Buffs.GarudasFavor))
+                        if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
                         {
                             if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
                                 return All.Swiftcast;
@@ -296,7 +296,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (STCombo)
                             return OriginalHook(Gemshine);
 
-                        if (AoECombo && PreciousBrilliance.LevelChecked())
+                        if (AoECombo && LevelChecked(PreciousBrilliance))
                             return OriginalHook(PreciousBrilliance);
                     }
 
@@ -313,23 +313,23 @@ namespace XIVSlothCombo.Combos.PvE
                         if (STCombo)
                             return OriginalHook(Gemshine);
 
-                        if (AoECombo && PreciousBrilliance.LevelChecked())
+                        if (AoECombo && LevelChecked(PreciousBrilliance))
                             return OriginalHook(PreciousBrilliance);
                     }
                     
                     if (gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
                     {
-                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && SummonRuby.LevelChecked())
+                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
                             return OriginalHook(SummonRuby);
 
-                        if (gauge.IsTitanReady && SummonTopaz.LevelChecked())
+                        if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
                             return OriginalHook(SummonTopaz);
 
-                        if (gauge.IsGarudaReady && SummonEmerald.LevelChecked())
+                        if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
                             return OriginalHook(SummonEmerald);
                     }
                     
-                    if (Ruin4.LevelChecked() && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                    if (LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
                         return Ruin4;
                 }
                 
@@ -350,7 +350,7 @@ namespace XIVSlothCombo.Combos.PvE
                 var lucidThreshold = PluginConfiguration.GetCustomIntValue(Config.SMN_Lucid);
                 var swiftcastPhase = PluginConfiguration.GetCustomIntValue(Config.SMN_SwiftcastPhase);
                 var burstDelay = PluginConfiguration.GetCustomIntValue(Config.SMN_Burst_Delay);
-                var inOpener = CombatEngageDuration().TotalSeconds < 30;
+                var inOpener = CombatEngageDuration().TotalSeconds < 40;
                 var STCombo = actionID is Ruin or Ruin2;
                 var AoECombo = actionID is Outburst or Tridisaster;
 
@@ -375,7 +375,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (CanSpellWeave(actionID))
                     {
                         // Searing Light
-                        if (IsEnabled(CustomComboPreset.SMN_SearingLight) && IsOffCooldown(SearingLight) && LevelChecked(SearingLight))
+                        if (IsEnabled(CustomComboPreset.SMN_SearingLight) && CanDelayedWeave(actionID) && IsOffCooldown(SearingLight) && LevelChecked(SearingLight))
                         {
                             if (IsEnabled(CustomComboPreset.SMN_SearingLight_Burst))
                             {
@@ -393,13 +393,32 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         
                         // ED/ES
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && (IsNotEnabled(CustomComboPreset.SMN_Advanced_ED_ES_Option) || (!inOpener || DemiAttackCount >= burstDelay)))
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && (!inOpener || DemiAttackCount >= burstDelay))
                         {
-                            if (STCombo && EnergyDrain.LevelChecked() && IsOffCooldown(EnergyDrain))
+                            if (STCombo && LevelChecked(EnergyDrain) && IsOffCooldown(EnergyDrain))
                                 return EnergyDrain;
 
-                            if (AoECombo && EnergySiphon.LevelChecked() && IsOffCooldown(EnergySiphon))
+                            if (AoECombo && LevelChecked(EnergySiphon) && IsOffCooldown(EnergySiphon))
                                 return EnergySiphon;
+                        }
+                        
+                        // Non-Opener first set Fester/Painfalre
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling) && gauge.HasAetherflowStacks && !inOpener)
+                        {
+                            if (GetCooldown(EnergyDrain).CooldownRemaining <= 2.85)
+                            {
+                                if (HasEffect(Buffs.SearingLight) &&
+                                    (SummonerBurstPhase is 0 or 1 or 2 ||
+                                     (SummonerBurstPhase == 3 && (GetCooldownRemainingTime(SearingLight) < 30 || GetCooldownRemainingTime(SearingLight) > 100)) ||
+                                     (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor))))
+                                {
+                                    if (STCombo)
+                                        return Fester;
+
+                                    if (AoECombo && LevelChecked(Painflare) && IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_Only))
+                                        return Painflare;
+                                }
+                            }
                         }
 
                         // Demi Nuke
@@ -407,11 +426,11 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && DemiAttackCount >= burstDelay)
                             {
-                                if (IsOffCooldown(Deathflare) && Deathflare.LevelChecked() && OriginalHook(Ruin) is AstralImpulse)
-                                    return OriginalHook(AstralFlow);
-                                
-                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
+                                if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
                                     return OriginalHook(EnkindleBahamut);
+                                
+                                if (IsOffCooldown(Deathflare) && LevelChecked(Deathflare) && OriginalHook(Ruin) is AstralImpulse)
+                                    return OriginalHook(AstralFlow);
                             }
 
                             // Demi Nuke 2: Electric Boogaloo
@@ -432,18 +451,18 @@ namespace XIVSlothCombo.Combos.PvE
                                     if (STCombo)
                                         return Fester;
 
-                                    if (AoECombo && Painflare.LevelChecked())
+                                    if (AoECombo && LevelChecked(Painflare))
                                         return Painflare;
                                 }
                                     
                                 if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling))
                                 {
-                                    if (!SearingLight.LevelChecked())
+                                    if (!LevelChecked(SearingLight))
                                     {
                                         if (STCombo)
                                             return Fester;
 
-                                        if (AoECombo && Painflare.LevelChecked() && IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_Only))
+                                        if (AoECombo && LevelChecked(Painflare) && IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_Only))
                                             return Painflare;
                                     }
 
@@ -455,7 +474,7 @@ namespace XIVSlothCombo.Combos.PvE
                                         if (STCombo)
                                             return Fester;
 
-                                        if (AoECombo && Painflare.LevelChecked() && IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_Only))
+                                        if (AoECombo && LevelChecked(Painflare) && IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling_Only))
                                             return Painflare;
                                     }
                                 }
@@ -471,9 +490,9 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons))
                     {
                         if (gauge.SummonTimerRemaining == 0 && IsOffCooldown(OriginalHook(Aethercharge)) &&
-                            (Aethercharge.LevelChecked() && !SummonBahamut.LevelChecked() ||    // Pre-Bahamut Phase
-                             gauge.IsBahamutReady && SummonBahamut.LevelChecked() ||            // Bahamut Phase
-                             gauge.IsPhoenixReady && SummonPhoenix.LevelChecked()))             // Phoenix Phase
+                            (LevelChecked(Aethercharge) && !LevelChecked(SummonBahamut) ||   // Pre-Bahamut Phase
+                             gauge.IsBahamutReady && LevelChecked(SummonBahamut) ||            // Bahamut Phase
+                             gauge.IsPhoenixReady && LevelChecked(SummonPhoenix)))             // Phoenix Phase
                             return OriginalHook(Aethercharge);
                     }
                     
@@ -481,7 +500,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) && level >= All.Levels.Swiftcast)
                     {
                         // Swiftcast Garuda Feature
-                        if (swiftcastPhase is 0 or 1 && Slipstream.LevelChecked() && HasEffect(Buffs.GarudasFavor))
+                        if (swiftcastPhase is 0 or 1 && LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
                         {
                             if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned)
                             {
@@ -510,7 +529,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (swiftcastPhase == 3)
                         {
                             // Swiftcast Garuda Feature
-                            if (Slipstream.LevelChecked() && HasEffect(Buffs.GarudasFavor))
+                            if (LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
                             {
                                 if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
                                 {
@@ -541,7 +560,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (STCombo)
                             return OriginalHook(Gemshine);
 
-                        if (AoECombo && PreciousBrilliance.LevelChecked())
+                        if (AoECombo && LevelChecked(PreciousBrilliance))
                             return OriginalHook(PreciousBrilliance);
                     }
                     
@@ -559,35 +578,35 @@ namespace XIVSlothCombo.Combos.PvE
                         if (STCombo)
                             return OriginalHook(Gemshine);
 
-                        if (AoECombo && PreciousBrilliance.LevelChecked())
+                        if (AoECombo && LevelChecked(PreciousBrilliance))
                             return OriginalHook(PreciousBrilliance);
                     }
 
                     if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
                     {
-                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && SummonRuby.LevelChecked())
+                        if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
                             return OriginalHook(SummonRuby);
 
                         if (summonerPrimalChoice is 0 or 1)
                         {
-                            if (gauge.IsTitanReady && SummonTopaz.LevelChecked())
+                            if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
                                 return OriginalHook(SummonTopaz);
 
-                            if (gauge.IsGarudaReady && SummonEmerald.LevelChecked())
+                            if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
                                 return OriginalHook(SummonEmerald);
                         }
 
                         if (summonerPrimalChoice == 2)
                         {
-                            if (gauge.IsGarudaReady && SummonEmerald.LevelChecked())
+                            if (gauge.IsGarudaReady && LevelChecked(SummonEmerald))
                                 return OriginalHook(SummonEmerald);
 
-                            if (gauge.IsTitanReady && SummonTopaz.LevelChecked())
+                            if (gauge.IsTitanReady && LevelChecked(SummonTopaz))
                                 return OriginalHook(SummonTopaz);
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && Ruin4.LevelChecked() && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && LevelChecked(Ruin4) && gauge.SummonTimerRemaining == 0 && gauge.AttunmentTimerRemaining == 0 && HasEffect(Buffs.FurtherRuin))
                         return Ruin4;
                 }
 

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -235,7 +235,7 @@ namespace XIVSlothCombo.Combos.PvE
                         
                         if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
                         {
-                            if (IsOffCooldown(Deathflare) && Deathflare.LevelChecked())
+                            if (IsOffCooldown(Deathflare) && Deathflare.LevelChecked() && OriginalHook(Ruin) is AstralImpulse)
                                 return OriginalHook(AstralFlow);
                             
                             if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())
@@ -401,7 +401,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && DemiAttackCount >= burstDelay)
                             {
-                                if (IsOffCooldown(Deathflare) && AstralFlow.LevelChecked() && Deathflare.LevelChecked())
+                                if (IsOffCooldown(Deathflare) && Deathflare.LevelChecked() && OriginalHook(Ruin) is AstralImpulse)
                                     return OriginalHook(AstralFlow);
                                 
                                 if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && SummonBahamut.LevelChecked())

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1176,7 +1176,7 @@ namespace XIVSlothCombo.Window.Functions
             }
             
             if (preset == CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling)
-                UserConfig.DrawSliderInt(0, 2, SMN.Config.SMN_Burst_Delay, "Sets the amount of GCDs under Demi summon to wait for oGCD use.", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 3, SMN.Config.SMN_Burst_Delay, "Sets the amount of GCDs under Demi summon to wait for oGCD use.", 150, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling)
             {


### PR DESCRIPTION
## SMN

- Adjusted `DemiAttackCount` to reset when summoning a demi rather than when the demi expires, this allows damage oGCDs to be used even after a demi has left, but still under searing light.
- Adjusted Demi oGCD priority above Festers/Painflare. (Kept ED/ES above them in priority as well)
- Removed LastComboMove checks for Demi Attacks and replaced them with *specific* phase checks. (This allows for doubleweaving `Astral Flow` and `Enkindle Bahamut` which wasn't possible before due to the LastComboMove checks)
- Removed specific phase checks for pooled damage oGCDs as they only really needed Searing to be used.
- `Searing Light` is now a delayed weave.
- `Energy oGCDs` now follow the burst delay slider setting inside your opener. (first 40s of combat)
- Added specific non-opener code for first set festers to have priority over demi oGCDs. (after 40s of combat)
- Added `Burst Delay Option` to ignore the burst delay slider (treats it as if it were 0 gcd delay) if outside of initial opener for high sps builds. (for now, this is 40s from the beginning of the fight.
- Moved DemiAttackCount logic outside of the incombat block, added logic to ignore burst delay slider if `Burst Delay Only During Opener` is active and outside of opener window, added additional reset state for DemiAttackCount.
- Set Demi GCD Burst Delay slider to max of 3.
- Changed actionID.LevelChecked() to LevelChecked(ActionID) for the memes, fight me Tauren.