### PR TITLE
[MCH & BRD] Bug fixes;

### DIFF
--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -752,9 +752,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     if (HasEffect(Buffs.StraightShotReady))
-                        return LevelChecked(RefulgentArrow)
-                            ? RefulgentArrow
-                            : StraightShot;
+                        return OriginalHook(StraightShot);
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -535,9 +535,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (songTimerInSeconds < 3 || (minuetReady && gauge.Repertoire == 4))
                                     return WanderersMinuet;
                             }
-                        }
-
-                        else if (songTimerInSeconds < 3)
+                        } else if (songTimerInSeconds < 3 && canWeave)
                         {
                             bool balladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
                             bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -468,7 +468,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool songMage = gauge.Song == Song.MAGE;
                     bool songArmy = gauge.Song == Song.ARMY;
                     bool canInterrupt = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze);
-                    int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_NoWasteHPPercentage);
+                    int  targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_NoWasteHPPercentage);
                     bool isEnemyHealthHigh = IsEnabled(CustomComboPreset.BRD_Simple_NoWaste)
                         ? GetTargetHPPercent() > targetHPThreshold
                         : true;
@@ -554,6 +554,7 @@ namespace XIVSlothCombo.Combos.PvE
                         bool radiantReady = LevelChecked(RadiantFinale) && IsOffCooldown(RadiantFinale);
                         bool ragingReady = LevelChecked(RagingStrikes) && IsOffCooldown(RagingStrikes);
                         bool battleVoiceReady = LevelChecked(BattleVoice) && IsOffCooldown(BattleVoice);
+                        bool barrageReady = LevelChecked(Barrage) && IsOffCooldown(Barrage);
                         bool firstMinute = CombatEngageDuration().Minutes == 0;
                         bool restOfFight = CombatEngageDuration().Minutes > 0;
 
@@ -564,21 +565,20 @@ namespace XIVSlothCombo.Combos.PvE
                         if (canWeaveBuffs && IsEnabled(CustomComboPreset.BRD_Simple_BuffsRadiant) && radiantReady &&
                             (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
                             (battleVoiceReady || GetCooldownRemainingTime(BattleVoice) < 0.7) &&
-                            (GetBuffRemainingTime(Buffs.RagingStrikes) <= 16.5 || openerFinished) && ragingReady)
+                            (GetBuffRemainingTime(Buffs.RagingStrikes) <= 16.5 || openerFinished) && IsOnCooldown(RagingStrikes))
                         {
                             if (!JustUsed(RagingStrikes))
                                 return RadiantFinale;
                         }
 
                         if (canWeaveBuffs && battleVoiceReady &&
-                            (GetBuffRemainingTime(Buffs.RagingStrikes) <= 16.5 || openerFinished) && ragingReady)
+                            (GetBuffRemainingTime(Buffs.RagingStrikes) <= 16.5 || openerFinished) && IsOnCooldown(RagingStrikes))
                         {
                             if (!JustUsed(RagingStrikes))
                                 return BattleVoice;
                         }
 
-                        if (canWeaveBuffs && LevelChecked(Barrage) && IsOffCooldown(Barrage) &&
-                            !HasEffect(Buffs.StraightShotReady) && HasEffect(Buffs.RagingStrikes))
+                        if (canWeaveBuffs && barrageReady && !HasEffect(Buffs.StraightShotReady) && HasEffect(Buffs.RagingStrikes))
                         {
                             if (LevelChecked(RadiantFinale) && HasEffect(Buffs.RadiantFinale))
                                 return Barrage;

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -468,7 +468,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool songMage = gauge.Song == Song.MAGE;
                     bool songArmy = gauge.Song == Song.ARMY;
                     bool canInterrupt = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze);
-                    int  targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_NoWasteHPPercentage);
+                    int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_NoWasteHPPercentage);
                     bool isEnemyHealthHigh = IsEnabled(CustomComboPreset.BRD_Simple_NoWaste)
                         ? GetTargetHPPercent() > targetHPThreshold
                         : true;
