### PR TITLE
[AST] Cleanup and Card Play enhancements

### DIFF
--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -1,5 +1,5 @@
-﻿using System.Linq;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
+using System.Linq;
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
@@ -119,11 +119,11 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID == Play)
                 {
-                    var haveCard = HasEffect(Buffs.Balance) || HasEffect(Buffs.Bole) || HasEffect(Buffs.Arrow) || HasEffect(Buffs.Spear) || HasEffect(Buffs.Ewer) || HasEffect(Buffs.Spire);
-                    var cardDrawn = Gauge.DrawnCard;
+                    bool haveCard = HasEffect(Buffs.Balance) || HasEffect(Buffs.Bole) || HasEffect(Buffs.Arrow) || HasEffect(Buffs.Spear) || HasEffect(Buffs.Ewer) || HasEffect(Buffs.Spire);
+                    CardType cardDrawn = Gauge.DrawnCard;
 
-                    if (!Gauge.ContainsSeal(SealType.NONE) && 
-                        IsEnabled(CustomComboPreset.AST_Cards_AstrodyneOnPlay) && 
+                    if (!Gauge.ContainsSeal(SealType.NONE) &&
+                        IsEnabled(CustomComboPreset.AST_Cards_AstrodyneOnPlay) &&
                         (Gauge.DrawnCard != CardType.NONE || GetCooldown(Draw).CooldownRemaining > 30)
                        ) return Astrodyne;
 
@@ -142,7 +142,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         if (IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay_AutoCardTarget))
                         {
-                            if (GetTarget || (IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay_TargetLock)))
+                            if (GetTarget || IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay_TargetLock))
                                 SetTarget();
 
 
@@ -173,7 +173,7 @@ namespace XIVSlothCombo.Combos.PvE
             private bool SetTarget()
             {
                 if (Gauge.DrawnCard.Equals(CardType.NONE)) return false;
-                var cardDrawn = Gauge.DrawnCard;
+                CardType cardDrawn = Gauge.DrawnCard;
                 if (GetTarget) CurrentTarget = LocalPlayer.TargetObject;
                 //Checks for trusts then normal parties. Buddylist does not include player, so +1
                 int maxPartySize = Services.Service.BuddyList.Length > 0 ? Services.Service.BuddyList.Length + 1 : GetPartyMembers().Length;
@@ -274,9 +274,9 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 bool AlternateMode = System.Convert.ToBoolean(GetOptionValue(Config.AST_DPS_AltMode)); //(0 or 1 radio values)
-                if (((!AlternateMode && actionID is FallMalefic or Malefic4 or Malefic3 or Malefic2 or Malefic1) || 
-                     (AlternateMode && actionID is Combust1 or Combust2 or Combust3 ) ||
-                     (IsEnabled(CustomComboPreset.AST_AoE_DPS) && actionID is Gravity or Gravity2)) && 
+                if (((!AlternateMode && actionID is FallMalefic or Malefic4 or Malefic3 or Malefic2 or Malefic1) ||
+                     (AlternateMode && actionID is Combust1 or Combust2 or Combust3) ||
+                     (IsEnabled(CustomComboPreset.AST_AoE_DPS) && actionID is Gravity or Gravity2)) &&
                     InCombat())
                 {
                     if (IsEnabled(CustomComboPreset.AST_DPS_LightSpeed) &&
@@ -308,7 +308,7 @@ namespace XIVSlothCombo.Combos.PvE
                         !Gauge.ContainsSeal(SealType.NONE) &&
                         CanSpellWeave(actionID)
                         ) return Astrodyne;
-                    
+
                     //Card Draw
                     if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
                         LevelChecked(Draw) &&
@@ -339,7 +339,7 @@ namespace XIVSlothCombo.Combos.PvE
                         HasBattleTarget())
                     {
                         //Determine which Combust debuff to check
-                        Status? CombustDebuffID; 
+                        Status? CombustDebuffID;
                         if (LevelChecked(Combust3)) CombustDebuffID = FindTargetEffect(Debuffs.Combust3);
                         else if (LevelChecked(Combust2)) CombustDebuffID = FindTargetEffect(Debuffs.Combust2);
                         else CombustDebuffID = FindTargetEffect(Debuffs.Combust1);
@@ -371,21 +371,21 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_LazyLady) &&
                         LevelChecked(CrownPlay) &&
                         InCombat() &&
-                        Gauge.DrawnCrownCard == CardType.LADY 
+                        Gauge.DrawnCrownCard == CardType.LADY
                        ) return LadyOfCrown;
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_CelestialOpposition) &&
                         LevelChecked(CelestialOpposition) &&
