### PR TITLE
[Framework] Internal cleanup

### DIFF
--- a/XIVSlothCombo/Attributes/BlueInactiveAttribute.cs
+++ b/XIVSlothCombo/Attributes/BlueInactiveAttribute.cs
@@ -12,12 +12,13 @@ namespace XIVSlothCombo.Attributes
         /// <param name="actionIDs"> List of actions the preset replaces. </param>
         internal BlueInactiveAttribute(params uint[] actionIDs)
         {
-            if (Service.Configuration is null) return;
+            if (Service.Configuration is null)
+                return;
 
-            foreach(uint id in actionIDs)
+            foreach (uint id in actionIDs)
             {
-                if (Service.Configuration.ActiveBLUSpells.Contains(id)) continue;
-
+                if (Service.Configuration.ActiveBLUSpells.Contains(id))
+                    continue;
                 Actions.Add(id);
             }
         }

--- a/XIVSlothCombo/Attributes/HoverInfoAttribute.cs
+++ b/XIVSlothCombo/Attributes/HoverInfoAttribute.cs
@@ -6,7 +6,6 @@ namespace XIVSlothCombo.Attributes
     public class HoverInfoAttribute : Attribute
     {
         internal HoverInfoAttribute(string hoverText) => HoverText = hoverText;
-
         public string HoverText { get; set; }
     }
 }

--- a/XIVSlothCombo/Attributes/ReplaceSkillAttribute.cs
+++ b/XIVSlothCombo/Attributes/ReplaceSkillAttribute.cs
@@ -17,7 +17,7 @@ namespace XIVSlothCombo.Attributes
         /// <param name="actionIDs"> List of actions the preset replaces. </param>
         internal ReplaceSkillAttribute(params uint[] actionIDs)
         {
-            foreach(uint id in actionIDs)
+            foreach (uint id in actionIDs)
             {
                 if (ActionSheet.TryGetValue(id, out var action) && action != null)
                 {

--- a/XIVSlothCombo/Core/IconReplacer.cs
+++ b/XIVSlothCombo/Core/IconReplacer.cs
@@ -63,15 +63,15 @@ namespace XIVSlothCombo.Core
 
                 if (ClassLocked()) return OriginalHook(actionID);
 
-                var lastComboMove = *(uint*)Service.Address.LastComboMove;
-                var comboTime = *(float*)Service.Address.ComboTimer;
-                var level = Service.ClientState.LocalPlayer?.Level ?? 0;
+                uint lastComboMove = *(uint*)Service.Address.LastComboMove;
+                float comboTime = *(float*)Service.Address.ComboTimer;
+                byte level = Service.ClientState.LocalPlayer?.Level ?? 0;
 
                 BlueMageService.PopulateBLUSpells();
 
-                foreach (var combo in customCombos)
+                foreach (CustomCombo? combo in customCombos)
                 {
-                    if (combo.TryInvoke(actionID, level, lastComboMove, comboTime, out var newActionID))
+                    if (combo.TryInvoke(actionID, level, lastComboMove, comboTime, out uint newActionID))
                         return newActionID;
                 }
 
@@ -90,10 +90,9 @@ namespace XIVSlothCombo.Core
         {
             if (Service.ClientState.LocalPlayer.Level <= 35) Service.ClassLocked = false;
 
-            if ((Service.ClientState.LocalPlayer.ClassJob.Id >= 8 &&
-                Service.ClientState.LocalPlayer.ClassJob.Id <= 25) ||
-                Service.ClientState.LocalPlayer.ClassJob.Id is 27 or 28 ||
-                Service.ClientState.LocalPlayer.ClassJob.Id >= 30) Service.ClassLocked = false;
+            if (Service.ClientState.LocalPlayer.ClassJob.Id is
+                (>= 8 and <= 25) or 27 or 28 or >= 30)
+                Service.ClassLocked = false;
 
             if ((Service.ClientState.LocalPlayer.ClassJob.Id is 1 or 2 or 3 or 4 or 5 or 6 or 7 or 26 or 29) &&
                 !Service.Condition[Dalamud.Game.ClientState.Conditions.ConditionFlag.BoundByDuty] &&

--- a/XIVSlothCombo/Core/PluginConfiguration.cs
+++ b/XIVSlothCombo/Core/PluginConfiguration.cs
@@ -116,16 +116,17 @@ namespace XIVSlothCombo.Core
         /// <summary> Gets a custom float value. </summary>
         public static float GetCustomFloatValue(string config, float defaultMinValue = 0)
         {
-            if (!CustomFloatValues.TryGetValue(config, out float configValue)) { SetCustomFloatValue(config, defaultMinValue); return defaultMinValue; }
+            if (!CustomFloatValues.TryGetValue(config, out float configValue))
+            {
+                SetCustomFloatValue(config, defaultMinValue);
+                return defaultMinValue;
+            }
 
             return configValue;
         }
 
         /// <summary> Sets a custom float value. </summary>
-        public static void SetCustomFloatValue(string config, float value)
-        {
-            CustomFloatValues[config] = value;
-        }
+        public static void SetCustomFloatValue(string config, float value) => CustomFloatValues[config] = value;
 
         #endregion
 
@@ -137,16 +138,17 @@ namespace XIVSlothCombo.Core
         /// <summary> Gets a custom integer value. </summary>
         public static int GetCustomIntValue(string config, int defaultMinVal = 0)
         {
-            if (!CustomIntValues.TryGetValue(config, out int configValue)) { SetCustomIntValue(config, defaultMinVal); return defaultMinVal; }
+            if (!CustomIntValues.TryGetValue(config, out int configValue))
+            {
+                SetCustomIntValue(config, defaultMinVal);
+                return defaultMinVal;
+            }
 
             return configValue;
         }
 
         /// <summary> Sets a custom integer value. </summary>
-        public static void SetCustomIntValue(string config, int value)
-        {
-            CustomIntValues[config] = value;
-        }
+        public static void SetCustomIntValue(string config, int value) => CustomIntValues[config] = value;
 
         #endregion
 
@@ -158,16 +160,17 @@ namespace XIVSlothCombo.Core
         /// <summary> Gets a custom boolean value. </summary>
         public static bool GetCustomBoolValue(string config)
         {
-            if (!CustomBoolValues.TryGetValue(config, out bool configValue)) { SetCustomBoolValue(config, false); return false; }
+            if (!CustomBoolValues.TryGetValue(config, out bool configValue))
+            {
+                SetCustomBoolValue(config, false);
+                return false;
+            }
 
             return configValue;
         }
 
         /// <summary> Sets a custom boolean value. </summary>
-        public static void SetCustomBoolValue(string config, bool value)
-        {
-            CustomBoolValues[config] = value;
-        }
+        public static void SetCustomBoolValue(string config, bool value) => CustomBoolValues[config] = value;
 
         #endregion
 
@@ -179,16 +182,17 @@ namespace XIVSlothCombo.Core
         /// <summary> Gets a custom boolean array value. </summary>
         public static bool[] GetCustomBoolArrayValue(string config)
         {
-            if (!CustomBoolArrayValues.TryGetValue(config, out bool[]? configValue)) { SetCustomBoolArrayValue(config, Array.Empty<bool>()); return Array.Empty<bool>(); }
+            if (!CustomBoolArrayValues.TryGetValue(config, out bool[]? configValue))
+            {
+                SetCustomBoolArrayValue(config, Array.Empty<bool>());
+                return Array.Empty<bool>();
+            }
 
             return configValue;
         }
 
         /// <summary> Sets a custom boolean array value. </summary>
-        public static void SetCustomBoolArrayValue(string config, bool[] value)
-        {
-            CustomBoolArrayValues[config] = value;
-        }
+        public static void SetCustomBoolArrayValue(string config, bool[] value) => CustomBoolArrayValues[config] = value;
 
         #endregion
 
@@ -216,7 +220,7 @@ namespace XIVSlothCombo.Core
         /// <summary> Handles 'special event' feature naming. </summary>
         public bool SpecialEvent { get; set; } = false;
 
-        /// <summary> Hide MotD. </summary>
+        /// <summary> Hides the message of the day. </summary>
         public bool HideMessageOfTheDay { get; set; } = false;
 
         /// <summary> Save the configuration to disk. </summary>

--- a/XIVSlothCombo/Core/PluginConfiguration.cs
+++ b/XIVSlothCombo/Core/PluginConfiguration.cs
@@ -101,7 +101,7 @@ namespace XIVSlothCombo.Core
         public static CustomComboPreset[] GetConflicts(CustomComboPreset preset) => ConflictingCombos[preset];
 
         /// <summary> Gets the full list of conflicted combos. </summary>
-        public List<CustomComboPreset> GetAllConflicts() => ConflictingCombos.Keys.ToList();
+        public static List<CustomComboPreset> GetAllConflicts() => ConflictingCombos.Keys.ToList();
 
         /// <summary> Get all the info from conflicted combos. </summary>
         public List<CustomComboPreset[]> GetAllConflictOriginals() => ConflictingCombos.Values.ToList();

--- a/XIVSlothCombo/Core/PluginConfiguration.cs
+++ b/XIVSlothCombo/Core/PluginConfiguration.cs
@@ -98,7 +98,7 @@ namespace XIVSlothCombo.Core
         /// <summary> Gets an array of conflicting combo presets. </summary>
         /// <param name="preset"> Preset to check. </param>
         /// <returns> The conflicting presets. </returns>
-        public CustomComboPreset[] GetConflicts(CustomComboPreset preset) => ConflictingCombos[preset];
+        public static CustomComboPreset[] GetConflicts(CustomComboPreset preset) => ConflictingCombos[preset];
 
         /// <summary> Gets the full list of conflicted combos. </summary>
         public List<CustomComboPreset> GetAllConflicts() => ConflictingCombos.Keys.ToList();

--- a/XIVSlothCombo/Core/PluginConfiguration.cs
+++ b/XIVSlothCombo/Core/PluginConfiguration.cs
@@ -104,7 +104,7 @@ namespace XIVSlothCombo.Core
         public static List<CustomComboPreset> GetAllConflicts() => ConflictingCombos.Keys.ToList();
 
         /// <summary> Get all the info from conflicted combos. </summary>
-        public List<CustomComboPreset[]> GetAllConflictOriginals() => ConflictingCombos.Values.ToList();
+        public static List<CustomComboPreset[]> GetAllConflictOriginals() => ConflictingCombos.Values.ToList();
 
         #endregion
 

--- a/XIVSlothCombo/CustomCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo/CustomCombo.cs
@@ -12,7 +12,7 @@ namespace XIVSlothCombo.CustomComboNS
         /// <summary> Initializes a new instance of the <see cref="CustomCombo"/> class. </summary>
         protected CustomCombo()
         {
-            var presetInfo = Preset.GetAttribute<CustomComboInfoAttribute>();
+            CustomComboInfoAttribute? presetInfo = Preset.GetAttribute<CustomComboInfoAttribute>();
             JobID = presetInfo.JobID;
             ClassID = JobID switch
             {
@@ -60,19 +60,19 @@ namespace XIVSlothCombo.CustomComboNS
             if (!IsEnabled(Preset))
                 return false;
 
-            var classJobID = LocalPlayer!.ClassJob.Id;
+            uint classJobID = LocalPlayer!.ClassJob.Id;
 
-            if (classJobID >= 8 && classJobID <= 15)
+            if (classJobID is >= 8 and <= 15)
                 classJobID = DOH.JobID;
 
-            if (classJobID >= 16 && classJobID <= 18)
+            if (classJobID is >= 16 and <= 18)
                 classJobID = DoL.JobID;
 
             if (JobID != ADV.JobID && ClassID != ADV.ClassID &&
                 JobID != classJobID && ClassID != classJobID)
                 return false;
 
-            var resultingActionID = Invoke(actionID, lastComboMove, comboTime, level);
+            uint resultingActionID = Invoke(actionID, lastComboMove, comboTime, level);
             //Dalamud.Logging.PluginLog.Debug(resultingActionID.ToString());
 
             if (resultingActionID == 0 || actionID == resultingActionID)

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -19,13 +19,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <summary> Checks if the player is high enough level to use the passed ID. </summary>
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>
-        public static bool LevelChecked(uint id)
-        {
-            if (LocalPlayer.Level < GetLevel(id))
-                return false;
-
-            return true;
-        }
+        public static bool LevelChecked(uint id) => LocalPlayer.Level >= GetLevel(id);
 
         /// <summary> Returns the name of an action from its ID. </summary>
         /// <param name="id"> ID of the action. </param>
@@ -151,11 +145,11 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns> True or false. </returns>
         public static bool CanSpellWeave(uint actionID, double weaveTime = 0.6)
         {
-            var castTimeRemaining = LocalPlayer.TotalCastTime - LocalPlayer.CurrentCastTime;
+            float castTimeRemaining = LocalPlayer.TotalCastTime - LocalPlayer.CurrentCastTime;
 
             if (GetCooldown(actionID).CooldownRemaining > weaveTime &&                          // Prevent GCD delay
-                (castTimeRemaining <= 0.5 &&                                                    // Show in last 0.5sec of cast so game can queue ability
-                GetCooldown(actionID).CooldownRemaining - castTimeRemaining - weaveTime >= 0))  // Don't show if spell is still casting in weave window
+                castTimeRemaining <= 0.5 &&                                                     // Show in last 0.5sec of cast so game can queue ability
+                GetCooldown(actionID).CooldownRemaining - castTimeRemaining - weaveTime >= 0)   // Don't show if spell is still casting in weave window
                 return true;
             return false;
         }
@@ -167,6 +161,4 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns> True or false. </returns>
         public static bool CanDelayedWeave(uint actionID, double start = 1.25, double end = 0.6) => GetCooldown(actionID).CooldownRemaining < start && GetCooldown(actionID).CooldownRemaining > end;
     }
-
-
 }

--- a/XIVSlothCombo/CustomCombo/Functions/Config.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Config.cs
@@ -6,7 +6,6 @@ namespace XIVSlothCombo.CustomComboNS.Functions
     internal abstract partial class CustomComboFunctions
     {
         public static int GetOptionValue(string SliderID) => PluginConfiguration.GetCustomIntValue(SliderID);
-
         public static bool GetOptionBool(string SliderID) => Convert.ToBoolean(GetOptionValue(SliderID));
     }
 }

--- a/XIVSlothCombo/CustomCombo/Functions/Misc.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Misc.cs
@@ -16,7 +16,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns> A value indicating whether the preset is not enabled. </returns>
         public bool IsNotEnabled(CustomComboPreset preset) => !IsEnabled(preset);
 
-        
+
         // Job & Class Names
         public class JobIDs
         {
@@ -48,7 +48,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
                 Combos.PvE.DRK.JobID,
                 Combos.PvE.GNB.JobID
             };
-            
+
             public static readonly List<byte> Healer = new()
             {
                 Combos.PvE.WHM.JobID, Combos.PvE.WHM.ClassID,

--- a/XIVSlothCombo/CustomCombo/Functions/Movement.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Movement.cs
@@ -18,7 +18,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
                 PlayerSpeed = Vector2.Distance(newPosition, Position);
                 IsMoving = PlayerSpeed > 0;
                 Position = LocalPlayer is null ? Vector2.Zero : newPosition;
-                MovingCounter = 50; // refreshes every 50 dalamud ticks for a more accurate representation of speed, otherwise it'll report 0.
+                MovingCounter = 50; // Refreshes every 50 Dalamud ticks for a more accurate representation of speed, otherwise it'll report 0.
             }
 
             if (MovingCounter > 0)

--- a/XIVSlothCombo/CustomCombo/Functions/Party.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Party.cs
@@ -1,6 +1,6 @@
-﻿using Dalamud.Game.ClientState.Objects.Types;
+﻿using System.Linq;
+using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Party;
-using System.Linq;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.CustomComboNS.Functions
@@ -27,11 +27,10 @@ namespace XIVSlothCombo.CustomComboNS.Functions
                     8 => GetTarget(TargetType.P8),
                     _ => GetTarget(TargetType.Self),
                 };
-                var i = PartyTargetingService.GetObjectID(o);
-                if (Service.ObjectTable.Where(x => x.ObjectId == i).Any())
-                    return Service.ObjectTable.Where(x => x.ObjectId == i).First();
-
-                return null;
+                long i = PartyTargetingService.GetObjectID(o);
+                return Service.ObjectTable.Where(x => x.ObjectId == i).Any()
+                    ? Service.ObjectTable.Where(x => x.ObjectId == i).First()
+                    : null;
             }
 
             catch

--- a/XIVSlothCombo/CustomCombo/Functions/PlayerCharacter.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/PlayerCharacter.cs
@@ -28,7 +28,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         public static bool HasCompanionPresent() => Service.BuddyList.CompanionBuddyPresent;
 
         /// <summary> Checks if the player is in a PVP enabled zone. </summary>
-        /// <returns></returns>
+        /// <returns> A value indicating whether the player is in a PVP enabled zone. </returns>
         public static bool InPvP() => GameMain.IsInPvPArea() || GameMain.IsInPvPInstance();
     }
 }

