### PR TITLE
Newline alignment on preset descriptions.

### DIFF
--- a/XIVSlothCombo/Window/Functions/Presets.cs
+++ b/XIVSlothCombo/Window/Functions/Presets.cs
@@ -57,7 +57,11 @@ namespace XIVSlothCombo.Window.Functions
                 }
             }
 
-            ImGui.TextWrapped($"#{i}: {info.Description}");
+            ImGui.Text($"#{i}: ");
+            var length = ImGui.CalcTextSize($"#{i}: ");
+            ImGui.SameLine();
+            ImGui.PushItemWidth(length.Length());
+            ImGui.TextWrapped($"{info.Description}");
 
             if (preset.GetAttribute<HoverInfoAttribute>() != null)
             {


### PR DESCRIPTION
[Framework]
- Preset descriptions with multiple lines are now aligned better with preset numbers.