-                        IsOffCooldown(CelestialOpposition) 
+                        IsOffCooldown(CelestialOpposition)
                        ) return CelestialOpposition;
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Horoscope))
                     {
-                        if (LevelChecked(Horoscope) && 
+                        if (LevelChecked(Horoscope) &&
                             IsOffCooldown(Horoscope)
                            ) return Horoscope;
 
-                        if ( (LevelChecked(AspectedHelios) && !HasEffect(Buffs.AspectedHelios))
+                        if ((LevelChecked(AspectedHelios) && !HasEffect(Buffs.AspectedHelios))
                              || HasEffect(Buffs.Horoscope)
                              || (HasEffect(Buffs.NeutralSect) && !HasEffect(Buffs.NeutralSectShield)))
                             return AspectedHelios;
@@ -427,21 +427,21 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_AspectedBenefic) && LevelChecked(AspectedBenefic))
                     {
-                        var aspectedBeneficHoT = FindTargetEffect(Buffs.AspectedBenefic);
-                        var NeutralSectShield = FindTargetEffect(Buffs.NeutralSectShield);
-                        var NeutralSectBuff = FindTargetEffect(Buffs.NeutralSect);
-                        if (((aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3))
+                        Status? aspectedBeneficHoT = FindTargetEffect(Buffs.AspectedBenefic);
+                        Status? NeutralSectShield = FindTargetEffect(Buffs.NeutralSectShield);
+                        Status? NeutralSectBuff = FindTargetEffect(Buffs.NeutralSect);
+                        if ((aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3)
                             || ((NeutralSectShield is null) && (NeutralSectBuff is not null))
                            ) return AspectedBenefic;
                     }
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity) &&
-                        LevelChecked(EssentialDignity) && 
-                        GetCooldown(EssentialDignity).RemainingCharges > 0 && 
+                        LevelChecked(EssentialDignity) &&
+                        GetCooldown(EssentialDignity).RemainingCharges > 0 &&
                         GetTargetHPPercent() <= GetOptionValue(Config.AST_EssentialDignity)
                        ) return EssentialDignity;
 
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Exaltation) && 
+                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Exaltation) &&
                         LevelChecked(Exaltation) &&
                         IsOffCooldown(Exaltation)
                        ) return Exaltation;

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -17,12 +17,14 @@ namespace XIVSlothCombo.Combos.PvE
         public const uint
             Benefic = 3594,
             Draw = 3590,
-            //Balance = 4401,
-            //Bole = 4404,
-            //Arrow = 4402,
-            //Spear = 4403,
-            //Ewer = 4405,
-            //Spire = 4406,
+            /*
+            Balance = 4401,
+            Bole = 4404,
+            Arrow = 4402,
+            Spear = 4403,
+            Ewer = 4405,
+            Spire = 4406,
+            */
             MinorArcana = 7443,
             //SleeveDraw = 7448,
             Malefic4 = 16555,
@@ -40,16 +42,16 @@ namespace XIVSlothCombo.Combos.PvE
             Lightspeed = 3606,
             Redraw = 3593,
 
-            // aoes
+            // AoEs
             Gravity = 3615,
             Gravity2 = 25872,
 
-            // dots
+            // DoTs
             Combust3 = 16554,
             Combust2 = 3608,
             Combust1 = 3599,
 
-            // heals
+            // Heals
             Helios = 3600,
             AspectedHelios = 3601,
             CelestialOpposition = 16553,

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -1,28 +1,30 @@
 ﻿using System.Linq;
+using System.Collections.Generic;
 using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
-using Dalamud.Game.ClientState.Objects.Enums;
+using Dalamud.Game.ClientState.Statuses;
 using XIVSlothCombo.CustomComboNS;
