### PR TITLE
[SGE] Features & Code Cleanup

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2333,8 +2333,17 @@ namespace XIVSlothCombo.Combos
             SGE_ST_Dosis_EDosis = 14120,
 
             [ParentCombo(SGE_ST_Dosis)]
-            [CustomComboInfo("Toxikon Movement Option", "Use Toxikon when you have Addersting charges and are moving.", SGE.JobID, 130, "", "")]
+            [CustomComboInfo("Toxikon Option", "Use Toxikon when you have Addersting charges.", SGE.JobID, 130, "", "")]
             SGE_ST_Dosis_Toxikon = 14130,
+
+            [ParentCombo(SGE_ST_Dosis)]
+            [CustomComboInfo("Phlegma Option", "Use Phlegma if available and within range.", SGE.JobID, 129, "", "")]
+            SGE_ST_Dosis_Phlegma = 14140,
+
+            [ParentCombo(SGE_ST_Dosis)]
+            [CustomComboInfo("Kardia Reminder Option", "Adds Kardia when not under the effect.", SGE.JobID, 109, "", "")]
+            SGE_ST_Dosis_Kardia = 14150,
+            
             #endregion
 
         #region AoE DPS Feature
@@ -2376,6 +2385,10 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(SGE_ST_Heal)]
             [CustomComboInfo("Eukrasian Diagnosis Option", "Diagnosis becomes Eukrasian Diagnosis if the shield is not applied to the target.", SGE.JobID, 313, "", "")]
             SGE_ST_Heal_Diagnosis = 14320,
+                
+                [ParentCombo(SGE_ST_Heal_Diagnosis)]
+                [CustomComboInfo("Ignore Shield Check", "Warning, will force the use of Eukrasia Diagnosis, and normal Diagnosis will be unavailable.", SGE.JobID, 313, "", "")]
+                SGE_ST_Heal_Diagnosis_IgnoreShield = 14321,
 
             [ParentCombo(SGE_ST_Heal)]
             [CustomComboInfo("Soteria Option", "Applies Soteria.", SGE.JobID, 306, "", "")]
@@ -2417,35 +2430,39 @@ namespace XIVSlothCombo.Combos
         SGE_AoE_Heal = 14500,
             
             [ParentCombo(SGE_AoE_Heal)]
-            [CustomComboInfo("Physis Option", "Adds Physis.", SGE.JobID, 510, "", "")]
+            [CustomComboInfo("Physis Option", "Adds Physis.", SGE.JobID, 504, "", "")]
             SGE_AoE_Heal_Physis = 14510,
 
             [ParentCombo(SGE_AoE_Heal)]
             [CustomComboInfo("Eukrasian Prognosis Option", "Prognosis becomes Eukrasian Prognosis if the shield is not applied.", SGE.JobID, 520, "", "")]
             SGE_AoE_Heal_EPrognosis = 14520,
 
+                [ParentCombo(SGE_AoE_Heal_EPrognosis)]
+                [CustomComboInfo("Ignore Shield Check", "Warning, will force the use of Eukrasia Prognosis, and normal Prognosis will be unavailable.", SGE.JobID, 520, "", "")]
+                SGE_AoE_Heal_EPrognosis_IgnoreShield = 14521,
+
             [ParentCombo(SGE_AoE_Heal)]
-            [CustomComboInfo("Holos Option", "Adds Holos.", SGE.JobID, 530, "", "")]
+            [CustomComboInfo("Holos Option", "Adds Holos.", SGE.JobID, 505, "", "")]
             SGE_AoE_Heal_Holos = 14530,
 
             [ParentCombo(SGE_AoE_Heal)]
-            [CustomComboInfo("Panhaima Option", "Adds Panhaima.", SGE.JobID, 540, "", "")]
+            [CustomComboInfo("Panhaima Option", "Adds Panhaima.", SGE.JobID, 506, "", "")]
             SGE_AoE_Heal_Panhaima = 14540,
 
             [ParentCombo(SGE_AoE_Heal)]
