### PR TITLE
[SGE/FRMWRK] Added ActionReady

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2127,7 +2127,7 @@ namespace XIVSlothCombo.Combos
         */
 
         #region Single Target DPS Feature
-        [ReplaceSkill(SGE.Dosis1, SGE.Dosis2, SGE.Dosis3)]
+        [ReplaceSkill(SGE.Dosis, SGE.Dosis2, SGE.Dosis3)]
         [CustomComboInfo("Single Target DPS Feature", "", SGE.JobID, 100, "", "")]
         SGE_ST_Dosis = 14100,
                 

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -29,18 +29,19 @@ namespace XIVSlothCombo.Combos.PvE
             Holos = 24310,
             EukrasianDiagnosis = 24291,
             EukrasianPrognosis = 24292,
+            Egeiro = 24287,
 
             // DPS
             Dosis = 24283,
             Dosis2 = 24306,
             Dosis3 = 24312,
-            EukrasianDosis  = 24293,
+            EukrasianDosis = 24293,
             EukrasianDosis2 = 24308,
             EukrasianDosis3 = 24314,
-            Phlegma  = 24289,
+            Phlegma = 24289,
             Phlegma2 = 24307,
             Phlegma3 = 24313,
-            Dyskrasia  = 24297,
+            Dyskrasia = 24297,
             Dyskrasia2 = 24315,
             Toxikon = 24304,
             Pneuma = 24318,
@@ -53,10 +54,7 @@ namespace XIVSlothCombo.Combos.PvE
             // Other
             Kardia = 24285,
             Eukrasia = 24290,
-            Rhizomata = 24309,
-
-            // Role
-            Egeiro = 24287;
+            Rhizomata = 24309;
 
         //Action Groups
         public static readonly List<uint>
@@ -136,7 +134,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 return AddersgalList.Contains(actionID) && 
-                    LevelAndCDChecked(Rhizomata) &&
+                    LevelAndOffCDChecked(Rhizomata) &&
                     Gauge.Addersgall is 0
                     ? Rhizomata
                     : actionID;
@@ -154,7 +152,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauro;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                return actionID is Druochole && LevelAndCDChecked(Taurochole)
+                return actionID is Druochole && LevelAndOffCDChecked(Taurochole)
                     ? Taurochole
                     : actionID;
             }
@@ -167,7 +165,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneuma;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                return actionID is Pneuma && LevelAndCDChecked(Pneuma) && IsOffCooldown(Zoe)
+                return actionID is Pneuma && LevelAndOffCDChecked(Pneuma) && IsOffCooldown(Zoe)
                     ? Zoe
                     : actionID;
             }
@@ -188,7 +186,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool NoTargetDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoTargetDyskrasia);
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) && LevelAndCDChecked(All.LucidDreaming) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) && LevelAndOffCDChecked(All.LucidDreaming) &&
                         LocalPlayer.CurrentMp <= GetOptionValue(Config.SGE_AoE_Phlegma_Lucid) &&
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
@@ -227,7 +225,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (DosisList.ContainsKey(actionID) && InCombat())
                 {
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) && LevelAndCDChecked(All.LucidDreaming) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) && LevelAndOffCDChecked(All.LucidDreaming) &&
                         LocalPlayer.CurrentMp <= GetOptionValue(Config.SGE_ST_Dosis_Lucid) &&
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
@@ -284,17 +282,17 @@ namespace XIVSlothCombo.Combos.PvE
                         ? CurrentTarget
                         : LocalPlayer;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && LevelAndCDChecked(Druochole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && LevelAndOffCDChecked(Druochole) &&
                         Gauge.Addersgall >= 1 &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Druochole))
                         return Druochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && LevelAndCDChecked(Taurochole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && LevelAndOffCDChecked(Taurochole) &&
                         Gauge.Addersgall >= 1 &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Taurochole))
                         return Taurochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && LevelAndCDChecked(Rhizomata) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && LevelAndOffCDChecked(Rhizomata) &&
                         Gauge.Addersgall is 0)
                         return Rhizomata;
 