-using XIVSlothCombo.Services;
+using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.PvE
 {
     internal static class AST
     {
         public const byte JobID = 33;
+        internal static ASTGauge Gauge => CustomComboNS.Functions.CustomComboFunctions.GetJobGauge<ASTGauge>();
 
         public const uint
             Benefic = 3594,
             Draw = 3590,
-            Balance = 4401,
-            Bole = 4404,
-            Arrow = 4402,
-            Spear = 4403,
-            Ewer = 4405,
-            Spire = 4406,
+            //Balance = 4401,
+            //Bole = 4404,
+            //Arrow = 4402,
+            //Spear = 4403,
+            //Ewer = 4405,
+            //Spire = 4406,
             MinorArcana = 7443,
-            SleeveDraw = 7448,
+            //SleeveDraw = 7448,
             Malefic4 = 16555,
             Ascend = 3603,
             CrownPlay = 25869,
@@ -47,7 +49,6 @@ namespace XIVSlothCombo.Combos.PvE
             Combust2 = 3608,
             Combust1 = 3599,
 
-
             // heals
             Helios = 3600,
             AspectedHelios = 3601,
@@ -59,62 +60,39 @@ namespace XIVSlothCombo.Combos.PvE
             Horoscope = 16557,
             Exaltation = 25873;
 
-        public static class Buffs
+        private static class Buffs
         {
             public const ushort
-            Divination = 1878,
-            LordOfCrownsDrawn = 2054,
-            LadyOfCrownsDrawn = 2055,
-            AspectedHelios = 836,
-            Balance = 913,
-            Bole = 914,
-            Arrow = 915,
-            Spear = 916,
-            Ewer = 917,
-            Spire = 918,
-            BalanceDamage = 1882,
-            BoleDamage = 1883,
-            ArrowDamage = 1884,
-            SpearDamage = 1885,
-            EwerDamage = 1886,
-            SpireDamage = 1887,
-            Horoscope = 1890,
-            HoroscopeHelios = 1891,
-            AspectedBenefic = 835,
-            NeutralSect = 1892,
-            NeutralSectShield = 1921,
-            ClarifyingDraw = 2713;
+                Divination = 1878,
+                LordOfCrownsDrawn = 2054,
+                LadyOfCrownsDrawn = 2055,
+                AspectedHelios = 836,
+                Balance = 913,
+                Bole = 914,
+                Arrow = 915,
+                Spear = 916,
+                Ewer = 917,
+                Spire = 918,
+                BalanceDamage = 1882,
+                BoleDamage = 1883,
+                ArrowDamage = 1884,
+                SpearDamage = 1885,
+                EwerDamage = 1886,
+                SpireDamage = 1887,
+                Horoscope = 1890,
+                HoroscopeHelios = 1891,
+                AspectedBenefic = 835,
+                NeutralSect = 1892,
+                NeutralSectShield = 1921,
+                ClarifyingDraw = 2713;
         }
 
         public static class Debuffs
         {
             public const ushort
-            Combust1 = 838,
-            Combust2 = 843,
-            Combust3 = 1881;
-        }
-
-        public static class Levels
-        {
-            public const byte
-                Combust = 4,
-                Lightspeed = 6,
-                EssentialDignity = 15,
-                Benefic2 = 26,
-                Draw = 30,
-                AspectedBenefic = 34,
-                AspectedHelios = 42,
-                Combust2 = 46,
-                Divination = 50,
-                Astrodyne = 50,
-                CelestialOpposition = 60,
-                MinorArcana = 70,
-                CrownPlay = 70,
-                Combust3 = 72,
-                CelestialIntersection = 74,
-                Horoscope = 76,
-                NeutralSect = 80,
-                Exaltation = 86;
+                Combust1 = 838,
+                Combust2 = 843,
+                Combust3 = 1881;
         }
 
         public static class Config
@@ -139,23 +117,24 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID == Play)
                 {
-                    var gauge = GetJobGauge<ASTGauge>();
                     var haveCard = HasEffect(Buffs.Balance) || HasEffect(Buffs.Bole) || HasEffect(Buffs.Arrow) || HasEffect(Buffs.Spear) || HasEffect(Buffs.Ewer) || HasEffect(Buffs.Spire);
-                    var cardDrawn = gauge.DrawnCard;
+                    var cardDrawn = Gauge.DrawnCard;
 
-                    if (!gauge.ContainsSeal(SealType.NONE) && IsEnabled(CustomComboPreset.AST_Cards_AstrodyneOnPlay) && (gauge.DrawnCard != CardType.NONE || GetCooldown(Draw).CooldownRemaining > 30))
-                        return Astrodyne;
+                    if (!Gauge.ContainsSeal(SealType.NONE) && 
+                        IsEnabled(CustomComboPreset.AST_Cards_AstrodyneOnPlay) && 
+                        (Gauge.DrawnCard != CardType.NONE || GetCooldown(Draw).CooldownRemaining > 30)
+                       ) return Astrodyne;
 
                     if (haveCard)
                     {
                         if (HasEffect(Buffs.ClarifyingDraw) && IsEnabled(CustomComboPreset.AST_Cards_Redraw))
                         {
-                            if ((cardDrawn == CardType.BALANCE && gauge.Seals.Contains(SealType.SUN)) ||
-                                (cardDrawn == CardType.ARROW && gauge.Seals.Contains(SealType.MOON)) ||
-                                (cardDrawn == CardType.SPEAR && gauge.Seals.Contains(SealType.CELESTIAL)) ||
-                                (cardDrawn == CardType.BOLE && gauge.Seals.Contains(SealType.SUN)) ||
-                                (cardDrawn == CardType.EWER && gauge.Seals.Contains(SealType.MOON)) ||
-                                (cardDrawn == CardType.SPIRE && gauge.Seals.Contains(SealType.CELESTIAL)))
+                            if ((cardDrawn == CardType.BALANCE && Gauge.Seals.Contains(SealType.SUN)) ||
+                                (cardDrawn == CardType.ARROW && Gauge.Seals.Contains(SealType.MOON)) ||
+                                (cardDrawn == CardType.SPEAR && Gauge.Seals.Contains(SealType.CELESTIAL)) ||
+                                (cardDrawn == CardType.BOLE && Gauge.Seals.Contains(SealType.SUN)) ||
+                                (cardDrawn == CardType.EWER && Gauge.Seals.Contains(SealType.MOON)) ||
+                                (cardDrawn == CardType.SPIRE && Gauge.Seals.Contains(SealType.CELESTIAL)))
 
                                 return Redraw;
                         }
@@ -191,23 +170,17 @@ namespace XIVSlothCombo.Combos.PvE
 
             private bool SetTarget()
             {
-                var gauge = GetJobGauge<ASTGauge>();
-                if (gauge.DrawnCard.Equals(CardType.NONE)) return false;
-                var cardDrawn = gauge.DrawnCard;
+                if (Gauge.DrawnCard.Equals(CardType.NONE)) return false;
+                var cardDrawn = Gauge.DrawnCard;
                 if (GetTarget) CurrentTarget = LocalPlayer.TargetObject;
-                //Checks for trusts then normal parties
-                int maxPartySize = GetPartySlot(5) == null ? 4 : 8;
-                if (GetPartyMembers().Length > 0) maxPartySize = GetPartyMembers().Length;
-                if (GetPartyMembers().Length == 0 && Service.BuddyList.Length == 0) maxPartySize = 0;
+                //Checks for trusts then normal parties. Buddylist does not include player, so +1
+                int maxPartySize = Services.Service.BuddyList.Length > 0 ? Services.Service.BuddyList.Length + 1 : GetPartyMembers().Length;
 
-                for (int i = 2; i <= maxPartySize; i++)
+                List<GameObject> PartyTargets = new();
+                for (int i = 1; i <= maxPartySize; i++)
                 {
                     GameObject? member = GetPartySlot(i);
-
-                    if (member == null) break;
-                    string job = "";
-                    if (member is BattleNpc) job = (member as BattleNpc).ClassJob.GameData.Name.ToString();
-                    if (member is BattleChara) job = (member as BattleChara).ClassJob.GameData.Name.ToString();
+                    if (member == null) continue; //Skip nulls/disconnected people
 
                     if (FindEffectOnMember(Buffs.BalanceDamage, member) is not null) continue;
                     if (FindEffectOnMember(Buffs.ArrowDamage, member) is not null) continue;
@@ -216,56 +189,41 @@ namespace XIVSlothCombo.Combos.PvE
                     if (FindEffectOnMember(Buffs.SpireDamage, member) is not null) continue;
                     if (FindEffectOnMember(Buffs.SpearDamage, member) is not null) continue;
 
-                    if (cardDrawn is CardType.BALANCE or CardType.ARROW or CardType.SPEAR && JobNames.Melee.Contains(job))
-                    {
-                        TargetObject(member);
-                        GetTarget = false;
-                        return true;
-                    }
-
-                    if (cardDrawn is CardType.BOLE or CardType.EWER or CardType.SPIRE && JobNames.Ranged.Contains(job))
-                    {
-                        TargetObject(member);
-                        GetTarget = false;
-                        return true;
-                    }
+                    PartyTargets.Add(member);
                 }
 
-                if (IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay_TargetExtra))
+                if (PartyTargets.Count > 0)
                 {
-                    for (int i = 1; i <= maxPartySize; i++)
+                    PartyTargets.Shuffle();
+                    //Give card to DPS first
+                    for (int i = 0; i <= PartyTargets.Count - 1; i++)
                     {
-                        GameObject? member = GetPartySlot(i);
-                        if (member == null) break;
-                        string job = "";
-                        if (member is BattleNpc) job = (member as BattleNpc).ClassJob.GameData.Name.ToString();
-                        if (member is BattleChara) job = (member as BattleChara).ClassJob.GameData.Name.ToString();
-
-                        if (FindEffectOnMember(Buffs.BalanceDamage, member) is not null) continue;
-                        if (FindEffectOnMember(Buffs.ArrowDamage, member) is not null) continue;
-                        if (FindEffectOnMember(Buffs.BoleDamage, member) is not null) continue;
-                        if (FindEffectOnMember(Buffs.EwerDamage, member) is not null) continue;
-                        if (FindEffectOnMember(Buffs.SpireDamage, member) is not null) continue;
-                        if (FindEffectOnMember(Buffs.SpearDamage, member) is not null) continue;
-
-                        if (cardDrawn is CardType.BALANCE or CardType.ARROW or CardType.SPEAR && JobNames.Tank.Contains(job))
-                        { 
-                            TargetObject(member);
-                            GetTarget = false;
-                            return true;
-                        }
-
-                        if (cardDrawn is CardType.BOLE or CardType.EWER or CardType.SPIRE && JobNames.Healer.Contains(job))
-                        { 
-                            TargetObject(member);
+                        byte job = PartyTargets[i] is BattleChara ? (byte)(PartyTargets[i] as BattleChara).ClassJob.Id : (byte)0;
+                        if ((cardDrawn is CardType.BALANCE or CardType.ARROW or CardType.SPEAR && JobIDs.Melee.Contains(job)) ||
+                            (cardDrawn is CardType.BOLE or CardType.EWER or CardType.SPIRE && JobIDs.Ranged.Contains(job)))
+                        {
+                            TargetObject(PartyTargets[i]);
                             GetTarget = false;
                             return true;
                         }
                     }
+                    //Give cards to healers/tanks if backup is turned on
+                    if (IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay_TargetExtra))
+                    {
+                        for (int i = 0; i <= PartyTargets.Count - 1; i++)
+                        {
+                            byte job = PartyTargets[i] is BattleChara ? (byte)(PartyTargets[i] as BattleChara).ClassJob.Id : (byte)0;
+                            if ((cardDrawn is CardType.BALANCE or CardType.ARROW or CardType.SPEAR && JobIDs.Tank.Contains(job)) ||
+                                (cardDrawn is CardType.BOLE or CardType.EWER or CardType.SPIRE && JobIDs.Healer.Contains(job)))
+                            {
+                                TargetObject(PartyTargets[i]);
+                                GetTarget = false;
+                                return true;
+                            }
+                        }
+                    }
                 }
-
                 return false;
-
             }
         }
 
@@ -277,11 +235,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID == CrownPlay)
                 {
-                    var gauge = GetJobGauge<ASTGauge>();
-                    /*var ladyofCrown = HasEffect(AST.Buffs.LadyOfCrownsDrawn);
-                    var lordofCrown = HasEffect(AST.Buffs.LordOfCrownsDrawn);
-                    var minorArcanaCD = GetCooldown(AST.MinorArcana);*/
-                    if (level >= Levels.MinorArcana && gauge.DrawnCrownCard == CardType.NONE)
+                    if (LevelChecked(MinorArcana) && Gauge.DrawnCrownCard == CardType.NONE)
                         return MinorArcana;
                 }
 
