### PR TITLE
[SGE] Bugfix / Light Cleanup

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2173,11 +2173,11 @@ namespace XIVSlothCombo.Combos
         #region Diagnosis Simple Single Target Heal
         [ReplaceSkill(SGE.Diagnosis)]
         [ConflictingCombos(SGE_Rhizo, SGE_DruoTauro)]
-        [CustomComboInfo("Single Target Heal Feature", "Supports soft-targeting.", SGE.JobID, 300, "", "")]
+        [CustomComboInfo("Single Target Heal Feature", "Supports soft-targeting.\nOptions below are in priority order", SGE.JobID, 300, "", "")]
         SGE_ST_Heal = 14300,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Apply Kardia Option", "Applies Kardia to your target if it's not applied to anyone else.\nOptions below are in priority order", SGE.JobID, 304, "", "")]
+            [CustomComboInfo("Apply Kardia Option", "Applies Kardia to your target if it's not applied to anyone else.", SGE.JobID, 304, "", "")]
             SGE_ST_Heal_Kardia = 14310,
 
             [ParentCombo(SGE_ST_Heal)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2177,43 +2177,43 @@ namespace XIVSlothCombo.Combos
         SGE_ST_Heal = 14300,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Apply Kardia Option", "Applies Kardia to your target if it's not applied to anyone else.", SGE.JobID, 310, "", "")]
+            [CustomComboInfo("Apply Kardia Option", "Applies Kardia to your target if it's not applied to anyone else.\nOptions below are in priority order", SGE.JobID, 304, "", "")]
             SGE_ST_Heal_Kardia = 14310,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Eukrasian Diagnosis Option", "Diagnosis becomes Eukrasian Diagnosis if the shield is not applied to the target.", SGE.JobID, 320, "", "")]
+            [CustomComboInfo("Eukrasian Diagnosis Option", "Diagnosis becomes Eukrasian Diagnosis if the shield is not applied to the target.", SGE.JobID, 313, "", "")]
             SGE_ST_Heal_Diagnosis = 14320,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Soteria Option", "Applies Soteria.", SGE.JobID, 330, "", "")]
+            [CustomComboInfo("Soteria Option", "Applies Soteria.", SGE.JobID, 306, "", "")]
             SGE_ST_Heal_Soteria = 14330,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Zoe Option", "Applies Zoe.", SGE.JobID, 340, "", "")]
+            [CustomComboInfo("Zoe Option", "Applies Zoe.", SGE.JobID, 307, "", "")]
             SGE_ST_Heal_Zoe = 14340,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Pepsis Option", "Triggers Pepsis if a shield is present.", SGE.JobID, 350, "", "")]
+            [CustomComboInfo("Pepsis Option", "Triggers Pepsis if a shield is present.", SGE.JobID, 309, "", "")]
             SGE_ST_Heal_Pepsis = 14350,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Taurochole Option", "Adds Taurochole.", SGE.JobID, 360, "", "")]
+            [CustomComboInfo("Taurochole Option", "Adds Taurochole.", SGE.JobID, 302, "", "")]
             SGE_ST_Heal_Taurochole = 14360,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Haima Option", "Applies Haima.", SGE.JobID, 370, "", "")]
+            [CustomComboInfo("Haima Option", "Applies Haima.", SGE.JobID, 310, "", "")]
             SGE_ST_Heal_Haima = 14370,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 380, "", "")]
+            [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 303, "", "")]
             SGE_ST_Heal_Rhizomata = 14380,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Krasis Option", "Applies Krasis.", SGE.JobID, 390, "", "")]
+            [CustomComboInfo("Krasis Option", "Applies Krasis.", SGE.JobID, 308, "", "")]
             SGE_ST_Heal_Krasis = 14390,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Druochole Option", "Applies Druochole.", SGE.JobID, 400, "", "")]
+            [CustomComboInfo("Druochole Option", "Applies Druochole.", SGE.JobID, 301, "", "")]
             SGE_ST_Heal_Druochole = 14400,
             #endregion
 

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -233,11 +233,12 @@ namespace XIVSlothCombo.Combos.PvE
                         LocalPlayer.CurrentMp <= lucidMPThreshold)
                         return All.LucidDreaming;
 
