### PR TITLE
[SMN] Movement tweaks for Garuda.

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2562,7 +2562,7 @@ namespace XIVSlothCombo.Combos
         SMN_CarbuncleReminder = 17010,
 
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Ruin IV Combo Option", "Adds Ruin IV to the single target and AoE combos.\nUses when moving during Garuda Phase and you have no attunement, during Ifrit phase, or when you have no active Egi or Demi summon.", SMN.JobID, 0, "", "")]
+        [CustomComboInfo("Ruin IV Combo Option", "Adds Ruin IV to the single target and AoE combos.\nUses when moving during Garuda Phase and you have no attunement, when moving during Ifrit phase, or when you have no active Egi or Demi summon.", SMN.JobID, 0, "", "")]
         SMN_Advanced_Combo_Ruin4 = 17011,
 
         [ParentCombo(SMN_EDFester)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2562,7 +2562,7 @@ namespace XIVSlothCombo.Combos
         SMN_CarbuncleReminder = 17010,
 
         [ParentCombo(SMN_Advanced_Combo)]
-        [CustomComboInfo("Ruin IV Combo Option", "Adds Ruin IV to the single target and AoE combos when you have no active Egi or Demi summon.", SMN.JobID, 0, "", "")]
+        [CustomComboInfo("Ruin IV Combo Option", "Adds Ruin IV to the single target and AoE combos.\nUses when moving during Garuda Phase and you have no attunement, during Ifrit phase, or when you have no active Egi or Demi summon.", SMN.JobID, 0, "", "")]
         SMN_Advanced_Combo_Ruin4 = 17011,
 
         [ParentCombo(SMN_EDFester)]

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -496,7 +496,7 @@ namespace XIVSlothCombo.Combos.PvE
                     
                     //Movement Ruin4 in Egi Phases
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && !HasEffect(All.Buffs.Swiftcast) && IsMoving && HasEffect(Buffs.FurtherRuin) &&
-                        ((HasEffect(Buffs.GarudasFavor) && !gauge.IsGarudaAttuned) || gauge.IsIfritAttuned))
+                        ((HasEffect(Buffs.GarudasFavor) && !gauge.IsGarudaAttuned) || (gauge.IsIfritAttuned || lastComboMove is not CrimsonCyclone)))
                         return Ruin4;
                     
                     // Egi Features

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -408,9 +408,8 @@ namespace XIVSlothCombo.Combos.PvE
                             if (GetCooldown(EnergyDrain).CooldownRemaining <= 3.2)
                             {
                                 if (HasEffect(Buffs.SearingLight) &&
-                                    (SummonerBurstPhase is 0 or 1 or 2 ||
-                                     (SummonerBurstPhase == 3 && (GetCooldownRemainingTime(SearingLight) < 30 || GetCooldownRemainingTime(SearingLight) > 100)) ||
-                                     (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor))))
+                                    (SummonerBurstPhase is 0 or 1 or 2 or 3) ||
+                                    (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
                                 {
                                     if (STCombo)
                                         return Fester;
@@ -466,10 +465,9 @@ namespace XIVSlothCombo.Combos.PvE
                                             return Painflare;
                                     }
 
-                                    if (HasEffect(Buffs.SearingLight) && 
-                                        (SummonerBurstPhase is 0 or 1 or 2 && DemiAttackCount >= burstDelay ||
-                                        (SummonerBurstPhase == 3 && DemiAttackCount >= burstDelay && (GetCooldownRemainingTime(SearingLight) < 30 || GetCooldownRemainingTime(SearingLight) > 100)) ||
-                                        (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor))))
+                                    if (HasEffect(Buffs.SearingLight) && inOpener &&
+                                        (SummonerBurstPhase is 0 or 1 or 2 or 3 && DemiAttackCount >= burstDelay) ||
+                                        (SummonerBurstPhase == 4 && !HasEffect(Buffs.TitansFavor)))
                                     {
                                         if (STCombo)
                                             return Fester;

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -496,7 +496,7 @@ namespace XIVSlothCombo.Combos.PvE
                     
                     //Movement Ruin4 in Egi Phases
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && !HasEffect(All.Buffs.Swiftcast) && IsMoving && HasEffect(Buffs.FurtherRuin) &&
-                        ((HasEffect(Buffs.GarudasFavor) && !gauge.IsGarudaAttuned) || (gauge.IsIfritAttuned || lastComboMove is not CrimsonCyclone)))
+                        ((HasEffect(Buffs.GarudasFavor) && !gauge.IsGarudaAttuned) || (gauge.IsIfritAttuned && lastComboMove is not CrimsonCyclone)))
                         return Ruin4;
                     
                     // Egi Features

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -580,7 +580,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && gauge.IsIfritAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
                         return Ruin4;
                     
