### PR TITLE
[NINPVP] Tweaks and Fixes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3022,15 +3022,23 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         #region NINJA
-        [ConflictingCombos(NINPvP_AoE_BurstMode)]
         [SecretCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Aeolian Edge Combo into an all-in-one damage button.", NINPVP.JobID)]
         NINPvP_ST_BurstMode = 80050,
 
-        [ConflictingCombos(NINPvP_ST_BurstMode)]
         [SecretCustomCombo]
         [CustomComboInfo("AoE Burst Mode", "Turns Fuma Shuriken into an all-in-one AoE damage button.", NINPVP.JobID)]
         NINPvP_AoE_BurstMode = 80051,
+
+        [ParentCombo(NINPvP_ST_BurstMode)]
+        [SecretCustomCombo]
+        [CustomComboInfo("Meisui Feature", "Uses Three Mudra on Meisui when HP under a certain threshold.", NINPVP.JobID)]
+        NINPvP_ST_Meisui = 80052,
+
+        [ParentCombo(NINPvP_AoE_BurstMode)]
+        [SecretCustomCombo]
+        [CustomComboInfo("Meisui Feature", "Uses Three Mudra on Meisui when HP under a certain threshold.", NINPVP.JobID)]
+        NINPvP_AoE_Meisui = 80053,
         #endregion
 
         #region SAGE

--- a/XIVSlothCombo/Combos/PvP/NINPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/NINPVP.cs
@@ -46,13 +46,20 @@ namespace XIVSlothCombo.Combos.PvP
                 SealedMeisui = 3198;
         }
 
