### PR TITLE
[DRG] Cleanup

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1056,7 +1056,12 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Ranged Uptime Option", "Replaces Main Combo with Piercing Talon when you are out of melee range.", DRG.JobID, 25, "", "")]
             DRG_ST_RangedUptime = 6111,
-            #endregion
+
+            [ParentCombo(DRG_ST_Dives)]
+            [CustomComboInfo("Melee Dives Option", "Uses Spineshatter Dive, Dragonfire Dive, and Stardiver when in the target's target ring (1 yalm) and closer.", DRG.JobID, 14, "", "")]
+            DRG_ST_Dives_Melee = 6112,
+
+        #endregion
 
         #region Advanced Dragoon AoE
         [ReplaceSkill(DRG.CoerthanTorment)]
@@ -1100,6 +1105,12 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Ranged Uptime Option", "Replaces Main AoE Combo with Piercing Talon when you are out of melee range.", DRG.JobID, 40, "", "")]
             DRG_AoE_RangedUptime = 6209,
+
+            [ParentCombo(DRG_AoE_Dives)]
+            [CustomComboInfo("Dives AoE Feature", "Uses Spineshatter Dive, Dragonfire Dive, and Stardiver when in the target's target ring (1 yalm) and closer.", DRG.JobID, 29, "", "")]
+            DRG_AoE_Dives_Melee= 6210,
+
+
         #endregion
         [ReplaceSkill(DRG.Stardiver)]
         [CustomComboInfo("Stardiver Feature", "Turns Stardiver into Nastrond during Life of the Dragon, and Geirskogul outside of Life of the Dragon.", DRG.JobID, 26, "", "")]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1011,96 +1011,110 @@ namespace XIVSlothCombo.Combos
         #region Advanced Dragoon
         [ReplaceSkill(DRG.FullThrust)]
         [CustomComboInfo("Advanced Dragoon", "Replaces Full Thrust with the entire ST combo chain.", DRG.JobID, 1, "", "")]
-        DRG_STCombo = 6500,
+        DRG_STCombo = 6100,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Level 88+ Opener", "Level 88+. Activates when Battle Litany and Lance Charge are off cooldown and when True North is used outside of combat. \nAdds opener to the Simple Dragoon rotation. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 12, "", "")]
-            DRG_ST_Opener = 6501,
+            DRG_ST_Opener = 6101,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Wyrmwind Thrust Option", "Includes Wyrmwind Thrust to the rotation.", DRG.JobID, 13, "", "")]
-            DRG_ST_Wyrmwind = 6502,
+            DRG_ST_Wyrmwind = 6102,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Geirskogul and Nastrond Option", "Includes Geirskogul and Nastrond to the rotation.", DRG.JobID, 18, "", "")]
-            DRG_ST_GeirskogulNastrond = 6503,
+            DRG_ST_GeirskogulNastrond = 6103,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Dives Option", "Adds Spineshatter Dive, Dragonfire Dive, and Stardiver to the rotation.\n Select options below for when to use dives.", DRG.JobID, 14, "", "")]
-            DRG_ST_Dives = 6504,
+            DRG_ST_Dives = 6104,
       
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("High Jump Option", "Includes High Jump/Jump to the rotation.", DRG.JobID, 19, "", "")]
-            DRG_ST_HighJump = 6508,
+            DRG_ST_HighJump = 6105,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Mirage Option", "Includes Mirage Dive to the rotation.", DRG.JobID, 20, "", "")]
-            DRG_ST_Mirage = 6509,
+            DRG_ST_Mirage = 6106,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Lance Charge Option", "Includes Lance Charge to the rotation.", DRG.JobID, 21, "", "")]
-            DRG_ST_Lance = 6510,
+            DRG_ST_Lance = 6107,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Dragon Sight Option", "Includes Dragon Sight to the rotation. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 22, "", "")]
-            DRG_ST_DragonSight = 6511,
+            DRG_ST_DragonSight = 6108,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Battle Litany Option", "Includes Battle Litany to the rotation.", DRG.JobID, 23, "", "")]
-            DRG_ST_Litany = 6514,
+            DRG_ST_Litany = 6109,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Life Surge Option", "Includes Life Surge, while under proper buffs, onto proper GCDs, to the rotation.", DRG.JobID, 24, "", "")]
-            DRG_ST_LifeSurge = 6512,
+            DRG_ST_LifeSurge = 6110,
 
             [ParentCombo(DRG_STCombo)]
             [CustomComboInfo("Ranged Uptime Option", "Replaces Main Combo with Piercing Talon when you are out of melee range.", DRG.JobID, 25, "", "")]
-            DRG_ST_RangedUptime = 6513,
+            DRG_ST_RangedUptime = 6111,
             #endregion
 
         #region Advanced Dragoon AoE
         [ReplaceSkill(DRG.CoerthanTorment)]
         [CustomComboInfo("Advanced Dragoon AoE", "Replaces Coerthan Torment with its combo chain", DRG.JobID, 26, "", "")]