@@ -303,24 +301,24 @@ namespace XIVSlothCombo.Combos.PvE
                         FindEffect(Buffs.Kardion, HealTarget, LocalPlayer?.ObjectId) is null)
                         return Kardia;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) && LevelAndCDChecked(Soteria) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) && LevelAndOffCDChecked(Soteria) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Soteria))
                         return Soteria;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) && LevelAndCDChecked(Zoe) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) && LevelAndOffCDChecked(Zoe) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Zoe))
                         return Zoe;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) && LevelAndCDChecked(Krasis) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) && LevelAndOffCDChecked(Krasis) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Krasis))
                         return Krasis;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) && LevelAndCDChecked(Pepsis) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) && LevelAndOffCDChecked(Pepsis) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Pepsis) &&
                         FindEffect(Buffs.EukrasianDiagnosis, HealTarget, LocalPlayer?.ObjectId) is not null)
                         return Pepsis;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && LevelAndCDChecked(Haima) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && LevelAndOffCDChecked(Haima) &&
                         GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Haima))
                         return Haima;
 
@@ -345,19 +343,19 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Prognosis)
                 {
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && LevelAndCDChecked(Rhizomata) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && LevelAndOffCDChecked(Rhizomata) &&
                         Gauge.Addersgall is 0)
                         return Rhizomata;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) && LevelAndCDChecked(Kerachole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) && LevelAndOffCDChecked(Kerachole) &&
                         Gauge.Addersgall >= 1)
                         return Kerachole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) && LevelAndCDChecked(Ixochole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) && LevelAndOffCDChecked(Ixochole) &&
                         Gauge.Addersgall >= 1)
                         return Ixochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) && LevelAndCDChecked(Physis))
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) && LevelAndOffCDChecked(Physis))
                         return OriginalHook(Physis);
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
@@ -370,13 +368,13 @@ namespace XIVSlothCombo.Combos.PvE
                             return EukrasianPrognosis;
                     }
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) && LevelAndCDChecked(Holos))
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) && LevelAndOffCDChecked(Holos))
                         return Holos;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) && LevelAndCDChecked(Panhaima))
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) && LevelAndOffCDChecked(Panhaima))
                         return Panhaima;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) && LevelAndCDChecked(Pepsis) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) && LevelAndOffCDChecked(Pepsis) &&
                         FindEffect(Buffs.EukrasianPrognosis) is not null)
                         return Pepsis;
                 }

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -242,7 +242,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Toxikon
                     if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
-                        CanUseAction(Toxikon) && HasBattleTarget() &&
+                        LevelChecked(Toxikon) && HasBattleTarget() && IsOffCooldown(actionID) &&
                         ((!GetOptionBool(Config.SGE_ST_Dosis_Toxikon) && this.IsMoving) || GetOptionBool(Config.SGE_ST_Dosis_Toxikon)) &&
                         Gauge.Addersting > 0)
                         return OriginalHook(Toxikon);

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -134,7 +134,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 return AddersgalList.Contains(actionID) && 
-                    LevelAndOffCDChecked(Rhizomata) &&
+                    ActionReady(Rhizomata) &&
                     Gauge.Addersgall is 0
                     ? Rhizomata
                     : actionID;
@@ -152,7 +152,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauro;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                return actionID is Druochole && LevelAndOffCDChecked(Taurochole)
+                return actionID is Druochole && ActionReady(Taurochole)
                     ? Taurochole
                     : actionID;
             }
@@ -165,7 +165,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneuma;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                return actionID is Pneuma && LevelAndOffCDChecked(Pneuma) && IsOffCooldown(Zoe)
+                return actionID is Pneuma && ActionReady(Pneuma) && IsOffCooldown(Zoe)
                     ? Zoe
                     : actionID;
             }
@@ -186,7 +186,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool NoTargetDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoTargetDyskrasia);
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) && LevelAndOffCDChecked(All.LucidDreaming) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) && ActionReady(All.LucidDreaming) &&
                         LocalPlayer.CurrentMp <= GetOptionValue(Config.SGE_AoE_Phlegma_Lucid) &&
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
@@ -225,7 +225,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (DosisList.ContainsKey(actionID) && InCombat())
                 {
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) && LevelAndOffCDChecked(All.LucidDreaming) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) && ActionReady(All.LucidDreaming) &&
                         LocalPlayer.CurrentMp <= GetOptionValue(Config.SGE_ST_Dosis_Lucid) &&
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
@@ -282,17 +282,17 @@ namespace XIVSlothCombo.Combos.PvE
                         ? CurrentTarget
                         : LocalPlayer;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && LevelAndOffCDChecked(Druochole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && ActionReady(Druochole) &&
                         Gauge.Addersgall >= 1 &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Druochole))
                         return Druochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && LevelAndOffCDChecked(Taurochole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && ActionReady(Taurochole) &&
                         Gauge.Addersgall >= 1 &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Taurochole))
                         return Taurochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && LevelAndOffCDChecked(Rhizomata) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && ActionReady(Rhizomata) &&
                         Gauge.Addersgall is 0)
                         return Rhizomata;
 
