### PR TITLE
[DNC] `LevelChecked()` + Standard Fills + Peloton Pre-pull

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -729,41 +729,47 @@ namespace XIVSlothCombo.Combos
             DNC_ST_Simple_Interrupt = 4051,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Standard Dance Option", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0, "", "")]
+            [ConflictingCombos(DNC_ST_Simple_StandardFill)]
+            [CustomComboInfo("Simple Standard Dance Option", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 1, "", "")]
             DNC_ST_Simple_SS = 4052,
 
             [ParentCombo(DNC_ST_SimpleMode)]
+            [ConflictingCombos(DNC_ST_Simple_SS)]
+            [CustomComboInfo("Simple Standard Fill Option", "Adds ONLY Standard dance steps and Standard Finish to the rotation.\nStandard Step itself needs to be initiated manually when using this option.", DNC.JobID, 2, "", "")]
+            DNC_ST_Simple_StandardFill = 4061,
+
+            [ParentCombo(DNC_ST_SimpleMode)]
             [ConflictingCombos(DNC_ST_Simple_TechFill)]
-            [CustomComboInfo("Simple Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 3, "", "")]
             DNC_ST_Simple_TS = 4053,
 
             [ParentCombo(DNC_ST_SimpleMode)]
             [ConflictingCombos(DNC_ST_Simple_TS)]
-            [CustomComboInfo("Simple Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the rotation.\nTechnical Step itself needs to be initiated manually when using this option.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the rotation.\nTechnical Step itself needs to be initiated manually when using this option.", DNC.JobID, 4, "", "")]
             DNC_ST_Simple_TechFill = 4054,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation.\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation.\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 5, "", "")]
             DNC_ST_Simple_Devilment = 4055,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Flourish Option", "Includes Flourish in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Flourish Option", "Includes Flourish in the rotation.", DNC.JobID, 6, "", "")]
             DNC_ST_Simple_Flourish = 4056,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Feathers Option", "Includes Feather usage in the rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Feathers Option", "Includes Feather usage in the rotation.", DNC.JobID, 7, "", "")]
             DNC_ST_Simple_Feathers = 4057,
 
             [ParentCombo(DNC_ST_Simple_Feathers)]
-            [CustomComboInfo("Simple Feather Pooling Option", "Expends a feather in the next available weave window when capped.\nWeaves feathers where possible during Technical Finish.\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple Feather Pooling Option", "Expends a feather in the next available weave window when capped.\nWeaves feathers where possible during Technical Finish.\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 8, "")]
             DNC_ST_Simple_FeatherPooling = 4058,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Panic Heals Option", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Panic Heals Option", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 9, "", "")]
             DNC_ST_Simple_PanicHeals = 4059,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Improvisation Option", "Includes Improvisation in the rotation when available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Improvisation Option", "Includes Improvisation in the rotation when available.", DNC.JobID, 10, "", "")]
             DNC_ST_Simple_Improvisation = 4060,
             #endregion
 
@@ -778,41 +784,47 @@ namespace XIVSlothCombo.Combos
             DNC_AoE_Simple_Interrupt = 4071,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Standard Dance Option", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0, "")]
+            [ConflictingCombos(DNC_AoE_Simple_StandardFill)]
+            [CustomComboInfo("Simple AoE Standard Dance Option", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 1, "", "")]
             DNC_AoE_Simple_SS = 4072,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
+            [ConflictingCombos(DNC_AoE_Simple_SS)]
+            [CustomComboInfo("Simple AoE Standard Fill Option", "Adds ONLY Standard dance steps and Standard Finish to the AoE rotation.\nStandard Step itself needs to be initiated manually when using this option.", DNC.JobID, 2, "", "")]
+            DNC_AoE_Simple_StandardFill = 4081,
+
+            [ParentCombo(DNC_AoE_SimpleMode)]
             [ConflictingCombos(DNC_AoE_Simple_TechFill)]
-            [CustomComboInfo("Simple AoE Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the AoE rotation.", DNC.JobID, 0, "")]
+            [CustomComboInfo("Simple AoE Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the AoE rotation.", DNC.JobID, 3, "", "")]
             DNC_AoE_Simple_TS = 4073,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
             [ConflictingCombos(DNC_AoE_Simple_TS)]
-            [CustomComboInfo("Simple AoE Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation.\nTechnical Step itself needs to be initiated manually when using this option.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation.\nTechnical Step itself needs to be initiated manually when using this option.", DNC.JobID, 4, "", "")]
             DNC_AoE_Simple_TechFill = 4074,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation.\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation.\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 5, "", "")]
             DNC_AoE_Simple_Devilment = 4075,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Flourish Option", "Includes Flourish in the AoE rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Flourish Option", "Includes Flourish in the AoE rotation.", DNC.JobID, 6, "", "")]
             DNC_AoE_Simple_Flourish = 4076,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Feathers Option", "Includes feather usage in the AoE rotation.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Feathers Option", "Includes feather usage in the AoE rotation.", DNC.JobID, 7, "", "")]
             DNC_AoE_Simple_Feathers = 4077,
 
             [ParentCombo(DNC_AoE_Simple_Feathers)]
-            [CustomComboInfo("Simple AoE Feather Pooling Option", "Expends a feather in the next available weave window when capped.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Feather Pooling Option", "Expends a feather in the next available weave window when capped.", DNC.JobID, 8, "", "")]
             DNC_AoE_Simple_FeatherPooling = 4078,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Panic Heals Option", "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Panic Heals Option", "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 9, "", "")]
             DNC_AoE_Simple_PanicHeals = 4079,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Improvisation Option", "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple AoE Improvisation Option", "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 10, "", "")]
             DNC_AoE_Simple_Improvisation = 4080,
             #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -645,7 +645,9 @@ namespace XIVSlothCombo.Combos
             [ReplaceSkill(DNC.StandardStep)]
             [ParentCombo(DNC_Dance_Menu)]
             [ConflictingCombos(DNC_DanceStepCombo, DNC_DanceComboReplacer, DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Combined Dance Feature", "Standard And Technical Dance on one button (SS). Standard > Technical. This combos out into Tillana and Starfall Dance.", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Combined Dance Feature", "Standard And Technical Dance on one button (SS)." +
+            "\nStandard > Technical." +
+            "\nThis combos out into Tillana and Starfall Dance.", DNC.JobID, 0, "", "")]
             DNC_CombinedDances = 4022,
 
                 [ParentCombo(DNC_CombinedDances)]
@@ -670,7 +672,8 @@ namespace XIVSlothCombo.Combos
 
         #region Flourishing Features
         [ConflictingCombos(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Flourishing Features", "Features and options involving Fourfold Feathers and Flourish.\nCollapsing this category does NOT disable the features inside.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Flourishing Features", "Features and options involving Fourfold Feathers and Flourish." +
+        "\nCollapsing this category does NOT disable the features inside.", DNC.JobID, 0, "", "")]
         DNC_FlourishingFeatures_Menu = 4030,
 
             [ReplaceSkill(DNC.Flourish)]