-        DRG_AoECombo = 6600,
+        DRG_AoECombo = 6200,
 
             [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Wyrmwind Thrust AoE Feature", "Includes Wyrmwind Thrust to the AoE rotation.", DRG.JobID, 27, "", "")]
-            DRG_AoE_WyrmwindFeature = 6601,
+            DRG_AoE_WyrmwindFeature = 6201,
 
             [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Geirskogul and Nastrond AoE Feature", "Includes Geirskogul and Nastrond to the AoE rotation.", DRG.JobID, 28, "", "")]
-            DRG_AoE_GeirskogulNastrond = 6602,
+            DRG_AoE_GeirskogulNastrond = 6202,
 
             [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Dives AoE Feature", "Includes Spineshatter Dive, Dragonfire Dive and Stardiver to the AoE rotation.", DRG.JobID, 29, "", "")]
-            DRG_AoE_Dives = 6603,
+            DRG_AoE_Dives = 6203,
 
             [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("High Jump AoE Feature", "Includes High Jump to the AoE rotation.", DRG.JobID, 33, "", "")]
-            DRG_AoE_HighJump = 6607,
+            DRG_AoE_HighJump = 6204,
 
             [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Mirage AoE Feature", "Includes Mirage to the AoE rotation.", DRG.JobID, 34, "", "")]
-            DRG_AoE_Mirage = 6608,
+            DRG_AoE_Mirage = 6205,
 
             #region Buffs AoE Feature
             [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Buffs AoE Feature", "Includes Lance Charge and Battle Litany to the AoE rotation.", DRG.JobID, 35, "", "")]
-            DRG_AoE_Buffs = 6609,
+            DRG_AoE_Buffs = 6206,
  
                 [ParentCombo(DRG_AoE_Buffs)]
                 [CustomComboInfo("Dragon Sight AoE Feature", "Includes Dragon Sight to the AoE rotation. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 36, "", "")]
-                DRG_AoE_DragonSight = 6610,
+                DRG_AoE_DragonSight = 6207,
                 #endregion
 
             [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Life Surge AoE Feature", "Includes Life Surge, while under proper buffs, onto proper GCDs, to the AoE rotation.", DRG.JobID, 37, "", "")]
-            DRG_AoE_LifeSurge = 6611,
+            DRG_AoE_LifeSurge = 6208,
 
             [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Ranged Uptime Option", "Replaces Main AoE Combo with Piercing Talon when you are out of melee range.", DRG.JobID, 40, "", "")]
-            DRG_AoE_RangedUptime = 6612,
-            #endregion
+            DRG_AoE_RangedUptime = 6209,
+        #endregion
+        [ReplaceSkill(DRG.Stardiver)]
+        [CustomComboInfo("Stardiver Feature", "Turns Stardiver into Nastrond during Life of the Dragon, and Geirskogul outside of Life of the Dragon.", DRG.JobID, 26, "", "")]
+        DRG_StardiverFeature = 6300,
+
+        [ReplaceSkill(DRG.LanceCharge)]
+        [CustomComboInfo("Lance Charge to Battle Litany Feature", "Turns Lance Charge into Battle Litany when the former is on cooldown.", DRG.JobID, 26, "", "")]
+        DRG_BurstCDFeature = 6400,
+
+        [ParentCombo(DRG_BurstCDFeature)]
+        [CustomComboInfo("Dragon Sight Option", "Adds Dragon Sight to Lance Charge, will take precedence over Battle Litany.", DRG.JobID, 26, "", "")]
+        DRG_BurstCDFeature_DragonSight = 6401,
+
+
+
         #endregion
 
         #region GUNBREAKER

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1014,42 +1014,50 @@ namespace XIVSlothCombo.Combos
         DRG_STCombo = 6100,
 
             [ParentCombo(DRG_STCombo)]
-            [CustomComboInfo("Level 88+ Opener", "Adds opener to the rotation.\nActivates when Battle Litany and Lance Charge are off cooldown and when True North is used outside of combat. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 12, "", "")]
+            [CustomComboInfo("Level 88+ Opener", "Adds opener to the rotation.\nActivates when Battle Litany and Lance Charge are off cooldown and when True North is used outside of combat. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 0, "", "")]
             DRG_ST_Opener = 6101,
 
             [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("CDs on Main Combo", "Collection of CD features on Main Combo.", DRG.JobID, 0, "", "")]
+            DRG_ST_CDs = 6199,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Buffs on Main Combo", "Collection of Buff features on Main Combo.", DRG.JobID, 0, "", "")]
+            DRG_ST_Buffs = 6198,
+
+            [ParentCombo(DRG_ST_CDs)]
             [CustomComboInfo("Wyrmwind Thrust Option", "Includes Wyrmwind Thrust to the rotation.", DRG.JobID, 13, "", "")]
             DRG_ST_Wyrmwind = 6102,
 
-            [ParentCombo(DRG_STCombo)]
+            [ParentCombo(DRG_ST_CDs)]
             [CustomComboInfo("Geirskogul and Nastrond Option", "Includes Geirskogul and Nastrond to the rotation.", DRG.JobID, 18, "", "")]
             DRG_ST_GeirskogulNastrond = 6103,
 
-            [ParentCombo(DRG_STCombo)]
+            [ParentCombo(DRG_ST_CDs)]
             [CustomComboInfo("Dives Option", "Adds Spineshatter Dive, Dragonfire Dive, and Stardiver to the rotation.\n Select options below for when to use dives.", DRG.JobID, 14, "", "")]
             DRG_ST_Dives = 6104,
       
-            [ParentCombo(DRG_STCombo)]
+            [ParentCombo(DRG_ST_CDs)]
             [CustomComboInfo("High Jump Option", "Includes High Jump/Jump to the rotation.", DRG.JobID, 19, "", "")]
             DRG_ST_HighJump = 6105,
 
-            [ParentCombo(DRG_STCombo)]
+            [ParentCombo(DRG_ST_CDs)]
             [CustomComboInfo("Mirage Option", "Includes Mirage Dive to the rotation.", DRG.JobID, 20, "", "")]
             DRG_ST_Mirage = 6106,
 
-            [ParentCombo(DRG_STCombo)]
+            [ParentCombo(DRG_ST_Buffs)]
             [CustomComboInfo("Lance Charge Option", "Includes Lance Charge to the rotation.", DRG.JobID, 21, "", "")]
             DRG_ST_Lance = 6107,
 
-            [ParentCombo(DRG_STCombo)]
+            [ParentCombo(DRG_ST_Buffs)]
             [CustomComboInfo("Dragon Sight Option", "Includes Dragon Sight to the rotation. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 22, "", "")]
             DRG_ST_DragonSight = 6108,
 
-            [ParentCombo(DRG_STCombo)]
+            [ParentCombo(DRG_ST_Buffs)]
             [CustomComboInfo("Battle Litany Option", "Includes Battle Litany to the rotation.", DRG.JobID, 23, "", "")]
             DRG_ST_Litany = 6109,
 
-            [ParentCombo(DRG_STCombo)]
+            [ParentCombo(DRG_ST_CDs)]
             [CustomComboInfo("Life Surge Option", "Includes Life Surge, while under proper buffs, onto proper GCDs, to the rotation.", DRG.JobID, 24, "", "")]
             DRG_ST_LifeSurge = 6110,
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1107,7 +1107,7 @@ namespace XIVSlothCombo.Combos
             DRG_AoE_RangedUptime = 6209,
 
             [ParentCombo(DRG_AoE_Dives)]
-            [CustomComboInfo("Dives AoE Feature", "Uses Spineshatter Dive, Dragonfire Dive, and Stardiver when in the target's target ring (1 yalm) and closer.", DRG.JobID, 29, "", "")]
+            [CustomComboInfo("Melee Dives Option", "Uses Spineshatter Dive, Dragonfire Dive, and Stardiver when in the target's target ring (1 yalm) and closer.", DRG.JobID, 29, "", "")]
             DRG_AoE_Dives_Melee= 6210,
 
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -894,7 +894,7 @@ namespace XIVSlothCombo.Combos
         DRK_MainComboCDs_Group = 5099,
 
         [ReplaceSkill(DRK.Souleater)]
-        [CustomComboInfo("Souleater Combo", "Replace Souleater with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Simple Dark Knight)", DRK.JobID, 0, "", "")]
+        [CustomComboInfo("Souleater Combo", "Replace Souleater with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Advanced Dark Knight)", DRK.JobID, 0, "", "")]
         DRK_SouleaterCombo = 5000,
 
         [ReplaceSkill(DRK.StalwartSoul)]
@@ -1008,199 +1008,105 @@ namespace XIVSlothCombo.Combos
 
         #region DRAGOON
 
+        #region Advanced Dragoon
+        [ReplaceSkill(DRG.FullThrust)]
+        [CustomComboInfo("Advanced Dragoon", "Replaces Full Thrust with the entire ST combo chain.", DRG.JobID, 1, "", "")]
+        DRG_STCombo = 6500,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Level 88+ Opener", "Level 88+. Activates when Battle Litany and Lance Charge are off cooldown and when True North is used outside of combat. \nAdds opener to the Simple Dragoon rotation. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 12, "", "")]
+            DRG_ST_Opener = 6501,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Wyrmwind Thrust Option", "Includes Wyrmwind Thrust to the rotation.", DRG.JobID, 13, "", "")]
+            DRG_ST_Wyrmwind = 6502,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Geirskogul and Nastrond Option", "Includes Geirskogul and Nastrond to the rotation.", DRG.JobID, 18, "", "")]
+            DRG_ST_GeirskogulNastrond = 6503,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Dives Option", "Adds Spineshatter Dive, Dragonfire Dive, and Stardiver to the rotation.\n Select options below for when to use dives.", DRG.JobID, 14, "", "")]
+            DRG_ST_Dives = 6504,
+      
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("High Jump Option", "Includes High Jump/Jump to the rotation.", DRG.JobID, 19, "", "")]
+            DRG_ST_HighJump = 6508,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Mirage Option", "Includes Mirage Dive to the rotation.", DRG.JobID, 20, "", "")]
+            DRG_ST_Mirage = 6509,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Lance Charge Option", "Includes Lance Charge to the rotation.", DRG.JobID, 21, "", "")]
+            DRG_ST_Lance = 6510,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Dragon Sight Option", "Includes Dragon Sight to the rotation. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 22, "", "")]
+            DRG_ST_DragonSight = 6511,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Battle Litany Option", "Includes Battle Litany to the rotation.", DRG.JobID, 23, "", "")]
+            DRG_ST_Litany = 6514,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Life Surge Option", "Includes Life Surge, while under proper buffs, onto proper GCDs, to the rotation.", DRG.JobID, 24, "", "")]
+            DRG_ST_LifeSurge = 6512,
+
+            [ParentCombo(DRG_STCombo)]
+            [CustomComboInfo("Ranged Uptime Option", "Replaces Main Combo with Piercing Talon when you are out of melee range.", DRG.JobID, 25, "", "")]
+            DRG_ST_RangedUptime = 6513,
+            #endregion
+
+        #region Advanced Dragoon AoE
         [ReplaceSkill(DRG.CoerthanTorment)]
-        [ConflictingCombos(DRG_AoE_SimpleMode)]
-        [CustomComboInfo("Coerthan Torment Combo", "Replace Coerthan Torment with its combo chain.", DRG.JobID, 1, "", "")]
-        DRG_CoerthanTormentCombo = 6100,
+        [CustomComboInfo("Advanced Dragoon AoE", "Replaces Coerthan Torment with its combo chain", DRG.JobID, 26, "", "")]
+        DRG_AoECombo = 6600,
 
-        #region Chaos Thrust Combo
-        [ReplaceSkill(DRG.ChaosThrust)]
-        [ConflictingCombos(DRG_SimpleMode)]
-        [CustomComboInfo("Chaos Thrust Combo", "Replace Chaos Thrust with its combo chain.", DRG.JobID, 2, "", "")]
-        DRG_ChaosThrustCombo = 6200,
+            [ParentCombo(DRG_AoECombo)]
+            [CustomComboInfo("Wyrmwind Thrust AoE Feature", "Includes Wyrmwind Thrust to the AoE rotation.", DRG.JobID, 27, "", "")]
+            DRG_AoE_WyrmwindFeature = 6601,
 
-            [ParentCombo(DRG_ChaosThrustCombo)]
-            [CustomComboInfo("Chaos Piercing Talon Uptime", "Replaces Chaos Thrust Combo with Piercing Talon when you are out of range.", DRG.JobID, 3, "", "")]
-            DRG_RangedUptimeChaos = 6201,
-            #endregion
+            [ParentCombo(DRG_AoECombo)]
+            [CustomComboInfo("Geirskogul and Nastrond AoE Feature", "Includes Geirskogul and Nastrond to the AoE rotation.", DRG.JobID, 28, "", "")]
+            DRG_AoE_GeirskogulNastrond = 6602,
 
-        #region Full Thrust Combo
-        [ReplaceSkill(DRG.FullThrust)]
-        [ConflictingCombos(DRG_FullThrustComboPlus, DRG_SimpleMode)]
-        [CustomComboInfo("Full Thrust Combo", "Replace Full Thrust with its combo chain.", DRG.JobID, 4, "", "")]
-        DRG_FullThrustCombo = 6300,
+            [ParentCombo(DRG_AoECombo)]
+            [CustomComboInfo("Dives AoE Feature", "Includes Spineshatter Dive, Dragonfire Dive and Stardiver to the AoE rotation.", DRG.JobID, 29, "", "")]
+            DRG_AoE_Dives = 6603,
 
-            [ParentCombo(DRG_FullThrustCombo)]
-            [CustomComboInfo("Full Piercing Talon Uptime", "Replaces Full Thrust Combo with Piercing Talon when you are out of range.", DRG.JobID, 5, "", "")]
-            DRG_RangedUptimeFullThrust = 6301,
-            #endregion
+            [ParentCombo(DRG_AoECombo)]
+            [CustomComboInfo("High Jump AoE Feature", "Includes High Jump to the AoE rotation.", DRG.JobID, 33, "", "")]
+            DRG_AoE_HighJump = 6607,
 
-        #region Full Thrust Combo Plus
-        [ReplaceSkill(DRG.FullThrust)]
-        [ConflictingCombos(DRG_FullThrustCombo, DRG_SimpleMode)]
-        [CustomComboInfo("Full Thrust Combo Plus", "Replace Full Thrust Plus Combo with its combo chain (Disembowel/Chaosthrust/life surge added).", DRG.JobID, 6, "", "")]
-        DRG_FullThrustComboPlus = 6400,
+            [ParentCombo(DRG_AoECombo)]
+            [CustomComboInfo("Mirage AoE Feature", "Includes Mirage to the AoE rotation.", DRG.JobID, 34, "", "")]
+            DRG_AoE_Mirage = 6608,
 
-            [ParentCombo(DRG_FullThrustComboPlus)]
-            [CustomComboInfo("High Jump Plus Feature", "Includes High Jump in the rotation.", DRG.JobID, 7, "", "")]
-            DRG_HighJumpPlus = 6401,
-
-            [ParentCombo(DRG_HighJumpPlus)]
-            [CustomComboInfo("Mirage Plus Feature", "Includes Mirage in the rotation.", DRG.JobID, 8, "", "")]
-            DRG_MiragePlus = 6402,
-
-            [ParentCombo(DRG_FullThrustComboPlus)]
-            [CustomComboInfo("Life Surge Plus Feature", "Includes Life Surge, while under proper buffs, onto proper GCDs, to the rotation.", DRG.JobID, 9, "", "")]
-            DRG_LifeSurgePlus = 6404,
-
-            [ParentCombo(DRG_FullThrustComboPlus)]
-            [CustomComboInfo("Plus Piercing Talon Uptime", "Replaces Full Thrust with Piercing Talon when you are out of range.", DRG.JobID, 10, "", "")]
-            DRG_RangedUptimePlus = 6403,
-            #endregion
-
-        #region Simple Dragoon
-        [ReplaceSkill(DRG.FullThrust)]
-        [ConflictingCombos(DRG_FullThrustCombo, DRG_FullThrustComboPlus, DRG_ChaosThrustCombo, DRG_FangThrust, DRG_FangAndClaw)]
-        [CustomComboInfo("Simple Dragoon", "Replaces Full Thrust with the entire DRG combo chain. Conflicts with every non-AoE feature.", DRG.JobID, 11, "", "")]
-        DRG_SimpleMode = 6500,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Simple Opener", "Level 88+. Use True North on prepull to activate. Adds opener to the Simple Dragoon rotation. Not recommended for use in dungeons. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 12, "", "")]
-            DRG_Simple_Opener = 6501,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Wyrmwind Thrust Feature", "Includes Wyrmwind Thrust to the Simple Dragoon rotation.", DRG.JobID, 13, "", "")]
-            DRG_Simple_Wyrmwind = 6502,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Geirskogul and Nastrond Feature", "Includes Geirskogul and Nastrond in the rotation.", DRG.JobID, 18, "", "")]
-            DRG_Simple_GeirskogulNastrond = 6503,
-
-            [ConflictingCombos(DRG_Simple_LitanyDives, DRG_Simple_LanceDives, DRG_Simple_LifeLitanyDives)]
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Dives Feature", "Single Weave Friendly, but not optimal: Includes Spineshatter Dive, Dragonfire Dive and Stardiver in the rotation.", DRG.JobID, 14, "", "")]
-            DRG_Simple_Dives = 6504,
-
-            [ConflictingCombos(DRG_Simple_Dives, DRG_Simple_LitanyDives, DRG_Simple_LifeLitanyDives)]
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Dives under Lance Charge Feature", "Single Weave Friendly: Includes Spineshatter Dive and Dragonfire Dive in the rotation, while under Lance Charge, and Stardiver while under Life of the Dragon.", DRG.JobID, 17, "", "")]
-            DRG_Simple_LanceDives = 6505,
-
-            [ConflictingCombos(DRG_Simple_Dives, DRG_Simple_LanceDives, DRG_Simple_LifeLitanyDives)]
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Dives under Litany Feature", "Double Weaves Required: Includes Spineshatter Dive and Dragonfire Dive in the rotation, while under Battle Litany, and Stardiver while under Life of the Dragon.", DRG.JobID, 15, "", "")]
-            DRG_Simple_LitanyDives = 6506,
-
-            [ConflictingCombos(DRG_Simple_Dives, DRG_Simple_LanceDives, DRG_Simple_LitanyDives)]
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Dives under Litany and Life of the Dragon Feature", "Double Weaves Required: Includes Spineshatter Dive and Dragonfire Dive in the rotation, while under Battle Litany and Life of the Dragon, and Stardiver while under Life of the Dragon.", DRG.JobID, 16, "", "")]
-            DRG_Simple_LifeLitanyDives = 6507,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("High Jump Feature", "Includes High Jump in the rotation.", DRG.JobID, 19, "", "")]
-            DRG_Simple_HighJump = 6508,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Mirage Feature", "Includes Mirage in the rotation.", DRG.JobID, 20, "", "")]
-            DRG_Simple_Mirage = 6509,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Lance Charge Feature", "Includes Lance Charge to the rotation.", DRG.JobID, 21, "", "")]
-            DRG_Simple_Lance = 6510,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Dragon Sight Feature", "Includes Dragon Sight to the rotation. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 22, "", "")]
-            DRG_Simple_DragonSight = 6511,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Battle Litany Feature", "Includes Battle Litany to the rotation.", DRG.JobID, 23, "", "")]
-            DRG_Simple_Litany = 6514,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Life Surge Feature", "Includes Life Surge, while under proper buffs, onto proper GCDs, to the rotation.", DRG.JobID, 24, "", "")]
-            DRG_Simple_LifeSurge = 6512,
-
-            [ParentCombo(DRG_SimpleMode)]
-            [CustomComboInfo("Ranged Uptime Option", "Replaces Main Combo with Piercing Talon when you are out of melee range.\nNOT OPTIMAL.", DRG.JobID, 25, "", "")]
-            DRG_Simple_RangedUptime = 6513,
-            #endregion
-
-        #region Simple Dragoon AoE
-        [ReplaceSkill(DRG.CoerthanTorment)]
-        [ConflictingCombos(DRG_CoerthanTormentCombo)]
-        [CustomComboInfo("Simple Dragoon AoE", "One Button, many enemies hit.", DRG.JobID, 26, "", "")]
-        DRG_AoE_SimpleMode = 6600,
-
-            [ParentCombo(DRG_AoE_SimpleMode)]
-            [CustomComboInfo("Wyrmwind Thrust AoE Feature", "Includes Wyrmwind Thrust to the Simple Dragoon AoE rotation.", DRG.JobID, 27, "", "")]
-            DRG_AoE_Simple_WyrmwindFeature = 6601,
-
-            [ParentCombo(DRG_AoE_SimpleMode)]
-            [CustomComboInfo("Geirskogul and Nastrond AoE Feature", "Includes Geirskogul and Nastrond in the AoE rotation.", DRG.JobID, 28, "", "")]
-            DRG_AoE_Simple_GeirskogulNastrond = 6602,
-
-            [ConflictingCombos(DRG_AoE_Simple_LitanyDives, DRG_AoE_Simple_LifeLitanyDives, DRG_AoE_Simple_LanceDives)]
-            [ParentCombo(DRG_AoE_SimpleMode)]
-            [CustomComboInfo("Dives AoE Feature", "Includes Spineshatter Dive, Dragonfire Dive and Stardiver in the AoE rotation.", DRG.JobID, 29, "", "")]
-            DRG_AoE_Simple_Dives = 6603,
-
-            [ConflictingCombos(DRG_AoE_Simple_Dives, DRG_AoE_Simple_LitanyDives, DRG_AoE_Simple_LifeLitanyDives)]
-            [ParentCombo(DRG_AoE_SimpleMode)]
-            [CustomComboInfo("Dives under Lance Charge AoE Feature", "Single Weave Friendly: Includes Spineshatter Dive and Dragonfire Dive in the AoE rotation, while under Lance Charge, and Stardiver while under Life of the Dragon.", DRG.JobID, 30, "", "")]
-            DRG_AoE_Simple_LanceDives = 6604,
-
-            [ConflictingCombos(DRG_AoE_Simple_Dives, DRG_AoE_Simple_LanceDives, DRG_AoE_Simple_LifeLitanyDives)]
-            [ParentCombo(DRG_AoE_SimpleMode)]
-            [CustomComboInfo("Dives under Litany AoE Features", "Includes Spineshatter Dive and Dragonfire Dive in the AoE rotation, while under Battle Litany, and Stardiver while under Life of the Dragon.", DRG.JobID, 31, "", "")]
-            DRG_AoE_Simple_LitanyDives = 6605,
-
-            [ConflictingCombos(DRG_AoE_Simple_Dives, DRG_AoE_Simple_LanceDives, DRG_AoE_Simple_LitanyDives)]
-            [ParentCombo(DRG_AoE_SimpleMode)]
-            [CustomComboInfo("Dives under Litany and Life of the Dragon AoE Features", "Includes Spineshatter Dive and Dragonfire Dive in the AoE rotation, while under Battle Litany and Life of the Dragon, and Stardiver while under Life of the Dragon.", DRG.JobID, 32, "", "")]
-            DRG_AoE_Simple_LifeLitanyDives = 6606,
-
-            [ParentCombo(DRG_AoE_SimpleMode)]
-            [CustomComboInfo("High Jump AoE Feature", "Includes High Jump in the AoE rotation.", DRG.JobID, 33, "", "")]
-            DRG_AoE_Simple_HighJump = 6607,
-
-            [ParentCombo(DRG_AoE_SimpleMode)]
-            [CustomComboInfo("Mirage AoE Feature", "Includes Mirage in the AoE rotation.", DRG.JobID, 34, "", "")]
-            DRG_AoE_Simple_Mirage = 6608,
-
-            [ParentCombo(DRG_AoE_SimpleMode)]
+            #region Buffs AoE Feature
+            [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Buffs AoE Feature", "Includes Lance Charge and Battle Litany to the AoE rotation.", DRG.JobID, 35, "", "")]
-            DRG_AoE_Simple_Buffs = 6609,
-
-                #region Buffs AoE Feature
-                [ParentCombo(DRG_AoE_Simple_Buffs)]
+            DRG_AoE_Buffs = 6609,
+ 
+                [ParentCombo(DRG_AoE_Buffs)]
                 [CustomComboInfo("Dragon Sight AoE Feature", "Includes Dragon Sight to the AoE rotation. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 36, "", "")]
-                DRG_AoE_Simple_DragonSight = 6610,
+                DRG_AoE_DragonSight = 6610,
                 #endregion
 
-            [ParentCombo(DRG_AoE_SimpleMode)]
+            [ParentCombo(DRG_AoECombo)]
             [CustomComboInfo("Life Surge AoE Feature", "Includes Life Surge, while under proper buffs, onto proper GCDs, to the AoE rotation.", DRG.JobID, 37, "", "")]
-            DRG_AoE_Simple_LifeSurge = 6611,
+            DRG_AoE_LifeSurge = 6611,
 
-            [ParentCombo(DRG_AoE_SimpleMode)]
-            [CustomComboInfo("Ranged Uptime Option", "Replaces Main AoE Combo with Piercing Talon when you are out of melee range.\nNOT OPTIMAL.", DRG.JobID, 40, "", "")]
-            DRG_AoE_Simple_RangedUptime = 6612,
+            [ParentCombo(DRG_AoECombo)]
+            [CustomComboInfo("Ranged Uptime Option", "Replaces Main AoE Combo with Piercing Talon when you are out of melee range.", DRG.JobID, 40, "", "")]
+            DRG_AoE_RangedUptime = 6612,
             #endregion
-
-        [ConflictingCombos(DRG_SimpleMode)]
-        [CustomComboInfo("Wheeling Thrust/Fang and Claw Option", "When you have either Enhanced Fang and Claw or Wheeling Thrust, Chaos Thrust Combo becomes Wheeling Thrust and Full Thrust Combo becomes Fang and Claw. Requires Chaos Thrust Combo and Full Thrust Combo.", DRG.JobID, 38, "", "")]
-        DRG_FangThrust = 6700,
-
-        [ReplaceSkill(DRG.FangAndClaw)]
-        [ConflictingCombos(DRG_SimpleMode)]
-        [CustomComboInfo("Wheeling Thrust/Fang and Claw Feature", "Fang And Claw Becomes Wheeling Thrust when under Enhanced Wheeling Thrust Buff.", DRG.JobID, 39, "", "")]
-        DRG_FangAndClaw = 6701,
-
         #endregion
 
         #region GUNBREAKER
 
         [ReplaceSkill(GNB.SolidBarrel)]
-        [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Simple Gunbreaker)", GNB.JobID, 0, "", "")]
+        [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Advanced Gunbreaker)", GNB.JobID, 0, "", "")]
         GNB_ST_MainCombo = 7000,
 
         [ParentCombo(GNB_ST_MainCombo)]
@@ -1840,7 +1746,7 @@ namespace XIVSlothCombo.Combos
 
         #region Single Target (Slice) Combo Section
         [ReplaceSkill(RPR.Slice)]
-        [CustomComboInfo("Slice Combo Feature", "Replace Slice with its combo chain.\nIf all sub options are toggled will turn into a full one button rotation (Simple Reaper)", RPR.JobID, 0, "", "")]
+        [CustomComboInfo("Slice Combo Feature", "Replace Slice with its combo chain.\nIf all sub options are toggled will turn into a full one button rotation (Advanced Reaper)", RPR.JobID, 0, "", "")]
         RPR_ST_SliceCombo = 12001,
 
         [ParentCombo(RPR_ST_SliceCombo)]
@@ -2354,7 +2260,7 @@ namespace XIVSlothCombo.Combos
 
         #region Main Combo (Gekko) Features
         [ReplaceSkill(SAM.Gekko)]
-        [CustomComboInfo("Gekko Combo", "Replace Gekko with its combo chain.\nIf all sub options are selected will turn into a full one button rotation (Simple Samurai)", SAM.JobID, 0, "", "")]
+        [CustomComboInfo("Gekko Combo", "Replace Gekko with its combo chain.\nIf all sub options are selected will turn into a full one button rotation (Advanced Samurai)", SAM.JobID, 0, "", "")]
         SAM_ST_GekkoCombo = 15003,
 
             [ParentCombo(SAM_ST_GekkoCombo)]
@@ -2755,7 +2661,7 @@ namespace XIVSlothCombo.Combos
         #region WARRIOR
 
         [ReplaceSkill(WAR.StormsEye)]
-        [CustomComboInfo("Storms Path Combo", "All in one main combo feature adds Storm's Eye/Path. \nIf all sub options and Fell Cleave/Decimate Options are toggled will turn into a full one button rotation (Simple Warrior)", WAR.JobID, 0, "", "")]
+        [CustomComboInfo("Storms Path Combo", "All in one main combo feature adds Storm's Eye/Path. \nIf all sub options and Fell Cleave/Decimate Options are toggled will turn into a full one button rotation (Advanced Warrior)", WAR.JobID, 0, "", "")]
         WAR_ST_StormsPath = 18000,
 
         [ReplaceSkill(WAR.StormsEye)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1014,7 +1014,7 @@ namespace XIVSlothCombo.Combos
         DRG_STCombo = 6100,
 
             [ParentCombo(DRG_STCombo)]
-            [CustomComboInfo("Level 88+ Opener", "Level 88+. Activates when Battle Litany and Lance Charge are off cooldown and when True North is used outside of combat. \nAdds opener to the Simple Dragoon rotation. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 12, "", "")]
+            [CustomComboInfo("Level 88+ Opener", "Adds opener to the rotation.\nActivates when Battle Litany and Lance Charge are off cooldown and when True North is used outside of combat. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 12, "", "")]
             DRG_ST_Opener = 6101,
 
             [ParentCombo(DRG_STCombo)]

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -179,50 +179,56 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (HasEffect(Buffs.PowerSurge))
                                 {
                                     //Wyrmwind Thrust Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_Wyrmwind) && gauge.FirstmindsFocusCount is 2)
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_CDs) && IsEnabled(CustomComboPreset.DRG_ST_Wyrmwind) && gauge.FirstmindsFocusCount is 2)
                                         return WyrmwindThrust;
 
-                                    //Lance Charge Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_Lance) && LevelChecked(LanceCharge) && IsOffCooldown(LanceCharge))
-                                        return LanceCharge;
-
-                                    //Dragon Sight Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_DragonSight) && LevelChecked(DragonSight) && IsOffCooldown(DragonSight))
-                                        return DragonSight;
-
-                                    //Battle Litany Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_Litany) && LevelChecked(BattleLitany) && IsOffCooldown(BattleLitany) && CanWeave(actionID, 1.3))
-                                        return BattleLitany;
-
-                                    //Geirskogul and Nastrond Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_GeirskogulNastrond) && LevelChecked(Geirskogul) && ((gauge.IsLOTDActive && IsOffCooldown(Nastrond)) || IsOffCooldown(Geirskogul)))
-                                        return OriginalHook(Geirskogul);
-
-                                    //(High) Jump Feature + Mirage Feature
-                                    if ((IsEnabled(CustomComboPreset.DRG_ST_HighJump) && LevelChecked(Jump) && IsOffCooldown(OriginalHook(Jump))) ||
-                                        (IsEnabled(CustomComboPreset.DRG_ST_Mirage) && LevelChecked(MirageDive) && HasEffect(Buffs.DiveReady)))
-                                        return OriginalHook(Jump);
-
-                                    //Life Surge Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_LifeSurge) && !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0 &&
-                                        (((HasEffect(Buffs.RightEye) || HasEffect(Buffs.LanceCharge)) && lastComboMove is VorpalThrust) ||
-                                        (HasEffect(Buffs.BattleLitany) && ((HasEffect(Buffs.EnhancedWheelingThrust) && WasLastWeaponskill(FangAndClaw)) || HasEffect(Buffs.SharperFangAndClaw) && WasLastWeaponskill(WheelingThrust)))))
-                                        return LifeSurge;
-
-                                    //Dives Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_Dives) && (IsNotEnabled(CustomComboPreset.DRG_ST_Dives_Melee) || (IsEnabled(CustomComboPreset.DRG_ST_Dives_Melee) && GetTargetDistance() <= 1)))
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_Buffs))
                                     {
-                                        if (diveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3) && IsOnCooldown(DragonfireDive))
-                                            return Stardiver;
+                                        //Lance Charge Feature
+                                        if (IsEnabled(CustomComboPreset.DRG_ST_Lance) && LevelChecked(LanceCharge) && IsOffCooldown(LanceCharge))
+                                            return LanceCharge;
 
-                                        if (diveOptions is 0 or 1 || //Dives on cooldown
-                                           (diveOptions is 2 && ((gauge.IsLOTDActive && LevelChecked(Nastrond)) || !LevelChecked(Nastrond)) && HasEffectAny(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
-                                           (diveOptions is 3 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
+                                        //Dragon Sight Feature
+                                        if (IsEnabled(CustomComboPreset.DRG_ST_DragonSight) && LevelChecked(DragonSight) && IsOffCooldown(DragonSight))
+                                            return DragonSight;
+
+                                        //Battle Litany Feature
+                                        if (IsEnabled(CustomComboPreset.DRG_ST_Litany) && LevelChecked(BattleLitany) && IsOffCooldown(BattleLitany) && CanWeave(actionID, 1.3))
+                                            return BattleLitany;
+                                    }
+
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_CDs))
+                                    {
+                                        //Geirskogul and Nastrond Feature
+                                        if (IsEnabled(CustomComboPreset.DRG_ST_GeirskogulNastrond) && LevelChecked(Geirskogul) && ((gauge.IsLOTDActive && IsOffCooldown(Nastrond)) || IsOffCooldown(Geirskogul)))
+                                            return OriginalHook(Geirskogul);
+
+                                        //(High) Jump Feature + Mirage Feature
+                                        if ((IsEnabled(CustomComboPreset.DRG_ST_HighJump) && LevelChecked(Jump) && IsOffCooldown(OriginalHook(Jump))) ||
+                                            (IsEnabled(CustomComboPreset.DRG_ST_Mirage) && LevelChecked(MirageDive) && HasEffect(Buffs.DiveReady)))
+                                            return OriginalHook(Jump);
+
+                                        //Life Surge Feature
+                                        if (IsEnabled(CustomComboPreset.DRG_ST_LifeSurge) && !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0 &&
+                                            (((HasEffect(Buffs.RightEye) || HasEffect(Buffs.LanceCharge)) && lastComboMove is VorpalThrust) ||
+                                            (HasEffect(Buffs.BattleLitany) && ((HasEffect(Buffs.EnhancedWheelingThrust) && WasLastWeaponskill(FangAndClaw)) || HasEffect(Buffs.SharperFangAndClaw) && WasLastWeaponskill(WheelingThrust)))))
+                                            return LifeSurge;
+
+                                        //Dives Feature
+                                        if (IsEnabled(CustomComboPreset.DRG_ST_Dives) && (IsNotEnabled(CustomComboPreset.DRG_ST_Dives_Melee) || (IsEnabled(CustomComboPreset.DRG_ST_Dives_Melee) && GetTargetDistance() <= 1)))
                                         {
-                                            if (LevelChecked(DragonfireDive) && IsOffCooldown(DragonfireDive))
-                                                return DragonfireDive;
-                                            if (LevelChecked(SpineshatterDive) && GetRemainingCharges(SpineshatterDive) > 0)
-                                                return SpineshatterDive;
+                                            if (diveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3) && IsOnCooldown(DragonfireDive))
+                                                return Stardiver;
+
+                                            if (diveOptions is 0 or 1 || //Dives on cooldown
+                                               (diveOptions is 2 && ((gauge.IsLOTDActive && LevelChecked(Nastrond)) || !LevelChecked(Nastrond)) && HasEffectAny(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
+                                               (diveOptions is 3 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
+                                            {
+                                                if (LevelChecked(DragonfireDive) && IsOffCooldown(DragonfireDive))
+                                                    return DragonfireDive;
+                                                if (LevelChecked(SpineshatterDive) && GetRemainingCharges(SpineshatterDive) > 0)
+                                                    return SpineshatterDive;
+                                            }
                                         }
                                     }
                                 }
@@ -288,8 +294,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
 
                             //Geirskogul and Nastrond AoE Feature
-                            if ((IsEnabled(CustomComboPreset.DRG_AoE_GeirskogulNastrond) && LevelChecked(Geirskogul) && IsOffCooldown(Geirskogul)) ||
-                                (IsEnabled(CustomComboPreset.DRG_AoE_GeirskogulNastrond) && gauge.IsLOTDActive && IsOffCooldown(Nastrond)))
+                            if (IsEnabled(CustomComboPreset.DRG_AoE_GeirskogulNastrond) && LevelChecked(Geirskogul) && ((gauge.IsLOTDActive && IsOffCooldown(Nastrond)) || IsOffCooldown(Geirskogul)))
                                 return OriginalHook(Geirskogul);
 
                             //(High) Jump AoE Feature + Mirage Dive Feature

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -105,6 +105,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (IsOnCooldown(BattleLitany) && !HasEffect(Buffs.LanceCharge))
                                 inOpener = false;
+
                             //oGCDs
                             if (CanWeave(actionID))
                             {
@@ -128,7 +129,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 if (WasLastWeaponskill(FangAndClaw))
                                 {
-                                    if (IsOffCooldown(OriginalHook(Jump)))
+                                    if (IsOffCooldown(OriginalHook(Jump)) && !HasEffect(Buffs.DiveReady))
                                         return OriginalHook(Jump);
                                     if (GetRemainingCharges(SpineshatterDive) > 0 && !HasEffect(Buffs.DiveReady))
                                         return SpineshatterDive;
@@ -147,26 +148,6 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (WasLastWeaponskill(HeavensThrust) && GetRemainingCharges(SpineshatterDive) > 0 && !WasLastAction(SpineshatterDive))
                                     return SpineshatterDive;
                             }
-
-                            //GCDs
-                            if (HasEffect(Buffs.SharperFangAndClaw))
-                                return FangAndClaw;
-                            if (HasEffect(Buffs.EnhancedWheelingThrust))
-                                return WheelingThrust;
-
-                            if (comboTime > 0)
-                            {
-                                if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(Disembowel) && GetBuffRemainingTime(Buffs.PowerSurge) < 10)
-                                    return Disembowel;
-                                if (lastComboMove is Disembowel && LevelChecked(ChaosThrust))
-                                    return OriginalHook(ChaosThrust);
-                                if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
-                                    return VorpalThrust;
-                                if (lastComboMove is VorpalThrust && LevelChecked(FullThrust))
-                                    return OriginalHook(FullThrust);
-                            }
-
-                            return OriginalHook(TrueThrust);
                         }
 
                         if (!inOpener)
@@ -225,24 +206,25 @@ namespace XIVSlothCombo.Combos.PvE
                                     }
                                 }
                             }
-
-                            //1-2-3 Combo
-                            if (HasEffect(Buffs.SharperFangAndClaw))
-                                return FangAndClaw;
-                            if (HasEffect(Buffs.EnhancedWheelingThrust))
-                                return WheelingThrust;
-                            if (comboTime > 0)
-                            {
-                                if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(Disembowel) && GetBuffRemainingTime(Buffs.PowerSurge) < 10)
-                                    return Disembowel;
-                                if (lastComboMove is Disembowel && LevelChecked(ChaosThrust))
-                                    return OriginalHook(ChaosThrust);
-                                if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
-                                    return VorpalThrust;
-                                if (lastComboMove is VorpalThrust && LevelChecked(FullThrust))
-                                    return OriginalHook(FullThrust);
-                            }
                         }
+
+                        //1-2-3 Combo
+                        if (HasEffect(Buffs.SharperFangAndClaw))
+                            return FangAndClaw;
+                        if (HasEffect(Buffs.EnhancedWheelingThrust))
+                            return WheelingThrust;
+                        if (comboTime > 0)
+                        {
+                            if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(Disembowel) && GetBuffRemainingTime(Buffs.PowerSurge) < 10)
+                                return Disembowel;
+                            if (lastComboMove is Disembowel && LevelChecked(ChaosThrust))
+                                return OriginalHook(ChaosThrust);
+                            if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
+                                return VorpalThrust;
+                            if (lastComboMove is VorpalThrust && LevelChecked(FullThrust))
+                                return OriginalHook(FullThrust);
+                        }
+
                     }
 
                     return OriginalHook(TrueThrust);
@@ -335,6 +317,47 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     return OriginalHook(DoomSpike);
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class DRG_StardiverFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_StardiverFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Stardiver)
+                {
+                    var gauge = GetJobGauge<DRGGauge>();
+
+                    if (gauge.IsLOTDActive && IsOffCooldown(Stardiver) && LevelChecked(Stardiver))
+                        return Stardiver;
+                    if ((LevelChecked(Geirskogul) && !gauge.IsLOTDActive) || gauge.IsLOTDActive)
+                        return OriginalHook(Geirskogul);
+
+                }
+                return actionID;
+            }
+        }
+
+        internal class DRG_BurstCDFeature : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_BurstCDFeature;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is LanceCharge)
+                {
+                    if (IsOnCooldown(LanceCharge))
+                    {
+                        if (IsEnabled(CustomComboPreset.DRG_BurstCDFeature_DragonSight) && IsOffCooldown(DragonSight) && LevelChecked(DragonSight))
+                            return DragonSight;
+                        if (LevelChecked(BattleLitany) && IsOffCooldown(BattleLitany))
+                            return BattleLitany;
+                    }
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -203,6 +203,12 @@ namespace XIVSlothCombo.Combos.PvE
                                         (IsEnabled(CustomComboPreset.DRG_ST_Mirage) && LevelChecked(MirageDive) && HasEffect(Buffs.DiveReady)))
                                         return OriginalHook(Jump);
 