+        internal class Config
+        {
+            internal const string
+                NINPvP_Meisui_ST = "NINPvP_Meisui_ST",
+                NINPvP_Meisui_AoE = "NINPvP_Meisui_AoE";
+        }
+
         internal class NINPvP_ST_BurstMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.NINPvP_ST_BurstMode;
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (actionID is SpinningEdge or AeolianEdge or GustSlash)
+                if (actionID is SpinningEdge)
                 {
                     var threeMudrasCD = GetCooldown(ThreeMudra);
                     var fumaCD = GetCooldown(FumaShuriken);
@@ -64,7 +71,13 @@ namespace XIVSlothCombo.Combos.PvP
                     bool gokaLocked = HasEffect(Debuffs.SealedGokaMekkyaku);
                     bool hutonLocked = HasEffect(Debuffs.SealedHuton);
                     bool mudraMode = HasEffect(Buffs.ThreeMudra);
-                    bool canWeave = CanWeave(actionID);
+                    bool canWeave = CanWeave(SpinningEdge);
+                    var jobMaxHp = LocalPlayer.MaxHp;
+                    var threshold = GetOptionValue(Config.NINPvP_Meisui_ST);
+                    var maxHPThreshold = jobMaxHp - 8000;
+                    var remainingPercentage = (float)LocalPlayer.CurrentHp / (float)maxHPThreshold;
+                    bool inMeisuiRange = threshold >= (remainingPercentage * 100);
+
 
                     if (HasEffect(Buffs.Hidden))
                         return OriginalHook(Assassinate);
@@ -83,6 +96,9 @@ namespace XIVSlothCombo.Combos.PvP
 
                     if (mudraMode)
                     {
+                        if (IsEnabled(CustomComboPreset.NINPvP_ST_Meisui) && inMeisuiRange && !meisuiLocked)
+                            return OriginalHook(Meisui);
+
                         if (!hyoshoLocked)
                             return OriginalHook(HyoshoRanryu);
 
@@ -90,7 +106,7 @@ namespace XIVSlothCombo.Combos.PvP
                             return OriginalHook(ForkedRaiju);
 
                         if (!hutonLocked)
-                            return Huton;
+                            return OriginalHook(Huton);
                     }
 
                     if (fumaCD.RemainingCharges > 0)
@@ -120,15 +136,23 @@ namespace XIVSlothCombo.Combos.PvP
                     bool gokaLocked = HasEffect(Debuffs.SealedGokaMekkyaku);
                     bool hutonLocked = HasEffect(Debuffs.SealedHuton);
                     bool mudraMode = HasEffect(Buffs.ThreeMudra);
-                    bool canWeave = CanWeave(actionID);
+                    bool canWeave = CanWeave(SpinningEdge);
+                    var jobMaxHp = LocalPlayer.MaxHp;
+                    var threshold = GetOptionValue(Config.NINPvP_Meisui_AoE);
+                    var maxHPThreshold = jobMaxHp - 8000;
+                    var remainingPercentage = (float)LocalPlayer.CurrentHp / (float)maxHPThreshold;
+                    bool inMeisuiRange = threshold >= (remainingPercentage * 100);
+
+                    if (HasEffect(Buffs.Hidden))
+                        return OriginalHook(Assassinate);
 
                     if (canWeave)
                     {
                         if (InMeleeRange() && !GetCooldown(Mug).IsCooldown)
-                            return Mug;
+                            return OriginalHook(Mug);
 
                         if (!GetCooldown(Bunshin).IsCooldown)
-                            return Bunshin;
+                            return OriginalHook(Bunshin);
 
                         if (threeMudrasCD.RemainingCharges > 0 && !mudraMode)
                             return OriginalHook(ThreeMudra);
@@ -136,6 +160,9 @@ namespace XIVSlothCombo.Combos.PvP
 
                     if (mudraMode)
                     {
+                        if (IsEnabled(CustomComboPreset.NINPvP_AoE_Meisui) && inMeisuiRange && !meisuiLocked)
+                            return OriginalHook(Meisui);
+
                         if (!dotonLocked)
                             return OriginalHook(Doton);
 

--- a/XIVSlothCombo/Combos/PvP/NINPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/NINPVP.cs
@@ -59,7 +59,7 @@ namespace XIVSlothCombo.Combos.PvP
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
-                if (actionID is SpinningEdge)
+                if (actionID is SpinningEdge or GustSlash or AeolianEdge)
                 {
                     var threeMudrasCD = GetCooldown(ThreeMudra);
                     var fumaCD = GetCooldown(FumaShuriken);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1282,9 +1282,10 @@ namespace XIVSlothCombo.Window.Functions
             // ====================================================================================
             #region PvP VALUES
 
+            PlayerCharacter? pc = Service.ClientState.LocalPlayer;
+
             if (preset == CustomComboPreset.PvP_EmergencyHeals)
             {
-                PlayerCharacter? pc = Service.ClientState.LocalPlayer;
                 if (pc != null)
                 {
                     uint maxHP = Service.ClientState.LocalPlayer?.MaxHp <= 15000 ? 0 : Service.ClientState.LocalPlayer.MaxHp - 15000;
@@ -1314,6 +1315,45 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.PvP_QuickPurify)
                 UserConfig.DrawPvPStatusMultiChoice(PvPCommon.Config.QuickPurifyStatuses);
+
+            if (preset == CustomComboPreset.NINPvP_ST_Meisui)
+            {
+                string description = "Set the HP percentage to be at or under for the feature to kick in.\n100% is considered to start at 8,000 less than your max HP to prevent wastage.";
+
+                if (pc != null)
+                {
+                    uint maxHP = pc.MaxHp <= 8000 ? 0 : pc.MaxHp - 8000;
+                    if (maxHP > 0)
+                    {
+                        int setting = PluginConfiguration.GetCustomIntValue(NINPVP.Config.NINPvP_Meisui_ST);
+                        float hpThreshold = (float)maxHP / 100 * setting;
+
+                        description += $"\nHP Value to be at or under: {hpThreshold}";
+                    }
+                }
+
+                UserConfig.DrawSliderInt(1, 100, NINPVP.Config.NINPvP_Meisui_ST, description);
+            }
+
+            if (preset == CustomComboPreset.NINPvP_AoE_Meisui)
+            {
+                string description = "Set the HP percentage to be at or under for the feature to kick in.\n100% is considered to start at 8,000 less than your max HP to prevent wastage.";
+
+                if (pc != null)
+                {
+                    uint maxHP = pc.MaxHp <= 8000 ? 0 : pc.MaxHp - 8000;
+                    if (maxHP > 0)
+                    {
+                        int setting = PluginConfiguration.GetCustomIntValue(NINPVP.Config.NINPvP_Meisui_AoE);
+                        float hpThreshold = (float)maxHP / 100 * setting;
+
+                        description += $"\nHP Value to be at or under: {hpThreshold}";
+                    }
+                }
+
+                UserConfig.DrawSliderInt(1, 100, NINPVP.Config.NINPvP_Meisui_AoE, description);
+            }
+
 
             #endregion
         }


### PR DESCRIPTION
[NINPVP]
- `Burst Mode` and `AoE Burst Mode` no longer conflict with each other. Both can now be used at the same time.
- `Assassinate` will now be used when `Hidden` on `AoE Burst Mode` (to match the functionality of `Burst Mode`).
- `Meisui Feature` added to both `Burst Mode` and `AoE Burst Mode`.