-                    // Gemshine
+                    // Gemshine/Precious Brilliance
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
                     {
                         if (STCombo)

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -496,12 +496,10 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(Aethercharge);
                     }
                     
-                    // Movement Ruin4 in Garuda Phase
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && HasEffect(Buffs.GarudasFavor) && !HasEffect(All.Buffs.Swiftcast) && !gauge.IsGarudaAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
-                        return Ruin4;
-                    //something broke when trying to merge these two into one check, I'll mess with it later.
-                    // Movement Ruin4 in Ifrit Phase
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && gauge.IsIfritAttuned && !HasEffect(All.Buffs.Swiftcast) && IsMoving && HasEffect(Buffs.FurtherRuin))
+                    //Movement Ruin4 in Egi Phases
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) &&
+                        ((HasEffect(Buffs.GarudasFavor) && !HasEffect(All.Buffs.Swiftcast) && !gauge.IsGarudaAttuned && IsMoving && HasEffect(Buffs.FurtherRuin)) ||
+                         (gauge.IsIfritAttuned && !HasEffect(All.Buffs.Swiftcast) && IsMoving && HasEffect(Buffs.FurtherRuin))))
                         return Ruin4;
                     
                     // Egi Features

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -496,6 +496,10 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(Aethercharge);
                     }
                     
+                    // Movement Ruin4 in Garuda Phase
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && HasEffect(Buffs.GarudasFavor) && !HasEffect(All.Buffs.Swiftcast) && !gauge.IsGarudaAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
+                        return Ruin4;
+                    
                     // Egi Features
                     if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) && level >= All.Levels.Swiftcast)
                     {
@@ -566,10 +570,6 @@ namespace XIVSlothCombo.Combos.PvE
                         if (AoECombo && LevelChecked(PreciousBrilliance))
                             return OriginalHook(PreciousBrilliance);
                     }
-                    
-                    // Movement Ruin4 in Garuda Phase
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && HasEffect(Buffs.GarudasFavor) && !HasEffect(All.Buffs.Swiftcast) && !gauge.IsGarudaAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
-                        return Ruin4;
                     
                     if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) ||                                             // Garuda
                         IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove is TopazRite or TopazCata && CanSpellWeave(actionID) ||                                                              // Titan

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -497,9 +497,8 @@ namespace XIVSlothCombo.Combos.PvE
                     }
                     
                     //Movement Ruin4 in Egi Phases
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) &&
-                        ((HasEffect(Buffs.GarudasFavor) && !HasEffect(All.Buffs.Swiftcast) && !gauge.IsGarudaAttuned && IsMoving && HasEffect(Buffs.FurtherRuin)) ||
-                         (!HasEffect(All.Buffs.Swiftcast) && !HasEffect(All.Buffs.Swiftcast) && gauge.IsIfritAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))))
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && !HasEffect(All.Buffs.Swiftcast) && IsMoving && HasEffect(Buffs.FurtherRuin) &&
+                        ((HasEffect(Buffs.GarudasFavor) && !gauge.IsGarudaAttuned) || gauge.IsIfritAttuned))
                         return Ruin4;
                     
                     // Egi Features

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -502,13 +502,14 @@ namespace XIVSlothCombo.Combos.PvE
                         // Swiftcast Garuda Feature
                         if (swiftcastPhase is 0 or 1 && LevelChecked(Slipstream) && HasEffect(Buffs.GarudasFavor))
                         {
-                            if (CanSpellWeave(actionID) && IsOffCooldown(All.Swiftcast) && gauge.IsGarudaAttuned)
+                            if (CanSpellWeave(actionID) && gauge.IsGarudaAttuned && IsOffCooldown(All.Swiftcast))
                             {
                                 if (STCombo || (AoECombo && IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi_Only)))
                                     return All.Swiftcast;
                             }
+                            
                             if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) &&
-                                ((gauge.IsGarudaAttuned && HasEffect(All.Buffs.Swiftcast)) || (gauge.Attunement == 0)))     // Astral Flow if Swiftcast is not ready throughout Garuda
+                                ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)) || (gauge.Attunement == 0)))     // Astral Flow if Swiftcast is not ready throughout Garuda
                                 return OriginalHook(AstralFlow);
                         }
 
@@ -538,8 +539,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 }
 
                                 if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) &&
-                                    ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)) ||
-                                     (gauge.Attunement == 0)))          // Astral Flow if Swiftcast is not ready throughout Garuda
+                                    ((HasEffect(Buffs.GarudasFavor) && HasEffect(All.Buffs.Swiftcast)) || (gauge.Attunement == 0)))     // Astral Flow if Swiftcast is not ready throughout Garuda
                                     return OriginalHook(AstralFlow);
                             }
 