--- a/XIVSlothCombo/CustomCombo/Functions/Resource.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Resource.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using XIVSlothCombo.Data;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.CustomComboNS.Functions
@@ -8,12 +9,12 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <summary> Gets the Resource Cost of the action. </summary>
         /// <param name="actionID"> Action ID to check. </param>
         /// <returns></returns>
-        public static int GetResourceCost(uint actionID) => Data.CustomComboCache.GetResourceCost(actionID);
+        public static int GetResourceCost(uint actionID) => CustomComboCache.GetResourceCost(actionID);
 
         /// <summary> Gets the Resource Type of the action. </summary>
         /// <param name="actionID"> Action ID to check. </param>
         /// <returns></returns>
-        public static bool IsResourceTypeNormal(uint actionID) => Data.CustomComboCache.GetResourceCost(actionID) >= 100 || Data.CustomComboCache.GetResourceCost(actionID) == 0;
+        public static bool IsResourceTypeNormal(uint actionID) => CustomComboCache.GetResourceCost(actionID) is >= 100 or 0;
 
         /// <summary> Get a job gauge. </summary>
         /// <typeparam name="T"> Type of job gauge.</typeparam>

--- a/XIVSlothCombo/CustomCombo/Functions/Status.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Status.cs
@@ -88,7 +88,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static bool HasSilence()
         {
-            foreach (var status in ActionWatching.GetStatusesByName("Silence"))
+            foreach (uint status in ActionWatching.GetStatusesByName("Silence"))
             {
                 if (HasEffectAny((ushort)status)) return true;
             }
@@ -100,7 +100,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static bool HasPacification()
         {
-            foreach (var status in ActionWatching.GetStatusesByName("Pacification"))
+            foreach (uint status in ActionWatching.GetStatusesByName("Pacification"))
             {
                 if (HasEffectAny((ushort)status)) return true;
             }
@@ -112,7 +112,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static bool HasAmnesia()
         {
-            foreach (var status in ActionWatching.GetStatusesByName("Amnesia"))
+            foreach (uint status in ActionWatching.GetStatusesByName("Amnesia"))
             {
                 if (HasEffectAny((ushort)status)) return true;
             }

--- a/XIVSlothCombo/CustomCombo/Functions/Target.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Target.cs
@@ -19,7 +19,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 
         /// <summary> Gets the distance from the target. </summary>
         /// <returns> Double representing the distance from the target. </returns>
-        public double GetTargetDistance()
+        public static float GetTargetDistance()
         {
             if (CurrentTarget is null || LocalPlayer is null)
                 return 0;
@@ -38,12 +38,12 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 
         /// <summary> Gets a value indicating whether you are in melee range from the current target. </summary>
         /// <returns> Bool indicating whether you are in melee range. </returns>
-        public bool InMeleeRange()
+        public static bool InMeleeRange()
         {
             if (LocalPlayer.TargetObject == null)
                 return false;
 
-            double distance = GetTargetDistance();
+            float distance = GetTargetDistance();
 
             if (distance == 0)
                 return true;
@@ -56,23 +56,21 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 
         /// <summary> Gets a value indicating target's HP Percent. CurrentTarget is default unless specified </summary>
         /// <returns> Double indicating percentage. </returns>
-        public static double GetTargetHPPercent(GameObject? OurTarget = null)
+        public static float GetTargetHPPercent(GameObject? OurTarget = null)
         {
             if (OurTarget is null)
             {
-                //Fallback to CurrentTarget
-                OurTarget = CurrentTarget;
+                OurTarget = CurrentTarget; // Fallback to CurrentTarget
                 if (OurTarget is null)
                     return 0;
             }
 
-            if (OurTarget is not BattleChara chara)
-                return 0;
-
-            return chara.CurrentHp / chara.MaxHp * 100;
+            return OurTarget is not BattleChara chara
+                ? 0
+                : chara.CurrentHp / chara.MaxHp * 100;
         }
 
-        public static double EnemyHealthMaxHp()
+        public static float EnemyHealthMaxHp()
         {
             if (CurrentTarget is null)
                 return 0;
@@ -82,7 +80,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
             return chara.MaxHp;
         }
 
-        public static double EnemyHealthCurrentHp()
+        public static float EnemyHealthCurrentHp()
         {
             if (CurrentTarget is null)
                 return 0;
@@ -92,13 +90,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
             return chara.CurrentHp;
         }
 
-        public double PlayerHealthPercentageHp()
-        {
-            double maxHealth = LocalPlayer.MaxHp;
-            double currentHealth = LocalPlayer.CurrentHp;
-
-            return currentHealth / maxHealth * 100;
-        }
+        public static float PlayerHealthPercentageHp() => LocalPlayer.CurrentHp / LocalPlayer.MaxHp * 100;
 
         public static bool HasBattleTarget() => (CurrentTarget as BattleNpc)?.BattleNpcKind is BattleNpcSubKind.Enemy;
 
@@ -112,6 +104,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
                 return false;
             if (chara.IsCasting)
                 return chara.IsCastInterruptible;
+
             return false;
         }
 
@@ -125,12 +118,13 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         {
             if (target == null || target.YalmDistanceX >= 30)
                 return false;
+
             return true;
         }
 
         /// <summary> Attempts to target the given party member </summary>
         /// <param name="target"></param>
-        protected unsafe void TargetObject(TargetType target)
+        protected static unsafe void TargetObject(TargetType target)
         {
             StructsObject.GameObject* t = GetTarget(target);
             if (t == null) return;

--- a/XIVSlothCombo/CustomCombo/Functions/Timer.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Timer.cs
@@ -35,10 +35,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 
         /// <summary> Tells the elapsed time since the combat started. </summary>
         /// <returns> Combat time in seconds. </returns>
-        protected TimeSpan CombatEngageDuration()
-        {
-            return combatDuration;
-        }
+        protected TimeSpan CombatEngageDuration() => combatDuration;
 
         protected void StartTimer()
         {

--- a/XIVSlothCombo/Data/ActionWatching.cs
+++ b/XIVSlothCombo/Data/ActionWatching.cs
@@ -1,13 +1,13 @@
-﻿using Dalamud.Hooking;
-using FFXIVClientStructs.FFXIV.Client.Game;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Dalamud.Hooking;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.Data
-{ 
+{
     public static class ActionWatching
     {
         internal static Dictionary<uint, Lumina.Excel.GeneratedSheets.Action> ActionSheet = Service.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>()!
@@ -24,9 +24,9 @@ namespace XIVSlothCombo.Data
         private static void ReceiveActionEffectDetour(int sourceObjectId, IntPtr sourceActor, IntPtr position, IntPtr effectHeader, IntPtr effectArray, IntPtr effectTrail)
         {
             ReceiveActionEffectHook!.Original(sourceObjectId, sourceActor, position, effectHeader, effectArray, effectTrail);
-            var header = Marshal.PtrToStructure<ActionEffectHeader>(effectHeader);
+            ActionEffectHeader header = Marshal.PtrToStructure<ActionEffectHeader>(effectHeader);
 
-            if (ActionType is (13 or 2)) return;
+            if (ActionType is 13 or 2) return;
             if (header.ActionId != 7 &&
                 header.ActionId != 8 &&
                 sourceObjectId == Service.ClientState.LocalPlayer.ObjectId)
@@ -36,6 +36,7 @@ namespace XIVSlothCombo.Data
                 {
                     LastActionUseCount = 1;
                 }
+
                 LastAction = header.ActionId;
 
                 ActionSheet.TryGetValue(header.ActionId, out var sheet);
@@ -69,21 +70,17 @@ namespace XIVSlothCombo.Data
         }
 
         public static uint LastAction { get; set; } = 0;
-
         public static int LastActionUseCount { get; set; } = 0;
-
         public static uint ActionType { get; set; } = 0;
-
         public static uint LastWeaponskill { get; set; } = 0;
-
         public static uint LastAbility { get; set; } = 0;
-
         public static uint LastSpell { get; set; } = 0;
 
         public static void OutputLog()
         {
             Service.ChatGui.Print($"You just used: {GetActionName(LastAction)} x{LastActionUseCount}");
         }
+
         public static void Dispose()
         {
             ReceiveActionEffectHook?.Dispose();
@@ -109,14 +106,12 @@ namespace XIVSlothCombo.Data
         }
 
         public static int GetLevel(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.ClassJobLevel : 0;
-
         public static string GetActionName(uint id) => ActionSheet.TryGetValue(id, out var action) ? (string)action.Name : "UNKNOWN ABILITY";
-
         public static string GetStatusName(uint id) => StatusSheet.TryGetValue(id, out var status) ? (string)status.Name : "Unknown Status";
 
         public static List<uint>? GetStatusesByName(string status)
         {
-            if (statusCache.TryGetValue(status, out var list))            
+            if (statusCache.TryGetValue(status, out List<uint>? list))
                 return list;
 
             return statusCache.TryAdd(status, StatusSheet.Where(x => x.Value.Name.ToString().Equals(status, StringComparison.CurrentCultureIgnoreCase)).Select(x => x.Key).ToList())
@@ -150,31 +145,14 @@ namespace XIVSlothCombo.Data
     internal unsafe static class ActionManagerHelper
     {
         private static readonly IntPtr actionMgrPtr;
-
-        internal static IntPtr FpUseAction =>
-            (IntPtr)ActionManager.fpUseAction;
-
-        internal static IntPtr FpUseActionLocation =>
-            (IntPtr)ActionManager.fpUseActionLocation;
-
-        internal static IntPtr CheckActionResources =>
-            (IntPtr)ActionManager.fpCheckActionResources;
-
-        public static ushort CurrentSeq => actionMgrPtr != IntPtr.Zero
-            ? (ushort)Marshal.ReadInt16(actionMgrPtr + 0x110) : (ushort)0;
-
-        public static ushort LastRecievedSeq => actionMgrPtr != IntPtr.Zero
-            ? (ushort)Marshal.ReadInt16(actionMgrPtr + 0x112) : (ushort)0;
-
-        public static bool IsCasting => actionMgrPtr != IntPtr.Zero
-            && Marshal.ReadByte(actionMgrPtr + 0x28) != 0;
-
-        public static uint CastingActionId => actionMgrPtr != IntPtr.Zero
-            ? (uint)Marshal.ReadInt32(actionMgrPtr + 0x24) : 0u;
-
-        public static uint CastTargetObjectId => actionMgrPtr != IntPtr.Zero
-            ? (uint)Marshal.ReadInt32(actionMgrPtr + 0x38) : 0u;
-
+        internal static IntPtr FpUseAction => (IntPtr)ActionManager.fpUseAction;
+        internal static IntPtr FpUseActionLocation => (IntPtr)ActionManager.fpUseActionLocation;
+        internal static IntPtr CheckActionResources => (IntPtr)ActionManager.fpCheckActionResources;
+        public static ushort CurrentSeq => actionMgrPtr != IntPtr.Zero ? (ushort)Marshal.ReadInt16(actionMgrPtr + 0x110) : (ushort)0;
+        public static ushort LastRecievedSeq => actionMgrPtr != IntPtr.Zero ? (ushort)Marshal.ReadInt16(actionMgrPtr + 0x112) : (ushort)0;
+        public static bool IsCasting => actionMgrPtr != IntPtr.Zero && Marshal.ReadByte(actionMgrPtr + 0x28) != 0;
+        public static uint CastingActionId => actionMgrPtr != IntPtr.Zero ? (uint)Marshal.ReadInt32(actionMgrPtr + 0x24) : 0u;
+        public static uint CastTargetObjectId => actionMgrPtr != IntPtr.Zero ? (uint)Marshal.ReadInt32(actionMgrPtr + 0x38) : 0u;
         static ActionManagerHelper() => actionMgrPtr = (IntPtr)ActionManager.Instance();
     }
 

--- a/XIVSlothCombo/Data/CooldownData.cs
+++ b/XIVSlothCombo/Data/CooldownData.cs
@@ -25,10 +25,9 @@ namespace XIVSlothCombo.Data
             get
             {
                 var (cur, max) = Service.ComboCache.GetMaxCharges(ActionID);
-                if (cur == max)
-                    return isCooldown;
-
-                return cooldownElapsed < CooldownTotal;
+                return cur == max
+                    ? isCooldown
+                    : cooldownElapsed < CooldownTotal;
             }
         }
 
@@ -64,12 +63,11 @@ namespace XIVSlothCombo.Data
                     return cooldownTotal;
 
                 // Rebase to the current charge count
-                var total = cooldownTotal / max * cur;
+                float total = cooldownTotal / max * cur;
 
-                if (cooldownElapsed > total)
-                    return 0;
-
-                return total;
+                return cooldownElapsed > total
+                    ? 0
+                    : total;
             }
         }
 
@@ -90,10 +88,9 @@ namespace XIVSlothCombo.Data
             {
                 var (cur, _) = Service.ComboCache.GetMaxCharges(ActionID);
 
-                if (!IsCooldown)
-                    return cur;
-
-                return (ushort)(CooldownElapsed / (CooldownTotal / MaxCharges));
+                return !IsCooldown
+                    ? cur
+                    : (ushort)(CooldownElapsed / (CooldownTotal / MaxCharges));
             }
         }
 

--- a/XIVSlothCombo/Data/CustomComboCache.cs
+++ b/XIVSlothCombo/Data/CustomComboCache.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using Dalamud.Game;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
-using Dalamud.Game.ClientState.Statuses;
+using Dalamud.Game.ClientState.Objects.SubKinds;
+using DalamudStatus = Dalamud.Game.ClientState.Statuses; // conflicts with structs if not defined
+using FFXIVClientStructs.FFXIV.Client.Game;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.Data
@@ -14,7 +16,7 @@ namespace XIVSlothCombo.Data
         private const uint InvalidObjectID = 0xE000_0000;
 
         // Invalidate these
-        private readonly Dictionary<(uint StatusID, uint? TargetID, uint? SourceID), Status?> statusCache = new();
+        private readonly Dictionary<(uint StatusID, uint? TargetID, uint? SourceID), DalamudStatus.Status?> statusCache = new();
         private readonly Dictionary<uint, CooldownData> cooldownCache = new();
 
         // Do not invalidate these
@@ -23,25 +25,19 @@ namespace XIVSlothCombo.Data
         private readonly Dictionary<(uint ActionID, uint ClassJobID, byte Level), (ushort CurrentMax, ushort Max)> chargesCache = new();
 
         /// <summary> Initializes a new instance of the <see cref="CustomComboCache"/> class. </summary>
-        public CustomComboCache()
-        {
-            Service.Framework.Update += Framework_Update;
-        }
+        public CustomComboCache() => Service.Framework.Update += Framework_Update;
 
         private delegate IntPtr GetActionCooldownSlotDelegate(IntPtr actionManager, int cooldownGroup);
 
         /// <inheritdoc/>
-        public void Dispose()
-        {
-            Service.Framework.Update -= Framework_Update;
-        }
+        public void Dispose() => Service.Framework.Update -= Framework_Update;
 
         /// <summary> Gets a job gauge. </summary>
         /// <typeparam name="T"> Type of job gauge. </typeparam>
         /// <returns> The job gauge. </returns>
         internal T GetJobGauge<T>() where T : JobGaugeBase
         {
-            if (!jobGaugeCache.TryGetValue(typeof(T), out var gauge))
+            if (!jobGaugeCache.TryGetValue(typeof(T), out JobGaugeBase? gauge))
                 gauge = jobGaugeCache[typeof(T)] = Service.JobGauges.Get<T>();
 
             return (T)gauge;
@@ -52,10 +48,10 @@ namespace XIVSlothCombo.Data
         /// <param name="obj"> Object to look for effects on. </param>
         /// <param name="sourceID"> Source object ID. </param>
         /// <returns> Status object or null. </returns>
-        internal Status? GetStatus(uint statusID, GameObject? obj, uint? sourceID)
+        internal DalamudStatus.Status? GetStatus(uint statusID, GameObject? obj, uint? sourceID)
         {
             var key = (statusID, obj?.ObjectId, sourceID);
-            if (statusCache.TryGetValue(key, out var found))
+            if (statusCache.TryGetValue(key, out DalamudStatus.Status? found))
                 return found;
 
             if (obj is null)
@@ -64,7 +60,7 @@ namespace XIVSlothCombo.Data
             if (obj is not BattleChara chara)
                 return statusCache[key] = null;
 
-            foreach (var status in chara.StatusList)
+            foreach (DalamudStatus.Status? status in chara.StatusList)
             {
                 if (status.StatusId == statusID && (!sourceID.HasValue || status.SourceID == 0 || status.SourceID == InvalidObjectID || status.SourceID == sourceID))
                     return statusCache[key] = status;
@@ -78,16 +74,16 @@ namespace XIVSlothCombo.Data
         /// <returns> Cooldown data. </returns>
         internal unsafe CooldownData GetCooldown(uint actionID)
         {
-            if (cooldownCache.TryGetValue(actionID, out var found))
+            if (cooldownCache.TryGetValue(actionID, out CooldownData found))
                 return found;
 
-            var actionManager = FFXIVClientStructs.FFXIV.Client.Game.ActionManager.Instance();
+            ActionManager* actionManager = ActionManager.Instance();
             if (actionManager == null)
                 return cooldownCache[actionID] = default;
 
-            var cooldownGroup = GetCooldownGroup(actionID);
+            byte cooldownGroup = GetCooldownGroup(actionID);
 
-            var cooldownPtr = actionManager->GetRecastGroupDetail(cooldownGroup - 1);
+            RecastDetail* cooldownPtr = actionManager->GetRecastGroupDetail(cooldownGroup - 1);
             cooldownPtr->ActionID = actionID;
 
             return cooldownCache[actionID] = *(CooldownData*)cooldownPtr;
@@ -98,12 +94,12 @@ namespace XIVSlothCombo.Data
         /// <returns> Max number of charges at current and max level. </returns>
         internal unsafe (ushort Current, ushort Max) GetMaxCharges(uint actionID)
         {
-            var player = Service.ClientState.LocalPlayer;
+            PlayerCharacter? player = Service.ClientState.LocalPlayer;
             if (player == null)
                 return (0, 0);
 
-            var job = player.ClassJob.Id;
-            var level = player.Level;
+            uint job = player.ClassJob.Id;
+            byte level = player.Level;
             if (job == 0 || level == 0)
                 return (0, 0);
 
@@ -111,8 +107,8 @@ namespace XIVSlothCombo.Data
             if (chargesCache.TryGetValue(key, out var found))
                 return found;
 
-            var cur = FFXIVClientStructs.FFXIV.Client.Game.ActionManager.GetMaxCharges(actionID, 0);
-            var max = FFXIVClientStructs.FFXIV.Client.Game.ActionManager.GetMaxCharges(actionID, 90);
+            ushort cur = ActionManager.GetMaxCharges(actionID, 0);
+            ushort max = ActionManager.GetMaxCharges(actionID, 90);
             return chargesCache[key] = (cur, max);
         }
 
@@ -121,11 +117,11 @@ namespace XIVSlothCombo.Data
         /// <returns> Returns the resource cost of an action. </returns>
         internal static unsafe int GetResourceCost(uint actionID)
         {
-            var actionManager = FFXIVClientStructs.FFXIV.Client.Game.ActionManager.Instance();
+            ActionManager* actionManager = ActionManager.Instance();
             if (actionManager == null)
                 return 0;
 
-            var cost = FFXIVClientStructs.FFXIV.Client.Game.ActionManager.GetActionCost(FFXIVClientStructs.FFXIV.Client.Game.ActionType.Spell, actionID, 0, 0, 0, 0);
+            int cost = ActionManager.GetActionCost(ActionType.Spell, actionID, 0, 0, 0, 0);
 
             return cost;
         }
@@ -134,7 +130,7 @@ namespace XIVSlothCombo.Data
         /// <param name="actionID"> Action ID to check. </param>
         private byte GetCooldownGroup(uint actionID)
         {
-            if (cooldownGroupCache.TryGetValue(actionID, out var cooldownGroup))
+            if (cooldownGroupCache.TryGetValue(actionID, out byte cooldownGroup))
                 return cooldownGroup;
 
             var sheet = Service.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>()!;

--- a/XIVSlothCombo/Services/BlueMageService.cs
+++ b/XIVSlothCombo/Services/BlueMageService.cs
@@ -1,8 +1,8 @@
-﻿using FFXIVClientStructs.FFXIV.Client.UI;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using FFXIVClientStructs.FFXIV.Client.UI;
 
 namespace XIVSlothCombo.Services
 {
@@ -17,7 +17,7 @@ namespace XIVSlothCombo.Services
             List<uint> prevList = Service.Configuration.ActiveBLUSpells.ToList();
 
             Service.Configuration.ActiveBLUSpells.Clear();
-            var notebook = Marshal.PtrToStructure<AddonAOZNotebook>(notebookPtr);
+            AddonAOZNotebook notebook = Marshal.PtrToStructure<AddonAOZNotebook>(notebookPtr);
 
             if (notebook.ActiveActions01.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions01.ActionID);
             if (notebook.ActiveActions02.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions02.ActionID);
@@ -48,7 +48,7 @@ namespace XIVSlothCombo.Services
             if (notebook.ActiveActions24.ActionID != 0) Service.Configuration.ActiveBLUSpells.Add((uint)notebook.ActiveActions24.ActionID);
 
             if (Service.Configuration.ActiveBLUSpells.Except(prevList).Any())
-            Service.Configuration.Save();
+                Service.Configuration.Save();
         }
     }
 }

--- a/XIVSlothCombo/Services/Service.cs
+++ b/XIVSlothCombo/Services/Service.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Reflection;
 using Dalamud.Data;
 using Dalamud.Game;
 using Dalamud.Game.ClientState;
@@ -10,9 +13,6 @@ using Dalamud.Game.Command;
 using Dalamud.Game.Gui;
 using Dalamud.IoC;
 using Dalamud.Plugin;
-using System;
-using System.IO;
-using System.Reflection;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.Data;
 

--- a/XIVSlothCombo/Window/ConfigWindow.cs
+++ b/XIVSlothCombo/Window/ConfigWindow.cs
@@ -1,9 +1,9 @@
-using Dalamud.Utility;
-using ImGuiNET;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Dalamud.Utility;
+using ImGuiNET;
 using XIVSlothCombo.Attributes;
 using XIVSlothCombo.Combos;
 using XIVSlothCombo.Core;
@@ -38,9 +38,9 @@ namespace XIVSlothCombo.Window
                 tpl => tpl,
                 tpl => new List<CustomComboPreset>());
 
-            foreach (var preset in Enum.GetValues<CustomComboPreset>())
+            foreach (CustomComboPreset preset in Enum.GetValues<CustomComboPreset>())
             {
-                var parent = preset.GetAttribute<ParentComboAttribute>()?.ParentPreset;
+                CustomComboPreset? parent = preset.GetAttribute<ParentComboAttribute>()?.ParentPreset;
                 if (parent != null)
                     childCombos[parent.Value].Add(preset);
             }
@@ -55,8 +55,8 @@ namespace XIVSlothCombo.Window
         private bool visible = false;
         public bool Visible
         {
-            get { return this.visible; }
-            set { this.visible = value; }
+            get => visible;
+            set => visible = value;
         }
 
         /// <summary> Initializes a new instance of the <see cref="ConfigWindow"/> class. </summary>

--- a/XIVSlothCombo/Window/Functions/Presets.cs
+++ b/XIVSlothCombo/Window/Functions/Presets.cs
@@ -16,7 +16,7 @@ namespace XIVSlothCombo.Window.Functions
         {
             var enabled = Service.Configuration.IsEnabled(preset);
             var secret = PluginConfiguration.IsSecret(preset);
-            var conflicts = Service.Configuration.GetConflicts(preset);
+            var conflicts = PluginConfiguration.GetConflicts(preset);
             var parent = PluginConfiguration.GetParent(preset);
             var blueAttr = preset.GetAttribute<BlueInactiveAttribute>();
 
@@ -129,7 +129,7 @@ namespace XIVSlothCombo.Window.Functions
                     {
                         if (Service.Configuration.HideConflictedCombos)
                         {
-                            var conflictOriginals = Service.Configuration.GetConflicts(childPreset);    // Presets that are contained within a ConflictedAttribute
+                            var conflictOriginals = PluginConfiguration.GetConflicts(childPreset);    // Presets that are contained within a ConflictedAttribute
                             var conflictsSource = Service.Configuration.GetAllConflicts();              // Presets with the ConflictedAttribute
 
                             if (!conflictsSource.Where(x => x == childPreset || x == preset).Any() || conflictOriginals.Length == 0)
@@ -193,7 +193,7 @@ namespace XIVSlothCombo.Window.Functions
                 if (!Service.Configuration.EnabledActions.Contains(parent))
                 {
                     Service.Configuration.EnabledActions.Add(parent);
-                    foreach (var conflict in Service.Configuration.GetConflicts(parent))
+                    foreach (var conflict in PluginConfiguration.GetConflicts(parent))
                     {
                         Service.Configuration.EnabledActions.Remove(conflict);
                     }

--- a/XIVSlothCombo/Window/Functions/Presets.cs
+++ b/XIVSlothCombo/Window/Functions/Presets.cs
@@ -130,7 +130,7 @@ namespace XIVSlothCombo.Window.Functions
                         if (Service.Configuration.HideConflictedCombos)
                         {
                             var conflictOriginals = PluginConfiguration.GetConflicts(childPreset);    // Presets that are contained within a ConflictedAttribute
-                            var conflictsSource = Service.Configuration.GetAllConflicts();              // Presets with the ConflictedAttribute
+                            var conflictsSource = PluginConfiguration.GetAllConflicts();              // Presets with the ConflictedAttribute
 
                             if (!conflictsSource.Where(x => x == childPreset || x == preset).Any() || conflictOriginals.Length == 0)
                             {

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1,9 +1,10 @@
-﻿using Dalamud.Interface.Colors;
-using Dalamud.Utility;
-using ImGuiNET;
-using System;
+﻿using System;
 using System.Linq;
 using System.Numerics;
+using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Interface.Colors;
+using Dalamud.Utility;
+using ImGuiNET;
 using XIVSlothCombo.Combos;
 using XIVSlothCombo.Combos.PvE;
 using XIVSlothCombo.Combos.PvP;
@@ -23,8 +24,8 @@ namespace XIVSlothCombo.Window.Functions
         /// <param name="sliderIncrement"> How much you want the user to increment the slider by. Uses SliderIncrements as a preset. </param>
         public static void DrawSliderInt(int minValue, int maxValue, string config, string sliderDescription, float itemWidth = 150, uint sliderIncrement = SliderIncrements.Ones)
         {
-            var output = PluginConfiguration.GetCustomIntValue(config, minValue);
-            var inputChanged = false;
+            int output = PluginConfiguration.GetCustomIntValue(config, minValue);
+            bool inputChanged = false;
             ImGui.PushItemWidth(itemWidth);
             ImGui.SameLine();
             ImGui.Dummy(new Vector2(21, 0));
@@ -55,8 +56,8 @@ namespace XIVSlothCombo.Window.Functions
         /// <param name="itemWidth"> How long the slider should be. </param>
         public static void DrawSliderFloat(float minValue, float maxValue, string config, string sliderDescription, float itemWidth = 150)
         {
-            var output = PluginConfiguration.GetCustomFloatValue(config, minValue);
-            var inputChanged = false;
+            float output = PluginConfiguration.GetCustomFloatValue(config, minValue);
+            bool inputChanged = false;
             ImGui.PushItemWidth(itemWidth);
             ImGui.SameLine();
             ImGui.Dummy(new Vector2(21, 0));
@@ -80,8 +81,8 @@ namespace XIVSlothCombo.Window.Functions
         /// <param name="itemWidth"> How long the slider should be. </param>
         public static void DrawRoundedSliderFloat(float minValue, float maxValue, string config, string sliderDescription, float itemWidth = 150)
         {
-            var output = PluginConfiguration.GetCustomFloatValue(config, minValue);
-            var inputChanged = false;
+            float output = PluginConfiguration.GetCustomFloatValue(config, minValue);
+            bool inputChanged = false;
             ImGui.PushItemWidth(itemWidth);
             ImGui.SameLine();
             ImGui.Dummy(new Vector2(21, 0));
@@ -108,12 +109,12 @@ namespace XIVSlothCombo.Window.Functions
         {
             ImGui.Indent();
             if (descriptionColor == new Vector4()) descriptionColor = ImGuiColors.DalamudYellow;
-            var output = PluginConfiguration.GetCustomIntValue(config, outputValue);
+            int output = PluginConfiguration.GetCustomIntValue(config, outputValue);
             ImGui.PushItemWidth(itemWidth);
             ImGui.SameLine();
             ImGui.Dummy(new Vector2(21, 0));
             ImGui.SameLine();
-            var enabled = output == outputValue;
+            bool enabled = output == outputValue;
 
             if (ImGui.Checkbox($"{checkBoxName}###{config}{outputValue}", ref enabled))
             {
@@ -122,11 +123,12 @@ namespace XIVSlothCombo.Window.Functions
             }
 
             if (!checkboxDescription.IsNullOrEmpty())
-            { 
+            {
                 ImGui.PushStyleColor(ImGuiCol.Text, descriptionColor);
                 ImGui.TextWrapped(checkboxDescription);
                 ImGui.PopStyleColor();
             }
+
             ImGui.Unindent();
             ImGui.Spacing();
         }
@@ -142,12 +144,12 @@ namespace XIVSlothCombo.Window.Functions
         {
             ImGui.Indent();
             if (descriptionColor == new Vector4()) descriptionColor = ImGuiColors.DalamudYellow;
-            var output = PluginConfiguration.GetCustomIntValue(config);
+            int output = PluginConfiguration.GetCustomIntValue(config);
             ImGui.PushItemWidth(itemWidth);
             ImGui.SameLine();
             ImGui.Dummy(new Vector2(21, 0));
             ImGui.SameLine();
-            var enabled = output == outputValue;
+            bool enabled = output == outputValue;
 
             ImGui.PushStyleColor(ImGuiCol.Text, descriptionColor);
             if (ImGui.Checkbox($"{checkBoxName}###{config}{outputValue}", ref enabled))
@@ -162,6 +164,7 @@ namespace XIVSlothCombo.Window.Functions
                 ImGui.TextUnformatted(checkboxDescription);
                 ImGui.EndTooltip();
             }
+
             ImGui.PopStyleColor();
 
             ImGui.Unindent();
@@ -169,11 +172,11 @@ namespace XIVSlothCombo.Window.Functions
 
         public static void DrawPvPStatusMultiChoice(string config)
         {
-            var values = PluginConfiguration.GetCustomBoolArrayValue(config);
+            bool[]? values = PluginConfiguration.GetCustomBoolArrayValue(config);
 
             ImGui.Columns(7, $"{config}", false);
 
-            if (values.Length == 0) Array.Resize<bool>(ref values, 7);
+            if (values.Length == 0) Array.Resize(ref values, 7);
 
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.ParsedPink);
 
@@ -238,11 +241,11 @@ namespace XIVSlothCombo.Window.Functions
 
         public static void DrawRoleGridMultiChoice(string config)
         {
-            var values = PluginConfiguration.GetCustomBoolArrayValue(config);
+            bool[]? values = PluginConfiguration.GetCustomBoolArrayValue(config);
 
             ImGui.Columns(5, $"{config}", false);
 
-            if (values.Length == 0) Array.Resize<bool>(ref values, 5);
+            if (values.Length == 0) Array.Resize(ref values, 5);
 
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.TankBlue);
 
@@ -299,7 +302,7 @@ namespace XIVSlothCombo.Window.Functions
 
         public static void DrawRoleGridSingleChoice(string config)
         {
-            var value = PluginConfiguration.GetCustomIntValue(config);
+            int value = PluginConfiguration.GetCustomIntValue(config);
             bool[] values = new bool[20];
 
             for (int i = 0; i <= 4; i++)
@@ -311,7 +314,7 @@ namespace XIVSlothCombo.Window.Functions
 
             ImGui.Columns(5, $"{config}", false);
 
-            if (values.Length == 0) Array.Resize<bool>(ref values, 5);
+            if (values.Length == 0) Array.Resize(ref values, 5);
 
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.TankBlue);
 
@@ -368,11 +371,11 @@ namespace XIVSlothCombo.Window.Functions
 
         public static void DrawJobGridMultiChoice(string config)
         {
-            var values = PluginConfiguration.GetCustomBoolArrayValue(config);
+            bool[]? values = PluginConfiguration.GetCustomBoolArrayValue(config);
 
             ImGui.Columns(5, $"{config}", false);
 
-            if (values.Length == 0) Array.Resize<bool>(ref values, 20);
+            if (values.Length == 0) Array.Resize(ref values, 20);
 
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.TankBlue);
 
@@ -381,6 +384,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Warrior###{config}1", ref values[1]))
@@ -388,6 +392,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Dark Knight###{config}2", ref values[2]))
@@ -395,6 +400,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Gunbreaker###{config}3", ref values[3]))
@@ -402,6 +408,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
             ImGui.NextColumn();
 
@@ -413,6 +420,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Scholar###{config}5", ref values[5]))
@@ -420,6 +428,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Astrologian###{config}6", ref values[6]))
@@ -427,6 +436,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Sage###{config}7", ref values[7]))
@@ -434,6 +444,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
             ImGui.NextColumn();
 
@@ -445,6 +456,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Dragoon###{config}9", ref values[9]))
@@ -452,6 +464,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Ninja###{config}10", ref values[10]))
@@ -459,6 +472,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Samurai###{config}11", ref values[11]))
@@ -466,6 +480,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Reaper###{config}12", ref values[12]))
@@ -473,6 +488,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.PopStyleColor();
             ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudYellow);
             ImGui.NextColumn();
@@ -482,6 +498,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Machinist###{config}14", ref values[14]))
@@ -489,6 +506,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Dancer###{config}15", ref values[15]))
@@ -496,6 +514,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
             ImGui.NextColumn();
             ImGui.NextColumn();
@@ -508,6 +527,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Summoner###{config}17", ref values[17]))
@@ -515,6 +535,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Red Mage###{config}18", ref values[18]))
@@ -522,6 +543,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Blue Mage###{config}19", ref values[19]))
@@ -529,6 +551,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomBoolArrayValue(config, values);
                 Service.Configuration.Save();
             }
+
             ImGui.PopStyleColor();
             ImGui.NextColumn();
             ImGui.Columns(1);
@@ -537,7 +560,7 @@ namespace XIVSlothCombo.Window.Functions
 
         public static void DrawJobGridSingleChoice(string config)
         {
-            var value = PluginConfiguration.GetCustomIntValue(config);
+            int value = PluginConfiguration.GetCustomIntValue(config);
             bool[] values = new bool[20];
 
             for (int i = 0; i <= 19; i++)
@@ -698,6 +721,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomIntValue(config, 16);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Summoner###{config}17", ref values[17]))
@@ -705,6 +729,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomIntValue(config, 17);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Red Mage###{config}18", ref values[18]))
@@ -712,6 +737,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomIntValue(config, 18);
                 Service.Configuration.Save();
             }
+
             ImGui.NextColumn();
 
             if (ImGui.Checkbox($"Blue Mage###{config}19", ref values[19]))
@@ -719,6 +745,7 @@ namespace XIVSlothCombo.Window.Functions
                 PluginConfiguration.SetCustomIntValue(config, 19);
                 Service.Configuration.Save();
             }
+
             ImGui.PopStyleColor();
             ImGui.NextColumn();
             ImGui.Columns(1);
@@ -780,7 +807,7 @@ namespace XIVSlothCombo.Window.Functions
             if (preset == CustomComboPreset.BLM_AoE_Simple_Foul)
                 UserConfig.DrawSliderInt(0, 2, BLM.Config.BLM_PolyglotsStored, "Number of Polyglot charges to store.\n(2 = Only use Polyglot with Manafont)");
 
-            if (preset == CustomComboPreset.BLM_SimpleMode || preset == CustomComboPreset.BLM_Simple_Transpose)
+            if (preset is CustomComboPreset.BLM_SimpleMode or CustomComboPreset.BLM_Simple_Transpose)
                 UserConfig.DrawRoundedSliderFloat(3.0f, 8.0f, BLM.Config.BLM_AstralFireRefresh, "Seconds before refreshing Astral Fire.\n(6s = Recommended)");
 
             if (preset == CustomComboPreset.BLM_Simple_CastMovement)
@@ -806,8 +833,8 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.DNC_DanceComboReplacer)
             {
-                var actions = Service.Configuration.DancerDanceCompatActionIDs.Cast<int>().ToArray();
-                var inputChanged = false;
+                int[]? actions = Service.Configuration.DancerDanceCompatActionIDs.Cast<int>().ToArray();
+                bool inputChanged = false;
 
                 inputChanged |= ImGui.InputInt("Emboite (Red) ActionID", ref actions[0], 0);
                 inputChanged |= ImGui.InputInt("Entrechat (Blue) ActionID", ref actions[1], 0);
@@ -912,7 +939,7 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.NIN_Simple_Mudras)
             {
-                var mudrapath = Service.Configuration.MudraPathSelection;
+                int mudrapath = Service.Configuration.MudraPathSelection;
                 bool path1 = mudrapath == 1;
                 bool path2 = mudrapath == 2;
 
@@ -1175,7 +1202,7 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawHorizontalRadioButton(SMN.Config.SMN_PrimalChoice, "Titan first", "Summons Titan, Garuda then Ifrit.", 1);
                 UserConfig.DrawHorizontalRadioButton(SMN.Config.SMN_PrimalChoice, "Garuda first", "Summons Garuda, Titan then Ifrit.", 2);
             }
-            
+
             if (preset == CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling)
                 UserConfig.DrawSliderInt(0, 3, SMN.Config.SMN_Burst_Delay, "Sets the amount of GCDs under Demi summon to wait for oGCD use.", 150, SliderIncrements.Ones);
 
@@ -1250,15 +1277,15 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.PvP_EmergencyHeals)
             {
-                var pc = Service.ClientState.LocalPlayer;
+                PlayerCharacter? pc = Service.ClientState.LocalPlayer;
                 if (pc != null)
                 {
-                    var maxHP = Service.ClientState.LocalPlayer?.MaxHp <= 15000 ? 0 : Service.ClientState.LocalPlayer.MaxHp - 15000;
+                    uint maxHP = Service.ClientState.LocalPlayer?.MaxHp <= 15000 ? 0 : Service.ClientState.LocalPlayer.MaxHp - 15000;
 
                     if (maxHP > 0)
                     {
-                        var setting = PluginConfiguration.GetCustomIntValue(PvPCommon.Config.EmergencyHealThreshold);
-                        var hpThreshold = ((float)maxHP / 100 * setting);
+                        int setting = PluginConfiguration.GetCustomIntValue(PvPCommon.Config.EmergencyHealThreshold);
+                        float hpThreshold = (float)maxHP / 100 * setting;
 
                         UserConfig.DrawSliderInt(1, 100, PvPCommon.Config.EmergencyHealThreshold, $"Set the percentage to be at or under for the feature to kick in.\n100% is considered to start at 15,000 less than your max HP to prevent wastage.\nHP Value to be at or under: {hpThreshold}");
                     }

--- a/XIVSlothCombo/Window/InfoBox.cs
+++ b/XIVSlothCombo/Window/InfoBox.cs
@@ -1,14 +1,14 @@
-﻿using Dalamud.Interface;
-using ImGuiNET;
-using System;
+﻿using System;
 using System.Numerics;
+using Dalamud.Interface;
+using ImGuiNET;
 
 namespace XIVSlothCombo.Window
 {
     internal class InfoBox
     {
         public Vector4 Color { get; set; } = Colors.White;
-        public Action ContentsAction { get; set; } = () => { ImGui.Text("Action Not Set"); };
+        public Action ContentsAction { get; set; } = () => ImGui.Text("Action Not Set");
         public float CurveRadius { get; set; } = 15.0f;
         public Vector2 Size { get; set; } = Vector2.Zero;
         public float BorderThickness { get; set; } = 2.0f;
@@ -35,12 +35,12 @@ namespace XIVSlothCombo.Window
 
             if (Size == Vector2.Zero)
             {
-                Size = ImGui.GetContentRegionAvail() with { Y = ImGui.GetItemRectMax().Y - ImGui.GetItemRectMin().Y + CurveRadius * 2.0f };
+                Size = ImGui.GetContentRegionAvail() with { Y = ImGui.GetItemRectMax().Y - ImGui.GetItemRectMin().Y + (CurveRadius * 2.0f) };
             }
 
             if (AutoResize)
             {
-                Size = Size with { Y = ImGui.GetItemRectMax().Y - ImGui.GetItemRectMin().Y + CurveRadius * 2.0f };
+                Size = Size with { Y = ImGui.GetItemRectMax().Y - ImGui.GetItemRectMin().Y + (CurveRadius * 2.0f) };
             }
 
             DrawCorners();
@@ -50,10 +50,10 @@ namespace XIVSlothCombo.Window
 
         public void DrawCentered(float percentSize = 0.80f)
         {
-            var region = ImGui.GetContentRegionAvail();
-            var currentPosition = ImGui.GetCursorPos();
-            var width = new Vector2(region.X * percentSize);
-            ImGui.SetCursorPos(currentPosition with { X = region.X / 2.0f - width.X / 2.0f });
+            Vector2 region = ImGui.GetContentRegionAvail();
+            Vector2 currentPosition = ImGui.GetCursorPos();
+            Vector2 width = new Vector2(region.X * percentSize);
+            ImGui.SetCursorPos(currentPosition with { X = (region.X / 2.0f) - (width.X / 2.0f) });
 
             Size = width;
             Draw();
@@ -61,7 +61,7 @@ namespace XIVSlothCombo.Window
 
         private void DrawContents()
         {
-            var topLeftCurveCenter = new Vector2(StartPosition.X + CurveRadius, StartPosition.Y + CurveRadius);
+            Vector2 topLeftCurveCenter = new Vector2(StartPosition.X + CurveRadius, StartPosition.Y + CurveRadius);
 
             ImGui.SetCursorScreenPos(topLeftCurveCenter);
             ImGui.PushTextWrapPos(Size.X);
@@ -77,10 +77,10 @@ namespace XIVSlothCombo.Window
 
         private void DrawCorners()
         {
-            var topLeftCurveCenter = new Vector2(StartPosition.X + CurveRadius, StartPosition.Y + CurveRadius);
-            var topRightCurveCenter = new Vector2(StartPosition.X + Size.X - CurveRadius, StartPosition.Y + CurveRadius);
-            var bottomLeftCurveCenter = new Vector2(StartPosition.X + CurveRadius, StartPosition.Y + Size.Y - CurveRadius);
-            var bottomRightCurveCenter = new Vector2(StartPosition.X + Size.X - CurveRadius, StartPosition.Y + Size.Y - CurveRadius);
+            Vector2 topLeftCurveCenter = new Vector2(StartPosition.X + CurveRadius, StartPosition.Y + CurveRadius);
+            Vector2 topRightCurveCenter = new Vector2(StartPosition.X + Size.X - CurveRadius, StartPosition.Y + CurveRadius);
+            Vector2 bottomLeftCurveCenter = new Vector2(StartPosition.X + CurveRadius, StartPosition.Y + Size.Y - CurveRadius);
+            Vector2 bottomRightCurveCenter = new Vector2(StartPosition.X + Size.X - CurveRadius, StartPosition.Y + Size.Y - CurveRadius);
 
             DrawList.PathArcTo(topLeftCurveCenter, CurveRadius, DegreesToRadians(180), DegreesToRadians(270), SegmentResolution);
             DrawList.PathStroke(ColorU32, ImDrawFlags.None, BorderThickness);
@@ -105,13 +105,13 @@ namespace XIVSlothCombo.Window
 
         private void DrawBorders()
         {
-            var color = Debug ? ImGui.GetColorU32(Colors.Red) : ColorU32;
+            uint color = Debug ? ImGui.GetColorU32(Colors.Red) : ColorU32;
 
             DrawList.AddLine(new Vector2(StartPosition.X - 0.5f, StartPosition.Y + CurveRadius - 0.5f), new Vector2(StartPosition.X - 0.5f, StartPosition.Y + Size.Y - CurveRadius + 0.5f), color, BorderThickness);
             DrawList.AddLine(new Vector2(StartPosition.X + Size.X - 0.5f, StartPosition.Y + CurveRadius - 0.5f), new Vector2(StartPosition.X + Size.X - 0.5f, StartPosition.Y + Size.Y - CurveRadius + 0.5f), color, BorderThickness);
             DrawList.AddLine(new Vector2(StartPosition.X + CurveRadius - 0.5f, StartPosition.Y + Size.Y - 0.5f), new Vector2(StartPosition.X + Size.X - CurveRadius + 0.5f, StartPosition.Y + Size.Y - 0.5f), color, BorderThickness);
 
-            var textSize = ImGui.CalcTextSize(Label);
+            Vector2 textSize = ImGui.CalcTextSize(Label);
             float textStartPadding;
             float textEndPadding;
             float textVerticalOffset;

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -6,6 +6,7 @@ using Dalamud.Game.ClientState.Statuses;
 using ImGuiNET;
 using XIVSlothCombo.Combos;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Data;
 using XIVSlothCombo.Services;
 
@@ -20,16 +21,13 @@ namespace XIVSlothCombo.Window.Tabs
         {
             protected internal override CustomComboPreset Preset { get; }
 
-            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
-            {
-                return actionID;
-            }
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level) => actionID;
         }
 
         internal static new void Draw()
         {
             PlayerCharacter? LocalPlayer = Service.ClientState.LocalPlayer;
-            DebugCombo? comboClass = new DebugCombo();
+            DebugCombo? comboClass = new();
 
             if (LocalPlayer != null)
             {
@@ -49,12 +47,12 @@ namespace XIVSlothCombo.Window.Tabs
                 ImGui.TextUnformatted($"TARGET OBJECT KIND: {Service.ClientState.LocalPlayer.TargetObject?.ObjectKind}");
                 ImGui.TextUnformatted($"TARGET IS BATTLE CHARA: {Service.ClientState.LocalPlayer.TargetObject is BattleChara}");
                 ImGui.TextUnformatted($"PLAYER IS BATTLE CHARA: {LocalPlayer is BattleChara}");
-                ImGui.TextUnformatted($"IN COMBAT: {CustomComboNS.Functions.CustomComboFunctions.InCombat()}");
-                ImGui.TextUnformatted($"IN MELEE RANGE: {comboClass.InMeleeRange()}");
-                ImGui.TextUnformatted($"DISTANCE FROM TARGET: {comboClass.GetTargetDistance()}");
-                ImGui.TextUnformatted($"TARGET HP VALUE: {CustomComboNS.Functions.CustomComboFunctions.EnemyHealthCurrentHp()}");
+                ImGui.TextUnformatted($"IN COMBAT: {CustomComboFunctions.InCombat()}");
+                ImGui.TextUnformatted($"IN MELEE RANGE: {CustomComboFunctions.InMeleeRange()}");
+                ImGui.TextUnformatted($"DISTANCE FROM TARGET: {CustomComboFunctions.GetTargetDistance()}");
+                ImGui.TextUnformatted($"TARGET HP VALUE: {CustomComboFunctions.EnemyHealthCurrentHp()}");
                 ImGui.TextUnformatted($"LAST ACTION: {ActionWatching.GetActionName(ActionWatching.LastAction)}");
-                ImGui.TextUnformatted($"LAST ACTION COST: {CustomComboNS.Functions.CustomComboFunctions.GetResourceCost(ActionWatching.LastAction)}");
+                ImGui.TextUnformatted($"LAST ACTION COST: {CustomComboFunctions.GetResourceCost(ActionWatching.LastAction)}");
                 ImGui.TextUnformatted($"LAST ACTION TYPE: {ActionWatching.GetAttackType(ActionWatching.LastAction)}");
                 ImGui.TextUnformatted($"LAST WEAPONSKILL: {ActionWatching.GetActionName(ActionWatching.LastWeaponskill)}");
                 ImGui.TextUnformatted($"LAST SPELL: {ActionWatching.GetActionName(ActionWatching.LastSpell)}");
@@ -71,6 +69,5 @@ namespace XIVSlothCombo.Window.Tabs
             }
         }
     }
-
 }
 #endif

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -1,7 +1,9 @@
-﻿using Dalamud.Game.ClientState.Objects.Types;
-using ImGuiNET;
-using System.Linq;
+﻿using System.Linq;
 using System.Numerics;
+using Dalamud.Game.ClientState.Objects.SubKinds;
+using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Game.ClientState.Statuses;
+using ImGuiNET;
 using XIVSlothCombo.Combos;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.Data;
@@ -26,20 +28,20 @@ namespace XIVSlothCombo.Window.Tabs
 
         internal static new void Draw()
         {
-            var LocalPlayer = Service.ClientState.LocalPlayer;
-            var comboClass = new DebugCombo();
+            PlayerCharacter? LocalPlayer = Service.ClientState.LocalPlayer;
+            DebugCombo? comboClass = new DebugCombo();
 
             if (LocalPlayer != null)
             {
                 if (Service.ClientState.LocalPlayer.TargetObject is BattleChara chara)
                 {
-                    foreach (var status in chara.StatusList)
+                    foreach (Status? status in chara.StatusList)
                     {
                         ImGui.TextUnformatted($"TARGET STATUS CHECK: {chara.Name} -> {ActionWatching.GetStatusName(status.StatusId)}: {status.StatusId}");
                     }
                 }
 
-                foreach (var status in (Service.ClientState.LocalPlayer as BattleChara).StatusList)
+                foreach (Status? status in (Service.ClientState.LocalPlayer as BattleChara).StatusList)
                 {
                     ImGui.TextUnformatted($"SELF STATUS CHECK: {Service.ClientState.LocalPlayer.Name} -> {ActionWatching.GetStatusName(status.StatusId)}: {status.StatusId}");
                 }

--- a/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
@@ -40,7 +40,7 @@ namespace XIVSlothCombo.Window.Tabs
 
                         if (Service.Configuration.HideConflictedCombos)
                         {
-                            var conflictOriginals = Service.Configuration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
+                            var conflictOriginals = PluginConfiguration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
                             var conflictsSource = Service.Configuration.GetAllConflicts();      // Presets with the ConflictedAttribute
 
                             if (!conflictsSource.Where(x => x == preset).Any() || conflictOriginals.Length == 0)

--- a/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
@@ -41,7 +41,7 @@ namespace XIVSlothCombo.Window.Tabs
                         if (Service.Configuration.HideConflictedCombos)
                         {
                             var conflictOriginals = PluginConfiguration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
-                            var conflictsSource = Service.Configuration.GetAllConflicts();      // Presets with the ConflictedAttribute
+                            var conflictsSource = PluginConfiguration.GetAllConflicts();      // Presets with the ConflictedAttribute
 
                             if (!conflictsSource.Where(x => x == preset).Any() || conflictOriginals.Length == 0)
                             {

--- a/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
@@ -1,7 +1,7 @@
-﻿using Dalamud.Interface;
-using ImGuiNET;
-using System.Linq;
+﻿using System.Linq;
 using System.Numerics;
+using Dalamud.Interface;
+using ImGuiNET;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.Services;
 using XIVSlothCombo.Window.Functions;
@@ -26,9 +26,9 @@ namespace XIVSlothCombo.Window.Tabs
 
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0, 5));
 
-            var i = 1;
+            int i = 1;
 
-            foreach (var jobName in groupedPresets.Keys)
+            foreach (string? jobName in groupedPresets.Keys)
             {
                 if (ImGui.CollapsingHeader(jobName))
                 {
@@ -36,7 +36,7 @@ namespace XIVSlothCombo.Window.Tabs
 
                     foreach (var (preset, info) in groupedPresets[jobName].Where(x => !PluginConfiguration.IsSecret(x.Preset)))
                     {
-                        InfoBox presetBox = new() { Color = Colors.Grey, BorderThickness = 1f, CurveRadius = 8f, ContentsAction = () => { Presets.DrawPreset(preset, info, ref i); } };
+                        InfoBox presetBox = new() { Color = Colors.Grey, BorderThickness = 1f, CurveRadius = 8f, ContentsAction = () => Presets.DrawPreset(preset, info, ref i) };
 
                         if (Service.Configuration.HideConflictedCombos)
                         {

--- a/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
@@ -1,7 +1,7 @@
-﻿using Dalamud.Interface;
-using ImGuiNET;
-using System.Linq;
+﻿using System.Linq;
 using System.Numerics;
+using Dalamud.Interface;
+using ImGuiNET;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.Services;
 using XIVSlothCombo.Window.Functions;
@@ -28,9 +28,9 @@ namespace XIVSlothCombo.Window.Tabs
 
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, new Vector2(0, 5));
 
-            var i = 1;
+            int i = 1;
 
-            foreach (var jobName in groupedPresets.Keys)
+            foreach (string? jobName in groupedPresets.Keys)
             {
                 if (!groupedPresets[jobName].Any(x => PluginConfiguration.IsSecret(x.Preset))) continue;
 
@@ -38,7 +38,7 @@ namespace XIVSlothCombo.Window.Tabs
                 {
                     foreach (var (preset, info) in groupedPresets[jobName].Where(x => PluginConfiguration.IsSecret(x.Preset)))
                     {
-                        InfoBox presetBox = new() { Color = Colors.Grey, BorderThickness = 1f, CurveRadius = 8f, ContentsAction = () => { Presets.DrawPreset(preset, info, ref i); } };
+                        InfoBox presetBox = new() { Color = Colors.Grey, BorderThickness = 1f, CurveRadius = 8f, ContentsAction = () => Presets.DrawPreset(preset, info, ref i) };
 
                         if (Service.Configuration.HideConflictedCombos)
                         {

--- a/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
@@ -43,7 +43,7 @@ namespace XIVSlothCombo.Window.Tabs
                         if (Service.Configuration.HideConflictedCombos)
                         {
                             var conflictOriginals = PluginConfiguration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
-                            var conflictsSource = Service.Configuration.GetAllConflicts();      // Presets with the ConflictedAttribute
+                            var conflictsSource = PluginConfiguration.GetAllConflicts();      // Presets with the ConflictedAttribute
 
                             if (!conflictsSource.Where(x => x == preset).Any() || conflictOriginals.Length == 0)
                             {

--- a/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
@@ -42,7 +42,7 @@ namespace XIVSlothCombo.Window.Tabs
 
                         if (Service.Configuration.HideConflictedCombos)
                         {
-                            var conflictOriginals = Service.Configuration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
+                            var conflictOriginals = PluginConfiguration.GetConflicts(preset); // Presets that are contained within a ConflictedAttribute
                             var conflictsSource = Service.Configuration.GetAllConflicts();      // Presets with the ConflictedAttribute
 
                             if (!conflictsSource.Where(x => x == preset).Any() || conflictOriginals.Length == 0)

--- a/XIVSlothCombo/Window/Tabs/Settings.cs
+++ b/XIVSlothCombo/Window/Tabs/Settings.cs
@@ -1,6 +1,6 @@
-﻿using ImGuiNET;
-using System;
+﻿using System;
 using System.Numerics;
+using ImGuiNET;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.Window.Tabs
@@ -14,7 +14,7 @@ namespace XIVSlothCombo.Window.Tabs
 
             #region SubCombos
 
-            var hideChildren = Service.Configuration.HideChildren;
+            bool hideChildren = Service.Configuration.HideChildren;
 
             if (ImGui.Checkbox("Hide SubCombo Options", ref hideChildren))
             {
@@ -34,7 +34,7 @@ namespace XIVSlothCombo.Window.Tabs
 
             #region Conflicting
 
-            var hideConflicting = Service.Configuration.HideConflictedCombos;
+            bool hideConflicting = Service.Configuration.HideConflictedCombos;
             if (ImGui.Checkbox("Hide Conflicted Combos", ref hideConflicting))
             {
                 Service.Configuration.HideConflictedCombos = hideConflicting;
@@ -52,7 +52,7 @@ namespace XIVSlothCombo.Window.Tabs
 
             #region Combat Log
 
-            var showCombatLog = Service.Configuration.EnabledOutputLog;
+            bool showCombatLog = Service.Configuration.EnabledOutputLog;
 
             if (ImGui.Checkbox("Output Log to Chat", ref showCombatLog))
             {
@@ -70,8 +70,8 @@ namespace XIVSlothCombo.Window.Tabs
 
             #region SpecialEvent
 
-            var isSpecialEvent = DateTime.Now.Day == 1 && DateTime.Now.Month == 4;
-            var slothIrl = isSpecialEvent && Service.Configuration.SpecialEvent;
+            bool isSpecialEvent = DateTime.Now.Day == 1 && DateTime.Now.Month == 4;
+            bool slothIrl = isSpecialEvent && Service.Configuration.SpecialEvent;
 
             if (isSpecialEvent)
 
@@ -93,7 +93,7 @@ namespace XIVSlothCombo.Window.Tabs
             float offset = (float)Service.Configuration.MeleeOffset;
             ImGui.PushItemWidth(75);
 
-            var inputChangedeth = false;
+            bool inputChangedeth = false;
             inputChangedeth |= ImGui.InputFloat("Melee Distance Offset", ref offset);
 
             if (inputChangedeth)
@@ -113,7 +113,7 @@ namespace XIVSlothCombo.Window.Tabs
 
             #region Message of the Day
 
-            var motd = Service.Configuration.HideMessageOfTheDay;
+            bool motd = Service.Configuration.HideMessageOfTheDay;
 
             if (ImGui.Checkbox("Hide Message of the Day", ref motd))
             {


### PR DESCRIPTION
All the chore work and then some
(refer to commit details)

@Taurenkey @Genesis-Nova @Tsusai 

- [x] bc41b4f - `IconReplacer.cs`
- [x] 11a05b4 - `BlueInactiveAttribute.cs`
- [x] b1a2943 - `HoverInfoAttribute.cs`
- [x] ab68008 - `ReplaceSkillAttribute.cs`
- [x] ab02123 - `GetAllConflictOriginals()` --> static
- [x] b7eb699 - `GetAllConflicts()` --> static
- [x] 459bf61 - `GetConflicts()` --> static
## Cleanup only
- [x] 8b54f23 - `PluginConfiguration.cs`
- [x] b5c0fb8 - `Timer.cs`
- [x] aa13103 - `Target.cs`
- [x] db32e59 - `Status.cs`
- [x] ea0abfc - `Resource.cs`
- [x] abd7297 - `PlayerCharacter.cs`
- [x] 4841ae0 - `Party.cs`
- [x] a045e49 - `Movement.cs`
- [x] 2b3172c - `Misc.cs`
- [x] a1e3673 - `Config.cs`
- [x] 81ca395 - `Action.cs`
- [x] ddfc6b4 - `CustomCombo.cs`
- [x] 1232420 - `CustomComboCache.cs`
- [x] 84ee65a - `CooldownData.cs`
- [x] e116733 - `ActionWatching.cs`
- [x] 07dadac - `BlueMageService.cs`
- [x] 2dc8d90 - `Service.cs`
- [x] 23b0e62 - `XIVSlothCombo.cs`
- [x] 2459c48 - `ConfigWindow.cs`
- [x] 37da172 - `InfoBox.cs`
- [x] 9cf4269 - `Settings.cs`
- [x] 87b380f - `PvPFeatures.cs`
- [x] e34db16 - `PvEFeatures.cs`
- [x] 083d063 - `Debug.cs`
- [x] e07624d - `UserConfig.cs`