### PR TITLE
[MULTI] Preset Menu Change + Bug fix(es)

### DIFF
--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -549,7 +549,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.BRD_Simple_Buffs) && (songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
+                    if (IsEnabled(CustomComboPreset.BRD_Simple_Buffs) && (!songNone || !LevelChecked(MagesBallad)) && isEnemyHealthHigh)
                     {
                         bool radiantReady = LevelChecked(RadiantFinale) && IsOffCooldown(RadiantFinale);
                         bool ragingReady = LevelChecked(RagingStrikes) && IsOffCooldown(RagingStrikes);

--- a/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
@@ -11,6 +11,8 @@ namespace XIVSlothCombo.Window.Tabs
 {
     internal class PvEFeatures : ConfigWindow
     {
+        //internal static Dictionary<string, bool> showHeader = new Dictionary<string, bool>();
+
         internal static new void Draw()
         {
 #if !DEBUG
@@ -32,46 +34,12 @@ namespace XIVSlothCombo.Window.Tabs
             {
                 if (ImGui.CollapsingHeader(jobName))
                 {
-                    if (!Messages.PrintBLUMessage(jobName)) continue;
-
-                    foreach (var (preset, info) in groupedPresets[jobName].Where(x => !PluginConfiguration.IsSecret(x.Preset)))
+                    foreach (var otherJob in groupedPresets.Keys.Where(x => x != jobName))
                     {
-                        InfoBox presetBox = new() { Color = Colors.Grey, BorderThickness = 1f, CurveRadius = 8f, ContentsAction = () => { Presets.DrawPreset(preset, info, ref i); } };
-
-                        if (Service.Configuration.HideConflictedCombos)
-                        {
-                            var conflictOriginals = Service.Configuration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
-                            var conflictsSource = Service.Configuration.GetAllConflicts();      // Presets with the ConflictedAttribute
-
-                            if (!conflictsSource.Where(x => x == preset).Any() || conflictOriginals.Length == 0)
-                            {
-                                presetBox.Draw();
-                                ImGuiHelpers.ScaledDummy(12.0f);
-                                continue;
-                            }
-
-                            if (conflictOriginals.Any(x => Service.Configuration.IsEnabled(x)))
-                            {
-                                Service.Configuration.EnabledActions.Remove(preset);
-                                Service.Configuration.Save();
-                            }
-
-                            else
-                            {
-                                presetBox.Draw();
-                                ImGuiHelpers.ScaledDummy(12.0f);
-                                continue;
-                            }
-                        }
-
-                        else
-                        {
-                            presetBox.Draw();
-                            ImGuiHelpers.ScaledDummy(12.0f);
-                        }
+                        ImGui.GetStateStorage().SetInt(ImGui.GetID(otherJob), 0);
                     }
+                    DrawHeadingContents(jobName, i);
                 }
-
                 else
                 {
                     i += groupedPresets[jobName].Where(x => !PluginConfiguration.IsSecret(x.Preset)).Count();
@@ -84,6 +52,48 @@ namespace XIVSlothCombo.Window.Tabs
 
             ImGui.PopStyleVar();
             ImGui.EndChild();
+        }
+
+        internal static void DrawHeadingContents(string jobName, int i)
+        {
+            if (!Messages.PrintBLUMessage(jobName)) return;
+
+            foreach (var (preset, info) in groupedPresets[jobName].Where(x => !PluginConfiguration.IsSecret(x.Preset)))
+            {
+                InfoBox presetBox = new() { Color = Colors.Grey, BorderThickness = 1f, CurveRadius = 8f, ContentsAction = () => { Presets.DrawPreset(preset, info, ref i); } };
+
+                if (Service.Configuration.HideConflictedCombos)
+                {
+                    var conflictOriginals = Service.Configuration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
+                    var conflictsSource = Service.Configuration.GetAllConflicts();      // Presets with the ConflictedAttribute
+
+                    if (!conflictsSource.Where(x => x == preset).Any() || conflictOriginals.Length == 0)
+                    {
+                        presetBox.Draw();
+                        ImGuiHelpers.ScaledDummy(12.0f);
+                        continue;
+                    }
+
+                    if (conflictOriginals.Any(x => Service.Configuration.IsEnabled(x)))
+                    {
+                        Service.Configuration.EnabledActions.Remove(preset);
+                        Service.Configuration.Save();
+                    }
+
+                    else
+                    {
+                        presetBox.Draw();
+                        ImGuiHelpers.ScaledDummy(12.0f);
+                        continue;
+                    }
+                }
+
+                else
+                {
+                    presetBox.Draw();
+                    ImGuiHelpers.ScaledDummy(12.0f);
+                }
+            }
         }
     }
 }

--- a/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
@@ -36,42 +36,11 @@ namespace XIVSlothCombo.Window.Tabs
 
                 if (ImGui.CollapsingHeader(jobName))
                 {
-                    foreach (var (preset, info) in groupedPresets[jobName].Where(x => PluginConfiguration.IsSecret(x.Preset)))
+                    foreach (var otherJob in groupedPresets.Keys.Where(x => x != jobName))
                     {
-                        InfoBox presetBox = new() { Color = Colors.Grey, BorderThickness = 1f, CurveRadius = 8f, ContentsAction = () => { Presets.DrawPreset(preset, info, ref i); } };
-
-                        if (Service.Configuration.HideConflictedCombos)
-                        {
-                            var conflictOriginals = Service.Configuration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
-                            var conflictsSource = Service.Configuration.GetAllConflicts();      // Presets with the ConflictedAttribute
-
-                            if (!conflictsSource.Where(x => x == preset).Any() || conflictOriginals.Length == 0)
-                            {
-                                presetBox.Draw();
-                                ImGuiHelpers.ScaledDummy(12.0f);
-                                continue;
-                            }
-
-                            if (conflictOriginals.Any(x => Service.Configuration.IsEnabled(x)))
-                            {
-                                Service.Configuration.EnabledActions.Remove(preset);
-                                Service.Configuration.Save();
-                            }
-
-                            else
-                            {
-                                presetBox.Draw();
-                                ImGuiHelpers.ScaledDummy(12.0f);
-                                continue;
-                            }
-                        }
-
-                        else
-                        {
-                            presetBox.Draw();
-                            ImGuiHelpers.ScaledDummy(12.0f);
-                        }
+                        ImGui.GetStateStorage().SetInt(ImGui.GetID(otherJob), 0);
                     }
+                    DrawHeadingContents(jobName, i);
                 }
 
                 else
@@ -85,6 +54,46 @@ namespace XIVSlothCombo.Window.Tabs
             }
             ImGui.PopStyleVar();
             ImGui.EndChild();
+        }
+
+        private static void DrawHeadingContents(string jobName, int i)
+        {
+            foreach (var (preset, info) in groupedPresets[jobName].Where(x => PluginConfiguration.IsSecret(x.Preset)))
+            {
+                InfoBox presetBox = new() { Color = Colors.Grey, BorderThickness = 1f, CurveRadius = 8f, ContentsAction = () => { Presets.DrawPreset(preset, info, ref i); } };
+
+                if (Service.Configuration.HideConflictedCombos)
+                {
+                    var conflictOriginals = Service.Configuration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
+                    var conflictsSource = Service.Configuration.GetAllConflicts();      // Presets with the ConflictedAttribute
+
+                    if (!conflictsSource.Where(x => x == preset).Any() || conflictOriginals.Length == 0)
+                    {
+                        presetBox.Draw();
+                        ImGuiHelpers.ScaledDummy(12.0f);
+                        continue;
+                    }
+
+                    if (conflictOriginals.Any(x => Service.Configuration.IsEnabled(x)))
+                    {
+                        Service.Configuration.EnabledActions.Remove(preset);
+                        Service.Configuration.Save();
+                    }
+
+                    else
+                    {
+                        presetBox.Draw();
+                        ImGuiHelpers.ScaledDummy(12.0f);
+                        continue;
+                    }
+                }
+
+                else
+                {
+                    presetBox.Draw();
+                    ImGuiHelpers.ScaledDummy(12.0f);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
[Framework]
- Only one job heading menu can be open at a time. This is to alleviate FPS issues where too many are open at once.

[BRD]
- Fixes issue where buffs were not being applied with the `Simple Buffs` option selected