-                    if (HasBattleTarget())
+                    if (HasBattleTarget() && (!HasEffect(Buffs.Eukrasia))) 
+                        //Buff check Above. Without it, Toxikon and any future option will interfere in the Eukrasia->Eukrasia Dosis combo
                     {
                         // Eukrasian Dosis.
                         // If we're too low level to use Eukrasia, we can stop here.
-                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia) && (!HasEffect(Buffs.Eukrasia)))
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia))
                         {
                             // Grab current Dosis via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
                             var dotDebuff = FindTargetEffect(DosisList[OriginalHook(actionID)]);
@@ -281,6 +282,8 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Diagnosis)
                 {
+                    if (HasEffect(Buffs.Eukrasia)) return EukrasianDiagnosis;
+
                     // Set Target. Soft -> Hard -> Self priority, matching normal in-game behavior
                     GameObject? HealTarget;
 
@@ -328,15 +331,11 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && ActionReady(Haima) &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Haima))
                         return Haima;
-
+                    
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Diagnosis) && LevelChecked(Eukrasia) &&
                         FindEffect(Buffs.EukrasianDiagnosis, HealTarget, LocalPlayer?.ObjectId) is null &&
                         GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Diagnosis))
-                    {
-                        return !HasEffect(Buffs.Eukrasia)
-                            ? Eukrasia
-                            : EukrasianDiagnosis;
-                    }
+                        return Eukrasia;
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -1,7 +1,6 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.Types;
-using Dalamud.Game.ClientState.Statuses;
 using System.Collections.Generic;
 using XIVSlothCombo.CustomComboNS;
 
@@ -241,7 +240,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia) && (!HasEffect(Buffs.Eukrasia)))
                         {
                             // Grab current Dosis via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
-                            Status? dotDebuff = FindTargetEffect(DosisList[OriginalHook(actionID)]);
+                            var dotDebuff = FindTargetEffect(DosisList[OriginalHook(actionID)]);
                             int eDosisHPThreshold = GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer);
 
                             if (((dotDebuff is null) || (dotDebuff.RemainingTime <= 3)) &&
@@ -363,8 +362,11 @@ namespace XIVSlothCombo.Combos.PvE
                         Gauge.Addersgall >= 1)
                         return Ixochole;
 
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis) && ActionReady(Physis))
-                        return OriginalHook(Physis);
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis))
+                    {
+                        uint physis = OriginalHook(Physis);
+                        if (ActionReady(physis)) return physis;
+                    }
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
                         FindEffect(Buffs.EukrasianPrognosis) is null)

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -10,7 +10,7 @@ namespace XIVSlothCombo.Combos.PvE
     {
         internal const byte JobID = 40;
 
-        private static SGEGauge Gauge => CustomComboNS.Functions.CustomComboFunctions.GetJobGauge<SGEGauge>();
+        private static SGEGauge Gauge = CustomComboNS.Functions.CustomComboFunctions.GetJobGauge<SGEGauge>();
 
         public const uint
             // Heals and Shields
@@ -326,7 +326,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Pepsis;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && ActionReady(Haima) &&
-                        GetTargetHPPercent() <= GetOptionValue(Config.SGE_ST_Heal_Haima))
+                        GetTargetHPPercent(HealTarget) <= GetOptionValue(Config.SGE_ST_Heal_Haima))
                         return Haima;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Diagnosis) && LevelChecked(Eukrasia) &&

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -1,6 +1,7 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Game.ClientState.Statuses;
 using System.Collections.Generic;
 using XIVSlothCombo.CustomComboNS;
 