@@ -301,24 +301,24 @@ namespace XIVSlothCombo.Combos.PvE
                         FindEffect(Buffs.Kardion, HealTarget, LocalPlayer?.ObjectId) is null)
                         return Kardia;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) && LevelAndOffCDChecked(Soteria) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) && ActionReady(Soteria) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Soteria))
                         return Soteria;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) && LevelAndOffCDChecked(Zoe) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) && ActionReady(Zoe) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Zoe))
                         return Zoe;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) && LevelAndOffCDChecked(Krasis) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) && ActionReady(Krasis) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Krasis))
                         return Krasis;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) && LevelAndOffCDChecked(Pepsis) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) && ActionReady(Pepsis) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Pepsis) &&
                         FindEffect(Buffs.EukrasianDiagnosis, HealTarget, LocalPlayer?.ObjectId) is not null)
                         return Pepsis;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && LevelAndOffCDChecked(Haima) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && ActionReady(Haima) &&
                         GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Haima))
                         return Haima;
 
@@ -343,19 +343,19 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Prognosis)
                 {
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && LevelAndOffCDChecked(Rhizomata) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && ActionReady(Rhizomata) &&
                         Gauge.Addersgall is 0)
                         return Rhizomata;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) && LevelAndOffCDChecked(Kerachole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) && ActionReady(Kerachole) &&
                         Gauge.Addersgall >= 1)
                         return Kerachole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) && LevelAndOffCDChecked(Ixochole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) && ActionReady(Ixochole) &&
                         Gauge.Addersgall >= 1)
                         return Ixochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) && LevelAndOffCDChecked(Physis))
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) && ActionReady(Physis))
                         return OriginalHook(Physis);
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
@@ -368,13 +368,13 @@ namespace XIVSlothCombo.Combos.PvE
                             return EukrasianPrognosis;
                     }
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) && LevelAndOffCDChecked(Holos))
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) && ActionReady(Holos))
                         return Holos;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) && LevelAndOffCDChecked(Panhaima))
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) && ActionReady(Panhaima))
                         return Panhaima;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) && LevelAndOffCDChecked(Pepsis) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) && ActionReady(Pepsis) &&
                         FindEffect(Buffs.EukrasianPrognosis) is not null)
                         return Pepsis;
                 }

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -123,7 +123,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 return actionID is Taurochole or Druochole or Ixochole or Kerachole &&
-                    CanUse(Rhizomata) &&
+                    CanUseAction(Rhizomata) &&
                     Gauge.Addersgall is 0
                     ? Rhizomata
                     : actionID;
@@ -141,7 +141,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauro;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                return actionID is Druochole && CanUse(Taurochole)
+                return actionID is Druochole && CanUseAction(Taurochole)
                     ? Taurochole
                     : actionID;
             }
@@ -154,7 +154,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneuma;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                return actionID is Pneuma && CanUse(Pneuma) && IsOffCooldown(Zoe)
+                return actionID is Pneuma && CanUseAction(Pneuma) && IsOffCooldown(Zoe)
                     ? Zoe
                     : actionID;
             }
@@ -175,7 +175,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool NoTargetDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoTargetDyskrasia);
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) && CanUse(All.LucidDreaming) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) && CanUseAction(All.LucidDreaming) &&
                         LocalPlayer.CurrentMp <= GetOptionValue(Config.SGE_AoE_Phlegma_Lucid) &&
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
@@ -214,7 +214,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Dosis1 or Dosis2 or Dosis3 && InCombat())
                 {
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) && CanUse(All.LucidDreaming) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) && CanUseAction(All.LucidDreaming) &&
                         LocalPlayer.CurrentMp <= GetOptionValue(Config.SGE_ST_Dosis_Lucid) &&
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
@@ -242,7 +242,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Toxikon
                     if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