+                                    //Life Surge Feature
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_LifeSurge) && !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0 &&
+                                        (((HasEffect(Buffs.RightEye) || HasEffect(Buffs.LanceCharge)) && lastComboMove is VorpalThrust) ||
+                                        (HasEffect(Buffs.BattleLitany) && ((HasEffect(Buffs.EnhancedWheelingThrust) && WasLastWeaponskill(FangAndClaw)) || HasEffect(Buffs.SharperFangAndClaw) && WasLastWeaponskill(WheelingThrust)))))
+                                        return LifeSurge;
+
                                     //Dives Feature
                                     if (IsEnabled(CustomComboPreset.DRG_ST_Dives) && (IsNotEnabled(CustomComboPreset.DRG_ST_Dives_Melee) || (IsEnabled(CustomComboPreset.DRG_ST_Dives_Melee) && GetTargetDistance() <= 1)))
                                     {
@@ -219,12 +225,6 @@ namespace XIVSlothCombo.Combos.PvE
                                                 return SpineshatterDive;
                                         }
                                     }
-
-                                    //Life Surge Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_LifeSurge) && !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0 &&
-                                        (((HasEffect(Buffs.RightEye) || HasEffect(Buffs.LanceCharge)) && lastComboMove is VorpalThrust) ||
-                                        (HasEffect(Buffs.BattleLitany) && ((HasEffect(Buffs.EnhancedWheelingThrust) && WasLastWeaponskill(FangAndClaw)) || HasEffect(Buffs.SharperFangAndClaw) && WasLastWeaponskill(WheelingThrust)))))
-                                        return LifeSurge;
                                 }
                             }
                         }

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -270,7 +270,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DRG_AoE_RangedUptime) && LevelChecked(PiercingTalon) && !InMeleeRange() && HasBattleTarget())
                         return PiercingTalon;
 
