### PR TITLE
Simple ST Feather Pooling

### DIFF
--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -455,7 +455,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             int featherBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
                             int minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep)
-                                ? 3
+                                ? (GetCooldownRemainingTime(TechnicalStep) < 5f?4:3)
                                 : 0;
 
                             if (HasEffect(Buffs.ThreeFoldFanDance))


### PR DESCRIPTION
Simply holds the 4th feather and pools it if TS is coming up in the next 5 seconds. Can very rarely overcap but greatly increases the chances of entering TS with 4 pooled feathers instead of 3. I think the potency trade-off to overcap risk is worth it.