@@ -683,7 +686,8 @@ namespace XIVSlothCombo.Combos
         #region Fan Dance Combo Features
         [ParentCombo(DNC_FlourishingFeatures_Menu)]
         [ConflictingCombos(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Fan Dance Combo Feature", "Options for Fan Dance combos. Fan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Fan Dance Combo Feature", "Options for Fan Dance combos." +
+        "\nFan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0, "", "")]
         DNC_FanDanceCombos = 4033,
 
             [ReplaceSkill(DNC.FanDance1)]
@@ -715,17 +719,19 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
         [ConflictingCombos(DNC_CombinedDances, DNC_DanceComboReplacer)]
-        [CustomComboInfo("Dance Step Combo Feature", "Change Standard Step and Technical Step into each dance step while dancing.\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Dance Step Combo Feature", "Change Standard Step and Technical Step into each dance step while dancing." +
+        "\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
         DNC_DanceStepCombo = 4039,
 
         #region Simple Dancer (Single Target)
         [ReplaceSkill(DNC.Cascade)]
         [ConflictingCombos(DNC_ST_MultiButton, DNC_AoE_MultiButton, DNC_CombinedDances, DNC_DanceComboReplacer, DNC_FlourishingFeatures_Menu, DNC_Starfall_Devilment)]
-        [CustomComboInfo("Simple Dancer (Single Target) Feature", "Single button, single target. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Simple Dancer (Single Target) Feature", "Single button, single target. Includes songs, flourishes and overprotections." +
+        "\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
         DNC_ST_SimpleMode = 4050,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Interrupt Option", "Includes an interrupt in the rotation (if applicable to your current target).", DNC.JobID, 0, "", "")]
+            [CustomComboInfo("Simple Interrupt Option", "Includes an interrupt in the rotation (if applicable to your current target).", DNC.JobID, 5, "", "")]
             DNC_ST_Simple_Interrupt = 4051,
 
             [ParentCombo(DNC_ST_SimpleMode)]
@@ -735,48 +741,59 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_ST_SimpleMode)]
             [ConflictingCombos(DNC_ST_Simple_SS)]
-            [CustomComboInfo("Simple Standard Fill Option", "Adds ONLY Standard dance steps and Standard Finish to the rotation.\nStandard Step itself needs to be initiated manually when using this option.", DNC.JobID, 2, "", "")]
+            [CustomComboInfo("Simple Standard Fill Option", "Adds ONLY Standard dance steps and Standard Finish to the rotation." +
+            "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 1, "", "")]
             DNC_ST_Simple_StandardFill = 4061,
 
             [ParentCombo(DNC_ST_SimpleMode)]
             [ConflictingCombos(DNC_ST_Simple_TechFill)]
-            [CustomComboInfo("Simple Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 3, "", "")]
+            [CustomComboInfo("Simple Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 2, "", "")]
             DNC_ST_Simple_TS = 4053,
 
             [ParentCombo(DNC_ST_SimpleMode)]
             [ConflictingCombos(DNC_ST_Simple_TS)]
-            [CustomComboInfo("Simple Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the rotation.\nTechnical Step itself needs to be initiated manually when using this option.", DNC.JobID, 4, "", "")]
+            [CustomComboInfo("Simple Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the rotation." +
+            "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 2, "", "")]
             DNC_ST_Simple_TechFill = 4054,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation.\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 5, "", "")]
+            [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation." +
+            "\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 2, "", "")]
             DNC_ST_Simple_Devilment = 4055,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Flourish Option", "Includes Flourish in the rotation.", DNC.JobID, 6, "", "")]
+            [CustomComboInfo("Simple Flourish Option", "Includes Flourish in the rotation.", DNC.JobID, 3, "", "")]
             DNC_ST_Simple_Flourish = 4056,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Feathers Option", "Includes Feather usage in the rotation.", DNC.JobID, 7, "", "")]
+            [CustomComboInfo("Simple Feathers Option", "Includes Feather usage in the rotation.", DNC.JobID, 4, "", "")]
             DNC_ST_Simple_Feathers = 4057,
 
             [ParentCombo(DNC_ST_Simple_Feathers)]
-            [CustomComboInfo("Simple Feather Pooling Option", "Expends a feather in the next available weave window when capped.\nWeaves feathers where possible during Technical Finish.\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 8, "")]
+            [CustomComboInfo("Simple Feather Pooling Option", "Expends a feather in the next available weave window when capped." +
+            "\nWeaves feathers where possible during Technical Finish." +
+            "\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 4, "", "")]
             DNC_ST_Simple_FeatherPooling = 4058,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Panic Heals Option", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 9, "", "")]
+            [CustomComboInfo("Simple Panic Heals Option", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 5, "", "")]
             DNC_ST_Simple_PanicHeals = 4059,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Improvisation Option", "Includes Improvisation in the rotation when available.", DNC.JobID, 10, "", "")]
+            [CustomComboInfo("Simple Improvisation Option", "Includes Improvisation in the rotation when available.", DNC.JobID, 5, "", "")]
             DNC_ST_Simple_Improvisation = 4060,
+
+            [ParentCombo(DNC_ST_SimpleMode)]
+            [CustomComboInfo("Simple Peloton Opener Option", "Uses Peloton when you are out of combat, do not already have the Peloton buff and are performing Standard Step with greater than 5s remaining of your dance." +
+            "\nWill not override Dance Step Combo Feature.", DNC.JobID, 5, "", "")]
+            DNC_ST_Simple_Peloton = 4062,
             #endregion
 
         #region Simple Dancer (AoE)
         [ReplaceSkill(DNC.Windmill)]
         [ConflictingCombos(DNC_ST_MultiButton, DNC_AoE_MultiButton, DNC_CombinedDances, DNC_DanceComboReplacer, DNC_FlourishingFeatures_Menu, DNC_Starfall_Devilment)]
-        [CustomComboInfo("Simple Dancer (AoE) Feature", "Single button, AoE. Includes songs, flourishes and overprotections.\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
+        [CustomComboInfo("Simple Dancer (AoE) Feature", "Single button, AoE. Includes songs, flourishes and overprotections." +
+        "\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
         DNC_AoE_SimpleMode = 4070,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
@@ -790,7 +807,8 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_AoE_SimpleMode)]
             [ConflictingCombos(DNC_AoE_Simple_SS)]
-            [CustomComboInfo("Simple AoE Standard Fill Option", "Adds ONLY Standard dance steps and Standard Finish to the AoE rotation.\nStandard Step itself needs to be initiated manually when using this option.", DNC.JobID, 2, "", "")]
+            [CustomComboInfo("Simple AoE Standard Fill Option", "Adds ONLY Standard dance steps and Standard Finish to the AoE rotation." +
+            "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 2, "", "")]
             DNC_AoE_Simple_StandardFill = 4081,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
@@ -800,11 +818,13 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_AoE_SimpleMode)]
             [ConflictingCombos(DNC_AoE_Simple_TS)]
-            [CustomComboInfo("Simple AoE Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation.\nTechnical Step itself needs to be initiated manually when using this option.", DNC.JobID, 4, "", "")]
+            [CustomComboInfo("Simple AoE Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation." +
+            "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 4, "", "")]
             DNC_AoE_Simple_TechFill = 4074,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation.\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 5, "", "")]
+            [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation." +
+            "\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 5, "", "")]
             DNC_AoE_Simple_Devilment = 4075,
 
             [ParentCombo(DNC_AoE_SimpleMode)]

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -270,9 +270,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return ReverseCascade;
 
                     // ST Cascade Combo
-                    if (lastComboMove is Cascade && LevelChecked(Fountain))
+                    if (LevelChecked(Fountain) && lastComboMove is Cascade)
                         return Fountain;
-                    return Cascade;
                 }
                 return actionID;
             }
@@ -326,9 +325,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return RisingWindmill;
 
                     // AoE Windmill Combo
-                    if (lastComboMove is Windmill && LevelChecked(Bladeshower))
+                    if (LevelChecked(Bladeshower) && lastComboMove is Windmill)
                         return Bladeshower;
-                    return Windmill;
                 }
                 return actionID;
             }
@@ -497,12 +495,12 @@ namespace XIVSlothCombo.Combos.PvE
                         // Simple ST Feathers
                         if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_ST_Simple_Feathers))
                         {
+                            // Simple ST Feather Pooling
+                            var minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
+
                             // Simple ST FD3
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
-
-                            // Simple ST Feather Pooling
-                            var minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
 
                             // Simple ST Feather Overcap & Burst
                             if (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) || GetTargetHPPercent() < featherBurstThreshold && gauge.Feathers > 0)

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -2,6 +2,7 @@
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.Services;
+using XIVSlothCombo.Data;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -121,7 +122,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (GetJobGauge<DNCGauge>().IsDancing)
                 {
-                    var actionIDs = Service.Configuration.DancerDanceCompatActionIDs;
+                    uint[]? actionIDs = Service.Configuration.DancerDanceCompatActionIDs;
 
                     // Cascade replacement
                     if (actionID == actionIDs[0] || (actionIDs[0] == 0 && actionID == Cascade))
@@ -149,8 +150,8 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var FD3Ready = HasEffect(Buffs.ThreeFoldFanDance);
-                var FD4Ready = HasEffect(Buffs.FourFoldFanDance);
+                bool FD3Ready = HasEffect(Buffs.ThreeFoldFanDance);
+                bool FD4Ready = HasEffect(Buffs.FourFoldFanDance);
 
                 if (actionID is FanDance1)
                 {
@@ -183,7 +184,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<DNCGauge>();
+                DNCGauge? gauge = GetJobGauge<DNCGauge>();
 
                 // Standard Step
                 if (actionID is StandardStep && gauge.IsDancing && HasEffect(Buffs.StandardStep))
@@ -230,11 +231,11 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Cascade)
                 {
                     #region Types
-                    var gauge = GetJobGauge<DNCGauge>();
-                    var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
-                    var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
-                    var canWeave = CanWeave(actionID);
-                    var espritThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_ST);
+                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
+                    bool flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
+                    bool symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
+                    bool canWeave = CanWeave(actionID);
+                    int espritThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_ST);
                     #endregion
 
                     // ST Esprit overcap options
@@ -285,11 +286,11 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Windmill)
                 {
                     #region Types
-                    var gauge = GetJobGauge<DNCGauge>();
-                    var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
-                    var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
-                    var canWeave = CanWeave(actionID);
-                    var espritThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_AoE);
+                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
+                    bool flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
+                    bool symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
+                    bool canWeave = CanWeave(actionID);
+                    int espritThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_AoE);
                     #endregion
 
                     // AoE Esprit overcap options
@@ -353,12 +354,12 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is StandardStep)
                 {
                     #region Types
-                    var gauge = GetJobGauge<DNCGauge>();
-                    var standardCD = GetCooldown(StandardStep);
-                    var techstepCD = GetCooldown(TechnicalStep);
-                    var devilmentCD = GetCooldown(Devilment);
-                    var flourishCD = GetCooldown(Flourish);
-                    var incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
+                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
+                    CooldownData standardCD = GetCooldown(StandardStep);
+                    CooldownData techstepCD = GetCooldown(TechnicalStep);
+                    CooldownData devilmentCD = GetCooldown(Devilment);
+                    CooldownData flourishCD = GetCooldown(Flourish);
+                    bool incombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
                     #endregion
 
                     // Devilment
@@ -419,25 +420,25 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Cascade)
                 {
                     #region Types
-                    var gauge = GetJobGauge<DNCGauge>();
-                    var canWeave = CanWeave(actionID);
-                    var flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
-                    var symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
-                    var techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
-                    var techBurst = HasEffect(Buffs.TechnicalFinish);
-                    var flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
-                    var devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
-                    var improvisationReady = LevelChecked(Improvisation) && IsOffCooldown(Improvisation);
-                    var curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
-                    var secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
-                    var standardStepReady = LevelChecked(StandardStep) && IsOffCooldown(StandardStep);
-                    var technicalStepReady = LevelChecked(TechnicalStep) && IsOffCooldown(TechnicalStep);
-                    var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && LevelChecked(All.HeadGraze);
-                    var standardStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
-                    var technicalStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent);
-                    var featherBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
-                    var waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent);
-                    var secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent);
+                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
+                    bool canWeave = CanWeave(actionID);
+                    bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
+                    bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
+                    float techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
+                    bool techBurst = HasEffect(Buffs.TechnicalFinish);
+                    bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
+                    bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
+                    bool improvisationReady = LevelChecked(Improvisation) && IsOffCooldown(Improvisation);
+                    bool curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
+                    bool secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
+                    bool standardStepReady = LevelChecked(StandardStep) && IsOffCooldown(StandardStep);
+                    bool technicalStepReady = LevelChecked(TechnicalStep) && IsOffCooldown(TechnicalStep);
+                    bool interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && LevelChecked(All.HeadGraze);
+                    int standardStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
+                    int technicalStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent);
+                    int featherBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
+                    int waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent);
+                    int secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent);
                     #endregion
 
                     // Simple Pre-pull Peloton
@@ -495,7 +496,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_ST_Simple_Feathers))
                         {
                             // Simple ST Feather Pooling
-                            var minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
+                            int minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
 
                             // Simple ST FD3
                             if (HasEffect(Buffs.ThreeFoldFanDance))
@@ -566,24 +567,24 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Windmill)
                 {
                     #region Types
-                    var gauge = GetJobGauge<DNCGauge>();
-                    var canWeave = CanWeave(actionID);
-                    var flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
-                    var symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
-                    var techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
-                    var techBurst = HasEffect(Buffs.TechnicalFinish);
-                    var flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish);
-                    var devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
-                    var improvisationReady = LevelChecked(Improvisation) && IsOffCooldown(Improvisation);
-                    var curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
-                    var secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
-                    var standardStepReady = LevelChecked(StandardStep) && IsOffCooldown(StandardStep);
-                    var technicalStepReady = LevelChecked(TechnicalStep) && IsOffCooldown(TechnicalStep);
-                    var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && LevelChecked(All.HeadGraze);
-                    var standardStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
-                    var technicalStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent);
-                    var waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent);
-                    var secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent);
+                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
+                    bool canWeave = CanWeave(actionID);
+                    bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
+                    bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
+                    float techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
+                    bool techBurst = HasEffect(Buffs.TechnicalFinish);
+                    bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish);
+                    bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
+                    bool improvisationReady = LevelChecked(Improvisation) && IsOffCooldown(Improvisation);
+                    bool curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
+                    bool secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
+                    bool standardStepReady = LevelChecked(StandardStep) && IsOffCooldown(StandardStep);
+                    bool technicalStepReady = LevelChecked(TechnicalStep) && IsOffCooldown(TechnicalStep);
+                    bool interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && LevelChecked(All.HeadGraze);
+                    int standardStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
+                    int technicalStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent);
+                    int waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent);
+                    int secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent);
                     #endregion
 
                     // Simple AoE Standard Steps & Fill Feature