-                    if (CanWeave(actionID, 0.5))
+                    if (CanWeave(actionID))
                     {
                         if (HasEffect(Buffs.PowerSurge))
                         {

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -1,5 +1,6 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.Core;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -63,622 +64,186 @@ namespace XIVSlothCombo.Combos.PvE
                 ChaoticSpring = 2719;
         }
 
-        public static class Levels
+        public static class Config
         {
-            public const byte
-                VorpalThrust = 4,
-                PiercingTalon = 15,
-                Disembowel = 18,
-                FullThrust = 26,
-                LanceCharge = 30,
-                Jump = 30,
-                SpineshatterDive = 45,
-                DragonfireDive = 50,
-                ChaosThrust = 50,
-                TrueNorth = 50,
-                BattleLitany = 52,
-                FangAndClaw = 56,
-                WheelingThrust = 58,
-                Geirskogul = 60,
-                SonicThrust = 62,
-                DragonSight = 66,
-                MirageDive = 68,
-                Nastrond = 70,
-                CoerthanTorment = 72,
-                HighJump = 74,
-                RaidenThrust = 76,
-                Stardiver = 80,
-                DraconianFury = 82,
-                ChaoticSpring = 86,
-                HeavensThrust = 86;
+            public const string
+                DRG_ST_DiveOptions = "DRG_ST_DiveOptions",
+                DRG_AOE_DiveOptions = "DRG_AOE_DiveOptions";
         }
 
-
-        internal class DRG_CoerthanTormentCombo : CustomCombo
+        internal class DRG_STCombo : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_CoerthanTormentCombo;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is CoerthanTorment)
-                {
-                    if (comboTime > 0)
-                    {
-                        if ((lastComboMove is DoomSpike or DraconianFury) && level >= Levels.SonicThrust)
-                            return SonicThrust;
-                        if (lastComboMove is SonicThrust && level >= Levels.CoerthanTorment)
-                            return CoerthanTorment;
-                    }
-                    return OriginalHook(DoomSpike);
-                }
-                return actionID;
-            }
-        }
-
-        internal class DRG_ChaosThrustCombo : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_ChaosThrustCombo;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is ChaosThrust or ChaoticSpring)
-                {
-
-                    //Piercing Talon Uptime Feature
-                    if (IsEnabled(CustomComboPreset.DRG_RangedUptimeChaos) && level >= Levels.PiercingTalon)
-                    {
-                        if (!InMeleeRange())
-                            return PiercingTalon;
-                    }
-
-                    if (comboTime > 0)
-                    {
-                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.Disembowel)
-                            return Disembowel;
-
-                        if (lastComboMove is Disembowel && level >= Levels.ChaosThrust)
-                            return OriginalHook(ChaosThrust);
-                    }
-
-                    if (IsEnabled(CustomComboPreset.DRG_FangThrust) && (HasEffect(Buffs.SharperFangAndClaw) || HasEffect(Buffs.EnhancedWheelingThrust)))
-                        return WheelingThrust;
-
-                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
-                        return FangAndClaw;
-
-                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
-                        return WheelingThrust;
-
-                    return TrueThrust;
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class DRG_FullThrustCombo : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_FullThrustCombo;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is FullThrust)
-                {
-
-                    //Piercing Talon Uptime Feature
-                    if (IsEnabled(CustomComboPreset.DRG_RangedUptimeFullThrust) && level >= Levels.PiercingTalon)
-                    {
-                        if (!InMeleeRange())
-                            return PiercingTalon;
-                    }
-
-                    if (comboTime > 0)
-                    {
-                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.VorpalThrust)
-                            return VorpalThrust;
-
-                        if (lastComboMove is VorpalThrust && level >= Levels.FullThrust)
-                            return FullThrust;
-                    }
-
-                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
-                        return FangAndClaw;
-
-                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
-                        return WheelingThrust;
-
-                    return OriginalHook(TrueThrust);
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class DRG_FullThrustComboPlus : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_FullThrustComboPlus;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is FullThrust)
-                {
-                    var canWeave = CanWeave(actionID);
-
-                    //Piercing Talon Uptime Feature
-                    if (IsEnabled(CustomComboPreset.DRG_RangedUptimePlus) && level >= Levels.PiercingTalon)
-                    {
-                        if (!InMeleeRange())
-                            return PiercingTalon;
-                    }
-
-                    //(High) Jump Plus Feature
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_HighJumpPlus))
-                        {
-                            if (
-                                level >= Levels.HighJump &&
-                                IsOffCooldown(HighJump) && canWeave
-                               ) return HighJump;
-
-                            if (
-                                level is >= Levels.Jump and <= Levels.HighJump && IsOffCooldown(Jump) && canWeave
-                               ) return Jump;
-                        }
-                    }
-
-                    //Life Surge Plus Feature
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_LifeSurgePlus) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && CanWeave(actionID, 0.001) && GetRemainingCharges(LifeSurge) > 0)
-                        {
-                            if (lastComboMove is VorpalThrust)
-                            {
-                                if (HasEffect(Buffs.LanceCharge))
-                                    return LifeSurge;
-
-                                if (HasEffect(Buffs.RightEye))
-                                    return LifeSurge;
-                            }
-
-                            if (HasEffect(Buffs.BattleLitany))
-                            {
-
-                                if (HasEffect(Buffs.EnhancedWheelingThrust))
-                                    return LifeSurge;
-
-                                if (HasEffect(Buffs.SharperFangAndClaw))
-                                    return LifeSurge;
-                            }
-                        }
-                    }
-
-                    //Mirage Feature
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_MiragePlus))
-                        {
-                            if (level >= Levels.MirageDive && HasEffect(Buffs.DiveReady) && canWeave)
-                                return MirageDive;
-                        }
-                    }
-
-                    var Disembowel = FindEffectAny(Buffs.PowerSurge);
-                    if (comboTime > 0)
-                    {
-                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.Disembowel && (Disembowel is null || (Disembowel.RemainingTime < 10)))
-                            return DRG.Disembowel;
-
-                        if (lastComboMove is DRG.Disembowel && level >= Levels.ChaoticSpring)
-                            return ChaoticSpring;
-
-                        if (lastComboMove is DRG.Disembowel && level >= Levels.ChaosThrust)
-                            return ChaosThrust;
-
-                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.VorpalThrust)
-                            return VorpalThrust;
-
-                        if (lastComboMove is VorpalThrust && !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0)
-                            return LifeSurge;
-
-                        if (lastComboMove is VorpalThrust && level >= Levels.FullThrust)
-                            return FullThrust;
-                    }
-
-                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
-                        return FangAndClaw;
-
-                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
-                        return WheelingThrust;
-
-                    return OriginalHook(TrueThrust);
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class DRG_SimpleMode : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_SimpleMode;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_STCombo;
             internal static bool inOpener = false;