-                        CanUse(Toxikon) && HasBattleTarget() &&
+                        CanUseAction(Toxikon) && HasBattleTarget() &&
                         ((!GetOptionBool(Config.SGE_ST_Dosis_Toxikon) && this.IsMoving) || GetOptionBool(Config.SGE_ST_Dosis_Toxikon)) &&
                         Gauge.Addersting > 0)
                         return OriginalHook(Toxikon);
@@ -278,17 +278,17 @@ namespace XIVSlothCombo.Combos.PvE
                         ? CurrentTarget
                         : LocalPlayer;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && CanUse(Druochole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && CanUseAction(Druochole) &&
                         Gauge.Addersgall >= 1 &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Druochole))
                         return Druochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && CanUse(Taurochole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && CanUseAction(Taurochole) &&
                         Gauge.Addersgall >= 1 &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Taurochole))
                         return Taurochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && CanUse(Rhizomata)
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && CanUseAction(Rhizomata)
                         && Gauge.Addersgall is 0)
                         return Rhizomata;
 
@@ -297,24 +297,24 @@ namespace XIVSlothCombo.Combos.PvE
                         FindEffect(Buffs.Kardion, HealTarget, LocalPlayer?.ObjectId) is null)
                         return Kardia;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) && CanUse(Soteria) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) && CanUseAction(Soteria) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Soteria))
                         return Soteria;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) && CanUse(Zoe) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) && CanUseAction(Zoe) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Zoe))
                         return Zoe;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) && CanUse(Krasis) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) && CanUseAction(Krasis) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Krasis))
                         return Krasis;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) && CanUse(Pepsis) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) && CanUseAction(Pepsis) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Pepsis) &&
                         FindEffect(Buffs.EukrasianDiagnosis, HealTarget, LocalPlayer?.ObjectId) is not null) // Update for HealTarget
                         return Pepsis;
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && CanUse(Haima) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && CanUseAction(Haima) &&
                         GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Haima))
                         return Haima;
 
@@ -339,19 +339,19 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Prognosis)
                 {
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && CanUse(Rhizomata) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && CanUseAction(Rhizomata) &&
                         Gauge.Addersgall is 0)
                         return Rhizomata;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) && CanUse(Kerachole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) && CanUseAction(Kerachole) &&
                         Gauge.Addersgall >= 1)
                         return Kerachole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) && CanUse(Ixochole) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) && CanUseAction(Ixochole) &&
                         Gauge.Addersgall >= 1)
                         return Ixochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) && CanUse(Physis))
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) && CanUseAction(Physis))
                         return OriginalHook(Physis);
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
@@ -364,13 +364,13 @@ namespace XIVSlothCombo.Combos.PvE
                             return EukrasianPrognosis;
                     }
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) && CanUse(Holos))
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) && CanUseAction(Holos))
                         return Holos;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) && CanUse(Panhaima))
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Panhaima) && CanUseAction(Panhaima))
                         return Panhaima;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) && CanUse(Pepsis) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) && CanUseAction(Pepsis) &&
                         FindEffect(Buffs.EukrasianPrognosis) is not null)
                         return Pepsis;
                 }

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -219,33 +219,36 @@ namespace XIVSlothCombo.Combos.PvE
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
 