@@ -641,7 +642,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers))
                         {
                             // Simple AoE Feather Pooling
-                            var minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
+                            int minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
 
                             // Simple AoE FD3
                             if (HasEffect(Buffs.ThreeFoldFanDance))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -77,10 +77,12 @@ namespace XIVSlothCombo.Combos.PvE
                 ShieldSamba = 1826;
         }
 
+        /*
         public static class Debuffs
         {
-            // public const short placeholder = 0;
+            public const short placeholder = 0;
         }
+        */
 
         public static class Config
         {
@@ -140,6 +142,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (actionID == actionIDs[3] || (actionIDs[3] == 0 && actionID == FanDance2))
                         return OriginalHook(Fountainfall);
                 }
+
                 return actionID;
             }
         }
@@ -174,6 +177,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (FD4Ready && IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo))
                         return FanDance4;
                 }
+
                 return actionID;
             }
         }
@@ -197,6 +201,7 @@ namespace XIVSlothCombo.Combos.PvE
                     return gauge.CompletedSteps < 4
                         ? gauge.NextStep
                         : TechnicalFinish4;
+
                 return actionID;
             }
         }
@@ -218,6 +223,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.FourFoldFanDance))
                         return FanDance4;
                 }
+
                 return actionID;
             }
         }
@@ -273,6 +279,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (LevelChecked(Fountain) && lastComboMove is Cascade)
                         return Fountain;
                 }
+
                 return actionID;
             }
         }
@@ -328,6 +335,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill)
                         return Bladeshower;
                 }
+
                 return actionID;
             }
         }
@@ -340,6 +348,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Devilment && HasEffect(Buffs.FlourishingStarfall))
                     return StarfallDance;
+
                 return actionID;
             }
         }
@@ -395,6 +404,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (gauge.CompletedSteps < 2)
                                 return gauge.NextStep;
+
                             return StandardFinish2;
                         }
 
@@ -403,6 +413,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (gauge.CompletedSteps < 4)
                                 return gauge.NextStep;
+
                             return TechnicalFinish4;
                         }
                     }
@@ -554,6 +565,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime > 0)
                         return Fountain;
                 }
+
                 return actionID;
             }
         }
@@ -698,6 +710,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime > 0)
                         return Bladeshower;
                 }
+
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -449,7 +449,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     // Simple ST Standard Steps
-                    if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DNC_ST_Simple_SS))
+                    if (HasEffect(Buffs.StandardStep) && (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_StandardFill)))
                         return gauge.CompletedSteps < 2
                             ? gauge.NextStep
                             : StandardFinish2;
@@ -591,7 +591,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     // Simple AoE Standard Step (step function)
-                    if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS))
+                    if (HasEffect(Buffs.StandardStep) && (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_StandardFill)))
                         return gauge.CompletedSteps < 2
                             ? gauge.NextStep
                             : StandardFinish2;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -339,7 +339,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // Devilment
                     if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Devilment) && IsOnCooldown(StandardStep) && IsOffCooldown(Devilment) && !gauge.IsDancing)
                     {
-                        if (LevelChecked(Devilment) && !LevelChecked(TechnicalStep) ||      // Lv.62 - 69
+                        if ((LevelChecked(Devilment) && !LevelChecked(TechnicalStep)) ||    // Lv. 62 - 69
                             (LevelChecked(TechnicalStep) && IsOnCooldown(TechnicalStep)))   // Lv. 70+ during Tech
                             return Devilment;
                     }
@@ -462,7 +462,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return FanDance3;
                             if (gauge.Feathers > minFeathers ||
                                 (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) ||
-                                GetTargetHPPercent() < featherBurstThreshold && gauge.Feathers > 0)
+                                (GetTargetHPPercent() < featherBurstThreshold && gauge.Feathers > 0))
                                 return FanDance1;
                         }
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -125,21 +125,14 @@ namespace XIVSlothCombo.Combos.PvE
                 if (GetJobGauge<DNCGauge>().IsDancing)
                 {
                     uint[]? actionIDs = Service.Configuration.DancerDanceCompatActionIDs;
-
-                    // Cascade replacement
-                    if (actionID == actionIDs[0] || (actionIDs[0] == 0 && actionID == Cascade))
+                    
+                    if (actionID == actionIDs[0] || (actionIDs[0] == 0 && actionID == Cascade))     // Cascade replacement
                         return OriginalHook(Cascade);
-
-                    // Fountain replacement
-                    if (actionID == actionIDs[1] || (actionIDs[1] == 0 && actionID == Flourish))
+                    if (actionID == actionIDs[1] || (actionIDs[1] == 0 && actionID == Flourish))    // Fountain replacement
                         return OriginalHook(Fountain);
-
-                    // Reverse Cascade replacement
-                    if (actionID == actionIDs[2] || (actionIDs[2] == 0 && actionID == FanDance1))
+                    if (actionID == actionIDs[2] || (actionIDs[2] == 0 && actionID == FanDance1))   // Reverse Cascade replacement
                         return OriginalHook(ReverseCascade);
-
-                    // Fountainfall replacement
-                    if (actionID == actionIDs[3] || (actionIDs[3] == 0 && actionID == FanDance2))
+                    if (actionID == actionIDs[3] || (actionIDs[3] == 0 && actionID == FanDance2))   // Fountainfall replacement
                         return OriginalHook(Fountainfall);
                 }
 