-            internal static bool openerFinished = false;
-            internal static byte step = 0;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var Disembowel = GetBuffRemainingTime(Buffs.PowerSurge);
                 var gauge = GetJobGauge<DRGGauge>();
+                bool openerReady = IsOffCooldown(LanceCharge) && IsOffCooldown(BattleLitany);
+                var DiveOptions = PluginConfiguration.GetCustomIntValue(Config.DRG_ST_DiveOptions);
 
                 if (actionID is FullThrust)
                 {
-                    var inCombat = HasCondition(Dalamud.Game.ClientState.Conditions.ConditionFlag.InCombat);
-                    var canWeave = CanWeave(actionID);
+                    // Piercing Talon Uptime Option
+                    if (IsEnabled(CustomComboPreset.DRG_ST_RangedUptime) && LevelChecked(PiercingTalon) && !InMeleeRange() && HasBattleTarget())
+                        return PiercingTalon;
 
                     // Lvl88+ Opener
-                    if (IsEnabled(CustomComboPreset.DRG_Simple_Opener) && level >= 88)
+                    if (!InCombat() && IsEnabled(CustomComboPreset.DRG_ST_Opener) && level >= 88)
                     {
-                        if (inCombat && HasEffect(Buffs.TrueNorth) && !inOpener)
-                        {
-                            inOpener = true;
-                        }
+                        inOpener = false;
 
-                        if (!inCombat && (inOpener || openerFinished))
+                        if (HasEffect(Buffs.TrueNorth) && openerReady)
+                            inOpener = true;
+                        if (inOpener)
+                            return OriginalHook(TrueThrust);
+                    }
+
+                    if (InCombat())
+                    {
+                        if (inOpener)
                         {
-                            inOpener = false;
-                            step = 0;
-                            openerFinished = false;
+                            if (IsOnCooldown(BattleLitany) && !HasEffect(Buffs.LanceCharge))
+                                inOpener = false;
+                            //oGCDs
+                            if (CanWeave(actionID))
+                            {
+                                if (WasLastWeaponskill(Disembowel))
+                                {
+                                    if (IsOffCooldown(LanceCharge))
+                                        return LanceCharge;
+                                    if (IsOffCooldown(DragonSight))
+                                        return DragonSight;
+                                }
+
+                                if (WasLastWeaponskill(ChaoticSpring) && IsOffCooldown(BattleLitany))
+                                    return BattleLitany;
+                                if (WasLastWeaponskill(WheelingThrust))
+                                {
+                                    if (IsOffCooldown(Geirskogul))
+                                        return Geirskogul;
+                                    if (GetRemainingCharges(LifeSurge) > 0 && !HasEffect(Buffs.LifeSurge))
+                                        return LifeSurge;
+                                }
+
+                                if (WasLastWeaponskill(FangAndClaw))
+                                {
+                                    if (IsOffCooldown(OriginalHook(Jump)))
+                                        return OriginalHook(Jump);
+                                    if (GetRemainingCharges(SpineshatterDive) > 0 && !HasEffect(Buffs.DiveReady))
+                                        return SpineshatterDive;
+                                }
+
+                                if (WasLastWeaponskill(RaidenThrust) && IsOffCooldown(DragonfireDive))
+                                    return DragonfireDive;
+                                if (WasLastWeaponskill(VorpalThrust))
+                                {
+                                    if (GetRemainingCharges(LifeSurge) > 0 && !HasEffect(Buffs.LifeSurge))
+                                        return LifeSurge;
+                                    if (HasEffect(Buffs.DiveReady))
+                                        return OriginalHook(Jump);
+                                }
+
+                                if (WasLastWeaponskill(HeavensThrust) && GetRemainingCharges(SpineshatterDive) > 0 && !WasLastAction(SpineshatterDive))
+                                    return SpineshatterDive;
+                            }
+
+                            //GCDs
+                            if (HasEffect(Buffs.SharperFangAndClaw))
+                                return FangAndClaw;
+                            if (HasEffect(Buffs.EnhancedWheelingThrust))
+                                return WheelingThrust;
+
+                            if (comboTime > 0)
+                            {
+                                if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(Disembowel) && GetBuffRemainingTime(Buffs.PowerSurge) < 10)
+                                    return Disembowel;
+                                if (lastComboMove is Disembowel && LevelChecked(ChaosThrust))
+                                    return OriginalHook(ChaosThrust);
+                                if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
+                                    return VorpalThrust;
+                                if (lastComboMove is VorpalThrust && LevelChecked(FullThrust))
+                                    return OriginalHook(FullThrust);
+                            }
 
                             return OriginalHook(TrueThrust);
                         }
 
-                        if (inCombat && inOpener && !openerFinished)
+                        if (!inOpener)
                         {
-                            if (step is 0)
+                            if (CanWeave(actionID, 0.5))
                             {
-                                if (gauge.EyeCount > 0) openerFinished = true;
-                                else step++;
+                                if (HasEffect(Buffs.PowerSurge))
+                                {
+                                    //Wyrmwind Thrust Feature
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_Wyrmwind) && gauge.FirstmindsFocusCount is 2)
+                                        return WyrmwindThrust;
+
+                                    //Lance Charge Feature
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_Lance) && LevelChecked(LanceCharge) && IsOffCooldown(LanceCharge))
+                                        return LanceCharge;
+
+                                    //Dragon Sight Feature
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_DragonSight) && LevelChecked(DragonSight) && IsOffCooldown(DragonSight))
+                                        return DragonSight;
+
+                                    //Battle Litany Feature
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_Litany) && LevelChecked(BattleLitany) && IsOffCooldown(BattleLitany) && CanWeave(actionID, 1.3))
+                                        return BattleLitany;
+
+                                    //Geirskogul and Nastrond Feature
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_GeirskogulNastrond) && LevelChecked(Geirskogul) && ((gauge.IsLOTDActive && IsOffCooldown(Nastrond)) || IsOffCooldown(Geirskogul)))
+                                        return OriginalHook(Geirskogul);
+
+                                    //(High) Jump Feature + Mirage Feature
+                                    if ((IsEnabled(CustomComboPreset.DRG_ST_HighJump) && LevelChecked(Jump) && IsOffCooldown(OriginalHook(Jump))) ||
+                                        (IsEnabled(CustomComboPreset.DRG_ST_Mirage) && LevelChecked(MirageDive) && HasEffect(Buffs.DiveReady)))
+                                        return OriginalHook(Jump);
+
+                                    //Life Surge Feature
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_LifeSurge) && !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0 &&
+                                        (((HasEffect(Buffs.RightEye) || HasEffect(Buffs.LanceCharge)) && lastComboMove is VorpalThrust) ||
+                                        (HasEffect(Buffs.BattleLitany) && ((HasEffect(Buffs.EnhancedWheelingThrust) && WasLastWeaponskill(FangAndClaw)) || HasEffect(Buffs.SharperFangAndClaw) && WasLastWeaponskill(WheelingThrust)))))
+                                        return LifeSurge;
+
+                                    //Dives Feature
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_Dives))
+                                    {
+                                        if (DiveOptions is 0 or 1 || //Dives on cooldown
+                                           (DiveOptions is 2 && gauge.IsLOTDActive && HasEffect(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
+                                           (DiveOptions is 3 && HasEffect(Buffs.BattleLitany)) || //Dives under Litany
+                                           (DiveOptions is 4 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
+                                        {
+                                            if (LevelChecked(DragonfireDive) && IsOffCooldown(DragonfireDive))
+                                                return DragonfireDive;
+                                            if (LevelChecked(SpineshatterDive) && GetRemainingCharges(SpineshatterDive) > 0)
+                                                return SpineshatterDive;
+                                        }
+ 
+                                        if (DiveOptions is 0 or 1 or 2 or 3 or 4 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
+                                            return Stardiver;
+                                    }
+                                }
                             }
 
-                            if (step is 1)
+                            //1-2-3 Combo
+                            if (HasEffect(Buffs.SharperFangAndClaw))
+                                return FangAndClaw;
+                            if (HasEffect(Buffs.EnhancedWheelingThrust))
+                                return WheelingThrust;
+                            if (comboTime > 0)
                             {
-                                if (lastComboMove is TrueThrust) step++;
-                                else return TrueThrust;
-                            }
-
-                            if (step is 2)
-                            {
-                                if (lastComboMove is DRG.Disembowel) step++;
-                                else return DRG.Disembowel;
-                            }
-
-                            if (step is 3)
-                            {
-                                if (IsOnCooldown(LanceCharge)) step++;
-                                else return LanceCharge;
-                            }
-
-                            if (step is 4)
-                            {
-                                if (IsOnCooldown(DragonSight)) step++;
-                                else return DragonSight;
-                            }
-
-                            if (step is 5)
-                            {
-                                if (TargetHasEffect(Debuffs.ChaoticSpring)) step++;
-                                return ChaoticSpring;
-                            }
-
-                            if (step is 6)
-                            {
-                                if (IsOnCooldown(BattleLitany)) step++;
-                                else return BattleLitany;
-                            }
-
-                            if (step is 7)
-                            {
-                                if (IsOnCooldown(Geirskogul)) step++;
-                                else return Geirskogul;
-                            }
-
-                            if (step is 8)
-                            {
-                                if (!HasEffect(Buffs.EnhancedWheelingThrust)) step++;
-                                else return WheelingThrust;
-                            }
-
-                            if (step is 9)
-                            {
-                                if (IsOnCooldown(HighJump)) step++;
-                                else return HighJump;
-                            }
-
-                            if (step is 10)
-                            {
-                                if (GetRemainingCharges(LifeSurge) is 0 or 1) step++;
-                                else return LifeSurge;
-                            }
-
-                            if (step is 11)
-                            {
-                                if (!HasEffect(Buffs.SharperFangAndClaw)) step++;
-                                else return FangAndClaw;
-                            }
-
-                            if (step is 12)
-                            {
-                                if (IsOnCooldown(DragonfireDive)) step++;
-                                else return DragonfireDive;
-                            }
-
-                            if (step is 13)
-                            {
-                                if (lastComboMove is (RaidenThrust)) step++;
-                                else return RaidenThrust;
-                            }
-
-                            if (step is 14)
-                            {
-                                if (GetRemainingCharges(SpineshatterDive) is 0 or 1) step++;
-                                else return SpineshatterDive;
-                            }
-
-                            if (step is 15)
-                            {
-                                if (lastComboMove is VorpalThrust) step++;
-                                else return VorpalThrust;
-                            }
-
-                            if (step is 16)
-                            {
-                                if (GetRemainingCharges(LifeSurge) is 0) step++;
-                                else return LifeSurge;
-                            }
-
-                            if (step is 17)
-                            {
-                                if (IsOnCooldown(MirageDive)) step++;
-                                else return MirageDive;
-                            }
-
-                            if (step is 18)
-                            {
-                                if (lastComboMove is HeavensThrust) step++;
-                                else return HeavensThrust;
-                            }
-
-                            if (step is 19)
-                            {
-                                if (GetRemainingCharges(SpineshatterDive) is 0) step++;
-                                else return SpineshatterDive;
-                            }
-
-                            if (step is 20)
-                            {
-                                if (!HasEffect(Buffs.SharperFangAndClaw)) step++;
-                                else return FangAndClaw;
-                            }
-
-                            if (step is 21)
-                            {
-                                if (!HasEffect(Buffs.EnhancedWheelingThrust)) step++;
-                                else return WheelingThrust;
-                            }
-
-                            openerFinished = true;
-                        }
-                    }
-
-                    // Piercing Talon Uptime Option
-                    if (IsEnabled(CustomComboPreset.DRG_Simple_RangedUptime) && level >= Levels.PiercingTalon && !InMeleeRange())
-                        return PiercingTalon;
-
-                    //Lance Charge Feature
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_Lance))
-                        {
-                            if (HasEffect(Buffs.PowerSurge) && canWeave)
-                            {
-                                if (level >= Levels.LanceCharge && IsOffCooldown(LanceCharge))
-                                    return LanceCharge;
+                                if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(Disembowel) && GetBuffRemainingTime(Buffs.PowerSurge) < 10)
+                                    return Disembowel;
+                                if (lastComboMove is Disembowel && LevelChecked(ChaosThrust))
+                                    return OriginalHook(ChaosThrust);
+                                if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
+                                    return VorpalThrust;
+                                if (lastComboMove is VorpalThrust && LevelChecked(FullThrust))
+                                    return OriginalHook(FullThrust);
                             }
                         }
                     }