@@ -295,7 +249,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is Benefic2 && level < Levels.Benefic2) return Benefic;
+                if (actionID is Benefic2 && !LevelChecked(Benefic2)) return Benefic;
                 else return actionID;
             }
         }
@@ -324,14 +278,14 @@ namespace XIVSlothCombo.Combos.PvE
                     InCombat())
                 {
                     if (IsEnabled(CustomComboPreset.AST_DPS_LightSpeed) &&
-                        level >= Levels.Lightspeed &&
+                        LevelChecked(Lightspeed) &&
                         IsOffCooldown(Lightspeed) &&
                         GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_LightSpeedOption) &&
                         CanSpellWeave(actionID)
                        ) return Lightspeed;
 
                     if (IsEnabled(CustomComboPreset.AST_DPS_Lucid) &&
-                        level >= All.Levels.LucidDreaming &&
+                        LevelChecked(All.LucidDreaming) &&
                         IsOffCooldown(All.LucidDreaming) &&
                         LocalPlayer.CurrentMp <= GetOptionValue(Config.AST_LucidDreaming) &&
                         CanSpellWeave(actionID)
@@ -339,7 +293,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     //Divination
                     if (IsEnabled(CustomComboPreset.AST_DPS_Divination) &&
-                        level >= Levels.Divination &&
+                        LevelChecked(Divination) &&
                         IsOffCooldown(Divination) &&
                         !HasEffect(Buffs.Divination) && //Overwrite protection
                         GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_DivinationOption) &&
@@ -348,49 +302,46 @@ namespace XIVSlothCombo.Combos.PvE
 
                     //Astrodyne
                     if (IsEnabled(CustomComboPreset.AST_DPS_Astrodyne) &&
-                        level >= Levels.Astrodyne &&
-                        !GetJobGauge<ASTGauge>().ContainsSeal(SealType.NONE) &&
+                        LevelChecked(Astrodyne) &&
+                        !Gauge.ContainsSeal(SealType.NONE) &&
                         CanSpellWeave(actionID)
                         ) return Astrodyne;
                     
                     //Card Draw
                     if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
-                        level >= Levels.Draw &&
-                        GetJobGauge<ASTGauge>().DrawnCard.Equals(CardType.NONE) &&
+                        LevelChecked(Draw) &&
+                        Gauge.DrawnCard.Equals(CardType.NONE) &&
                         GetCooldown(Draw).RemainingCharges > 0 &&
                         CanSpellWeave(actionID)
                        ) return Draw;
 
                     //Minor Arcana
                     if (IsEnabled(CustomComboPreset.AST_DPS_AutoCrownDraw) &&
-                        level >= Levels.MinorArcana &&
-                        GetJobGauge<ASTGauge>().DrawnCrownCard == CardType.NONE &&
+                        LevelChecked(MinorArcana) &&
+                        Gauge.DrawnCrownCard == CardType.NONE &&
                         IsOffCooldown(MinorArcana) &&
                         CanSpellWeave(actionID)
                        ) return MinorArcana;
 
                     //Lord of Crowns
                     if (IsEnabled(CustomComboPreset.AST_DPS_LazyLord) &&
-                        level >= Levels.CrownPlay &&
-                        GetJobGauge<ASTGauge>().DrawnCrownCard is CardType.LORD &&
+                        LevelChecked(CrownPlay) &&
+                        Gauge.DrawnCrownCard is CardType.LORD &&
                         CanSpellWeave(actionID)
                        ) return LordOfCrowns;
 
                     //Combust
                     if (IsEnabled(CustomComboPreset.AST_ST_DPS_CombustUptime) &&
                         actionID is not Gravity and not Gravity2 &&
-                        level >= Levels.Combust &&
-                        (CurrentTarget as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy)
+                        LevelChecked(Combust1) &&
+                        HasBattleTarget())
                     {
                         //Determine which Combust debuff to check
-                        var CombustDebuffID = level switch
-                        {
-                            //Using FindEffect b/c we have a custom Target variable
-                            >= Levels.Combust3 => FindTargetEffect(Debuffs.Combust3),
-                            >= Levels.Combust2 => FindTargetEffect(Debuffs.Combust2),
-                            //Combust 1 level checked at the start, fine for default
-                            _ => FindTargetEffect(Debuffs.Combust1),
-                        };
+                        Status? CombustDebuffID; 
+                        if (LevelChecked(Combust3)) CombustDebuffID = FindTargetEffect(Debuffs.Combust3);
+                        else if (LevelChecked(Combust2)) CombustDebuffID = FindTargetEffect(Debuffs.Combust2);
+                        else CombustDebuffID = FindTargetEffect(Debuffs.Combust1);
+
                         if ((CombustDebuffID is null || CombustDebuffID?.RemainingTime <= 3) &&
                             (GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_CombustOption))
                            ) return OriginalHook(Combust1);