@@ -155,25 +148,21 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 bool FD3Ready = HasEffect(Buffs.ThreeFoldFanDance);
                 bool FD4Ready = HasEffect(Buffs.FourFoldFanDance);
-
+                
+                // FD 1 --> 3, FD 1 --> 4
                 if (actionID is FanDance1)
                 {
-                    // FD 1 -> 3
                     if (FD3Ready && IsEnabled(CustomComboPreset.DNC_FanDance_1to3_Combo))
                         return FanDance3;
-
-                    // FD 1 -> 4
                     if (FD4Ready && IsEnabled(CustomComboPreset.DNC_FanDance_1to4_Combo))
                         return FanDance4;
                 }
 
+                // FD 2 --> 3, FD 2 --> 4
                 if (actionID is FanDance2)
                 {
-                    // FD 2 -> 3
                     if (FD3Ready && IsEnabled(CustomComboPreset.DNC_FanDance_2to3_Combo))
                         return FanDance3;
-
-                    // FD 2 -> 4
                     if (FD4Ready && IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo))
                         return FanDance4;
                 }
@@ -215,11 +204,8 @@ namespace XIVSlothCombo.Combos.PvE
                 // Fan Dance 3 & 4 on Flourish when relevant
                 if (actionID is Flourish && CanWeave(actionID))
                 {
-                    // FD3
                     if (HasEffect(Buffs.ThreeFoldFanDance))
                         return FanDance3;
-
-                    // FD4
                     if (HasEffect(Buffs.FourFoldFanDance))
                         return FanDance4;
                 }
@@ -245,37 +231,31 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     // ST Esprit overcap options
-                    if (LevelChecked(SaberDance) && gauge.Esprit >= espritThreshold && IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap))
+                    if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) &&
+                        LevelChecked(SaberDance) && gauge.Esprit >= espritThreshold)
                         return SaberDance;
 
                     if (canWeave)
                     {
                         // ST Fan Dance overcap protection
-                        if (gauge.Feathers is 4 && LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap))
+                        if (IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap) &&
+                            gauge.Feathers is 4 && LevelChecked(FanDance1))
                             return FanDance1;
 
                         // ST Fan Dance 3/4 on combo
                         if (IsEnabled(CustomComboPreset.DNC_ST_FanDance34))
                         {
-                            // FD3
                             if (HasEffect(Buffs.ThreeFoldFanDance) && LevelChecked(FanDance3))
                                 return FanDance3;
-
-                            // FD4
                             if (HasEffect(Buffs.FourFoldFanDance) && LevelChecked(FanDance4))
                                 return FanDance4;
                         }
                     }
 
-                    // ST From Fountain
                     if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
-
-                    // ST From Cascade
                     if (LevelChecked(ReverseCascade) && symmetry)
                         return ReverseCascade;
-
-                    // ST Cascade Combo
                     if (LevelChecked(Fountain) && lastComboMove is Cascade)
                         return Fountain;
                 }
@@ -300,38 +280,32 @@ namespace XIVSlothCombo.Combos.PvE
                     int espritThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_AoE);
                     #endregion
 
-                    // AoE Esprit overcap options
-                    if (LevelChecked(SaberDance) && gauge.Esprit >= espritThreshold && IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap))
+                    // AoE Esprit overcap
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) &&
+                        LevelChecked(SaberDance) && gauge.Esprit >= espritThreshold)
                         return SaberDance;
 
                     if (canWeave)
                     {
                         // AoE Fan Dance overcap protection
-                        if (gauge.Feathers is 4 && LevelChecked(FanDance2) && IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap))
+                        if (IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap) &&
+                            gauge.Feathers is 4 && LevelChecked(FanDance2))
                             return FanDance2;
 
                         // AoE Fan Dance 3/4 on combo
                         if (IsEnabled(CustomComboPreset.DNC_AoE_FanDance34))
                         {
-                            // FD3
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
-
-                            // FD4
                             if (HasEffect(Buffs.FourFoldFanDance))
                                 return FanDance4;
                         }
                     }
 
-                    // AoE From Bladeshower
                     if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;
-
-                    // AoE From Windmill
                     if (LevelChecked(RisingWindmill) && symmetry)
                         return RisingWindmill;
-
-                    // AoE Windmill Combo
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill)
                         return Bladeshower;
                 }
@@ -346,10 +320,9 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is Devilment && HasEffect(Buffs.FlourishingStarfall))
-                    return StarfallDance;
-
-                return actionID;
+                return actionID is Devilment && HasEffect(Buffs.FlourishingStarfall)
+                    ? StarfallDance
+                    : actionID;
             }
         }
 
@@ -378,11 +351,8 @@ namespace XIVSlothCombo.Combos.PvE
                         IsOnCooldown(StandardStep))
                         return Flourish;
 
-                    // Starfall Dance
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
-
-                    // Tillana
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
 
@@ -393,7 +363,6 @@ namespace XIVSlothCombo.Combos.PvE
                     // Dance steps
                     if (gauge.IsDancing)
                     {
-                        // SS Steps
                         if (HasEffect(Buffs.StandardStep))
                         {
                             return gauge.CompletedSteps < 2
@@ -401,7 +370,6 @@ namespace XIVSlothCombo.Combos.PvE
                                 : StandardFinish2;
                         }
 
-                        // TS Steps
                         if (HasEffect(Buffs.TechnicalStep))
                         {
                             return gauge.CompletedSteps < 4
@@ -430,22 +398,14 @@ namespace XIVSlothCombo.Combos.PvE
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     float techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
                     bool techBurst = HasEffect(Buffs.TechnicalFinish);
-                    bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
-                    bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
                     bool improvisationReady = LevelChecked(Improvisation) && IsOffCooldown(Improvisation);
-                    bool curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
-                    bool secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
                     bool standardStepReady = LevelChecked(StandardStep) && IsOffCooldown(StandardStep);
                     bool technicalStepReady = LevelChecked(TechnicalStep) && IsOffCooldown(TechnicalStep);
                     bool interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && LevelChecked(All.HeadGraze);
                     int standardStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
                     int technicalStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent);
-                    int featherBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
-                    int waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent);
-                    int secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent);
                     #endregion
 
-                    // Simple Pre-pull Peloton
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Peloton) && !InCombat() && !HasEffectAny(Buffs.Peloton) && GetBuffRemainingTime(Buffs.StandardStep) > 5)
                         return Peloton;
 
@@ -463,100 +423,86 @@ namespace XIVSlothCombo.Combos.PvE
                             ? gauge.NextStep
                             : TechnicalFinish4;
 
-                    // Simple ST Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Interrupt) && interruptable)
                         return All.HeadGraze;
 
                     // Simple ST Standard (activates dance with no target, or when target is over HP% threshold)
-                    if (!HasTarget() || GetTargetHPPercent() > standardStepBurstThreshold)
-                    {
-                        if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && standardStepReady &&
-                            ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer > 5)) 
-                            return StandardStep;
-                    }
+                    if ((!HasTarget() || GetTargetHPPercent() > standardStepBurstThreshold) &&
+                        IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && standardStepReady &&
+                        ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer > 5))
+                        return StandardStep;
 
                     // Simple ST Tech (activates dance with no target, or when target is over HP% threshold)
-                    if (!HasTarget() || GetTargetHPPercent() > technicalStepBurstThreshold)
-                    {
-                        if (IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) && technicalStepReady && !HasEffect(Buffs.StandardStep))
-                            return TechnicalStep;
-                    }
+                    if ((!HasTarget() || GetTargetHPPercent() > technicalStepBurstThreshold) &&
+                        IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) && technicalStepReady && !HasEffect(Buffs.StandardStep))
+                        return TechnicalStep;
 
-                    if (canWeave)
+                    // Devilment & Flourish
+                    if (canWeave) 
                     {
-                        // Simple ST Devilment
+                        bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
+                        bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
+
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Devilment) && devilmentReady && (techBurst || !LevelChecked(TechnicalStep)))
                             return Devilment;
-
-                        // Simple ST Flourish
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Flourish) && flourishReady)
                             return Flourish;
                     }
 
-                    // Occurring within weave windows
                     if (canWeave)
                     {
-                        // Simple ST Feathers
+                        // Feathers
                         if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_ST_Simple_Feathers))
                         {
-                            // Simple ST Feather Pooling
-                            int minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
+                            int featherBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
+                            int minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep)
+                                ? 3
+                                : 0;
 
-                            // Simple ST FD3
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
-
-                            // Simple ST Feather Overcap & Burst
                             if (gauge.Feathers > minFeathers ||
                                 (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) ||
                                 GetTargetHPPercent() < featherBurstThreshold && gauge.Feathers > 0)
                                 return FanDance1;
                         }
 
-                        // Simple ST FD4 
                         if (HasEffect(Buffs.FourFoldFanDance))
                             return FanDance4;
 