@@ -10,7 +11,7 @@ namespace XIVSlothCombo.Combos.PvE
     {
         internal const byte JobID = 40;
 
-        private static SGEGauge Gauge = CustomComboNS.Functions.CustomComboFunctions.GetJobGauge<SGEGauge>();
+        private static readonly SGEGauge Gauge = CustomComboNS.Functions.CustomComboFunctions.GetJobGauge<SGEGauge>();
 
         public const uint
             // Heals and Shields
@@ -57,8 +58,8 @@ namespace XIVSlothCombo.Combos.PvE
 
         // Action Groups
         internal static readonly List<uint>
-            AddersgallList = new() { Taurochole, Druochole, Ixochole, Kerachole },
-            PhlegmaList = new () { Phlegma, Phlegma2, Phlegma3 };
+            AddersgallList = new()  { Taurochole, Druochole, Ixochole, Kerachole },
+            PhlegmaList = new()     { Phlegma, Phlegma2, Phlegma3 };
 
         internal static class Buffs
         {
@@ -116,46 +117,42 @@ namespace XIVSlothCombo.Combos.PvE
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Kardia;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                return actionID is Soteria && (!HasEffect(Buffs.Kardia) || IsOnCooldown(Soteria))
+                => actionID is Soteria &&
+                    (!HasEffect(Buffs.Kardia) || IsOnCooldown(Soteria))
                     ? Kardia
                     : actionID;
-            }
         }
 
         /*
-        Rhizomata
-        Replaces all Addersgal using Abilities (Taurochole/Druochole/Ixochole/Kerachole) with Rhizomata if out of Addersgall stacks
-        (Scholar speak: Replaces all Aetherflow abilities with Aetherflow when out)
-        */
+         * Rhizomata
+         * Replaces all Addersgal using Abilities (Taurochole/Druochole/Ixochole/Kerachole) with Rhizomata if out of Addersgall stacks
+         * (Scholar speak: Replaces all Aetherflow abilities with Aetherflow when out)
+         */
         internal class SGE_Rhizo : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Rhizo;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                return AddersgallList.Contains(actionID) && 
+                => AddersgallList.Contains(actionID) &&
                     ActionReady(Rhizomata) &&
                     Gauge.Addersgall is 0
                     ? Rhizomata
                     : actionID;
-            }
         }
 
         /*
-        Druo/Tauro
-        Druochole Upgrade to Taurochole (like a trait upgrade)
-        Replaces Druocole with Taurochole when Taurochole is available
-        (As of 6.0) Taurochole (single target massive insta heal w/ cooldown), Druochole (Single target insta heal)
-        */
+         * Druo/Tauro
+         * Druochole Upgrade to Taurochole (like a trait upgrade)
+         * Replaces Druocole with Taurochole when Taurochole is available
+         * (As of 6.0) Taurochole (single target massive insta heal w/ cooldown), Druochole (Single target insta heal)
+         */
         internal class SGE_DruoTauro : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauro;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                return actionID is Druochole && ActionReady(Taurochole)
+                => actionID is Druochole &&
+                    ActionReady(Taurochole)
                     ? Taurochole
                     : actionID;
-            }
         }
 
         // Zoe Pneuma
@@ -164,11 +161,11 @@ namespace XIVSlothCombo.Combos.PvE
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneuma;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                return actionID is Pneuma && ActionReady(Pneuma) && IsOffCooldown(Zoe)
+                => actionID is Pneuma &&
+                    ActionReady(Pneuma) &&
+                    IsOffCooldown(Zoe)
                     ? Zoe
                     : actionID;
-            }
         }
 
         // AoE/Phlegma Replacement
@@ -214,10 +211,10 @@ namespace XIVSlothCombo.Combos.PvE
         }
 
         /*
-        Single Target Dosis Combo
-        Currently Replaces Dosis with Eukrasia when the debuff on the target is < 3 seconds or not existing
-        Lucid Dreaming, Toxikon optional
-        */
+         * Single Target Dosis Combo
+         * Currently Replaces Dosis with Eukrasia when the debuff on the target is < 3 seconds or not existing
+         * Lucid Dreaming, Toxikon optional
+         */
         internal class SGE_ST_Dosis : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_Dosis;
@@ -234,14 +231,14 @@ namespace XIVSlothCombo.Combos.PvE
                         return All.LucidDreaming;
 
                     if (HasBattleTarget() && (!HasEffect(Buffs.Eukrasia))) 
