### PR TITLE
[SMN] Small tweaks

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2636,7 +2636,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Swiftcast Egi Ability Option", "Uses Swiftcast during the selected Egi summon.", SMN.JobID, 8, "", "")]
         SMN_DemiEgiMenu_SwiftcastEgi = 17023,
 
-        [CustomComboInfo("Astral Flow/Enkindle on Demi Summons Feature", "Adds Enkindle Bahamut, Enkindle Phoenix and Astral Flow to their relevant summons.", SMN.JobID, 11, "", "")]
+        [CustomComboInfo("Astral Flow/Enkindle on Demis Feature", "Adds Enkindle Bahamut, Enkindle Phoenix and Astral Flow to their relevant summons.", SMN.JobID, 11, "", "")]
         SMN_DemiAbilities = 17024,
 
         [ParentCombo(SMN_Advanced_Combo_EDFester)]

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -424,7 +424,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return EnergySiphon;
                         }
                         
-                        // Non-Opener first set Fester/Painflare
+                        // First set Fester/Painflare if ED is close to being off CD, or off CD while you have aetherflow stacks.
                         if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling) && gauge.HasAetherflowStacks)
                         {
                             if (GetCooldown(EnergyDrain).CooldownRemaining <= 3.2)

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -696,7 +696,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is Aethercharge or SummonBahamut or SummonPhoenix)
+                if (actionID is Aethercharge or DreadwyrmTrance or SummonBahamut or SummonPhoenix)
                 {
                     if (IsOffCooldown(EnkindleBahamut) && OriginalHook(Ruin) is AstralImpulse)
                         return OriginalHook(EnkindleBahamut);

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -424,8 +424,8 @@ namespace XIVSlothCombo.Combos.PvE
                                 return EnergySiphon;
                         }
                         
-                        // Non-Opener first set Fester/Painfalre
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling) && gauge.HasAetherflowStacks && !inOpener)
+                        // Non-Opener first set Fester/Painflare
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_oGCDPooling) && gauge.HasAetherflowStacks)
                         {
                             if (GetCooldown(EnergyDrain).CooldownRemaining <= 3.2)
                             {
@@ -696,7 +696,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is SummonBahamut or SummonPhoenix)
+                if (actionID is Aethercharge or SummonBahamut or SummonPhoenix)
                 {
                     if (IsOffCooldown(EnkindleBahamut) && OriginalHook(Ruin) is AstralImpulse)
                         return OriginalHook(EnkindleBahamut);
@@ -704,7 +704,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsOffCooldown(EnkindlePhoenix) && OriginalHook(Ruin) is FountainOfFire)
                         return OriginalHook(EnkindlePhoenix);
 
-                    if (OriginalHook(AstralFlow) is Deathflare or Rekindle)
+                    if ((OriginalHook(AstralFlow) is Deathflare && IsOffCooldown(Deathflare)) || (OriginalHook(AstralFlow) is Rekindle && IsOffCooldown(Rekindle)))
                         return OriginalHook(AstralFlow);
                 }
 


### PR DESCRIPTION
## SMN
None of these are really *bugs*, but just slight behavior tweaks.

- Adjust comment.
- Remove redundant inopener check for first set of festers as it already checks if you have aetherflow stacks, and ED is either almost (3.2s) off cooldown, or off cooldown. This change allows you to use your first set of festers before your demi oGCDs if you start a fight with aetherflow stacks (dungeon or long downtime in a fight)
- Make `Astral Flow/Enkindle on Demi Summons Feature` work with `Aethercharge`, `Dreadwyrm Trance` as well as `Summon Bahamut` or `Summon Phoenix`. (OriginalHook does *not* work for this.) 
- Make demi astral flows not show up if on cooldown for `Astral Flow/Enkindle on Demi Summons Feature`.