@@ -555,8 +555,10 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
-                    // Gemshine/Precious Brilliance if has Swiftcast
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) && gauge.IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && lastComboMove is not CrimsonCyclone)
+                    // Gemshine/Precious Brilliance priority casting
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) && 
+                        ((gauge.IsIfritAttuned && gauge.Attunement >= 1 && HasEffect(All.Buffs.Swiftcast) && lastComboMove is not CrimsonCyclone) ||
+                        (HasEffect(Buffs.GarudasFavor) && gauge.Attunement >= 1 && !HasEffect(All.Buffs.Swiftcast) && IsMoving)))
                     {
                         if (STCombo)
                             return OriginalHook(Gemshine);
@@ -564,6 +566,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (AoECombo && LevelChecked(PreciousBrilliance))
                             return OriginalHook(PreciousBrilliance);
                     }
+                    
+                    // Movement Ruin4 in Garuda Phase
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && HasEffect(Buffs.GarudasFavor) && !HasEffect(All.Buffs.Swiftcast) && !gauge.IsGarudaAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
+                        return Ruin4;
                     
                     if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) ||                                             // Garuda
                         IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove is TopazRite or TopazCata && CanSpellWeave(actionID) ||                                                              // Titan

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -519,7 +519,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
                         if (swiftcastPhase == 2)
                         {
-                            if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned)
+                            if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned && lastComboMove is not CrimsonCyclone)
                             {
                                 if (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) || (IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && gauge.Attunement >= 1))
                                 {
@@ -547,7 +547,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
 
                             // Swiftcast Ifrit Feature (Conditions to allow for SpS Ruins to still be under the effect of Swiftcast)
-                            if (gauge.IsIfritAttuned && IsOffCooldown(All.Swiftcast))
+                            if (IsOffCooldown(All.Swiftcast) && gauge.IsIfritAttuned && lastComboMove is not CrimsonCyclone)
                             {
                                 if (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) || (IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && gauge.Attunement >= 1))
                                 {

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -570,10 +570,10 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(PreciousBrilliance);
                     }
                     
-                    if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) ||     // Garuda
-                        IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove is TopazRite or TopazCata && CanSpellWeave(actionID) ||                      // Titan
+                    if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) ||                 // Garuda
+                        IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove is TopazRite or TopazCata && CanSpellWeave(actionID) ||                                  // Titan
                         IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) &&
-                        ((HasEffect(Buffs.IfritsFavor) && (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone_Option) || (IsMoving || gauge.Attunement == 0))) || (lastComboMove == CrimsonCyclone && InMeleeRange())))           // Ifrit
+                        ((HasEffect(Buffs.IfritsFavor) && (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone_Option) || (IsMoving || gauge.Attunement == 0))) || (lastComboMove == CrimsonCyclone && InMeleeRange())))   // Ifrit
                         return OriginalHook(AstralFlow);
 
                     // Gemshine/Precious Brilliance

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -421,9 +421,9 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // Demi Nuke
-                        if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire)
+                        if (OriginalHook(Ruin) is AstralImpulse or FountainOfFire && DemiAttackCount >= burstDelay)
                         {
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && DemiAttackCount >= burstDelay)
+                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks))
                             {
                                 if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
                                     return OriginalHook(EnkindleBahamut);

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -499,6 +499,10 @@ namespace XIVSlothCombo.Combos.PvE
                     // Movement Ruin4 in Garuda Phase
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && HasEffect(Buffs.GarudasFavor) && !HasEffect(All.Buffs.Swiftcast) && !gauge.IsGarudaAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
                         return Ruin4;
+                    //something broke when trying to merge these two into one check, I'll mess with it later.
+                    // Movement Ruin4 in Ifrit Phase
+                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && gauge.IsIfritAttuned && !HasEffect(All.Buffs.Swiftcast) && IsMoving && HasEffect(Buffs.FurtherRuin))
+                        return Ruin4;
                     
                     // Egi Features
                     if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) && level >= All.Levels.Swiftcast)
@@ -576,10 +580,6 @@ namespace XIVSlothCombo.Combos.PvE
                         IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && ((HasEffect(Buffs.IfritsFavor) && (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone_Option) || (IsMoving || gauge.Attunement == 0))) || lastComboMove == CrimsonCyclone)) // Ifrit
                         return OriginalHook(AstralFlow);
 