-                        //Buff check Above. Without it, Toxikon and any future option will interfere in the Eukrasia->Eukrasia Dosis combo
+                        // Buff check Above. Without it, Toxikon and any future option will interfere in the Eukrasia->Eukrasia Dosis combo
                     {
                         // Eukrasian Dosis.
                         // If we're too low level to use Eukrasia, we can stop here.
                         if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia))
                         {
                             // Grab current Dosis via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
-                            var dotDebuff = FindTargetEffect(DosisList[OriginalHook(actionID)]);
+                            Status? dotDebuff = FindTargetEffect(DosisList[OriginalHook(actionID)]);
                             int eDosisHPThreshold = GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer);
 
                             if (((dotDebuff is null) || (dotDebuff.RemainingTime <= 3)) &&
@@ -250,9 +247,9 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // Toxikon
-                        bool alwaysShowToxikon = GetOptionBool(Config.SGE_ST_Dosis_Toxikon); //False for moving only, True for Show All Times
+                        bool alwaysShowToxikon = GetOptionBool(Config.SGE_ST_Dosis_Toxikon);    // False for moving only, True for Show All Times
                         if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
-                            LevelChecked(Toxikon) && IsOffCooldown(actionID) &&     // Cooldown check against original action to stop cooldown animation seizure
+                            LevelChecked(Toxikon) && IsOffCooldown(actionID) &&                 // Cooldown check against original action to stop cooldown animation seizure
                             ((!alwaysShowToxikon && IsMoving) || alwaysShowToxikon) &&
                             Gauge.Addersting > 0)
                             return OriginalHook(Toxikon);
@@ -268,11 +265,10 @@ namespace XIVSlothCombo.Combos.PvE
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Raise;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                return actionID is All.Swiftcast && IsOnCooldown(All.Swiftcast)
+                    => actionID is All.Swiftcast &&
+                    IsOnCooldown(All.Swiftcast)
                     ? Egeiro
                     : actionID;
-            }
         }
 
         internal class SGE_ST_Heal : CustomCombo
@@ -282,12 +278,14 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Diagnosis)
                 {
-                    if (HasEffect(Buffs.Eukrasia)) return EukrasianDiagnosis;
+                    if (HasEffect(Buffs.Eukrasia))
+                        return EukrasianDiagnosis;
 
                     // Set Target. Soft -> Hard -> Self priority, matching normal in-game behavior
                     GameObject? HealTarget;
 
-                    if (Services.Service.TargetManager.SoftTarget?.ObjectKind is ObjectKind.Player) HealTarget = Services.Service.TargetManager.SoftTarget;
+                    if (Services.Service.TargetManager.SoftTarget?.ObjectKind is ObjectKind.Player)
+                         HealTarget = Services.Service.TargetManager.SoftTarget;
                     else HealTarget = CurrentTarget?.ObjectKind is ObjectKind.Player
                         ? CurrentTarget
                         : LocalPlayer;
@@ -349,7 +347,8 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Prognosis)
                 {
-                    if (HasEffect(Buffs.Eukrasia)) return EukrasianPrognosis;
+                    if (HasEffect(Buffs.Eukrasia))
+                        return EukrasianPrognosis;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && ActionReady(Rhizomata) &&
                         Gauge.Addersgall is 0)

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -349,6 +349,8 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Prognosis)
                 {
+                    if (HasEffect(Buffs.Eukrasia)) return EukrasianPrognosis;
+
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && ActionReady(Rhizomata) &&
                         Gauge.Addersgall is 0)
                         return Rhizomata;
@@ -369,12 +371,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
                         FindEffect(Buffs.EukrasianPrognosis) is null)