-            [CustomComboInfo("Pepsis Option", "Triggers Pepsis if a shield is present.", SGE.JobID, 550, "", "")]
+            [CustomComboInfo("Pepsis Option", "Triggers Pepsis if a shield is present.", SGE.JobID, 507, "", "")]
             SGE_AoE_Heal_Pepsis = 14550,
 
             [ParentCombo(SGE_AoE_Heal)]
-            [CustomComboInfo("Ixochole Option", "Adds Ixochole.", SGE.JobID, 560, "", "")]
+            [CustomComboInfo("Ixochole Option", "Adds Ixochole.", SGE.JobID, 503, "", "")]
             SGE_AoE_Heal_Ixochole = 14560,
 
             [ParentCombo(SGE_AoE_Heal)]
-            [CustomComboInfo("Kerachole Option", "Adds Kerachole.", SGE.JobID, 570, "", "")]
+            [CustomComboInfo("Kerachole Option", "Adds Kerachole.", SGE.JobID, 502, "", "")]
             SGE_AoE_Heal_Kerachole = 14570,
 
             [ParentCombo(SGE_AoE_Heal)]
-            [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 580, "", "")]
+            [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 501, "", "")]
             SGE_AoE_Heal_Rhizomata = 14580,
             #endregion
 

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -1,9 +1,10 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
-using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Statuses;
 using System.Collections.Generic;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
+using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -11,9 +12,8 @@ namespace XIVSlothCombo.Combos.PvE
     {
         internal const byte JobID = 40;
 
-        private static SGEGauge Gauge => CustomComboNS.Functions.CustomComboFunctions.GetJobGauge<SGEGauge>();
-
-        public const uint
+        // Actions
+        internal const uint
             // Heals and Shields
             Diagnosis = 24284,
             Prognosis = 24286,
@@ -58,9 +58,10 @@ namespace XIVSlothCombo.Combos.PvE
 
         // Action Groups
         internal static readonly List<uint>
-            AddersgallList = new()  { Taurochole, Druochole, Ixochole, Kerachole },
-            PhlegmaList = new()     { Phlegma, Phlegma2, Phlegma3 };
+            AddersgallList = new() { Taurochole, Druochole, Ixochole, Kerachole },
+            PhlegmaList =    new() { Phlegma, Phlegma2, Phlegma3 };
 
+        // Action Buffs
         internal static class Buffs
         {
             internal const ushort
@@ -88,44 +89,42 @@ namespace XIVSlothCombo.Combos.PvE
                 { Dosis3, Debuffs.EukrasianDosis3 }
             };
 
-        internal static class Range
-        {
-            internal const byte Phlegma = 6;
-        }
+        // Sage Gauge & Extensions
+        private static SGEGauge Gauge => CustomComboFunctions.GetJobGauge<SGEGauge>();
+        private static bool HasAddersgall(this SGEGauge gauge) => gauge.Addersgall > 0;
+        private static bool HasAddersting(this SGEGauge gauge) => gauge.Addersting > 0;
 
         internal static class Config
         {
-            internal const string
-                // GUI Customization Storage Names
-                SGE_ST_Dosis_EDosisHPPer = "SGE_ST_Dosis_EDosisHPPer",
-                SGE_ST_Dosis_Lucid = "SGE_ST_Dosis_Lucid",
-                SGE_ST_Dosis_Toxikon = "SGE_ST_Dosis_Toxikon",
-                SGE_ST_Heal_Zoe = "SGE_ST_Heal_Zoe",
-                SGE_ST_Heal_Haima = "SGE_ST_Heal_Haima",
-                SGE_ST_Heal_Krasis = "SGE_ST_Heal_Krasis",
-                SGE_ST_Heal_Pepsis = "SGE_ST_Heal_Pepsis",
-                SGE_ST_Heal_Soteria = "SGE_ST_Heal_Soteria",
-                SGE_ST_Heal_Diagnosis = "SGE_ST_Heal_Diagnosis",
-                SGE_ST_Heal_Druochole = "SGE_ST_Heal_Druochole",
-                SGE_ST_Heal_Taurochole = "SGE_ST_Heal_Taurochole",
-                SGE_AoE_Phlegma_Lucid = "SGE_AoE_Phlegma_Lucid",
-                SGE_Eukrasia_Mode = "SGE_ST_Eukrasia_Mode";
+            internal static bool SGE_ST_Dosis_AltMode => CustomComboFunctions.GetIntOptionAsBool(nameof(SGE_ST_Dosis_AltMode)); 
+            internal static bool SGE_ST_Dosis_Toxikon => CustomComboFunctions.GetIntOptionAsBool(nameof(SGE_ST_Dosis_Toxikon));
+            internal static int SGE_ST_Dosis_EDosisHPPer => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Dosis_EDosisHPPer));
+            internal static int SGE_ST_Dosis_Lucid => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Dosis_Lucid));
+            internal static int SGE_ST_Heal_Zoe => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Zoe));
+            internal static int SGE_ST_Heal_Haima => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Haima));
+            internal static int SGE_ST_Heal_Krasis => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Krasis));
+            internal static int SGE_ST_Heal_Pepsis => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Pepsis));
+            internal static int SGE_ST_Heal_Soteria => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Soteria));
+            internal static int SGE_ST_Heal_Diagnosis => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Diagnosis));
+            internal static int SGE_ST_Heal_Druochole => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Druochole));
+            internal static int SGE_ST_Heal_Taurochole => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Taurochole));
+            internal static int SGE_AoE_Phlegma_Lucid => CustomComboFunctions.GetOptionValue(nameof(SGE_AoE_Phlegma_Lucid));
+            internal static int SGE_Eukrasia_Mode => CustomComboFunctions.GetOptionValue(nameof(SGE_Eukrasia_Mode));
         }
 
