### PR TITLE
[SCH] Deployment Tactics Feature

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2518,6 +2518,15 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(SCH.WhisperingDawn, SCH.FeyBlessing, SCH.FeyBlessing, SCH.Aetherpact, SCH.Dissipation)]
         [CustomComboInfo("Fairy Feature", "Change all fairy actions into Fairy Summons if you do not have a fairy summoned.", SCH.JobID, 500, "", "")]
         SCH_FairyReminder = 16500,
+
+        [ReplaceSkill(SCH.DeploymentTactics)]
+        [CustomComboInfo("Deployment Tactics Feature", "Deployment Tactics idles as Adloquium until the Party Member has the Galvanize Buff", SCH.JobID, 600, "", "")]
+        SCH_DeploymentTactics = 16600,
+
+            [ParentCombo(SCH_DeploymentTactics)]
+            [CustomComboInfo("Recitation Option", "Adds Recitation when off cooldown to force a Galvanize Buff on the Party Member.", SCH.JobID, 601, "", "")]
+            SCH_DeploymentTactics_Recitation = 16610,
+        
         #endregion
 
         #endregion

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -59,7 +59,7 @@ namespace XIVSlothCombo.Combos.PvE
         public static class Buffs
         {
             public const ushort
-            Galvanize = 297, //or 1331
+            Galvanize = 297,
             Recitation = 1896;
         }
 

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -226,7 +226,9 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsOffCooldown(DeploymentTactics) && DeploymentTactics.LevelChecked()) //Allows Adlo to work at sync
                     {
                         bool found = false;
-                        GameObject? target = CurrentTarget;
+                        //If we have a soft target, use that, else CurrentTarget.
+                        GameObject? target = Services.Service.TargetManager.SoftTarget is not null ? Services.Service.TargetManager.SoftTarget : CurrentTarget;
+
                         if (target is not null)
                         {
 
@@ -241,7 +243,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (found) break;
                             }
                             //Check if it's our chocobo?
-                            if (found is false) found = (HasCompanionPresent() && CurrentTarget == Services.Service.BuddyList.CompanionBuddy.GameObject);
+                            if (found is false) found = (HasCompanionPresent() && target == Services.Service.BuddyList.CompanionBuddy.GameObject);
                         }
 
                         //Fall back to self, skills won't work with anyone else.

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -2,7 +2,6 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Objects.Enums;
 using XIVSlothCombo.CustomComboNS;
-using XIVSlothCombo.Extensions;
 
 
 namespace XIVSlothCombo.Combos.PvE
@@ -223,7 +222,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is DeploymentTactics)
                 {
-                    if (IsOffCooldown(DeploymentTactics) && DeploymentTactics.LevelChecked()) //Allows Adlo to work at sync
+                    if (IsOffCooldown(DeploymentTactics) && LevelChecked(DeploymentTactics)) //Allows Adlo to work at sync
                     {
                         bool found = false;
                         //If we have a soft target, use that, else CurrentTarget.
@@ -258,7 +257,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if (FindEffect(Buffs.Galvanize, target, LocalPlayer.ObjectId) is not null) return DeploymentTactics;
                             //Recitation is down here as not to waste it on bad targets.
                             if (IsEnabled(CustomComboPreset.SCH_DeploymentTactics_Recitation) 
-                                && Recitation.LevelChecked() 
+                                && LevelChecked(Recitation)
                                 && IsOffCooldown(Recitation)
                                ) return Recitation;
                         }

--- a/XIVSlothCombo/CustomCombo/Functions/Party.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Party.cs
@@ -9,7 +9,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
     {
         /// <summary> Gets the party list </summary>
         /// <returns> Current party list. </returns>
-        public PartyList GetPartyMembers() => Service.PartyList;
+        public static PartyList GetPartyMembers() => Service.PartyList;
 
         protected unsafe static GameObject? GetPartySlot(int slot)
         {

--- a/XIVSlothCombo/CustomCombo/Functions/PlayerCharacter.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/PlayerCharacter.cs
@@ -20,8 +20,12 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         public static bool InCombat() => Service.Condition[ConditionFlag.InCombat];
 
         /// <summary> Find if the player has a pet present. </summary>
-        /// <returns> A value indicating whether the player has a pet present. </returns>
+        /// <returns> A value indicating whether the player has a pet (fairy/carbuncle) present. </returns>
         public static bool HasPetPresent() => Service.BuddyList.PetBuddyPresent;
+
+        /// <summary> Find if the player has a companion (chocobo) present. </summary>
+        /// <returns> A value indicating whether the player has a companion (chocobo). </returns>
+        public static bool HasCompanionPresent() => Service.BuddyList.CompanionBuddyPresent;
 
         /// <summary> Checks if the player is in a PVP enabled zone. </summary>
         /// <returns></returns>


### PR DESCRIPTION
SCH.cs-SCH_DeploymentTactics : DeploymentTactics idles as Adloquium until the party target or self has the Galvanize buff. Recitation is sub option
PlayerCharacter.cs: Added HasCompanionPresent. Clarified HasPetPresent