-                        // Simple ST Panic Heals
+                        // Panic Heals
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_PanicHeals))
                         {
+                            bool curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
+                            bool secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
+                            int waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent);
+                            int secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent);
+
                             if (PlayerHealthPercentageHp() < waltzThreshold && curingWaltzReady)
                                 return CuringWaltz;
-
                             if (PlayerHealthPercentageHp() < secondWindThreshold && secondWindReady)
                                 return All.SecondWind;
                         }
 
-                        // Simple ST Improvisation
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Improvisation) && improvisationReady)
                             return Improvisation;
                     }
 
-                    // Simple ST Saber Dance
                     if (LevelChecked(SaberDance) && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
                         return SaberDance;
 
-                    // Simple ST Combos and burst attacks
                     if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime is < 2 and > 0)
                         return Fountain;
 
-                    // Tillana
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
-
-                    // Starfall Dance
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
 
-                    // Fountainfall
                     if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
-
-                    // Reverse Cascade
                     if (LevelChecked(ReverseCascade) && symmetry)
                         return ReverseCascade;
-                
-                    // Fountain
                     if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime > 0)
                         return Fountain;
                 }
@@ -580,18 +526,12 @@ namespace XIVSlothCombo.Combos.PvE
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     float techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
                     bool techBurst = HasEffect(Buffs.TechnicalFinish);
-                    bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish);
-                    bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
                     bool improvisationReady = LevelChecked(Improvisation) && IsOffCooldown(Improvisation);
-                    bool curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
-                    bool secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
                     bool standardStepReady = LevelChecked(StandardStep) && IsOffCooldown(StandardStep);
                     bool technicalStepReady = LevelChecked(TechnicalStep) && IsOffCooldown(TechnicalStep);
                     bool interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && LevelChecked(All.HeadGraze);
                     int standardStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
                     int technicalStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent);
-                    int waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent);
-                    int secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent);
                     #endregion
 
                     // Simple AoE Standard Steps & Fill Feature
@@ -606,77 +546,69 @@ namespace XIVSlothCombo.Combos.PvE
                             ? gauge.NextStep
                             : TechnicalFinish4;
 
-                    // Simple AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Interrupt) && interruptable)
                         return All.HeadGraze;
 
                     // Simple AoE Standard (activates dance with no target, or when target is over HP% threshold)
-                    if (!HasTarget() || GetTargetHPPercent() > standardStepBurstThreshold)
-                    {
-                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) &&standardStepReady &&
-                            ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer > 5))
-                            return StandardStep;
-                    }
+                    if ((!HasTarget() || GetTargetHPPercent() > standardStepBurstThreshold) &&
+                        IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && standardStepReady &&
+                        ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer > 5))
+                        return StandardStep;
 
                     // Simple AoE Tech (activates dance with no target, or when target is over HP% threshold)
-                    if (!HasTarget() || GetTargetHPPercent() > technicalStepBurstThreshold)
-                    {
-                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && technicalStepReady &&
-                            !HasEffect(Buffs.StandardStep))
-                            return TechnicalStep;
-                    }
+                    if ((!HasTarget() || GetTargetHPPercent() > technicalStepBurstThreshold) &&
+                        IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && technicalStepReady && !HasEffect(Buffs.StandardStep))
+                        return TechnicalStep;
 
                     if (canWeave)
                     {
+                        bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
+                        bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
+
                         // Simple AoE Tech Devilment
                         if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Devilment) && devilmentReady &&
                             (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                             return Devilment;
-
-                        // Simple AoE Flourish
                         if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Flourish) && flourishReady)
                             return Flourish;
                     }
 
-                    // Simple AoE Saber Dance
                     if (LevelChecked(SaberDance) && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
                         return SaberDance;
 
-                    // Occurring within weave windows
                     if (canWeave)
                     {
-                        // Simple AoE Feathers
+                        // Feathers
                         if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers))
                         {
-                            // Simple AoE Feather Pooling
-                            int minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
+                            // Pooling
+                            int minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep)
+                                ? 3
+                                : 0;
 
-                            // Simple AoE FD3
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
-
-                            // Simple AoE Overcap & Burst
                             if (LevelChecked(FanDance2) && (gauge.Feathers > minFeathers || (techBurst && gauge.Feathers > 0)))
                                 return FanDance2;
                         }
 
-                        // Simple AoE FD4 
                         if (HasEffect(Buffs.FourFoldFanDance))
                             return FanDance4;
 
-                        // Simple AoE Panic Heals
+                        // Panic Heals
                         if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_PanicHeals))
                         {
-                            // Curing Waltz
+                            bool curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
+                            bool secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
+                            int waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent);
+                            int secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent);
+
                             if (PlayerHealthPercentageHp() < waltzThreshold && curingWaltzReady)
                                 return CuringWaltz;
-
-                            // Second Wind
                             if (PlayerHealthPercentageHp() < secondWindThreshold && secondWindReady)
                                 return All.SecondWind;
                         }
 
-                        // Simple AoE Improvisation
                         if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Improvisation) && improvisationReady)
                             return Improvisation;
                     }
@@ -685,23 +617,15 @@ namespace XIVSlothCombo.Combos.PvE
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime is < 2 and > 0)
                         return Bladeshower;
 
-                    // Tillana
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
-
-                    // Starfall Dance
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
 
-                    // Bloodshower
                     if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;
-
-                    // Rising Windmill
                     if (LevelChecked(RisingWindmill) && symmetry)
                         return RisingWindmill;
-
-                    // Bladeshower
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime > 0)
                         return Bladeshower;
                 }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -39,6 +39,7 @@ namespace XIVSlothCombo.Combos.PvE
             FanDance3 = 16009,
             FanDance4 = 25791,
             // Other
+            Peloton = 7557,
             SaberDance = 16005,
             EnAvant = 16010,
             Devilment = 16011,
@@ -70,6 +71,7 @@ namespace XIVSlothCombo.Combos.PvE
                 ThreeFoldFanDance = 1820,
                 FourFoldFanDance = 2699,
                 // Other
+                Peloton = 1199,
                 ShieldSamba = 1826;
         }
 
@@ -431,8 +433,8 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Types
                     var gauge = GetJobGauge<DNCGauge>();
                     var canWeave = CanWeave(actionID);
-                    var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
-                    var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
+                    var flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
+                    var symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     var techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
                     var techBurst = HasEffect(Buffs.TechnicalFinish);
                     var flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
@@ -447,6 +449,10 @@ namespace XIVSlothCombo.Combos.PvE
                     var waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent);
                     var secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent);
                     #endregion
+
+                    // Simple Pre-pull Peloton
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Peloton) && !InCombat() && !HasEffectAny(Buffs.Peloton) && GetBuffRemainingTime(Buffs.StandardStep) > 5)
+                        return Peloton;
 
                     // Simple ST Standard Steps
                     if (HasEffect(Buffs.StandardStep) && (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_StandardFill)))
@@ -574,8 +580,8 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Types
                     var gauge = GetJobGauge<DNCGauge>();
                     var canWeave = CanWeave(actionID);
-                    var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
-                    var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
+                    var flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
+                    var symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     var techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
                     var techBurst = HasEffect(Buffs.TechnicalFinish);
                     var flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish);

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -50,23 +50,27 @@ namespace XIVSlothCombo.Combos.PvE
         public static class Buffs
         {
             public const ushort
+                // Flourishing & Silken (Procs)
                 FlourishingCascade = 1814,
                 FlourishingFountain = 1815,
                 FlourishingWindmill = 1816,
                 FlourishingShower = 1817,
-                StandardStep = 1818,
-                TechnicalStep = 1819,
-                ShieldSamba = 1826,
+                FlourishingFanDance = 2021,
                 SilkenSymmetry = 2693,
                 SilkenFlow = 2694,
+                FlourishingFinish = 2698,
+                FlourishingStarfall = 2700,
                 FlourishingSymmetry = 3017,
                 FlourishingFlow = 3018,
-                FlourishingFanDance = 1820,
-                FlourishingStarfall = 2700,
-                FlourishingFinish = 2698,
+                // Dances
+                StandardStep = 1818,
+                TechnicalStep = 1819,
+                TechnicalFinish = 1822,
+                // Fan Dances
                 ThreeFoldFanDance = 1820,
                 FourFoldFanDance = 2699,
-                TechnicalFinish = 1822;
+                // Other
+                ShieldSamba = 1826;
         }
 
         public static class Debuffs
@@ -74,62 +78,35 @@ namespace XIVSlothCombo.Combos.PvE
             // public const short placeholder = 0;
         }
 