-
-                    //Dragon Sight Feature
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_DragonSight))
-                        {
-                            if (level >= Levels.DragonSight && HasEffect(Buffs.PowerSurge) && IsOffCooldown(DragonSight) && canWeave)
-                                return DragonSight;
-                        }
-                    }
-
-                    //Battle Litany Feature
-                    if (CanWeave(actionID, 1.3))
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_Litany))
-                        {
-                            if (HasEffect(Buffs.PowerSurge))
-                            {
-                                if (level >= Levels.BattleLitany && IsOffCooldown(BattleLitany))
-                                    return BattleLitany;
-                            }
-                        }
-                    }
-
-                    //Geirskogul and Nastrond Feature Part 1
-                    if (CanWeave(actionID, 0.001))
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_GeirskogulNastrond))
-                        {
-                            if (level >= Levels.Geirskogul && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Geirskogul))
-                                return Geirskogul;
-                        }
-                    }
-
-                    //(High) Jump Feature
-                    if (CanWeave(actionID, 0.5))
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_HighJump))
-                        {
-                            if (HasEffect(Buffs.PowerSurge))
-                            {
-
-                                if (level >= Levels.HighJump && IsOffCooldown(HighJump))
-                                    return HighJump;
-
-                                if (level is >= Levels.Jump and < Levels.HighJump && IsOffCooldown(Jump))
-                                    return Jump;
-                            }
-                        }
-                    }
-
-                    //Life Surge Feature
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_LifeSurge))
-                        {
-                            if (HasEffect(Buffs.LanceCharge) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && lastComboMove is VorpalThrust && GetRemainingCharges(LifeSurge) > 0 && CanWeave(actionID, 0.001))
-                                return LifeSurge;
-
-                            if (HasEffect(Buffs.RightEye) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && lastComboMove is VorpalThrust && GetRemainingCharges(LifeSurge) > 0 && CanWeave(actionID, 0.001))
-                                return LifeSurge;
-
-                            if (HasEffect(Buffs.BattleLitany) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && lastComboMove is FangAndClaw && HasEffect(Buffs.EnhancedWheelingThrust) && GetRemainingCharges(LifeSurge) > 0 && CanWeave(actionID, 0.001))
-                                return LifeSurge;
-
-                            if (HasEffect(Buffs.BattleLitany) && HasEffect(Buffs.PowerSurge) && !HasEffect(Buffs.LifeSurge) && lastComboMove is WheelingThrust && HasEffect(Buffs.SharperFangAndClaw) && GetRemainingCharges(LifeSurge) > 0 && CanWeave(actionID, 0.001))
-                                return LifeSurge;
-                        }
-                    }
-
-                    //Wyrmwind Thrust Feature
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_Wyrmwind))
-                        {
-                            if (
-                                gauge.FirstmindsFocusCount is 2 && canWeave
-                               ) return WyrmwindThrust;
-                        }
-                    }
-
-                    //Geirskogul and Nastrond Feature Part 2
-                    if (canWeave)
-                    {
-
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_GeirskogulNastrond))
-                        {
-                            if (gauge.IsLOTDActive is true && level >= Levels.Nastrond && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Nastrond) && CanWeave(actionID, 0.001))
-                                return Nastrond;
-                        }
-                    }
-
-                    //Dives under Litany and Life of the Dragon Feature
-                    if (canWeave)
-                    {
-
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_LifeLitanyDives))
-                        {
-                            if (gauge.IsLOTDActive is true && level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && IsOffCooldown(DragonfireDive) && canWeave)
-                                return DragonfireDive;
-
-                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
-                                return Stardiver;
-
-                            if (HasEffect(Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) > 0 && canWeave)
-                                return SpineshatterDive;
-                        }
-                    }
-
-                    //Dives under Litany Feature
-                    if (canWeave)
-                    {
-
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_LitanyDives))
-                        {
-                            if (level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && IsOffCooldown(DragonfireDive) && canWeave)
-                                return DragonfireDive;
-
-                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
-                                return Stardiver;
-
-                            if (level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && GetRemainingCharges(SpineshatterDive) > 0 && canWeave)
-                                return SpineshatterDive;
-                        }
-                    }
-
-                    //Dives Feature
-                    if (canWeave)
-                    {
-
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_LifeLitanyDives))
-                        {
-                            if (level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && IsOffCooldown(DragonfireDive) && canWeave)
-                                return DragonfireDive;
-
-                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
-                                return Stardiver;
-
-                            if (level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) > 0 && canWeave)
-                                return SpineshatterDive;
-                        }
-                    }
-
-                    //Dives under Lance Charge Feature
-                    if (canWeave)
-                    {
-
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_LanceDives))
-                        {
-                            if (level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.LanceCharge) && IsOffCooldown(DragonfireDive) && canWeave)
-                                return DragonfireDive;
-
-                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
-                                return Stardiver;
-
-                            if (level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.LanceCharge) && GetRemainingCharges(SpineshatterDive) > 0 && canWeave)
-                                return SpineshatterDive;
-                        }
-                    }
-
-                    //Mirage Feature
-                    if (canWeave)
-                    {
-                        if (IsEnabled(CustomComboPreset.DRG_Simple_Mirage))
-                        {
-                            if (level >= Levels.MirageDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.DiveReady) && CanWeave(actionID, 0.001))
-                                return MirageDive;
-                        }
-                    }
-
-                    if (comboTime > 0)
-                    {
-                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.Disembowel && Disembowel < 10)
-                            return DRG.Disembowel;
-
-                        if (lastComboMove is DRG.Disembowel && level >= Levels.ChaoticSpring)
-                            return ChaoticSpring;
-
-                        if (lastComboMove is DRG.Disembowel && level >= Levels.ChaosThrust)
-                            return ChaosThrust;
-
-                        if ((lastComboMove is TrueThrust or RaidenThrust) && level >= Levels.VorpalThrust)
-                            return VorpalThrust;
-
-                        if (lastComboMove is VorpalThrust && level >= Levels.FullThrust)
-                            return FullThrust;
-                    }
-
-                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
-                        return FangAndClaw;
-
-                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
-                        return WheelingThrust;
 
                     return OriginalHook(TrueThrust);
                 }