-                    // Movement Ruin4 in Ifrit Phase
-                    if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) && gauge.IsIfritAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))
-                        return Ruin4;
-                    
                     // Gemshine/Precious Brilliance
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EgiSummons_Attacks) && (gauge.IsGarudaAttuned || gauge.IsTitanAttuned || gauge.IsIfritAttuned))
                     {

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -499,7 +499,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Movement Ruin4 in Egi Phases
                     if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_Ruin4) &&
                         ((HasEffect(Buffs.GarudasFavor) && !HasEffect(All.Buffs.Swiftcast) && !gauge.IsGarudaAttuned && IsMoving && HasEffect(Buffs.FurtherRuin)) ||
-                         (gauge.IsIfritAttuned && !HasEffect(All.Buffs.Swiftcast) && IsMoving && HasEffect(Buffs.FurtherRuin))))
+                         (!HasEffect(All.Buffs.Swiftcast) && !HasEffect(All.Buffs.Swiftcast) && gauge.IsIfritAttuned && IsMoving && HasEffect(Buffs.FurtherRuin))))
                         return Ruin4;
                     
                     // Egi Features

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -570,9 +570,10 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(PreciousBrilliance);
                     }
                     
-                    if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) ||                                             // Garuda
-                        IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove is TopazRite or TopazCata && CanSpellWeave(actionID) ||                                                              // Titan
-                        IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) && ((HasEffect(Buffs.IfritsFavor) && (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone_Option) || (IsMoving || gauge.Attunement == 0))) || lastComboMove == CrimsonCyclone)) // Ifrit
+                    if (IsEnabled(CustomComboPreset.SMN_Garuda_Slipstream) && HasEffect(Buffs.GarudasFavor) && (IsNotEnabled(CustomComboPreset.SMN_DemiEgiMenu_SwiftcastEgi) || swiftcastPhase == 2) ||     // Garuda
+                        IsEnabled(CustomComboPreset.SMN_Titan_MountainBuster) && HasEffect(Buffs.TitansFavor) && lastComboMove is TopazRite or TopazCata && CanSpellWeave(actionID) ||                      // Titan
+                        IsEnabled(CustomComboPreset.SMN_Ifrit_Cyclone) &&
+                        ((HasEffect(Buffs.IfritsFavor) && (IsNotEnabled(CustomComboPreset.SMN_Ifrit_Cyclone_Option) || (IsMoving || gauge.Attunement == 0))) || (lastComboMove == CrimsonCyclone && InMeleeRange())))           // Ifrit
                         return OriginalHook(AstralFlow);
 
                     // Gemshine/Precious Brilliance

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -661,7 +661,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if ((actionID is SummonTopaz or SummonTitan or SummonTitan2 or SummonEmerald or SummonGaruda or SummonGaruda2 or SummonRuby or SummonIfrit or SummonIfrit2 && HasEffect(Buffs.TitansFavor)) ||
                     (actionID is SummonTopaz or SummonTitan or SummonTitan2 or SummonEmerald or SummonGaruda or SummonGaruda2 && HasEffect(Buffs.GarudasFavor)) ||
-                    (actionID is SummonTopaz or SummonTitan or SummonTitan2 or SummonRuby or SummonIfrit or SummonIfrit2 && (HasEffect(Buffs.IfritsFavor) || lastComboMove == CrimsonCyclone)))
+                    (actionID is SummonTopaz or SummonTitan or SummonTitan2 or SummonRuby or SummonIfrit or SummonIfrit2 && (HasEffect(Buffs.IfritsFavor) || (lastComboMove == CrimsonCyclone && InMeleeRange()))))
                     return OriginalHook(AstralFlow);
 
                 return actionID;


### PR DESCRIPTION
## SMN
- Adjust description of `Ruin IV Combo Option`.
- Changed order of gauge/cooldown checks for swiftcast garuda for personal reading preference.
- Fixed a small bug in swiftcast garuda astral flow checking attunement rather than buff check (bug didn't exist in sps swiftcast garuda)
- removed a newline
- Uses gemshine/precious brilliance during garuda before slipstream while moving if you don't have swiftcast.
- Added ruin4 while moving during garuda if you have no attunement stacks
- Moved Ruin4 movement code above swiftcast demi code for priority.
- added precious brilliance comment to gemshine.
- Adjusted movement Ruin4 and Swiftcast (ifrit and sps swiftcast) to not interfere if you're in mid ifrit combo (Crimson Cyclone > Crimson Strike)
- Removed redundant searing light checks from `SummonerBurstPhase 3`, which was bursting on Bahamut *or* Phoenix as searing light now applies to the whole fester/painflare block.
- Added a melee range check for the second half of ifrit combo `Crimson Strike` so you wouldn't be locked out of using attacks if the move is unusable due to range.