### PR TITLE
[ALL] Raise Protection

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -107,7 +107,11 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(ALL_Healer_Menu)]
             [CustomComboInfo("Healer: Raise Feature", "Changes the class' Raise Ability into Swiftcast.", ADV.JobID)]
             ALL_Healer_Raise = 100010,
-            #endregion
+
+                [ParentCombo(ALL_Healer_Raise)]
+                [CustomComboInfo("Healer: Double Raise Protection", "Attempts to prevent the use of Raise if the target is has been given a Raise.", ADV.JobID)]
+                ALL_Healer_Raise_Protection = 100011,
+        #endregion
 
         #region Global Magical Ranged Features
         [CustomComboInfo("Global Magical Ranged Features", "Features and options involving shared role actions for Magical Ranged DPS.\nCollapsing this category does NOT disable the features inside.", ADV.JobID)]
@@ -121,7 +125,11 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(ALL_Caster_Menu)]
             [CustomComboInfo("Magical Ranged DPS: Raise Feature", "Changes the class' Raise Ability into Swiftcast or Dualcast in the case of RDM.", ADV.JobID)]
             ALL_Caster_Raise = 100021,
-            #endregion
+
+                [ParentCombo(ALL_Caster_Raise)]
+                [CustomComboInfo("Magical Ranged DPS: Double Raise Protection", "Attempts to prevent the use of Raise if the target is has been given a Raise.", ADV.JobID)]
+                ALL_Caster_Raise_Protection = 100022,
+        #endregion
 
         #region Global Melee Features
         [CustomComboInfo("Global Melee DPS Features", "Features and options involving shared role actions for Melee DPS.\nCollapsing this category does NOT disable the features inside.", ADV.JobID)]

--- a/XIVSlothCombo/Combos/PvE/ALL.cs
+++ b/XIVSlothCombo/Combos/PvE/ALL.cs
@@ -46,7 +46,8 @@ namespace XIVSlothCombo.Combos.PvE
                 Rampart = 1191,
                 Peloton = 1199,
                 LucidDreaming = 1204,
-                TrueNorth = 1250;
+                TrueNorth = 1250,
+                Raise = 148;
         }
 
         public static class Debuffs
@@ -138,6 +139,8 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsOffCooldown(Swiftcast))
                         return Swiftcast;
 
+                    if (IsEnabled(CustomComboPreset.ALL_Healer_Raise_Protection) && TargetHasEffectAny(Buffs.Raise)) return Addle;
+
                     if (actionID == WHM.Raise && IsEnabled(CustomComboPreset.WHM_ThinAirRaise) && GetRemainingCharges(WHM.ThinAir) > 0 && !HasEffect(WHM.Buffs.ThinAir) && LevelChecked(WHM.ThinAir))
                         return WHM.ThinAir;
 
@@ -176,6 +179,9 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     if (HasEffect(Buffs.Swiftcast) || HasEffect(RDM.Buffs.Dualcast))
                         return actionID;
+                    
+                    if (IsEnabled(CustomComboPreset.ALL_Caster_Raise_Protection) && TargetHasEffectAny(Buffs.Raise)) return Esuna;
+
                     if (IsOffCooldown(Swiftcast))
                         return Swiftcast;
                 }


### PR DESCRIPTION
Healer & Caster Roles: Added code to attempt to stop raising a target that has been raised. Due to raise buff applying after the raise animation, there is no 100% guarantee