-                    // Eukrasian Dosis.
-                    // If we're too low level to use Eukrasia, we can stop here.
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia) && HasBattleTarget())
-                    {
-                        // If we're already Eukrasian'd, the whole point of this section is moot
-                        if (HasEffect(Buffs.Eukrasia))
-                            return OriginalHook(Dosis1); // OriginalHook will select the correct Dosis for us
+                    if (HasBattleTarget())
+                    { 
+                        // Eukrasian Dosis.
+                        // If we're too low level to use Eukrasia, we can stop here.
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia))
+                        {
+                            // If we're already Eukrasian'd, the whole point of this section is moot
+                            if (HasEffect(Buffs.Eukrasia))
+                                return OriginalHook(Dosis1); // OriginalHook will select the correct Dosis for us
 
-                        // Determine which Dosis debuff to check
-                        // Check level backwards from max level to find the appropriate level for debuff checking
-                        Status? DosisDebuffID;
-                        if (LevelChecked(Dosis3)) DosisDebuffID = FindTargetEffect(Debuffs.EukrasianDosis3);
-                        else if (LevelChecked(Dosis2)) DosisDebuffID = FindTargetEffect(Debuffs.EukrasianDosis2);
-                        else DosisDebuffID = FindTargetEffect(Debuffs.EukrasianDosis1);
+                            // Determine which Dosis debuff to check
+                            // Check level backwards from max level to find the appropriate level for debuff checking
+                            Status? DosisDebuffID;
+                            if (LevelChecked(Dosis3)) DosisDebuffID = FindTargetEffect(Debuffs.EukrasianDosis3);
+                            else if (LevelChecked(Dosis2)) DosisDebuffID = FindTargetEffect(Debuffs.EukrasianDosis2);
+                            else DosisDebuffID = FindTargetEffect(Debuffs.EukrasianDosis1);
 
-                        // Got our Debuff for our level, check for it and procede 
-                        if (((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3)) &&
-                            (GetTargetHPPercent() > GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer)))
-                            return Eukrasia;
+                            // Got our Debuff for our level, check for it and procede 
+                            if (((DosisDebuffID is null) || (DosisDebuffID.RemainingTime <= 3)) &&
+                                (GetTargetHPPercent() > GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer)))
+                                return Eukrasia;
+                        }
+
+                        // Toxikon
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
+                            LevelChecked(Toxikon) && IsOffCooldown(actionID) &&
+                            ((!GetOptionBool(Config.SGE_ST_Dosis_Toxikon) && this.IsMoving) || GetOptionBool(Config.SGE_ST_Dosis_Toxikon)) &&
+                            Gauge.Addersting > 0)
+                           return OriginalHook(Toxikon);
                     }