-        // Soteria Kardia
-        // Soteria becomes Kardia when Kardia's Buff is not active or Soteria is on cooldown.
+        /*
+         * SGE_Kardia
+         * Soteria becomes Kardia when Kardia's Buff is not active or Soteria is on cooldown.
+         */
         internal class SGE_Kardia : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Kardia;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-                => actionID is Soteria &&
-                    (!HasEffect(Buffs.Kardia) || IsOnCooldown(Soteria))
-                    ? Kardia
-                    : actionID;
+                => actionID is Soteria && (!HasEffect(Buffs.Kardia) || IsOnCooldown(Soteria)) ? Kardia : actionID;
         }
 
         /*
-         * Rhizomata
+         * SGE_Rhizo
          * Replaces all Addersgal using Abilities (Taurochole/Druochole/Ixochole/Kerachole) with Rhizomata if out of Addersgall stacks
          * (Scholar speak: Replaces all Aetherflow abilities with Aetherflow when out)
          */
@@ -133,11 +132,7 @@ namespace XIVSlothCombo.Combos.PvE
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Rhizo;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-                => AddersgallList.Contains(actionID) &&
-                    ActionReady(Rhizomata) &&
-                    Gauge.Addersgall is 0
-                    ? Rhizomata
-                    : actionID;
+                => AddersgallList.Contains(actionID) && ActionReady(Rhizomata) && !Gauge.HasAddersgall() ? Rhizomata : actionID;
         }
 
         /*
@@ -150,27 +145,25 @@ namespace XIVSlothCombo.Combos.PvE
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauro;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-                => actionID is Druochole &&
-                    ActionReady(Taurochole)
-                    ? Taurochole
-                    : actionID;
+                => actionID is Druochole && ActionReady(Taurochole) ? Taurochole : actionID;
         }
 
-        // Zoe Pneuma
-        // Places Zoe on top of Pneuma when both are available.
+        /*
+         * SGE_ZoePneuma (Zoe to Pneuma Combo)
+         * Places Zoe on top of Pneuma when both are available.
+         */
         internal class SGE_ZoePneuma : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneuma;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-                => actionID is Pneuma &&