-                    {
-                        if (!HasEffect(Buffs.Eukrasia))
-                            return Eukrasia;
-                        if (HasEffect(Buffs.Eukrasia))
-                            return EukrasianPrognosis;
-                    }
+                        return Eukrasia;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) && ActionReady(Holos))
                         return Holos;

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -9,9 +9,9 @@ namespace XIVSlothCombo.Combos.PvE
 {
     internal static class SGE
     {
-        public const byte JobID = 40;
+        internal const byte JobID = 40;
 
-        public static SGEGauge Gauge = CustomComboNS.Functions.CustomComboFunctions.GetJobGauge<SGEGauge>();
+        private static SGEGauge Gauge => CustomComboNS.Functions.CustomComboFunctions.GetJobGauge<SGEGauge>();
 
         public const uint
             // Heals and Shields
@@ -57,13 +57,13 @@ namespace XIVSlothCombo.Combos.PvE
             Rhizomata = 24309;
 
         // Action Groups
-        public static readonly List<uint>
+        internal static readonly List<uint>
             AddersgallList = new() { Taurochole, Druochole, Ixochole, Kerachole },
             PhlegmaList = new () { Phlegma, Phlegma2, Phlegma3 };
 
-        public static class Buffs
+        internal static class Buffs
         {
-            public const ushort
+            internal const ushort
                 Kardia = 2604,
                 Eukrasia = 2606,
                 EukrasianDiagnosis = 2607,
@@ -71,16 +71,16 @@ namespace XIVSlothCombo.Combos.PvE
                 Kardion = 2872;
         }
 
-        public static class Debuffs
+        internal static class Debuffs
         {
-            public const ushort
+            internal const ushort
                 EukrasianDosis = 2614,
                 EukrasianDosis2 = 2615,
                 EukrasianDosis3 = 2616;
         }
 
         // Debuff Pairs of Actions and Debuff
-        public static readonly Dictionary<uint, ushort>
+        internal static readonly Dictionary<uint, ushort>
             DosisList = new()
             {
                 { Dosis,  Debuffs.EukrasianDosis  },
@@ -88,14 +88,14 @@ namespace XIVSlothCombo.Combos.PvE
                 { Dosis3, Debuffs.EukrasianDosis3 }
             };
 
-        public static class Range
+        internal static class Range
         {
-            public const byte Phlegma = 6;
+            internal const byte Phlegma = 6;
         }
 
-        public static class Config
+        internal static class Config
         {
-            public const string
+            internal const string
                 // GUI Customization Storage Names
                 SGE_ST_Dosis_EDosisHPPer = "SGE_ST_Dosis_EDosisHPPer",
                 SGE_ST_Dosis_Lucid = "SGE_ST_Dosis_Lucid",
@@ -236,8 +236,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (HasBattleTarget())
                     {
-                        bool toxikonMovement = GetOptionBool(Config.SGE_ST_Dosis_Toxikon);
-
                         // Eukrasian Dosis.
                         // If we're too low level to use Eukrasia, we can stop here.
                         if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia) && (!HasEffect(Buffs.Eukrasia)))
@@ -252,9 +250,10 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // Toxikon
+                        bool alwaysShowToxikon = GetOptionBool(Config.SGE_ST_Dosis_Toxikon); //False for moving only, True for Show All Times
                         if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
                             LevelChecked(Toxikon) && IsOffCooldown(actionID) &&     // Cooldown check against original action to stop cooldown animation seizure
-                            ((!toxikonMovement && IsMoving) || toxikonMovement) &&
+                            ((!alwaysShowToxikon && IsMoving) || alwaysShowToxikon) &&
                             Gauge.Addersting > 0)
                             return OriginalHook(Toxikon);
                     }


### PR DESCRIPTION
SGE
* Actions made internal vs public
* Gauge made private, should point to function instead of being function result (Bugfix?) 
* SGE_ST_Dosis
  * Toxikon: Clarified/Renamed Toxikon bool per Discord discussion w/ k
  * Bugfix: Eukrasia buff check moved higher to encompass DoT & Toxikon code. Toxikon was interrupting Eukrasia/Eukrasia Dosis two button combo.
* SGE_AoE_Heal 
  * Bugfix. Didn't do OriginalHook on Physis correctly with ActionReady
  * Eukrasia buff check moved to the top to stop replacement actions from breaking the Eukrasia->Eukrasia Prognosis combo
* SGE_ST_Heal:
  *  Haima was looking for current target still. Fixed. Ingame configuration will now show the options (Haima, Zoe, etc) in the same order as the code
  * Eukrasia buff check moved to the top to stop replacement actions from breaking the Eukrasia->Eukrasia Diagnosis combo