@@ -412,27 +363,27 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is AspectedHelios)
                 {
                     //Level check to exit if we can't use
-                    if (level < Levels.AspectedHelios)
+                    if (!LevelChecked(AspectedHelios))
                         return Helios;
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_LazyLady) &&
-                        level >= Levels.CrownPlay &&
+                        LevelChecked(CrownPlay) &&
                         InCombat() &&
-                        GetJobGauge<ASTGauge>().DrawnCrownCard == CardType.LADY 
+                        Gauge.DrawnCrownCard == CardType.LADY 
                        ) return LadyOfCrown;
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_CelestialOpposition) &&
-                        level >= Levels.CelestialOpposition &&
+                        LevelChecked(CelestialOpposition) &&
                         IsOffCooldown(CelestialOpposition) 
                        ) return CelestialOpposition;
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Horoscope))
                     {
-                        if (level >= Levels.Horoscope && 
+                        if (LevelChecked(Horoscope) && 
                             IsOffCooldown(Horoscope)
                            ) return Horoscope;
 
-                        if ( (level >= Levels.AspectedHelios && !HasEffect(Buffs.AspectedHelios))
+                        if ( (LevelChecked(AspectedHelios) && !HasEffect(Buffs.AspectedHelios))
                              || HasEffect(Buffs.Horoscope)
                              || (HasEffect(Buffs.NeutralSect) && !HasEffect(Buffs.NeutralSectShield)))
                             return AspectedHelios;
@@ -457,8 +408,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID == Play && !IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay))
                 {
-                    var gauge = GetJobGauge<ASTGauge>();
-                    if (!gauge.ContainsSeal(SealType.NONE))
+                    if (!Gauge.ContainsSeal(SealType.NONE))
                         return Astrodyne;
                 }
                 return actionID;
@@ -473,7 +423,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Benefic2)
                 {
-                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_AspectedBenefic) && level >= Levels.AspectedBenefic)
+                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_AspectedBenefic) && LevelChecked(AspectedBenefic))
                     {
                         var aspectedBeneficHoT = FindTargetEffect(Buffs.AspectedBenefic);
                         var NeutralSectShield = FindTargetEffect(Buffs.NeutralSectShield);
@@ -484,18 +434,18 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity) &&
-                        level >= Levels.EssentialDignity && 
+                        LevelChecked(EssentialDignity) && 
                         GetCooldown(EssentialDignity).RemainingCharges > 0 && 
                         GetTargetHPPercent() <= GetOptionValue(Config.AST_EssentialDignity)
                        ) return EssentialDignity;
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Exaltation) && 
-                        level >= Levels.Exaltation &&
+                        LevelChecked(Exaltation) &&
                         IsOffCooldown(Exaltation)
                        ) return Exaltation;
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_CelestialIntersection) &&
-                        level >= Levels.CelestialIntersection &&
+                        LevelChecked(CelestialIntersection) &&
                         GetCooldown(CelestialIntersection).RemainingCharges > 0
                        ) return CelestialIntersection;
                 }