@@ -687,202 +252,89 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class DRG_AoE_SimpleMode : CustomCombo
+        internal class DRG_AoECombo : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_AoE_SimpleMode;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_AoECombo;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID is CoerthanTorment)
                 {
-                    var canWeave = CanWeave(actionID);
                     var gauge = GetJobGauge<DRGGauge>();
+                    var DiveOptions = PluginConfiguration.GetCustomIntValue(Config.DRG_AOE_DiveOptions);
+
                     // Piercing Talon Uptime Option
-                    if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_RangedUptime) && level >= Levels.PiercingTalon && !InMeleeRange())
+                    if (IsEnabled(CustomComboPreset.DRG_AoE_RangedUptime) && LevelChecked(PiercingTalon) && !InMeleeRange() && HasBattleTarget())
                         return PiercingTalon;
 
-                    if (canWeave)
+                    if (CanWeave(actionID, 0.5))
                     {
-                        //Buffs AoE Feature
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_Buffs))
+                        if (HasEffect(Buffs.PowerSurge))
                         {
-
-                            if (level >= Levels.LanceCharge &&
-                                IsOffCooldown(LanceCharge))
-                                return LanceCharge;
-
-                            if (level >= Levels.BattleLitany &&
-                                IsOffCooldown(BattleLitany))
-                                return BattleLitany;
-
-                            //Dragon Sight AoE Feature
-                            if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_DragonSight))
+                            //Buffs AoE Feature
+                            if (IsEnabled(CustomComboPreset.DRG_AoE_Buffs))
                             {
-                                if (level >= Levels.DragonSight &&
-                                    IsOffCooldown(DragonSight))
+                                if (LevelChecked(LanceCharge) && IsOffCooldown(LanceCharge))
+                                    return LanceCharge;
+                                if (LevelChecked(BattleLitany) && IsOffCooldown(BattleLitany))
+                                    return BattleLitany;
+
+                                //Dragon Sight AoE Feature
+                                if (IsEnabled(CustomComboPreset.DRG_AoE_DragonSight) && LevelChecked(DragonSight) && IsOffCooldown(DragonSight))
                                     return DragonSight;
                             }
-                        }
 
-                        //Geirskogul and Nastrond AoE Feature Part 1
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_GeirskogulNastrond))
-                        {
-                            if (level >= Levels.Geirskogul &&
-                                IsOffCooldown(Geirskogul))
-                                return Geirskogul;
+                            //Geirskogul and Nastrond AoE Feature
+                            if ((IsEnabled(CustomComboPreset.DRG_AoE_GeirskogulNastrond) && LevelChecked(Geirskogul) && IsOffCooldown(Geirskogul)) ||
+                                (IsEnabled(CustomComboPreset.DRG_AoE_GeirskogulNastrond) && gauge.IsLOTDActive && IsOffCooldown(Nastrond)))
+                                return OriginalHook(Geirskogul);
 
-                        }
+                            //(High) Jump AoE Feature + Mirage Dive Feature
+                            if ((IsEnabled(CustomComboPreset.DRG_AoE_HighJump) && LevelChecked(Jump) && IsOffCooldown(OriginalHook(Jump)) && CanWeave(actionID, 1)) ||
+                                (IsEnabled(CustomComboPreset.DRG_AoE_Mirage) && LevelChecked(MirageDive) && HasEffect(Buffs.DiveReady)))
+                                return OriginalHook(Jump);
 
-                        //(High) Jump AoE Feature
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_HighJump))
-                        {
-                            if (level >= Levels.HighJump &&
-                                IsOffCooldown(HighJump) && CanWeave(actionID, 1))
-                                return HighJump;
-
-                            if (level is >= Levels.Jump and <= Levels.HighJump && IsOffCooldown(Jump) && CanWeave(actionID, 1))
-                                return Jump;
-                        }
-
-                        //Life Surge AoE Feature
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_LifeSurge))
-                        {
-                            if ((HasEffect(Buffs.LanceCharge) || HasEffect(Buffs.RightEye)) &&
-                                ((lastComboMove is CoerthanTorment && level >= Levels.CoerthanTorment) ||
-                                (lastComboMove is SonicThrust && level is >= Levels.SonicThrust and <= Levels.CoerthanTorment) ||
-                                (lastComboMove is DoomSpike && level <= Levels.SonicThrust)) &&
-                                !HasEffect(Buffs.LifeSurge) &&
-                                GetRemainingCharges(LifeSurge) > 0 &&
-                                CanWeave(actionID, weaveTime: 0.3))
+                            //Life Surge AoE Feature
+                            if (IsEnabled(CustomComboPreset.DRG_AoE_LifeSurge) &&
+                                !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0 && (HasEffect(Buffs.LanceCharge) || HasEffect(Buffs.RightEye)) &&
+                                ((lastComboMove is CoerthanTorment && LevelChecked(CoerthanTorment)) ||
+                                (lastComboMove is SonicThrust && LevelChecked(SonicThrust) && !LevelChecked(CoerthanTorment)) ||
+                                (lastComboMove is DoomSpike && !LevelChecked(SonicThrust))))
                                 return LifeSurge;
 
-                        }
-
-
-                        //Wyrmwind Thrust AoE Feature
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_WyrmwindFeature))
-                        {
-                            if (gauge.FirstmindsFocusCount is 2)
+                            //Wyrmwind Thrust AoE Feature
+                            if (IsEnabled(CustomComboPreset.DRG_AoE_WyrmwindFeature) && gauge.FirstmindsFocusCount is 2)
                                 return WyrmwindThrust;
-                        }
 
-                        //Geirskogul and Nastrond AoE Feature Part 2
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_GeirskogulNastrond))
-                        {
-                            if (gauge.IsLOTDActive is true && level >= Levels.Nastrond && IsOffCooldown(Nastrond))
-                                return Nastrond;
+                            //Dives AoE Feature
+                            if (IsEnabled(CustomComboPreset.DRG_AoE_Dives))
+                            {
+                                if (DiveOptions is 0 or 1 || //Dives on cooldown
+                                   (DiveOptions is 2 && gauge.IsLOTDActive && HasEffect(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
+                                   (DiveOptions is 3 && HasEffect(Buffs.BattleLitany)) || //Dives under Litany
+                                   (DiveOptions is 4 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
+                                {
+                                    if (LevelChecked(DragonfireDive) && IsOffCooldown(DragonfireDive))
+                                        return DragonfireDive;
+                                    if (LevelChecked(SpineshatterDive) && GetRemainingCharges(SpineshatterDive) > 0)
+                                        return SpineshatterDive;
+                                }
 
-                        }
-
-                        //Dives AoE Feature
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_Dives))
-                        {
-                            if (level >= Levels.DragonfireDive && IsOffCooldown(DragonfireDive))
-                                return DragonfireDive;
-
-                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
-                                return Stardiver;
-
-                            if (level >= Levels.SpineshatterDive && GetRemainingCharges(SpineshatterDive) > 0)
-                                return SpineshatterDive;
-
-                        }
-
-                        //Dives under Lance Charge
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_LanceDives))
-                        {
-                            if (level >= Levels.DragonfireDive && IsOffCooldown(DragonfireDive) && HasEffect(Buffs.LanceCharge))
-                                return DragonfireDive;
-
-                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && IsOffCooldown(Stardiver) && HasEffect(Buffs.LanceCharge) && CanWeave(actionID, 1.5))
-                                return Stardiver;
-
-                            if (level >= Levels.SpineshatterDive && GetRemainingCharges(SpineshatterDive) > 0 && HasEffect(Buffs.LanceCharge))
-                                return SpineshatterDive;
-                        }
-
-                        //Dives under Litany AoE Feature
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_LitanyDives))
-                        {
-                            if (gauge.IsLOTDActive is true && level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && IsOffCooldown(DragonfireDive))
-                                return DragonfireDive;
-
-                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
-                                return Stardiver;
-
-                            if (HasEffect(Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) == 2)
-                                return SpineshatterDive;
-
-                        }
-
-                        //Dives under Litany and Life of the Dragon AoE Feature
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_LifeLitanyDives))
-                        {
-                            if (gauge.IsLOTDActive is true && level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.BattleLitany) && IsOffCooldown(DragonfireDive))
-                                return DragonfireDive;
-
-                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
-                                return Stardiver;
-
-                            if (HasEffect(Buffs.BattleLitany) && gauge.IsLOTDActive is true && level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && GetRemainingCharges(SpineshatterDive) == 2)
-                                return SpineshatterDive;
-
-                        }
-
-                        //Dives under Lance Charge AoE Feature
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_LitanyDives))
-                        {
-                            if (level >= Levels.DragonfireDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.LanceCharge) && IsOffCooldown(DragonfireDive))
-                                return DragonfireDive;
-
-                            if (gauge.IsLOTDActive is true && level >= Levels.Stardiver && HasEffect(Buffs.PowerSurge) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.5))
-                                return Stardiver;
-
-                            if (level >= Levels.SpineshatterDive && HasEffect(Buffs.PowerSurge) && HasEffect(Buffs.LanceCharge) && GetRemainingCharges(SpineshatterDive) > 0)
-                                return SpineshatterDive;
-
-                        }
-
-                        //Mirage AoE Feature
-                        if (IsEnabled(CustomComboPreset.DRG_AoE_Simple_Mirage))
-                        {
-                            if (level >= Levels.MirageDive &&
-                                HasEffect(Buffs.DiveReady))
-                                return MirageDive;
+                                if (DiveOptions is 0 or 1 or 2 or 3 or 4 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
+                                    return Stardiver;
+                            }
                         }
                     }