-        public static class Levels
-        {
-            public const byte
-                Fountain = 2,
-                StandardStep = 15,
-                ReverseCascade = 20,
-                Bladeshower = 25,
-                FanDance1 = 30,
-                RisingWindmill = 35,
-                Fountainfall = 40,
-                Bloodshower = 45,
-                FanDance2 = 50,
-                EnAvant = 50,
-                CuringWaltz = 52,
-                ShieldSamba = 56,
-                ClosedPosition = 60,
-                Devilment = 62,
-                FanDance3 = 66,
-                TechnicalStep = 70,
-                Flourish = 72,
-                SaberDance = 76,
-                Improvisation = 80,
-                Tillana = 82,
-                FanDance4 = 86,
-                StarfallDance = 90;
-        }
-
         public static class Config
         {
             public const string
-                DNCEspritThreshold_ST = "DNCEspritThreshold_ST";
+                DNCEspritThreshold_ST = "DNCEspritThreshold_ST";                            // Single target Esprit threshold
             public const string
-                DNCEspritThreshold_AoE = "DNCEspritThreshold_AoE";
+                DNCEspritThreshold_AoE = "DNCEspritThreshold_AoE";                          // AoE Esprit threshold
 
             #region Simple ST Sliders
             public const string
-                DNCSimpleSSBurstPercent = "DNCSimpleSSBurstPercent";
+                DNCSimpleSSBurstPercent = "DNCSimpleSSBurstPercent";                        // Standard Step    target HP% threshold
             public const string
-                DNCSimpleTSBurstPercent = "DNCSimpleTSBurstPercent";
+                DNCSimpleTSBurstPercent = "DNCSimpleTSBurstPercent";                        // Technical Step   target HP% threshold
             public const string
-                DNCSimpleFeatherBurstPercent = "DNCSimpleFeatherBurstPercent";
+                DNCSimpleFeatherBurstPercent = "DNCSimpleFeatherBurstPercent";              // Feather burst    target HP% threshold
             public const string
-                DNCSimplePanicHealWaltzPercent = "DNCSimplePanicHealWaltzPercent";
+                DNCSimplePanicHealWaltzPercent = "DNCSimplePanicHealWaltzPercent";          // Curing Waltz     player HP% threshold
             public const string
-                DNCSimplePanicHealWindPercent = "DNCSimplePanicHealWindPercent";
+                DNCSimplePanicHealWindPercent = "DNCSimplePanicHealWindPercent";            // Second Wind      player HP% threshold
             #endregion
 
             #region Simple AoE Sliders
             public const string
-                DNCSimpleSSAoEBurstPercent = "DNCSimpleSSAoEBurstPercent";
+                DNCSimpleSSAoEBurstPercent = "DNCSimpleSSAoEBurstPercent";                  // Standard Step    target HP% threshold
             public const string
-                DNCSimpleTSAoEBurstPercent = "DNCSimpleTSAoEBurstPercent";
+                DNCSimpleTSAoEBurstPercent = "DNCSimpleTSAoEBurstPercent";                  // Technical Step   target HP% threshold
             public const string
-                DNCSimpleAoEPanicHealWaltzPercent = "DNCSimpleAoEPanicHealWaltzPercent";
+                DNCSimpleAoEPanicHealWaltzPercent = "DNCSimpleAoEPanicHealWaltzPercent";    // Curing Waltz     player HP% threshold 
             public const string
-                DNCSimpleAoEPanicHealWindPercent = "DNCSimpleAoEPanicHealWindPercent";
+                DNCSimpleAoEPanicHealWindPercent = "DNCSimpleAoEPanicHealWindPercent";      // Second Wind      player HP% threshold
             #endregion
         }
 
@@ -194,7 +171,6 @@ namespace XIVSlothCombo.Combos.PvE
                     if (FD4Ready && IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo))
                         return FanDance4;
                 }
-
                 return actionID;
             }
         }
@@ -214,7 +190,6 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (gauge.CompletedSteps < 2)
                             return gauge.NextStep;
-
                         return StandardFinish2;
                     }
                 }
@@ -226,11 +201,9 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (gauge.CompletedSteps < 4)
                             return gauge.NextStep;
-
                         return TechnicalFinish4;
                     }
                 }
-
                 return actionID;
             }
         }
@@ -252,7 +225,6 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.FourFoldFanDance))
                         return FanDance4;
                 }
-
                 return actionID;
             }
         }
@@ -275,7 +247,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Esprit overcap options
                     if (LevelChecked(SaberDance) && gauge.Esprit >= espritThreshold && IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap))
-                            return SaberDance;
+                        return SaberDance;
 
                     if (canWeave)
                     {
@@ -307,10 +279,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Cascade Combo
                     if (lastComboMove is Cascade && LevelChecked(Fountain))
                         return Fountain;
-
                     return Cascade;
                 }
-
                 return actionID;
             }
         }
@@ -365,10 +335,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Windmill Combo
                     if (lastComboMove is Windmill && LevelChecked(Bladeshower))
                         return Bladeshower;
-
                     return Windmill;
                 }
-
                 return actionID;
             }
         }
@@ -380,8 +348,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID is Devilment && HasEffect(Buffs.FlourishingStarfall))
-                        return StarfallDance;
-
+                    return StarfallDance;
                 return actionID;
             }
         }
@@ -408,7 +375,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Devilment) && standardCD.IsCooldown && !devilmentCD.IsCooldown && !gauge.IsDancing)
                     {
                         if (LevelChecked(Devilment) && !LevelChecked(TechnicalStep) ||  // Lv.62 - 69
-                            (LevelChecked(TechnicalStep) && techstepCD.IsCooldown))   // Lv. 70+ during Tech
+                            (LevelChecked(TechnicalStep) && techstepCD.IsCooldown))     // Lv. 70+ during Tech
                             return Devilment;
                     }
 
@@ -437,7 +404,6 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (gauge.CompletedSteps < 2)
                                 return gauge.NextStep;
-
                             return StandardFinish2;
                         }
 
@@ -446,12 +412,10 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (gauge.CompletedSteps < 4)
                                 return gauge.NextStep;
-
                             return TechnicalFinish4;
                         }
                     }
                 }
-
                 return actionID;
             }
         }
@@ -593,10 +557,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // Fountain
                     if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime > 0)
                         return Fountain;
-
                     return Cascade;
                 }
-
                 return actionID;
             }
         }
@@ -683,7 +645,6 @@ namespace XIVSlothCombo.Combos.PvE
                         // Simple AoE Feathers
                         if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers))
                         {
-
                             // Simple AoE Feather Pooling
                             var minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
 
@@ -744,7 +705,6 @@ namespace XIVSlothCombo.Combos.PvE
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime > 0)
                         return Bladeshower;
                 }
-
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -139,7 +139,6 @@ namespace XIVSlothCombo.Combos.PvE
                     if (actionID == actionIDs[3] || (actionIDs[3] == 0 && actionID == FanDance2))
                         return OriginalHook(Fountainfall);
                 }
-
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -220,7 +220,7 @@ namespace XIVSlothCombo.Combos.PvE
                 }
 
                 // Technical Step
-                if ((actionID is TechnicalStep) && level >= Levels.TechnicalStep)
+                if ((actionID is TechnicalStep) && LevelChecked(TechnicalStep))
                 {
                     if (gauge.IsDancing && HasEffect(Buffs.TechnicalStep))
                     {
@@ -274,38 +274,38 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     // ST Esprit overcap options
-                    if (level >= Levels.SaberDance && gauge.Esprit >= espritThreshold && IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap))
+                    if (LevelChecked(SaberDance) && gauge.Esprit >= espritThreshold && IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap))
                             return SaberDance;
 
                     if (canWeave)
                     {
                         // ST Fan Dance overcap protection
-                        if (gauge.Feathers is 4 && level >= Levels.FanDance1 && IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap))
+                        if (gauge.Feathers is 4 && LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap))
                             return FanDance1;
 
                         // ST Fan Dance 3/4 on combo
                         if (IsEnabled(CustomComboPreset.DNC_ST_FanDance34))
                         {
                             // FD3
-                            if (HasEffect(Buffs.ThreeFoldFanDance) && level >= Levels.FanDance3)
+                            if (HasEffect(Buffs.ThreeFoldFanDance) && LevelChecked(FanDance3))
                                 return FanDance3;
 
                             // FD4
-                            if (HasEffect(Buffs.FourFoldFanDance) && level >= Levels.FanDance4)
+                            if (HasEffect(Buffs.FourFoldFanDance) && LevelChecked(FanDance4))
                                 return FanDance4;
                         }
                     }
 
                     // ST From Fountain
-                    if (level >= Levels.Fountainfall && flow)
+                    if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
 
                     // ST From Cascade
-                    if (level >= Levels.ReverseCascade && symmetry)
+                    if (LevelChecked(ReverseCascade) && symmetry)
                         return ReverseCascade;
 
                     // ST Cascade Combo
-                    if (lastComboMove is Cascade && level >= Levels.Fountain)
+                    if (lastComboMove is Cascade && LevelChecked(Fountain))
                         return Fountain;
 
                     return Cascade;
@@ -332,13 +332,13 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     // AoE Esprit overcap options
-                    if (level >= Levels.SaberDance && gauge.Esprit >= espritThreshold && IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap))
+                    if (LevelChecked(SaberDance) && gauge.Esprit >= espritThreshold && IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap))
                         return SaberDance;
 
                     if (canWeave)
                     {
                         // AoE Fan Dance overcap protection
-                        if (gauge.Feathers is 4 && level >= Levels.FanDance2 && IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap))
+                        if (gauge.Feathers is 4 && LevelChecked(FanDance2) && IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap))
                             return FanDance2;
 
                         // AoE Fan Dance 3/4 on combo
