### PR TITLE
[SCH] Energy Drain DPS Option, AoE DPS Feature, and code stuff

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2702,7 +2702,7 @@ namespace XIVSlothCombo.Combos
 
         #region DPS
         [ReplaceSkill(SCH.Ruin, SCH.Broil, SCH.Broil2, SCH.Broil3, SCH.Broil4, SCH.Bio, SCH.Bio2, SCH.Biolysis)]
-        [CustomComboInfo("Single Target DPS Feature", "Replace Ruin I / Broils or Bios with options below", SCH.JobID, 100, "", "")]
+        [CustomComboInfo("Single Target DPS Feature", "Replaces Ruin I / Broils or Bios with options below", SCH.JobID, 100, "", "")]
         SCH_DPS = 16100,
 
             [ParentCombo(SCH_DPS)]
@@ -2727,8 +2727,21 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(SCH_DPS)]
             [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT Uptime", SCH.JobID, 140, "", "")]
-            SCH_DPS_Bio = 16150,        
-            #endregion
+            SCH_DPS_Bio = 16150,
+
+        [ReplaceSkill(SCH.ArtOfWar, SCH.ArtOfWarII)]
+        [CustomComboInfo("AoE DPS Feature", "Replaces Art of War with options below", SCH.JobID, 101)]
+        SCH_AoE = 16101,
+
+            [ParentCombo(SCH_AoE)]
+            [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
+            SCH_AoE_Lucid = 16111,
+
+            [ParentCombo(SCH_AoE)]
+            [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of aetherflow stacks", SCH.JobID)]
+            SCH_AoE_Aetherflow = 16121,
+
+        #endregion
 
         #region Healing
         [ReplaceSkill(SCH.FeyBlessing)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2649,11 +2649,15 @@ namespace XIVSlothCombo.Combos
             SCH_DPS_Aetherflow = 16130,
 
             [ParentCombo(SCH_DPS)]
-            [CustomComboInfo("Ruin II Moving Option", "Use Ruin 2 when you have to move", SCH.JobID, 140, "", "")]
+            [CustomComboInfo("Energy Drain Weave Option", "Use Energy Drain to use up aetherflows stacks when Aetherflow's cooldown has been set below", SCH.JobID, 131, "", "")]
+            SCH_DPS_EnergyDrain = 16160,
+
+            [ParentCombo(SCH_DPS)]
+            [CustomComboInfo("Ruin II Moving Option", "Use Ruin II when you have to move", SCH.JobID, 150, "", "")]
             SCH_DPS_Ruin2Movement = 16140,
 
             [ParentCombo(SCH_DPS)]
-            [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT Uptime", SCH.JobID, 150, "", "")]
+            [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT Uptime", SCH.JobID, 140, "", "")]
             SCH_DPS_Bio = 16150,        
             #endregion
 

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -36,7 +36,6 @@ namespace XIVSlothCombo.Combos.PvE
             Broil2 = 7435,
             Broil3 = 16541,
             Broil4 = 25865,
-            Scourge = 16539,
             EnergyDrain = 167,
             ArtOfWar = 16539,
             ArtOfWarII = 25866,

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -235,44 +235,42 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 bool AlternateMode = Config.SCH_ST_DPS_AltMode; //(0 or 1 radio values)
                 if (((!AlternateMode && BroilList.Contains(actionID)) ||
-                     (AlternateMode && BioList.ContainsKey(actionID))) &&
-                    InCombat())
+                     (AlternateMode && BioList.ContainsKey(actionID))))
                 {
-                    if (CanSpellWeave(actionID))
-                    { 
-                        // Lucid Dreaming
-                        if (IsEnabled(CustomComboPreset.SCH_DPS_Lucid) &&
-                            ActionReady(All.LucidDreaming) &&
-                            LocalPlayer.CurrentMp <= Config.SCH_ST_DPS_LucidOption)
-                            return All.LucidDreaming;
+                    // Lucid Dreaming
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_Lucid) &&
+                        ActionReady(All.LucidDreaming) &&
+                        LocalPlayer.CurrentMp <= Config.SCH_ST_DPS_LucidOption &&
+                        CanSpellWeave(actionID))
+                        return All.LucidDreaming;
 
-                        // Aetherflow
-                        if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) &&
-                            ActionReady(Aetherflow) && !Gauge.HasAetherflow())
-                            return Aetherflow;
-                    }
+                    // Aetherflow
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) &&
+                        ActionReady(Aetherflow) && !Gauge.HasAetherflow() && 
+                        InCombat() && CanSpellWeave(actionID))
+                        return Aetherflow;
 
                     //Target based options
                     if (HasBattleTarget())
                     {
-                        if (CanSpellWeave(actionID))
-                        {
-                            // Energy Drain
-                            if (IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain) &&
-                                LevelChecked(EnergyDrain) && Gauge.HasAetherflow() &&
-                                GetCooldownRemainingTime(Aetherflow) <= Config.SCH_ST_DPS_EnergyDrain)
-                                return EnergyDrain;
+                        // Energy Drain
+                        if (IsEnabled(CustomComboPreset.SCH_DPS_EnergyDrain) &&
+                            LevelChecked(EnergyDrain) && InCombat() &&
+                            Gauge.HasAetherflow() &&
+                            GetCooldownRemainingTime(Aetherflow) <= Config.SCH_ST_DPS_EnergyDrain &&
+                            CanSpellWeave(actionID))
+                            return EnergyDrain;
 
-                            // Chain Stratagem
-                            if (IsEnabled(CustomComboPreset.SCH_DPS_ChainStrat) &&
-                                ActionReady(ChainStratagem) &&
-                                !TargetHasEffectAny(Debuffs.ChainStratagem) && //Overwrite protection
-                                GetTargetHPPercent() > Config.SCH_ST_DPS_ChainStratagemOption)
-                                return ChainStratagem;
-                        }
+                        // Chain Stratagem
+                        if (IsEnabled(CustomComboPreset.SCH_DPS_ChainStrat) &&
+                            ActionReady(ChainStratagem) && InCombat() &&
+                            !TargetHasEffectAny(Debuffs.ChainStratagem) && //Overwrite protection
+                            GetTargetHPPercent() > Config.SCH_ST_DPS_ChainStratagemOption &&
+                            CanSpellWeave(actionID))
+                            return ChainStratagem;
 
                         //Bio/Biolysis