+
                     if (comboTime > 0)
                     {
-                        if (lastComboMove == OriginalHook(DoomSpike) && level >= Levels.SonicThrust)
+                        if (lastComboMove is DoomSpike or DraconianFury && LevelChecked(SonicThrust))
                             return SonicThrust;
-
-                        if (lastComboMove is SonicThrust && level >= Levels.CoerthanTorment)
+                        if (lastComboMove is SonicThrust && LevelChecked(CoerthanTorment))
                             return CoerthanTorment;
-
-                        if ((lastComboMove is DraconianFury))
-                            return SonicThrust;
                     }
 
                     return OriginalHook(DoomSpike);
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class DRG_FangAndClaw : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRG_FangAndClaw;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is FangAndClaw)
-                {
-                    if (HasEffect(Buffs.EnhancedWheelingThrust) && level >= Levels.WheelingThrust)
-                        return WheelingThrust;
-                    if (HasEffect(Buffs.SharperFangAndClaw) && level >= Levels.FangAndClaw)
-                        return FangAndClaw;
-
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -213,9 +213,8 @@ namespace XIVSlothCombo.Combos.PvE
                                     if (IsEnabled(CustomComboPreset.DRG_ST_Dives))
                                     {
                                         if (diveOptions is 0 or 1 || //Dives on cooldown
-                                           (diveOptions is 2 && gauge.IsLOTDActive && HasEffect(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
-                                           (diveOptions is 3 && HasEffect(Buffs.BattleLitany)) || //Dives under Litany
-                                           (diveOptions is 4 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
+                                           (diveOptions is 2 && ((gauge.IsLOTDActive && LevelChecked(Nastrond)) || !LevelChecked(Nastrond)) && HasEffectAny(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
+                                           (diveOptions is 3 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
                                         {
                                             if (LevelChecked(DragonfireDive) && IsOffCooldown(DragonfireDive))
                                                 return DragonfireDive;
@@ -223,7 +222,7 @@ namespace XIVSlothCombo.Combos.PvE
                                                 return SpineshatterDive;
                                         }
  
-                                        if (diveOptions is 0 or 1 or 2 or 3 or 4 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
+                                        if (diveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
                                             return Stardiver;
                                     }
                                 }
@@ -314,9 +313,8 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.DRG_AoE_Dives))
                             {
                                 if (DiveOptions is 0 or 1 || //Dives on cooldown
-                                   (DiveOptions is 2 && gauge.IsLOTDActive && HasEffect(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
-                                   (DiveOptions is 3 && HasEffect(Buffs.BattleLitany)) || //Dives under Litany
-                                   (DiveOptions is 4 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
+                                   (DiveOptions is 2 && ((LevelChecked(Nastrond) && gauge.IsLOTDActive) || !LevelChecked(Nastrond)) && HasEffectAny(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
+                                   (DiveOptions is 3 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
                                 {
                                     if (LevelChecked(DragonfireDive) && IsOffCooldown(DragonfireDive))
                                         return DragonfireDive;
@@ -324,7 +322,7 @@ namespace XIVSlothCombo.Combos.PvE
                                         return SpineshatterDive;
                                 }
 
-                                if (DiveOptions is 0 or 1 or 2 or 3 or 4 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
+                                if (DiveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
                                     return Stardiver;
                             }
                         }

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -174,7 +174,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (!inOpener)
                         {
-                            if (CanWeave(actionID, 0.5))
+                            if (CanWeave(actionID))
                             {                                
                                 if (HasEffect(Buffs.PowerSurge))
                                 {
@@ -203,15 +203,12 @@ namespace XIVSlothCombo.Combos.PvE
                                         (IsEnabled(CustomComboPreset.DRG_ST_Mirage) && LevelChecked(MirageDive) && HasEffect(Buffs.DiveReady)))
                                         return OriginalHook(Jump);
 
-                                    //Life Surge Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_LifeSurge) && !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0 &&
-                                        (((HasEffect(Buffs.RightEye) || HasEffect(Buffs.LanceCharge)) && lastComboMove is VorpalThrust) ||
-                                        (HasEffect(Buffs.BattleLitany) && ((HasEffect(Buffs.EnhancedWheelingThrust) && WasLastWeaponskill(FangAndClaw)) || HasEffect(Buffs.SharperFangAndClaw) && WasLastWeaponskill(WheelingThrust)))))
-                                        return LifeSurge;
-
                                     //Dives Feature
-                                    if (IsEnabled(CustomComboPreset.DRG_ST_Dives))
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_Dives) && (IsNotEnabled(CustomComboPreset.DRG_ST_Dives_Melee) || (IsEnabled(CustomComboPreset.DRG_ST_Dives_Melee) && GetTargetDistance() <= 1)))
                                     {
+                                        if (diveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3) && IsOnCooldown(DragonfireDive))
+                                            return Stardiver;
+
                                         if (diveOptions is 0 or 1 || //Dives on cooldown
                                            (diveOptions is 2 && ((gauge.IsLOTDActive && LevelChecked(Nastrond)) || !LevelChecked(Nastrond)) && HasEffectAny(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
                                            (diveOptions is 3 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
@@ -221,10 +218,13 @@ namespace XIVSlothCombo.Combos.PvE
                                             if (LevelChecked(SpineshatterDive) && GetRemainingCharges(SpineshatterDive) > 0)
                                                 return SpineshatterDive;
                                         }
- 
-                                        if (diveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
-                                            return Stardiver;
                                     }
+
+                                    //Life Surge Feature
+                                    if (IsEnabled(CustomComboPreset.DRG_ST_LifeSurge) && !HasEffect(Buffs.LifeSurge) && GetRemainingCharges(LifeSurge) > 0 &&
+                                        (((HasEffect(Buffs.RightEye) || HasEffect(Buffs.LanceCharge)) && lastComboMove is VorpalThrust) ||
+                                        (HasEffect(Buffs.BattleLitany) && ((HasEffect(Buffs.EnhancedWheelingThrust) && WasLastWeaponskill(FangAndClaw)) || HasEffect(Buffs.SharperFangAndClaw) && WasLastWeaponskill(WheelingThrust)))))
+                                        return LifeSurge;
                                 }
                             }
                         }
@@ -310,8 +310,11 @@ namespace XIVSlothCombo.Combos.PvE
                                 return WyrmwindThrust;
 
                             //Dives AoE Feature
-                            if (IsEnabled(CustomComboPreset.DRG_AoE_Dives))
+                            if (IsEnabled(CustomComboPreset.DRG_AoE_Dives) && (IsNotEnabled(CustomComboPreset.DRG_AoE_Dives_Melee) || (IsEnabled(CustomComboPreset.DRG_AoE_Dives_Melee) && GetTargetDistance() <= 1)))
                             {
+                                if (DiveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3) && IsOnCooldown(DragonfireDive))
+                                    return Stardiver;
+
                                 if (DiveOptions is 0 or 1 || //Dives on cooldown
                                    (DiveOptions is 2 && ((LevelChecked(Nastrond) && gauge.IsLOTDActive) || !LevelChecked(Nastrond)) && HasEffectAny(Buffs.BattleLitany)) || //Dives under Litany and Life of the Dragon
                                    (DiveOptions is 3 && HasEffect(Buffs.LanceCharge))) //Dives under Lance Charge Feature
@@ -321,9 +324,6 @@ namespace XIVSlothCombo.Combos.PvE
                                     if (LevelChecked(SpineshatterDive) && GetRemainingCharges(SpineshatterDive) > 0)
                                         return SpineshatterDive;
                                 }
-
-                                if (DiveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3))
-                                    return Stardiver;
                             }
                         }
                     }

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -950,7 +950,21 @@ namespace XIVSlothCombo.Window.Functions
             #endregion
             // ====================================================================================
             #region DRAGOON
+            if (preset == CustomComboPreset.DRG_ST_Dives && enabled)
+            {
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_ST_DiveOptions, "On Cooldown", "Single Weave friendly. Uses skills on cooldown.", 1);
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_ST_DiveOptions, "Under Battle Litany and Life of the Dragon", "Requires Double Weaving. Uses Spineshatter Dive and Dragonfire Dive under Battle Litany and Life of the Dragon, and Stardiver under Life of the Dragon.", 2);
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_ST_DiveOptions, "Under Battle Litany", "Requires Double Weaving. Uses Spineshatter Dive and Dragonfire Dive under Battle Litany, and Stardiver under Life of the Dragon.", 3);
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_ST_DiveOptions, "Under Lance Charge", "Single Weave friendly. Uses Spineshatter Dive and Dragonfire Dive under Lance Charge, and Stardiver under Life of the Dragon.", 4);
+            }
 
+            if (preset == CustomComboPreset.DRG_AoE_Dives && enabled)
+            {
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "On Cooldown", "Single Weave friendly. Uses skills on cooldown.", 1);
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "Under Battle Litany and Life of the Dragon", "Requires Double Weaving. Uses Spineshatter Dive and Dragonfire Dive under Battle Litany and Life of the Dragon, and Stardiver under Life of the Dragon.", 2);
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "Under Battle Litany", "Requires Double Weaving. Uses Spineshatter Dive and Dragonfire Dive under Battle Litany, and Stardiver under Life of the Dragon.", 3);
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "Under Lance Charge", "Single Weave friendly. Uses Spineshatter Dive and Dragonfire Dive under Lance Charge, and Stardiver under Life of the Dragon.", 4);
+            }
             #endregion
             // ====================================================================================
             #region GUNBREAKER

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -954,16 +954,14 @@ namespace XIVSlothCombo.Window.Functions
             {
                 UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_ST_DiveOptions, "On Cooldown", "Single Weave friendly. Uses skills on cooldown.", 1);
                 UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_ST_DiveOptions, "Under Battle Litany and Life of the Dragon", "Requires Double Weaving. Uses Spineshatter Dive and Dragonfire Dive under Battle Litany and Life of the Dragon, and Stardiver under Life of the Dragon.", 2);
-                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_ST_DiveOptions, "Under Battle Litany", "Requires Double Weaving. Uses Spineshatter Dive and Dragonfire Dive under Battle Litany, and Stardiver under Life of the Dragon.", 3);
-                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_ST_DiveOptions, "Under Lance Charge", "Single Weave friendly. Uses Spineshatter Dive and Dragonfire Dive under Lance Charge, and Stardiver under Life of the Dragon.", 4);
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_ST_DiveOptions, "Under Lance Charge", "Single Weave friendly. Uses Spineshatter Dive and Dragonfire Dive under Lance Charge, and Stardiver under Life of the Dragon.", 3);
             }
 
             if (preset == CustomComboPreset.DRG_AoE_Dives && enabled)
             {
                 UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "On Cooldown", "Single Weave friendly. Uses skills on cooldown.", 1);
                 UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "Under Battle Litany and Life of the Dragon", "Requires Double Weaving. Uses Spineshatter Dive and Dragonfire Dive under Battle Litany and Life of the Dragon, and Stardiver under Life of the Dragon.", 2);
-                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "Under Battle Litany", "Requires Double Weaving. Uses Spineshatter Dive and Dragonfire Dive under Battle Litany, and Stardiver under Life of the Dragon.", 3);
-                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "Under Lance Charge", "Single Weave friendly. Uses Spineshatter Dive and Dragonfire Dive under Lance Charge, and Stardiver under Life of the Dragon.", 4);
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "Under Lance Charge", "Single Weave friendly. Uses Spineshatter Dive and Dragonfire Dive under Lance Charge, and Stardiver under Life of the Dragon.", 3);
             }
 
             if (preset == CustomComboPreset.DRG_ST_Opener && enabled)

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -965,6 +965,12 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "Under Battle Litany", "Requires Double Weaving. Uses Spineshatter Dive and Dragonfire Dive under Battle Litany, and Stardiver under Life of the Dragon.", 3);
                 UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_AOE_DiveOptions, "Under Lance Charge", "Single Weave friendly. Uses Spineshatter Dive and Dragonfire Dive under Lance Charge, and Stardiver under Life of the Dragon.", 4);
             }
+
+            if (preset == CustomComboPreset.DRG_ST_Opener && enabled)
+            {
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_OpenerOptions, "Standard Opener", "Uses the Standard Tincture Opener.", 1);
+                UserConfig.DrawHorizontalRadioButton(DRG.Config.DRG_OpenerOptions, "Low Ping Opener", "Uses the Low Ping Opener. Use Lance Charge after True Thrust for the No Tincture opener.", 2);                
+            }
             #endregion
             // ====================================================================================
             #region GUNBREAKER

--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -70,14 +70,15 @@ namespace XIVSlothCombo
             }
 
             Service.Configuration.Save();
-            
 
         }
 
         private void ResetFeatures()
         {
-            //Enumerable.Range is a start and count, not a start and end.
-            Service.Configuration.ResetFeatures("NINRework", Enumerable.Range(10000, 100).ToArray());
+            // Enumerable.Range is a start and count, not a start and end.
+            // Enumerable.Range(Start, Count)
+            Service.Configuration.ResetFeatures("v3.0.17.0_NINRework", Enumerable.Range(10000, 100).ToArray());
+            Service.Configuration.ResetFeatures("v3.0.17.0_DRGCleanup", Enumerable.Range(6100, 400).ToArray());
         }
 
         private void DrawUI() => configWindow.Draw();


### PR DESCRIPTION
Cleaned up simple DRG. Renamed to Advanced.
Removed all the other combo options.
Dives option now on CD, double weave, or single weave.
Added Stardiver Feature: Stardiver turns into Nastrond during Life of the Dragon and Geirskogul outside of it.
Added Lance Charge to Battle Litany Feature, and Dragon Sight sub option.
Added Melee feature for dives.
Redid DRG config. Remind users to check settings.