--- a/XIVSlothCombo/CustomCombo/Functions/Misc.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Misc.cs
@@ -16,62 +16,47 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns> A value indicating whether the preset is not enabled. </returns>
         public bool IsNotEnabled(CustomComboPreset preset) => !IsEnabled(preset);
 
+        
         // Job & Class Names
-        public class JobNames
+        public class JobIDs
         {
-            public static readonly List<string> Melee = new() {
-                // English
-                "monk", "dragoon", "ninja", "reaper", "samurai", "pugilist", "lancer", "rogue",
-                // Chinese
-                "武僧", "龙骑士", "忍者", "钐镰客", "武士", "格斗家", "枪术师", "双剑师",
-                // Japanese
-                "モンク", "竜騎士", "忍者", "リーパー", "侍", "格闘士", "槍術士", "双剣士",
-                // French (ninja is french for ninja)
-                "moine", "chevalier dragon", "faucheur", "samouraï", "pugiliste", "maître d'hast", "surineur",
-                // German (dragoon/ninja/samurai are as is)
-                "mönch", "schnitter", "faustkämpfer", "pikenier", "schurke"
-            };
-
-            public static readonly List<string> Ranged = new() {
-                // English
-                "bard", "machinist", "dancer", "red mage", "black mage", "summoner", "blue mage", "archer", "thaumaturge", "arcanist",
-                // Chinese
-                "吟游诗人", "机工士", "舞者", "赤魔法师", "黑魔法师", "召唤师", "青魔法师", "弓箭手", "咒术师", "秘术师",
-                // Japanese
-                "吟遊詩人", "機工士", "踊り子", "赤魔道士", "黒魔道士", "召喚士", "青魔道士", "弓術士", "呪術士", "巴術士",
-                // French (archer skipped)
-                "barde", "machiniste", "danseur", "mage rouge", "mage noir", "invocateur", "mage bleu", "occultiste", "arcaniste",
-                // German (bard skipped)
-                "maschinist", "tänzser", "rotmagier", "schwarzmagier", "beschwörer", "blaumagier", "waldäufer", "thaumaturg", "hermetiker"
-            };
-
-            public static readonly List<string> Tank = new()
+            //  Job IDs               ClassIDs (no jobstone) (Lancer, Pugilist, etc)
+            public static readonly List<byte> Melee = new()
             {
-                // English
-                "paladin", "warrior", "dark knight", "gunbreaker", "gladiator", "marauder",
-                // Chinese
-                "骑士", "战士", "暗黑骑士", "绝枪战士", "剑术师", "斧术师",
-                // Japanese
-                "ナイト", "戦士", "暗黒騎士", "ガンブレイカー", "剣術士", "斧術士",
-                // French (paladin)
-                "guerrier", "chevalier noir", "pistosabreur", "gladiateur", "maraudeur",
-                // German (paladin/gladiator are as is)
-                "krieger", "dunkelritter", "revolverklinge", "marodeur"
+                Combos.PvE.DRG.JobID, Combos.PvE.DRG.ClassID,
+                Combos.PvE.MNK.JobID, Combos.PvE.MNK.ClassID,
+                Combos.PvE.NIN.JobID, Combos.PvE.NIN.ClassID,
+                Combos.PvE.RPR.JobID,
+                Combos.PvE.SAM.JobID
             };
 
-            public static readonly List<string> Healer = new()
+            public static readonly List<byte> Ranged = new()
             {
-                // English
-                "white mage", "astrologian", "scholar", "sage", "conjurer",
-                // Chinese
-                "白魔法师", "占星术士", "学者", "贤者", "幻术师",
-                // Japanese
-                "白魔道士", "占星術師", "学者", "賢者", "幻術士",
-                // French (sage is the same as en)
-                "mage blanc", "astromancien", "érudits", "élémentaliste",
-                // German
-                "weißmagier", "weissmagier", "gelehrter", "astrologe", "weiser", "druide"
+                Combos.PvE.BLM.JobID, Combos.PvE.BLM.ClassID,
+                Combos.PvE.BRD.JobID, Combos.PvE.BRD.ClassID,
+                Combos.PvE.SMN.JobID, Combos.PvE.SMN.ClassID,
+                Combos.PvE.MCH.JobID,
+                Combos.PvE.RDM.JobID,
+                Combos.PvE.DNC.JobID,
+                Combos.PvE.BLU.JobID
             };
+
+            public static readonly List<byte> Tank = new()
+            {
+                Combos.PvE.PLD.JobID, Combos.PvE.PLD.ClassID,
+                Combos.PvE.WAR.JobID, Combos.PvE.WAR.ClassID,
+                Combos.PvE.DRK.JobID,
+                Combos.PvE.GNB.JobID
+            };
+            
+            public static readonly List<byte> Healer = new()
+            {
+                Combos.PvE.WHM.JobID, Combos.PvE.WHM.ClassID,
+                Combos.PvE.SCH.JobID,
+                Combos.PvE.AST.JobID,
+                Combos.PvE.SGE.JobID
+            };
+
         }
     }
 }