-                        if (IsEnabled(CustomComboPreset.SCH_DPS_Bio) && LevelChecked(Bio))
+                        if (IsEnabled(CustomComboPreset.SCH_DPS_Bio) && LevelChecked(Bio) && InCombat())
                         {
                             uint dot = OriginalHook(Bio); //Grab the appropriate DoT Action
                             Status? dotDebuff = FindTargetEffect(BioList[dot]); //Match it with it's Debuff ID, and check for the Debuff
@@ -287,7 +285,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         //Ruin 2 Movement 
                         if (IsEnabled(CustomComboPreset.SCH_DPS_Ruin2Movement) &&
-                            LevelChecked(Ruin2) &&
+                            LevelChecked(Ruin2) && InCombat() &&
                             IsOffCooldown(actionID) && //Check against actionID to stop seizure during cooldown 
                             IsMoving) return OriginalHook(Ruin2); //Who knows in the future
                     }

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -278,9 +278,6 @@ namespace XIVSlothCombo.Combos.PvE
                             if ((dotDebuff is null || dotDebuff?.RemainingTime <= 3) &&
                                 (GetTargetHPPercent() > Config.SCH_ST_DPS_BioOption))
                                 return dot; //Use appropriate DoT Action
-
-                            //AlterateMode idles as Ruin/Broil
-                            if (AlternateMode) return OriginalHook(Ruin);
                         }
 
                         //Ruin 2 Movement 
@@ -288,6 +285,9 @@ namespace XIVSlothCombo.Combos.PvE
                             LevelChecked(Ruin2) && InCombat() &&
                             IsOffCooldown(actionID) && //Check against actionID to stop seizure during cooldown 
                             IsMoving) return OriginalHook(Ruin2); //Who knows in the future