@@ -535,7 +535,8 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (songTimerInSeconds < 3 || (minuetReady && gauge.Repertoire == 4))
                                     return WanderersMinuet;
                             }
-                        } else if (songTimerInSeconds < 3 && canWeave)
+                        }
+                        else if (songTimerInSeconds < 3 && canWeave)
                         {
                             bool balladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
                             bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);

--- a/XIVSlothCombo/Combos/PvE/MCH.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH.cs
@@ -457,8 +457,6 @@ namespace XIVSlothCombo.Combos.PvE
                             var gaussCharges = GetRemainingCharges(GaussRound);
                             var gaussMaxCharges = GetMaxCharges(GaussRound);
 
-                            var ricochetCharges = GetRemainingCharges(Ricochet);
-
                             var overheatTime = gauge.OverheatTimeRemaining;
                             var reasmCharges = GetRemainingCharges(Reassemble);
 
@@ -472,17 +470,16 @@ namespace XIVSlothCombo.Combos.PvE
                                     (IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_Drill) && reasmCharges >= 1 && GetCooldownRemainingTime(Drill) <= 2)
                                 ))
                                 return Reassemble;
-                            else if ( ((gaussCharges > ricochetCharges || gaussCharges == gaussMaxCharges || level < Levels.Ricochet) && !IsEnabled(CustomComboPreset.MCH_ST_Simple_High_Latency_Mode)) ||
-                                       (gaussCharges >= gaussMaxCharges - 1 && IsEnabled(CustomComboPreset.MCH_ST_Simple_High_Latency_Mode)) )
+                            else if ( (!IsEnabled(CustomComboPreset.MCH_ST_Simple_High_Latency_Mode) && HasCharges(GaussRound) && (level < Levels.Ricochet || GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)) ) ||
+                                       (IsEnabled(CustomComboPreset.MCH_ST_Simple_High_Latency_Mode) && gaussCharges >= gaussMaxCharges - 1 ) )
                             {
                                 return GaussRound;
                             }
-                            else if (level >= Levels.Ricochet && ricochetCharges > 0 && !IsEnabled(CustomComboPreset.MCH_ST_Simple_High_Latency_Mode))
+                            else if (level >= Levels.Ricochet && HasCharges(Ricochet) && !IsEnabled(CustomComboPreset.MCH_ST_Simple_High_Latency_Mode))
                             {
                                return Ricochet;
                             }
-                                
-                            
+
                         }
 
                         return HeatBlast;
@@ -555,14 +552,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (IsEnabled(CustomComboPreset.MCH_ST_Simple_GaussRicochet) && CanWeave(actionID))
                     {
-                        var gaussCharges = GetRemainingCharges(GaussRound);
-                        var gaussMaxCharges = GetMaxCharges(GaussRound);
-
-                        var ricochetCharges = GetRemainingCharges(Ricochet);
-
-                        if (gaussCharges > ricochetCharges || gaussCharges == gaussMaxCharges || level < Levels.Ricochet)
+                        if (HasCharges(GaussRound) && (level < Levels.Ricochet || GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
                             return GaussRound;
-                        else if (ricochetCharges > 0 && level >= Levels.Ricochet)
+                        else if (HasCharges(Ricochet) && level >= Levels.Ricochet)
                             return Ricochet;
                     }
                     


### PR DESCRIPTION
### MCH

- Fixed an issue of `Gauss` & `Ricochet` hanging up during `Hypercharge` windows;
   - Note: at the 1st 2m window you can still hit the cap sometimes, because there is an abundance of resources being generated because you do 3 `Hypercharge`s back to back, thats normal since you cant reliably use them all fast enough, dps should not suffer from that.

### BRD
- Fixed a bug that prevented the uses of the main Buffs .
- Fixed a missed `canWeave` call for levels lower than `Wanderer Minuet`, on song calls in `Simple Bard`.