-                    ActionReady(Pneuma) &&
-                    IsOffCooldown(Zoe)
-                    ? Zoe
-                    : actionID;
+                => actionID is Pneuma && ActionReady(Pneuma) && IsOffCooldown(Zoe) ? Zoe : actionID;
         }
 
-        // AoE/Phlegma Replacement
-        // Replaces Zero Charges/Stacks of Phlegma with Toxikon (if you can use it) or Dyskrasia 
+        /*
+         * SGE_AoE_Phlegma (Phlegma AoE Feature)
+         * Replaces Zero Charges/Stacks of Phlegma with various options
+         * Lucid Dreaming, Toxikon, or Dyskrasia
+         */
         internal class SGE_AoE_Phlegma : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_Phlegma;
@@ -182,26 +175,26 @@ namespace XIVSlothCombo.Combos.PvE
                     bool OutOfRangeToxikon = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_OutOfRangeToxikon);
                     bool NoPhlegmaDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoPhlegmaDyskrasia);
                     bool NoTargetDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoTargetDyskrasia);
-                    int lucidMPThreshold = GetOptionValue(Config.SGE_AoE_Phlegma_Lucid);
+                    uint phlegma = OriginalHook(Phlegma); //Level appropriate Phlegma
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) &&
                         ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) &&
-                        LocalPlayer.CurrentMp <= lucidMPThreshold)
+                        LocalPlayer.CurrentMp <= Config.SGE_AoE_Phlegma_Lucid)
                         return All.LucidDreaming;
 
-                    if ((NoPhlegmaToxikon || OutOfRangeToxikon) &&
-                        LevelChecked(Toxikon) && HasBattleTarget() &&
-                        Gauge.Addersting > 0)
+                    //Toxikon
+                    if (LevelChecked(Toxikon) && HasBattleTarget() && Gauge.HasAddersting())
                     {
-                        if ((NoPhlegmaToxikon && !HasCharges(OriginalHook(Phlegma))) ||
-                            (OutOfRangeToxikon && (GetTargetDistance() > Range.Phlegma)))
+                        if ((NoPhlegmaToxikon && !HasCharges(phlegma)) ||
+                            (OutOfRangeToxikon && !InActionRange(phlegma)))
                             return OriginalHook(Toxikon);
                     }
 
-                    if ((NoPhlegmaDyskrasia || NoTargetDyskrasia) && LevelChecked(Phlegma))
+                    //Dyskrasia
+                    if (LevelChecked(Dyskrasia))
                     {
-                        if ((NoPhlegmaDyskrasia && !HasCharges(OriginalHook(Phlegma))) ||
+                        if ((NoPhlegmaDyskrasia && !HasCharges(phlegma)) ||
                             (NoTargetDyskrasia && CurrentTarget is null))
                             return OriginalHook(Dyskrasia);
                     }
@@ -212,72 +205,85 @@ namespace XIVSlothCombo.Combos.PvE
         }
 
         /*
-         * Single Target Dosis Combo
+         * SGE_ST_Dosis (Single Target Dosis Combo)
          * Currently Replaces Dosis with Eukrasia when the debuff on the target is < 3 seconds or not existing
-         * Lucid Dreaming, Toxikon optional
+         * Kardia reminder, Lucid Dreaming, & Toxikon optional
          */
         internal class SGE_ST_Dosis : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_Dosis;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (DosisList.ContainsKey(actionID) && InCombat())
+                bool AlternateMode = Config.SGE_ST_Dosis_AltMode;
+                if ((!AlternateMode && DosisList.ContainsKey(actionID)) ||
+                    (AlternateMode && actionID is Dosis2))
                 {
-                    int lucidMPThreshold = GetOptionValue(Config.SGE_ST_Dosis_Lucid);
+                    // Kardia Reminder
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Kardia) && LevelChecked(Kardia) &&
+                        FindEffect(Buffs.Kardia) is null)
+                        return Kardia;
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) &&
                         ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) &&