+
+                        //AlterateMode idles as Ruin/Broil
+                        if (AlternateMode && InCombat()) return OriginalHook(Ruin);
                     }
                 }
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -38,6 +38,8 @@ namespace XIVSlothCombo.Combos.PvE
             Broil4 = 25865,
             Scourge = 16539,
             EnergyDrain = 167,
+            ArtOfWar = 16539,
+            ArtOfWarII = 25866,
 
             // Faerie
             SummonSeraph = 16545,
@@ -92,10 +94,11 @@ namespace XIVSlothCombo.Combos.PvE
         internal static class Config
         {
             internal static bool SCH_ST_DPS_AltMode => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_ST_DPS_AltMode));
-            internal static int  SCH_ST_DPS_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_LucidOption));
-            internal static int  SCH_ST_DPS_BioOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_BioOption));
-            internal static int  SCH_ST_DPS_ChainStratagemOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_ChainStratagemOption));
-            internal static int  SCH_ST_DPS_EnergyDrain => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_EnergyDrain));
+            internal static int SCH_ST_DPS_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_LucidOption));
+            internal static int SCH_ST_DPS_BioOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_BioOption));
+            internal static int SCH_ST_DPS_ChainStratagemOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_ChainStratagemOption));
+            internal static int SCH_ST_DPS_EnergyDrain => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_EnergyDrain));
+            internal static int SCH_AoE_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_AoE_LucidOption));
             internal static bool SCH_Aetherflow_Display => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_Aetherflow_Display));
             internal static bool SCH_Aetherflow_Recite_Excog => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_Aetherflow_Recite_Excog));
             internal static bool SCH_Aetherflow_Recite_Indom => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_Aetherflow_Recite_Indom));
@@ -106,7 +109,7 @@ namespace XIVSlothCombo.Combos.PvE
          * SCH_Consolation
          * Even though Summon Seraph becomes Consolation, 
          * This Feature also places Seraph's AoE heal+barrier ontop of the existing fairy AoE skill, Fey Blessing
-         */ 
+         */
         internal class SCH_Consolation : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Consolation;
@@ -246,7 +249,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Aetherflow
                     if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) &&
-                        ActionReady(Aetherflow) && !Gauge.HasAetherflow() && 
+                        ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
                         InCombat() && CanSpellWeave(actionID))
                         return Aetherflow;
 
@@ -289,6 +292,35 @@ namespace XIVSlothCombo.Combos.PvE
                         //AlterateMode idles as Ruin/Broil
                         if (AlternateMode && InCombat()) return OriginalHook(Ruin);
                     }
+                }
+                return actionID;
+            }
+        }
+
+        /*
+        * SCH_AoE
+        * Overrides main AoE DPS ability, Art of War
+        * Lucid Dreaming and Aetherflow weave options
+       */
+        internal class SCH_AoE : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is ArtOfWar or ArtOfWarII)
+                {
+                    // Lucid Dreaming
+                    if (IsEnabled(CustomComboPreset.SCH_AoE_Lucid) &&
+                        ActionReady(All.LucidDreaming) &&
+                        LocalPlayer.CurrentMp <= Config.SCH_AoE_LucidOption &&
+                        CanSpellWeave(actionID))
+                        return All.LucidDreaming;
+
+                    // Aetherflow
+                    if (IsEnabled(CustomComboPreset.SCH_AoE_Aetherflow) &&
+                        ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
+                        InCombat() && CanSpellWeave(actionID))
+                        return Aetherflow;
                 }
                 return actionID;
             }

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1481,6 +1481,9 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.SCH_DPS_ChainStrat)
                 UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_DPS_ChainStratagemOption), "Stop using at Enemy HP %. Set to Zero to disable this check");
 