-
-                    // Toxikon
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
-                        LevelChecked(Toxikon) && HasBattleTarget() && IsOffCooldown(actionID) &&
-                        ((!GetOptionBool(Config.SGE_ST_Dosis_Toxikon) && this.IsMoving) || GetOptionBool(Config.SGE_ST_Dosis_Toxikon)) &&
-                        Gauge.Addersting > 0)
-                        return OriginalHook(Toxikon);
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -215,7 +215,7 @@ namespace XIVSlothCombo.Combos.PvE
         /*
         Single Target Dosis Combo
         Currently Replaces Dosis with Eukrasia when the debuff on the target is < 3 seconds or not existing
-        Lucid Dreaming, Target of Target optional
+        Lucid Dreaming, Toxikon optional
         */
         internal class SGE_ST_Dosis : CustomCombo
         {

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -40,7 +40,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <summary> Checks if the player can use an action based on the level required and it's cooldown status. Also checks action charges.</summary>
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>
-        public static bool CanUse(uint id)
+        public static bool CanUseAction(uint id)
         {
             if (LevelChecked(id))
             {

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -41,7 +41,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>
         //Note: Testing so far shows non charge skills have a max charge of 1, and it's zero during cooldown
-        public static bool LevelAndOffCDChecked(uint id) => LevelChecked(id) && HasCharges(id);
+        public static bool ActionReady(uint id) => LevelChecked(id) && HasCharges(id);
 
         /// <summary> Checks if the last action performed was the passed ID. </summary>
         /// <param name="id"> ID of the action. </param>

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -37,20 +37,11 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static int GetLevel(uint id) => ActionWatching.GetLevel(id);
 
-        /// <summary> Checks if the player can use an action based on the level required and it's cooldown status. Also checks action charges.</summary>
+        /// <summary> Checks if the player can use an action based on the level required and it's cooldown status (includes charges).</summary>
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>
-        public static bool CanUseAction(uint id)
-        {
-            if (LevelChecked(id))
-            {
-                //Asking for cooldown data one time for two checks
-                CooldownData cd = GetCooldown(id);
-                //Are we off cooldown, else do we have a charge?
-                return (!cd.IsCooldown || cd.RemainingCharges > 0);
-            }
-            return false;
-        }
+        //Note: Testing so far shows non charge skills have a max charge of 1, and it's zero during cooldown
+        public static bool LevelAndCDChecked(uint id) => LevelChecked(id) && HasCharges(id);
 
         /// <summary> Checks if the last action performed was the passed ID. </summary>
         /// <param name="id"> ID of the action. </param>

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -37,6 +37,21 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static int GetLevel(uint id) => ActionWatching.GetLevel(id);
 
+        /// <summary> Checks if the player can use an action based on the level required and it's cooldown status. Also checks action charges.</summary>
+        /// <param name="id"> ID of the action. </param>
+        /// <returns></returns>
+        public static bool CanUse(uint id)
+        {
+            if (LevelChecked(id))
+            {
+                //Asking for cooldown data one time for two checks
+                CooldownData cd = GetCooldown(id);
+                //Are we off cooldown, else do we have a charge?
+                return (!cd.IsCooldown || cd.RemainingCharges > 0);
+            }
+            return false;
+        }
+
         /// <summary> Checks if the last action performed was the passed ID. </summary>
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>
@@ -161,4 +176,6 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns> True or false. </returns>
         public static bool CanDelayedWeave(uint actionID, double start = 1.25, double end = 0.6) => GetCooldown(actionID).CooldownRemaining < start && GetCooldown(actionID).CooldownRemaining > end;
     }
+
+
 }

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -37,11 +37,11 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static int GetLevel(uint id) => ActionWatching.GetLevel(id);
 
-        /// <summary> Checks if the player can use an action based on the level required and it's cooldown status (includes charges).</summary>
+        /// <summary> Checks if the player can use an action based on the level required and off cooldown / has charges.</summary>
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>
         //Note: Testing so far shows non charge skills have a max charge of 1, and it's zero during cooldown
-        public static bool LevelAndCDChecked(uint id) => LevelChecked(id) && HasCharges(id);
+        public static bool LevelAndOffCDChecked(uint id) => LevelChecked(id) && HasCharges(id);
 
         /// <summary> Checks if the last action performed was the passed ID. </summary>
         /// <param name="id"> ID of the action. </param>

--- a/XIVSlothCombo/CustomCombo/Functions/Cooldown.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Cooldown.cs
@@ -28,17 +28,17 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <summary> Gets a value indicating whether an action is off cooldown. </summary>
         /// <param name="actionID"> Action ID to check. </param>
         /// <returns> True or false. </returns>
-        public bool IsOffCooldown(uint actionID) => !GetCooldown(actionID).IsCooldown;
+        public static bool IsOffCooldown(uint actionID) => !GetCooldown(actionID).IsCooldown;
 
         /// <summary> Check if the Cooldown was just used. </summary>
         /// <param name="actionID"> Action ID to check. </param>
         /// <returns> True or false. </returns>
-        public bool JustUsed(uint actionID) => IsOnCooldown(actionID) && GetCooldownRemainingTime(actionID) > (GetCooldown(actionID).CooldownTotal - 3);
+        public static bool JustUsed(uint actionID) => IsOnCooldown(actionID) && GetCooldownRemainingTime(actionID) > (GetCooldown(actionID).CooldownTotal - 3);
 
         /// <summary> Gets a value indicating whether an action has any available charges. </summary>
         /// <param name="actionID"> Action ID to check. </param>
         /// <returns> True or false. </returns>
-        public bool HasCharges(uint actionID) => GetCooldown(actionID).RemainingCharges > 0;
+        public static bool HasCharges(uint actionID) => GetCooldown(actionID).RemainingCharges > 0;
 
         /// <summary> Get the current number of charges remaining for an action. </summary>
         /// <param name="actionID"> Action ID to check. </param>


### PR DESCRIPTION
## Framework
- Action
  - Added `ActionReady()`. Combines repetitive Level and Cooldown checks into one function  (works with all actions, including charges)
- Cooldown
  - Added "static" to methods

## SGE
- Cleaned up/sorted action IDs
- Updated for `ActionReady()`
- SGE.Gauge added
- Action List added for `Addersgall` & `Phlegma `
- DoT Dictionary added for `Dosis`/`Eukrasian Dosis debuffs`.
- SGE_ST_Dosis 
  - `Toxikon Movement Option`: Cooldown checking added to stop cooldown seizure effect.
  - `Eukrasian Dosis`: Level checks no longer required. Now reads the appropriate `Dosis` available, then using DoT dictionary to find it's appropriate debuff