--- a/XIVSlothCombo/CustomCombo/Functions/Party.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Party.cs
@@ -9,7 +9,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
     {
         /// <summary> Gets the party list </summary>
         /// <returns> Current party list. </returns>
-        public PartyList GetPartyMembers() => Service.PartyList;
+        public static PartyList GetPartyMembers() => Service.PartyList;
 
         protected unsafe static GameObject? GetPartySlot(int slot)
         {

--- a/XIVSlothCombo/Extensions/ListExtensions.cs
+++ b/XIVSlothCombo/Extensions/ListExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace XIVSlothCombo.Extensions
+{
+    internal static class ListExtensions
+    {
+        private static readonly Random rng = new();
+
+        public static void Shuffle<T>(this IList<T> list)
+        {
+            int n = list.Count;
+            while (n > 1)
+            {
+                n--;
+                int k = rng.Next(n + 1);
+                (list[n], list[k]) = (list[k], list[n]);
+            }
+        }
+    }
+}

--- a/XIVSlothCombo/Extensions/UIntExtensions.cs
+++ b/XIVSlothCombo/Extensions/UIntExtensions.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using XIVSlothCombo.CustomComboNS.Functions;
+﻿using XIVSlothCombo.CustomComboNS.Functions;
 
 namespace XIVSlothCombo.Extensions
 {


### PR DESCRIPTION
AST:

- LevelChecked implemented. 
- Level constants removed. 
- Gauge attached to class for cleaner use.

- AST_Cards_DrawOnPlay
  - Randomization to party member selection added.
  - Card -> Party selection based on Job IDs (language agnostic)

Misc.cs: Job Names changed to Job IDs.
UIntExtensions.cs: Usage cleanup
Party.cs: VS said it was safe to add a static to the PartyList
ListExtensions.cs: Added. Used for AST's target shuffling.