### PR TITLE
[SCH] Deployment Tactics Party Size Fix

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -196,8 +196,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (target is not null)
                         {
-
-                            int maxPartySize = GetPartySlot(5) == null ? 4 : 8;
+                            int maxPartySize = GetPartySize();
 
                             //Check if our target is in the party. Will skip if partysize is zero
                             for (int i = 1; i <= maxPartySize; i++)

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -196,16 +196,17 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (target is not null)
                         {
-                            int maxPartySize = GetPartySize();
-
-                            //Check if our target is in the party. Will skip if partysize is zero
-                            for (int i = 1; i <= maxPartySize; i++)
+                            if (IsInParty())
                             {
-                                GameObject? member = GetPartySlot(i);
-                                if (member == null) continue; //Skip nulls/disconnected people
+                                //Search the party
+                                for (int i = 1; i <= 8; i++)
+                                {
+                                    GameObject? member = GetPartySlot(i);
+                                    if (member == null) continue; //Skip nulls/disconnected people
 
-                                found = (member == target);
-                                if (found) break;
+                                    found = (member == target);
+                                    if (found) break;
+                                }
                             }
                             //Check if it's our chocobo?
                             if (found is false) found = HasCompanionPresent() && target == Services.Service.BuddyList.CompanionBuddy.GameObject;

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -202,7 +202,10 @@ namespace XIVSlothCombo.Combos.PvE
                             //Check if our target is in the party. Will skip if partysize is zero
                             for (int i = 1; i <= maxPartySize; i++)
                             {
-                                found = GetPartySlot(i) == target;
+                                GameObject? member = GetPartySlot(i);
+                                if (member == null) continue; //Skip nulls/disconnected people
+
+                                found = (member == target);
                                 if (found) break;
                             }
                             //Check if it's our chocobo?

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -197,12 +197,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (target is not null)
                         {
 
-                            //What's our party size? Check if trust, and add 1 (trust does not include player), else get Party Count
-                            //It's okay if both Buddy/Party are Zero. For loop will skip
-                            int PartySize = Services.Service.BuddyList.Length > 0 ? Services.Service.BuddyList.Length + 1 : GetPartyMembers().Length;
+                            int maxPartySize = GetPartySlot(5) == null ? 4 : 8;
 
                             //Check if our target is in the party. Will skip if partysize is zero
-                            for (int i = 1; i <= PartySize; i++)
+                            for (int i = 1; i <= maxPartySize; i++)
                             {
                                 found = GetPartySlot(i) == target;
                                 if (found) break;

--- a/XIVSlothCombo/CustomCombo/Functions/Party.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Party.cs
@@ -7,20 +7,9 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 {
     internal abstract partial class CustomComboFunctions
     {
-        /// <summary> Gets the party / trust size </summary>
-        /// <returns> Current party size</returns>
-        public static int GetPartySize()
-        {
-            int partySize = Service.PartyList.Length;
-            int buddySize = Service.BuddyList.Length;
-            //Check Party
-            if (partySize > 0) return partySize;
-            //Else check buddylist (Trust/Squad)
-            //20220711: Dalamud API currently returns a max of 3 for BuddyList.Length
-            //So checking Party Slot 5 is needed for 8 man trust trial
-            if (buddySize > 0) return GetPartySlot(5) == null ? 4 : 8;
-            return 0;
-        }
+        /// <summary> Checks if player is in a party </summary>
+        public static bool IsInParty() => (Service.PartyList.PartyId > 0);
+
         /// <summary> Gets the party list </summary>
         /// <returns> Current party list. </returns>
         public static PartyList GetPartyMembers() => Service.PartyList;

--- a/XIVSlothCombo/CustomCombo/Functions/Party.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Party.cs
@@ -7,6 +7,20 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 {
     internal abstract partial class CustomComboFunctions
     {
+        /// <summary> Gets the party / trust size </summary>
+        /// <returns> Current party size</returns>
+        public static int GetPartySize()
+        {
+            int partySize = Service.PartyList.Length;
+            int buddySize = Service.BuddyList.Length;
+            //Check Party
+            if (partySize > 0) return partySize;
+            //Else check buddylist (Trust/Squad)
+            //20220711: Dalamud API currently returns a max of 3 for BuddyList.Length
+            //So checking Party Slot 5 is needed for 8 man trust trial
+            if (buddySize > 0) return GetPartySlot(5) == null ? 4 : 8;
+            return 0;
+        }
         /// <summary> Gets the party list </summary>
         /// <returns> Current party list. </returns>
         public static PartyList GetPartyMembers() => Service.PartyList;


### PR DESCRIPTION
FRMWRK
 - Added _IsInParty()_
 
SCH
- DeploymentTactics feature checks for a party before checking 8 fixed party slots (skipping nulls/disconnecteds)