-                        LocalPlayer.CurrentMp <= lucidMPThreshold)
+                        LocalPlayer.CurrentMp <= Config.SGE_ST_Dosis_Lucid)
                         return All.LucidDreaming;
 
-                    if (HasBattleTarget() && (!HasEffect(Buffs.Eukrasia))) 
-                        // Buff check Above. Without it, Toxikon and any future option will interfere in the Eukrasia->Eukrasia Dosis combo
+                    if (HasBattleTarget() && (!HasEffect(Buffs.Eukrasia)))
+                    // Buff check Above. Without it, Toxikon and any future option will interfere in the Eukrasia->Eukrasia Dosis combo
                     {
                         // Eukrasian Dosis.
                         // If we're too low level to use Eukrasia, we can stop here.
-                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia))
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia) && InCombat())
                         {
                             // Grab current Dosis via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
-                            // Using TryGetValue due to edge case where actionID would return as Eukrasian Dosis instead of Dosis
+                            // Using TryGetValue due to edge case where the actionID would be read as Eukrasian Dosis instead of Dosis
                             // EDosis will show for half a second if the buff is removed manually or some other act of God
                             if (DosisList.TryGetValue(OriginalHook(actionID), out ushort dotDebuffID))
                             {
                                 Status? dotDebuff = FindTargetEffect(dotDebuffID);
-
-                                int eDosisHPThreshold = GetOptionValue(Config.SGE_ST_Dosis_EDosisHPPer);
-
                                 if (((dotDebuff is null) || (dotDebuff.RemainingTime <= 3)) &&
-                                    (GetTargetHPPercent() > eDosisHPThreshold))
+                                    (GetTargetHPPercent() > Config.SGE_ST_Dosis_EDosisHPPer))
                                     return Eukrasia;
                             }
                         }
 
+                        // Phlegma
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Phlegma) && InCombat())
+                        {
+                            uint phlegma = OriginalHook(Phlegma);
+                            if (InActionRange(phlegma) && ActionReady(phlegma)) return phlegma;
+                        }
+
                         // Toxikon
-                        bool alwaysShowToxikon = GetIntOptionAsBool(Config.SGE_ST_Dosis_Toxikon);    // False for moving only, True for Show All Times
-                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) &&
-                            LevelChecked(Toxikon) && IsOffCooldown(actionID) &&                 // Cooldown check against original action to stop cooldown animation seizure
+                        bool alwaysShowToxikon = Config.SGE_ST_Dosis_Toxikon;    // False for moving only, True for Show All Times
+                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) && InCombat() &&
+                            LevelChecked(Toxikon) && IsOffCooldown(actionID) &&  // Cooldown check against original action to stop cooldown animation seizure
                             ((!alwaysShowToxikon && IsMoving) || alwaysShowToxikon) &&
-                            Gauge.Addersting > 0)
+                            Gauge.HasAddersting())
                             return OriginalHook(Toxikon);
                     }
                 }
-
                 return actionID;
             }
         }
 
-        // Swiftcast combos to Egeiro (Raise) while Swiftcast is on cooldown
+        /*
+         * SGE_Raise (Swiftcast Raise)
+         * Swiftcast becomes Egeiro when on cooldown
+         */
         internal class SGE_Raise : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Raise;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-                    => actionID is All.Swiftcast &&
-                    IsOnCooldown(All.Swiftcast)
-                    ? Egeiro
-                    : actionID;
+                    => actionID is All.Swiftcast && IsOnCooldown(All.Swiftcast) ? Egeiro : actionID;
         }
 
+        /* 
+         * SGE_Eukrasia (Eukrasia combo)
+         * Normally after Eukrasia is used and updates the abilities, it becomes disabled
+         * This will "combo" the action to user selected action
+         */
         internal class SGE_Eukrasia : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_Eukrasia;