+            if (preset is CustomComboPreset.SCH_AoE_Lucid)
+                UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_AoE_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
+
             if (preset is CustomComboPreset.SCH_FairyReminder)
             {
                 UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_FairyFeature), "Eos", "", 0);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1420,41 +1420,41 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset is CustomComboPreset.SCH_DPS)
             {
-                UserConfig.DrawRadioButton(SCH.Config.SCH_ST_DPS_AltMode, "On Ruin I / Broils", "", 0);
-                UserConfig.DrawRadioButton(SCH.Config.SCH_ST_DPS_AltMode, "On Bio", "Alternative DPS Mode. Leaves Ruin I / Broil alone for pure DPS, becomes Ruin I / Broil when features are on cooldown", 1);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_ST_DPS_AltMode), "On Ruin I / Broils", "", 0);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_ST_DPS_AltMode), "On Bio", "Alternative DPS Mode. Leaves Ruin I / Broil alone for pure DPS, becomes Ruin I / Broil when features are on cooldown", 1);
             }
 
             if (preset is CustomComboPreset.SCH_DPS_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, SCH.Config.SCH_ST_DPS_LucidOption, "MP Threshold", 150, SliderIncrements.Hundreds);
+                UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_ST_DPS_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
 
             if (preset is CustomComboPreset.SCH_DPS_Bio)
-                UserConfig.DrawSliderInt(0, 100, SCH.Config.SCH_ST_DPS_BioOption, "Stop using at Enemy HP %. Set to Zero to disable this check");
+                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_DPS_BioOption), "Stop using at Enemy HP %. Set to Zero to disable this check");
 
             if (preset is CustomComboPreset.SCH_DPS_ChainStrat)
-                UserConfig.DrawSliderInt(0, 100, SCH.Config.SCH_ST_DPS_ChainStratagemOption, "Stop using at Enemy HP %. Set to Zero to disable this check");
+                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_DPS_ChainStratagemOption), "Stop using at Enemy HP %. Set to Zero to disable this check");
 
             if (preset is CustomComboPreset.SCH_FairyReminder)
             {
-                UserConfig.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Eos", "", 0);
-                UserConfig.DrawRadioButton(SCH.Config.SCH_FairyFeature, "Selene", "", 1);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_FairyFeature), "Eos", "", 0);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_FairyFeature), "Selene", "", 1);
             }
 
             if (preset is CustomComboPreset.SCH_Aetherflow)
             {
-                UserConfig.DrawRadioButton(SCH.Config.SCH_Aetherflow_Display, "Show Aetherflow On Energy Drain Only", "", 0);
-                UserConfig.DrawRadioButton(SCH.Config.SCH_Aetherflow_Display, "Show Aetherflow On All Aetherflow Skills", "", 1);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_Aetherflow_Display), "Show Aetherflow On Energy Drain Only", "", 0);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_Aetherflow_Display), "Show Aetherflow On All Aetherflow Skills", "", 1);
             }
 
             if (preset is CustomComboPreset.SCH_Aetherflow_Recite_Excog)
             {
-                UserConfig.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Excog, "Only when out of Aetherflow Stacks", "", 0);
-                UserConfig.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Excog, "Always when available", "", 1);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_Aetherflow_Recite_Excog), "Only when out of Aetherflow Stacks", "", 0);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_Aetherflow_Recite_Excog), "Always when available", "", 1);
             }
 
             if (preset is CustomComboPreset.SCH_Aetherflow_Recite_Indom)
             {
-                UserConfig.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Indom, "Only when out of Aetherflow Stacks", "", 0);
-                UserConfig.DrawRadioButton(SCH.Config.SCH_Aetherflow_Recite_Indom, "Always when available", "", 1);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_Aetherflow_Recite_Indom), "Only when out of Aetherflow Stacks", "", 0);
+                UserConfig.DrawRadioButton(nameof(SCH.Config.SCH_Aetherflow_Recite_Indom), "Always when available", "", 1);
             }
 
             #endregion


### PR DESCRIPTION
- SCH
  - Gauge now has extension HasAetherflow
  - Configs return the user config information instead of holding just a string.
  - SCH_DeploymentTactics
    - No more hand holding on what can Deployment Tactics can work on.  Aldo only shows when Deployment Tactics is on cooldown.
  - SCH_DPS
    - [NEW] Energy Drain Weave Option. Uses up Aetherflow stacks when Aetherflow's remaining cooldown is <= user setting (0-10 seconds)
    - Ruin II Movement option moved to have less priority than Bio Option
    - Better usage of InCombat checking.
    - AltMode was nested incorrectly. Added InCombat check to enable DoT prepull
  - [NEW] SCH_AoE Feature.  Options are Aetherflow and Lucid Dreaming weaving