@@ -355,15 +355,15 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // AoE From Bladeshower
-                    if (level >= Levels.Bloodshower && flow)
+                    if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;
 
                     // AoE From Windmill
-                    if (level >= Levels.RisingWindmill && symmetry)
+                    if (LevelChecked(RisingWindmill) && symmetry)
                         return RisingWindmill;
 
                     // AoE Windmill Combo
-                    if (lastComboMove is Windmill && level >= Levels.Bladeshower)
+                    if (lastComboMove is Windmill && LevelChecked(Bladeshower))
                         return Bladeshower;
 
                     return Windmill;
@@ -407,14 +407,14 @@ namespace XIVSlothCombo.Combos.PvE
                     // Devilment
                     if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Devilment) && standardCD.IsCooldown && !devilmentCD.IsCooldown && !gauge.IsDancing)
                     {
-                        if (level is >= Levels.Devilment and < Levels.TechnicalStep ||  // Lv.62 - 69
-                            (level >= Levels.TechnicalStep && techstepCD.IsCooldown))   // Lv. 70+ during Tech
+                        if (LevelChecked(Devilment) && !LevelChecked(TechnicalStep) ||  // Lv.62 - 69
+                            (LevelChecked(TechnicalStep) && techstepCD.IsCooldown))   // Lv. 70+ during Tech
                             return Devilment;
                     }
 
                     // Flourish
                     if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Flourish) && !gauge.IsDancing && !flourishCD.IsCooldown &&
-                        incombat && level >= Levels.Flourish && standardCD.IsCooldown)
+                        incombat && LevelChecked(Flourish) && standardCD.IsCooldown)
                         return Flourish;
 
                     // Starfall Dance
@@ -451,7 +451,8 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
                 }
-                    return actionID;
+
+                return actionID;
             }
         }
 
@@ -470,12 +471,12 @@ namespace XIVSlothCombo.Combos.PvE
                     var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
                     var techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
                     var techBurst = HasEffect(Buffs.TechnicalFinish);
-                    var flourishReady = level >= Levels.Flourish && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
-                    var devilmentReady = level >= Levels.Devilment && IsOffCooldown(Devilment);
-                    var improvisationReady = level >= Levels.Improvisation && IsOffCooldown(Improvisation);
-                    var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
-                    var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
-                    var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
+                    var flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
+                    var devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
+                    var improvisationReady = LevelChecked(Improvisation) && IsOffCooldown(Improvisation);
+                    var curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
+                    var secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
+                    var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && LevelChecked(All.HeadGraze);
                     var standardStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent);
                     var technicalStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent);
                     var featherBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
@@ -502,7 +503,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // Simple ST Standard (activates dance with no target, or when target is over HP% threshold)
                     if (!HasTarget() || GetTargetHPPercent() > standardStepBurstThreshold)
                     {
-                        if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && IsOffCooldown(StandardStep)
+                        if (LevelChecked(StandardStep) && IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && IsOffCooldown(StandardStep)
                             && ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer > 5))
                             return StandardStep;
                     }
@@ -510,7 +511,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // Simple ST Tech (activates dance with no target, or when target is over HP% threshold)
                     if (!HasTarget() || GetTargetHPPercent() > technicalStepBurstThreshold)
                     {
-                        if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
+                        if (LevelChecked(TechnicalStep) && IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
                             return TechnicalStep;
                     }
 
@@ -519,7 +520,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Simple ST Devilment
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Devilment) && devilmentReady)
                         {
-                            if (techBurst || (level < Levels.TechnicalStep))
+                            if (techBurst || !LevelChecked(TechnicalStep))
                                 return Devilment;
                         }
 
@@ -532,14 +533,14 @@ namespace XIVSlothCombo.Combos.PvE
                     if (canWeave)
                     {
                         // Simple ST Feathers
-                        if (level >= Levels.FanDance1 && IsEnabled(CustomComboPreset.DNC_ST_Simple_Feathers))
+                        if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_ST_Simple_Feathers))
                         {
                             // Simple ST FD3
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
 
                             // Simple ST Feather Pooling
-                            var minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && level >= Levels.TechnicalStep ? 3 : 0;
+                            var minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
 
                             // Simple ST Feather Overcap & Burst
                             if (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) || GetTargetHPPercent() < featherBurstThreshold && gauge.Feathers > 0)
@@ -566,11 +567,11 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Simple ST Saber Dance
-                    if (level >= Levels.SaberDance && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
+                    if (LevelChecked(SaberDance) && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
                         return SaberDance;
 
                     // Simple ST Combos and burst attacks
-                    if (level >= Levels.Fountain && lastComboMove is Cascade && comboTime is < 2 and > 0)
+                    if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime is < 2 and > 0)
                         return Fountain;
 
                     // Tillana
@@ -582,15 +583,15 @@ namespace XIVSlothCombo.Combos.PvE
                         return StarfallDance;
 
                     // Fountainfall
-                    if (level >= Levels.Fountainfall && flow)
+                    if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
 
                     // Reverse Cascade
-                    if (level >= Levels.ReverseCascade && symmetry)
+                    if (LevelChecked(ReverseCascade) && symmetry)
                         return ReverseCascade;
                 
                     // Fountain
-                    if (level >= Levels.Fountain && lastComboMove is Cascade && comboTime > 0)
+                    if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime > 0)
                         return Fountain;
 
                     return Cascade;
