### PR TITLE
Fixed MNK Demolish/Twin Snakes slider not working correctly.

### DIFF
--- a/XIVSlothCombo/Combos/PvE/MNK.cs
+++ b/XIVSlothCombo/Combos/PvE/MNK.cs
@@ -563,7 +563,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (level >= Levels.TrueStrike && HasEffect(Buffs.RaptorForm))
                     {
-                        if (level >= Levels.TwinSnakes && (!HasEffect(Buffs.DisciplinedFist) || twinsnakeDuration <= PluginConfiguration.GetCustomIntValue(Config.MNK_DisciplinedFist_Apply)))
+                        if (level >= Levels.TwinSnakes && (!HasEffect(Buffs.DisciplinedFist) || twinsnakeDuration <= PluginConfiguration.GetCustomFloatValue(Config.MNK_DisciplinedFist_Apply)))
                         {
                             return TwinSnakes;
                         }
@@ -572,7 +572,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (level >= Levels.SnapPunch && HasEffect(Buffs.CoerlForm))
                     {
-                        if (level >= Levels.Demolish && HasEffect(Buffs.DisciplinedFist) && (!TargetHasEffect(Debuffs.Demolish) || demolishDuration <= PluginConfiguration.GetCustomIntValue(Config.MNK_Demolish_Apply)))
+                        if (level >= Levels.Demolish && HasEffect(Buffs.DisciplinedFist) && (!TargetHasEffect(Debuffs.Demolish) || demolishDuration <= PluginConfiguration.GetCustomFloatValue(Config.MNK_Demolish_Apply)))
                         {
                             return Demolish;
                         }


### PR DESCRIPTION
Changed `GetCustomIntValue` to `GetCustomFloatValue` since the value is a float.