@@ -285,8 +291,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Eukrasia && HasEffect(Buffs.Eukrasia))
                 {
-                    int mode = GetOptionValue(Config.SGE_Eukrasia_Mode);
-                    switch (mode)
+                    switch (Config.SGE_Eukrasia_Mode)
                     {
                         case 0: return OriginalHook(Dosis);
                         case 1: return OriginalHook(Diagnosis);
@@ -299,6 +304,11 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
+        /* 
+         * SGE_ST_Heal (Diagnosis Single Target Heal)
+         * Replaces Diagnosis with various Single Target healing options, 
+         * Pseudo priority set by various custom user percentages
+         */
         internal class SGE_ST_Heal : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_Heal;
@@ -311,23 +321,23 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Set Target. Soft -> Hard -> Self priority, matching normal in-game behavior
                     GameObject? healTarget = null;
-                    GameObject? softTarget = Services.Service.TargetManager.SoftTarget;
+                    GameObject? softTarget = Service.TargetManager.SoftTarget;
                     if (HasFriendlyTarget(softTarget)) healTarget = softTarget;
                     if (healTarget is null && HasFriendlyTarget(CurrentTarget)) healTarget = CurrentTarget;
                     if (healTarget is null) healTarget = LocalPlayer;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && ActionReady(Druochole) &&
-                        Gauge.Addersgall >= 1 &&
-                        GetTargetHPPercent(healTarget) <= GetOptionValue(Config.SGE_ST_Heal_Druochole))
+                        Gauge.HasAddersgall() &&
+                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Druochole)
                         return Druochole;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && ActionReady(Taurochole) &&
-                        Gauge.Addersgall >= 1 &&
-                        GetTargetHPPercent(healTarget) <= GetOptionValue(Config.SGE_ST_Heal_Taurochole))
+                        Gauge.HasAddersgall() &&
+                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Taurochole)
                         return Taurochole;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && ActionReady(Rhizomata) &&
-                        Gauge.Addersgall is 0)
+                        !Gauge.HasAddersgall())
                         return Rhizomata;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Kardia) && LevelChecked(Kardia) &&
@@ -336,29 +346,30 @@ namespace XIVSlothCombo.Combos.PvE
                         return Kardia;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) && ActionReady(Soteria) &&
-                        GetTargetHPPercent(healTarget) <= GetOptionValue(Config.SGE_ST_Heal_Soteria))
+                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Soteria)
                         return Soteria;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) && ActionReady(Zoe) &&
-                        GetTargetHPPercent(healTarget) <= GetOptionValue(Config.SGE_ST_Heal_Zoe))
+                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Zoe)
                         return Zoe;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) && ActionReady(Krasis) &&
-                        GetTargetHPPercent(healTarget) <= GetOptionValue(Config.SGE_ST_Heal_Krasis))
+                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Krasis)
                         return Krasis;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) && ActionReady(Pepsis) &&
-                        GetTargetHPPercent(healTarget) <= GetOptionValue(Config.SGE_ST_Heal_Pepsis) &&
+                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Pepsis &&
                         FindEffect(Buffs.EukrasianDiagnosis, healTarget, LocalPlayer?.ObjectId) is not null)
                         return Pepsis;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && ActionReady(Haima) &&
-                        GetTargetHPPercent(healTarget) <= GetOptionValue(Config.SGE_ST_Heal_Haima))
+                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Haima)
                         return Haima;
-                    
+
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Diagnosis) && LevelChecked(Eukrasia) &&
-                        FindEffect(Buffs.EukrasianDiagnosis, healTarget, LocalPlayer?.ObjectId) is null &&
-                        GetTargetHPPercent(healTarget) <= GetOptionValue(Config.SGE_ST_Heal_Diagnosis))
+                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Diagnosis &&
+                        (IsEnabled(CustomComboPreset.SGE_ST_Heal_Diagnosis_IgnoreShield) || 
+                         FindEffect(Buffs.EukrasianDiagnosis, healTarget, LocalPlayer?.ObjectId) is null))
                         return Eukrasia;
                 }
 
