### PR TITLE
Burn the witches (Redundant ID eliminator)

### DIFF
--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -57,6 +57,18 @@ namespace XIVSlothCombo
             });
 
             Service.ClientState.Login += PrintLoginMessage;
+
+            KillRedundantIDs();
+        }
+
+        private void KillRedundantIDs()
+        {
+            List<int> redundantIDs = Service.Configuration.EnabledActions.Where(x => int.TryParse(x.ToString(), out _)).OrderBy(x => x).Cast<int>().ToList();
+            foreach (int id in redundantIDs)
+            {
+                Service.Configuration.EnabledActions.RemoveWhere(x => (int)x == id);
+            }
+            Service.Configuration.Save();
         }
 
         private void DrawUI()


### PR DESCRIPTION
@k-kz It's finally done, redundant IDs are no longer a thing.

*coughs*

[Framework]
- Redundant IDs now cleared on boot.