@@ -602,150 +603,150 @@ namespace XIVSlothCombo.Combos.PvE
 
         internal class DNC_AoE_SimpleMode : CustomCombo
             {
-                protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_AoE_SimpleMode;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_AoE_SimpleMode;
 
-                protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Windmill)
                 {
-                    if (actionID is Windmill)
+                    #region Types
+                    var gauge = GetJobGauge<DNCGauge>();
+                    var canWeave = CanWeave(actionID);
+                    var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
+                    var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
+                    var techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
+                    var techBurst = HasEffect(Buffs.TechnicalFinish);
+                    var flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish);
+                    var devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
+                    var improvisationReady = LevelChecked(Improvisation) && IsOffCooldown(Improvisation);
+                    var curingWaltzReady = LevelChecked(CuringWaltz) && IsOffCooldown(CuringWaltz);
+                    var secondWindReady = LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind);
+                    var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && LevelChecked(All.HeadGraze);
+                    var standardStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
+                    var technicalStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent);
+                    var waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent);
+                    var secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent);
+                    #endregion
+
+                    // Simple AoE Standard Step (step function)
+                    if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS))
+                        return gauge.CompletedSteps < 2
+                            ? gauge.NextStep
+                            : StandardFinish2;
+
+                    // Simple AoE Tech Step (step function)
+                    if (HasEffect(Buffs.TechnicalStep) && (IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_TechFill)))
+                        return gauge.CompletedSteps < 4
+                            ? gauge.NextStep
+                            : TechnicalFinish4;
+
+                    // Simple AoE Interrupt
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Interrupt) && interruptable)
+                        return All.HeadGraze;
+
+                    // Simple AoE Standard (activates dance with no target, or when target is over HP% threshold)
+                    if (!HasTarget() || GetTargetHPPercent() > standardStepBurstThreshold)
                     {
-                        #region Types
-                        var gauge = GetJobGauge<DNCGauge>();
-                        var canWeave = CanWeave(actionID);
-                        var flow = (HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow));
-                        var symmetry = (HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry));
-                        var techBurstTimer = GetBuffRemainingTime(Buffs.TechnicalFinish);
-                        var techBurst = HasEffect(Buffs.TechnicalFinish);
-                        var flourishReady = level >= Levels.Flourish && IsOffCooldown(Flourish);
-                        var devilmentReady = level >= Levels.Devilment && IsOffCooldown(Devilment);
-                        var improvisationReady = level >= Levels.Improvisation && IsOffCooldown(Improvisation);
-                        var curingWaltzReady = level >= Levels.CuringWaltz && IsOffCooldown(CuringWaltz);
-                        var secondWindReady = level >= All.Levels.SecondWind && IsOffCooldown(All.SecondWind);
-                        var interruptable = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze) && level >= All.Levels.HeadGraze;
-                        var standardStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent);
-                        var technicalStepBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent);
-                        var waltzThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent);
-                        var secondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent);
-                        #endregion
-
-                        // Simple AoE Standard Step (step function)
-                        if (HasEffect(Buffs.StandardStep) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS))
-                            return gauge.CompletedSteps < 2
-                                ? gauge.NextStep
-                                : StandardFinish2;
-
-                        // Simple AoE Tech Step (step function)
-                        if (HasEffect(Buffs.TechnicalStep) && (IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_TechFill)))
-                            return gauge.CompletedSteps < 4
-                                ? gauge.NextStep
-                                : TechnicalFinish4;
-
-                        // Simple AoE Interrupt
-                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Interrupt) && interruptable)
-                            return All.HeadGraze;
-
-                        // Simple AoE Standard (activates dance with no target, or when target is over HP% threshold)
-                        if (!HasTarget() || GetTargetHPPercent() > standardStepBurstThreshold)
-                        {
-                            if (level >= Levels.StandardStep && IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && IsOffCooldown(StandardStep)
-                                && ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer > 5))
-                                return StandardStep;
-                        }
-
-                        // Simple AoE Tech (activates dance with no target, or when target is over HP% threshold)
-                        if (!HasTarget() || GetTargetHPPercent() > technicalStepBurstThreshold)
-                        {
-                            if (level >= Levels.TechnicalStep && IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
-                                return TechnicalStep;
-                        }
-
-                        if (canWeave)
-                        {
-                            // Simple AoE Tech Devilment
-                            if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Devilment) && devilmentReady)
-                            {
-                                if (HasEffect(Buffs.TechnicalFinish) || (level < Levels.TechnicalStep))
-                                    return Devilment;
-                            }
-
-                            // Simple AoE Flourish
-                            if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Flourish) && flourishReady)
-                                return Flourish;
-                        }
-
-                        // Simple AoE Saber Dance
-                        if (level >= Levels.SaberDance && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
-                            return SaberDance;
-
-                        // Occurring within weave windows
-                        if (canWeave)
-                        {
-                            // Simple AoE Feathers
-                            if (level >= Levels.FanDance1 && IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers))
-                            {
-
-                                // Simple AoE Feather Pooling
-                                var minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && level >= Levels.TechnicalStep ? 3 : 0;
-
-                                // Simple AoE FD3
-                                if (HasEffect(Buffs.ThreeFoldFanDance))
-                                    return FanDance3;
-
-                                // Simple AoE Overcap & Burst
-                                if (level >= Levels.FanDance2)
-                                {
-                                    if (gauge.Feathers > minFeathers || (techBurst && gauge.Feathers > 0))
-                                        return FanDance2;
-                                }
-                            }
-
-                            // Simple AoE FD4 
-                            if (HasEffect(Buffs.FourFoldFanDance))
-                                return FanDance4;
-
-                            // Simple AoE Panic Heals
-                            if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_PanicHeals))
-                            {
-                                // Curing Waltz
-                                if (PlayerHealthPercentageHp() < waltzThreshold && curingWaltzReady)
-                                    return CuringWaltz;
-
-                                // Second Wind
-                                if (PlayerHealthPercentageHp() < secondWindThreshold && secondWindReady)
-                                    return All.SecondWind;
-                            }
-
-                            // Simple AoE Improvisation
-                            if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Improvisation) && improvisationReady)
-                                return Improvisation;
-                        }
-
-                        // Simple AoE combos and burst attacks
-                        if (level >= Levels.Bladeshower && lastComboMove is Windmill && comboTime is < 2 and > 0)
-                            return Bladeshower;
-
-                        // Tillana
-                        if (HasEffect(Buffs.FlourishingFinish))
-                            return Tillana;
-
-                        // Starfall Dance
-                        if (HasEffect(Buffs.FlourishingStarfall))
-                            return StarfallDance;
-
-                        // Bloodshower
-                        if (level >= Levels.Bloodshower && flow)
-                            return Bloodshower;
-
-                        // Rising Windmill
-                        if (level >= Levels.RisingWindmill && symmetry)
-                            return RisingWindmill;
-
-                        // Bladeshower
-                        if (level >= Levels.Bladeshower && lastComboMove is Windmill && comboTime > 0)
-                            return Bladeshower;
+                        if (LevelChecked(StandardStep) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && IsOffCooldown(StandardStep)
+                            && ((!HasEffect(Buffs.TechnicalStep) && !techBurst) || techBurstTimer > 5))
+                            return StandardStep;
                     }
 
-                    return actionID;
+                    // Simple AoE Tech (activates dance with no target, or when target is over HP% threshold)
+                    if (!HasTarget() || GetTargetHPPercent() > technicalStepBurstThreshold)
+                    {
+                        if (LevelChecked(TechnicalStep) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && !HasEffect(Buffs.StandardStep) && IsOffCooldown(TechnicalStep))
+                            return TechnicalStep;
+                    }
+
+                    if (canWeave)
+                    {
+                        // Simple AoE Tech Devilment
+                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Devilment) && devilmentReady)
+                        {
+                            if (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep))
+                                return Devilment;
+                        }
+
+                        // Simple AoE Flourish
+                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Flourish) && flourishReady)
+                            return Flourish;
+                    }
+
+                    // Simple AoE Saber Dance
+                    if (LevelChecked(SaberDance) && (gauge.Esprit >= 85 || (techBurst && gauge.Esprit > 50)))
+                        return SaberDance;
+
+                    // Occurring within weave windows
+                    if (canWeave)
+                    {
+                        // Simple AoE Feathers
+                        if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers))
+                        {
+
+                            // Simple AoE Feather Pooling
+                            var minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep) ? 3 : 0;
+
+                            // Simple AoE FD3
+                            if (HasEffect(Buffs.ThreeFoldFanDance))
+                                return FanDance3;
+
+                            // Simple AoE Overcap & Burst
+                            if (LevelChecked(FanDance2))
+                            {
+                                if (gauge.Feathers > minFeathers || (techBurst && gauge.Feathers > 0))
+                                    return FanDance2;
+                            }
+                        }
+
+                        // Simple AoE FD4 
+                        if (HasEffect(Buffs.FourFoldFanDance))
+                            return FanDance4;
+
+                        // Simple AoE Panic Heals
+                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_PanicHeals))
+                        {
+                            // Curing Waltz
+                            if (PlayerHealthPercentageHp() < waltzThreshold && curingWaltzReady)
+                                return CuringWaltz;
+
+                            // Second Wind
+                            if (PlayerHealthPercentageHp() < secondWindThreshold && secondWindReady)
+                                return All.SecondWind;
+                        }
+
+                        // Simple AoE Improvisation
+                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Improvisation) && improvisationReady)
+                            return Improvisation;
+                    }
+
+                    // Simple AoE combos and burst attacks
+                    if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime is < 2 and > 0)
+                        return Bladeshower;
+
+                    // Tillana
+                    if (HasEffect(Buffs.FlourishingFinish))
+                        return Tillana;
+
+                    // Starfall Dance
+                    if (HasEffect(Buffs.FlourishingStarfall))
+                        return StarfallDance;
+
+                    // Bloodshower
+                    if (LevelChecked(Bloodshower) && flow)
+                        return Bloodshower;
+
+                    // Rising Windmill
+                    if (LevelChecked(RisingWindmill) && symmetry)
+                        return RisingWindmill;
+
+                    // Bladeshower
+                    if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime > 0)
+                        return Bladeshower;
                 }
+
+                return actionID;
             }
+        }
     }
 }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -2,7 +2,6 @@
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.Services;
-using XIVSlothCombo.Data;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -125,7 +124,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (GetJobGauge<DNCGauge>().IsDancing)
                 {
                     uint[]? actionIDs = Service.Configuration.DancerDanceCompatActionIDs;
-                    
+
                     if (actionID == actionIDs[0] || (actionIDs[0] == 0 && actionID == Cascade))     // Cascade replacement
                         return OriginalHook(Cascade);
                     if (actionID == actionIDs[1] || (actionIDs[1] == 0 && actionID == Flourish))    // Fountain replacement
@@ -148,7 +147,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 bool FD3Ready = HasEffect(Buffs.ThreeFoldFanDance);
                 bool FD4Ready = HasEffect(Buffs.FourFoldFanDance);
-                
+
                 // FD 1 --> 3, FD 1 --> 4
                 if (actionID is FanDance1)
                 {
@@ -438,7 +437,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return TechnicalStep;
 
                     // Devilment & Flourish
-                    if (canWeave) 
+                    if (canWeave)
                     {
                         bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
                         bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
@@ -512,7 +511,7 @@ namespace XIVSlothCombo.Combos.PvE
         }
 
         internal class DNC_AoE_SimpleMode : CustomCombo
-            {
+        {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_AoE_SimpleMode;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)


### PR DESCRIPTION
## Changes
Added `Simple Standard Fill Option`
Added `Simple AoE Standard Fill Option`
Added `Simple Peloton Opener Option`
Fixed `Tech Step` burst threshold ST slider
Fixed `Tech Step` burst threshold AoE slider
Fixed `Flourishing Fan Dance` buffID
Reordered some `Simple Mode` options inside the GUI
Ordered buffs according to section, then buffID
Migrated level checks to `LevelChecked()`
Converted to explicit types
Added extra code comments
Removed unnecessary parentheses/variables/whitespace
Fixed indentation
Type regions to reduce visual clutter
Updated feature/option descriptions

## To-Do
- [x] Migrate to `LevelChecked()`
- [x] Add `Peloton` pre-pull feature
- [x] Add Standard Fill (Simple)
- [x] Add Standard Fill (Simple AoE)
- [x] Fix bugged Tech Step sliders (ST & AoE)
- [x] File cleanup (whitespace, comments, etc)
- [ ] Test