@@ -366,6 +377,11 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
+        /* 
+         * SGE_AoE_Heal (Prognosis AoE Heal)
+         * Replaces Prognosis with various AoE healing options, 
+         * Pseudo priority set by various custom user percentages
+         */
         internal class SGE_AoE_Heal : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_Heal;
@@ -377,15 +393,15 @@ namespace XIVSlothCombo.Combos.PvE
                         return EukrasianPrognosis;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Rhizomata) && ActionReady(Rhizomata) &&
-                        Gauge.Addersgall is 0)
+                        !Gauge.HasAddersgall())
                         return Rhizomata;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Kerachole) && ActionReady(Kerachole) &&
-                        Gauge.Addersgall >= 1)
+                        Gauge.HasAddersgall())
                         return Kerachole;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Ixochole) && ActionReady(Ixochole) &&
-                        Gauge.Addersgall >= 1)
+                        Gauge.HasAddersgall())
                         return Ixochole;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Physis))
@@ -393,10 +409,6 @@ namespace XIVSlothCombo.Combos.PvE
                         uint physis = OriginalHook(Physis);
                         if (ActionReady(physis)) return physis;
                     }
-
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
-                        FindEffect(Buffs.EukrasianPrognosis) is null)
-                        return Eukrasia;
 
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Holos) && ActionReady(Holos))
                         return Holos;
@@ -407,6 +419,11 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_Pepsis) && ActionReady(Pepsis) &&
                         FindEffect(Buffs.EukrasianPrognosis) is not null)
                         return Pepsis;
+
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis) && LevelChecked(Eukrasia) &&
+                        (IsEnabled(CustomComboPreset.SGE_AoE_Heal_EPrognosis_IgnoreShield) ||
+                         FindEffect(Buffs.EukrasianPrognosis) is null))
+                        return Eukrasia;
                 }
 
                 return actionID;

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -31,6 +31,21 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static int GetLevel(uint id) => ActionWatching.GetLevel(id);
 
+        /// <summary> Checks if the player is in range to use an action. Best used with actions with irregular ranges.</summary>
+        /// <param name="id"> ID of the action. </param>
+        /// <returns></returns>
+        public static bool InActionRange(uint id)
+        {
+            int range = ActionWatching.GetActionRange(id);
+            return range switch
+            {
+                -2 => false,//Doesn't exist in ActionWatching
+                -1 => InMeleeRange(),//In the Sheet, all Melee skills appear to be -1
+                0 => true,//In the Sheet, all self use abilities appear to be 0 (ie no range restriction)
+                _ => GetTargetDistance() <= range,
+            };
+        } 
+
         /// <summary> Checks if the player can use an action based on the level required and off cooldown / has charges.</summary>
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>

--- a/XIVSlothCombo/Data/ActionWatching.cs
+++ b/XIVSlothCombo/Data/ActionWatching.cs
@@ -162,6 +162,7 @@ namespace XIVSlothCombo.Data
         }
 
         public static int GetLevel(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.ClassJobLevel : 0;
+        public static int GetActionRange(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.Range : -2; // 0 & -1 are valid numbers. -2 is our failure code for InActionRange
         public static string GetActionName(uint id) => ActionSheet.TryGetValue(id, out var action) ? (string)action.Name : "UNKNOWN ABILITY";
         public static string GetStatusName(uint id) => StatusSheet.TryGetValue(id, out var status) ? (string)status.Name : "Unknown Status";
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1391,50 +1391,56 @@ namespace XIVSlothCombo.Window.Functions
             // ====================================================================================
             #region SAGE
 
+            if (preset is CustomComboPreset.SGE_ST_Dosis)
+            {
+                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_ST_Dosis_AltMode), "On All Dosis Actions", "", 0);
+                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_ST_Dosis_AltMode), "On Dosis II", "Alternative DPS Mode. Leaves Dosis & Dosis III alone for normal DPS", 1);
+            }
+
             if (preset is CustomComboPreset.SGE_ST_Dosis_EDosis)
-                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Dosis_EDosisHPPer, "Stop using at Enemy HP %. Set to Zero to disable this check");
+                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Dosis_EDosisHPPer), "Stop using at Enemy HP %. Set to Zero to disable this check");
 
             if (preset is CustomComboPreset.SGE_ST_Dosis_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_Dosis_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
+                UserConfig.DrawSliderInt(4000, 9500, nameof(SGE.Config.SGE_ST_Dosis_Lucid), "MP Threshold", 150, SliderIncrements.Hundreds);
 
             if (preset is CustomComboPreset.SGE_ST_Dosis_Toxikon)
             {
-                UserConfig.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show when moving only", "", 0);
-                UserConfig.DrawRadioButton(SGE.Config.SGE_ST_Dosis_Toxikon, "Show at all times", "", 1);
+                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_ST_Dosis_Toxikon), "Show when moving only", "", 0);
+                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_ST_Dosis_Toxikon), "Show at all times", "", 1);
             }
 
             if (preset is CustomComboPreset.SGE_AoE_Phlegma_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, SGE.Config.SGE_AoE_Phlegma_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
+                UserConfig.DrawSliderInt(4000, 9500, nameof(SGE.Config.SGE_AoE_Phlegma_Lucid), "MP Threshold", 150, SliderIncrements.Hundreds);
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Soteria)
-                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Soteria, "Use Soteria when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Soteria), "Use Soteria when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Zoe)
-                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Zoe, "Use Zoe when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Zoe), "Use Zoe when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Pepsis)
-                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Pepsis, "Use Pepsis when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Pepsis), "Use Pepsis when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Taurochole)
-                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Taurochole, "Use Taurochole when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Taurochole), "Use Taurochole when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Haima)
-                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Haima, "Use Haima when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Haima), "Use Haima when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Krasis)
-                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Krasis, "Use Krasis when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Krasis), "Use Krasis when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Druochole)
-                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Druochole, "Use Druochole when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Druochole), "Use Druochole when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Diagnosis)
-                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Diagnosis, "Use Diagnosis when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Diagnosis), "Use Diagnosis when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_Eukrasia)
             {
-                UserConfig.DrawRadioButton(SGE.Config.SGE_Eukrasia_Mode, "Eukrasian Dosis", "", 0);
-                UserConfig.DrawRadioButton(SGE.Config.SGE_Eukrasia_Mode, "Eukrasian Diagnosis", "", 1);
-                UserConfig.DrawRadioButton(SGE.Config.SGE_Eukrasia_Mode, "Eukrasian Prognosis", "", 2);
+                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_Eukrasia_Mode), "Eukrasian Dosis", "", 0);
+                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_Eukrasia_Mode), "Eukrasian Diagnosis", "", 1);
+                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_Eukrasia_Mode), "Eukrasian Prognosis", "", 2);
             }
 
             #endregion


### PR DESCRIPTION
Framework
- InActionRange / GetRange added to pull action ranges from ActionWatching. Best used for actions with irregular ranges like Phlegma, but should work with all action range types.

SGE
- Gauge has extensions HasAddersgall & HasAddersting. Used in various existing checks
- Config now directly reads the userconfig values instead of being a string placeholder.
- Phlegma Range constant removed. All references updated for InActionRange(Phlegma)
- SGE_ST_Dosis
  - Alternative mode added (Feature runs on Dosis II only. Similar to AST/SCH Alternative Modes)
  - Kardia reminder option added
  - Phlegma option added. Closes #893 
- SGE_ST_Heal: Ignore Diagnosis Shield Check suboption added to Eukrasian Diagnosis Option. Caveat Emptor. Closes #445 
- SGE_AoE_Heal: Ignore Prognosis Shield Check suboption added to Eukrasian Prognosis Option. Caveat Emptor. Closes #445 