### PR TITLE
[Framework] TraitSheet/GetTraitLevel/TraitLevelChecked, [ReplaceSkill] Attribute Update, & Genesis's IsMoving Code

### DIFF
--- a/XIVSlothCombo/Attributes/ReplaceSkillAttribute.cs
+++ b/XIVSlothCombo/Attributes/ReplaceSkillAttribute.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using XIVSlothCombo.Services;
+using XIVSlothCombo.Data;
 
 namespace XIVSlothCombo.Attributes
 {
@@ -9,17 +8,13 @@ namespace XIVSlothCombo.Attributes
     [AttributeUsage(AttributeTargets.Field)]
     public class ReplaceSkillAttribute : Attribute
     {
-        private static readonly Dictionary<uint, Lumina.Excel.GeneratedSheets.Action>? ActionSheet = Service.DataManager?.GetExcelSheet<Lumina.Excel.GeneratedSheets.Action>()?
-                    .Where(i => i.ClassJobCategory.Row > 0 && i.ActionCategory.Row <= 4 && i.RowId is not 7)
-                    .ToDictionary(i => i.RowId, i => i);
-
         /// <summary> List of each action the feature replaces. Initializes a new instance of the <see cref="ReplaceSkillAttribute"/> class. </summary>
         /// <param name="actionIDs"> List of actions the preset replaces. </param>
         internal ReplaceSkillAttribute(params uint[] actionIDs)
         {
             foreach (uint id in actionIDs)
             {
-                if (ActionSheet.TryGetValue(id, out var action) && action != null)
+                if (ActionWatching.ActionSheet.TryGetValue(id, out var action) && action != null)
                 {
                     ActionNames.Add($"{action.Name}");
                 }

--- a/XIVSlothCombo/CustomCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo/CustomCombo.cs
@@ -54,9 +54,6 @@ namespace XIVSlothCombo.CustomComboNS
         {
             newActionID = 0;
 
-            // Movement
-            CheckMovement();
-
             if (!IsEnabled(Preset))
                 return false;
 

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -16,10 +16,15 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns> A value indicating whether the action would be modified. </returns>
         public static bool IsOriginal(uint actionID) => Service.IconReplacer.OriginalHook(actionID) == actionID;
 
-        /// <summary> Checks if the player is high enough level to use the passed ID. </summary>
-        /// <param name="id"> ID of the action. </param>
+        /// <summary> Checks if the player is high enough level to use the passed Action ID. </summary>
+        /// <param name="actionid"> ID of the action. </param>
         /// <returns></returns>
-        public static bool LevelChecked(uint id) => LocalPlayer.Level >= GetLevel(id);
+        public static bool LevelChecked(uint actionid) => LocalPlayer.Level >= GetLevel(actionid);
+
+        /// <summary> Checks if the player is high enough level to use the passed Trait ID. </summary>
+        /// <param name="traitid"> ID of the action. </param>
+        /// <returns></returns>
+        public static bool TraitLevelChecked(uint traitid) => LocalPlayer.Level >= GetTraitLevel(traitid);
 
         /// <summary> Returns the name of an action from its ID. </summary>
         /// <param name="id"> ID of the action. </param>
@@ -30,6 +35,11 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>
         public static int GetLevel(uint id) => ActionWatching.GetLevel(id);
+
+        /// <summary> Returns the level of a trait. </summary>
+        /// <param name="id"> ID of the action. </param>
+        /// <returns></returns>
+        public static int GetTraitLevel(uint id) => ActionWatching.GetTraitLevel(id);
 
         /// <summary> Checks if the player can use an action based on the level required and off cooldown / has charges.</summary>
         /// <param name="id"> ID of the action. </param>

--- a/XIVSlothCombo/CustomCombo/Functions/Movement.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Movement.cs
@@ -1,28 +1,11 @@
-﻿using System.Numerics;
+﻿using FFXIVClientStructs.FFXIV.Client.UI.Agent;
 
 namespace XIVSlothCombo.CustomComboNS.Functions
 {
     internal abstract partial class CustomComboFunctions
     {
-        public Vector2 Position { get; set; }
-        public float PlayerSpeed { get; set; }
-        public uint MovingCounter { get; set; }
-        public static bool IsMoving { get; set; }
-
         /// <summary> Checks player movement </summary>
-        public void CheckMovement()
-        {
-            if (MovingCounter == 0)
-            {
-                Vector2 newPosition = LocalPlayer is null ? Vector2.Zero : new Vector2(LocalPlayer.Position.X, LocalPlayer.Position.Z);
-                PlayerSpeed = Vector2.Distance(newPosition, Position);
-                IsMoving = PlayerSpeed > 0;
-                Position = LocalPlayer is null ? Vector2.Zero : newPosition;
-                MovingCounter = 50; // Refreshes every 50 Dalamud ticks for a more accurate representation of speed, otherwise it'll report 0.
-            }
-
-            if (MovingCounter > 0)
-                MovingCounter--;
-        }
+        public static unsafe bool IsMoving =>
+            AgentMap.Instance() is not null && AgentMap.Instance()->IsPlayerMoving > 0;
     }
 }

--- a/XIVSlothCombo/Data/ActionWatching.cs
+++ b/XIVSlothCombo/Data/ActionWatching.cs
@@ -17,6 +17,10 @@ namespace XIVSlothCombo.Data
         internal static Dictionary<uint, Lumina.Excel.GeneratedSheets.Status> StatusSheet = Service.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets.Status>()!
             .ToDictionary(i => i.RowId, i => i);
 
+        internal static Dictionary<uint, Lumina.Excel.GeneratedSheets.Trait> TraitSheet = Service.DataManager.GetExcelSheet<Lumina.Excel.GeneratedSheets.Trait>()!
+            .Where(i => i.ClassJobCategory is not null) //All player traits are assigned to a category. Chocobo and other garbage lacks this, thus excluded.
+            .ToDictionary(i => i.RowId, i => i);
+
         private static readonly Dictionary<string, List<uint>> statusCache = new();
 
         public static List<uint> CombatActions = new List<uint>();
@@ -162,6 +166,7 @@ namespace XIVSlothCombo.Data
         }
 
         public static int GetLevel(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.ClassJobLevel : 0;
+        public static int GetTraitLevel(uint id) => TraitSheet.TryGetValue(id, out var trait) ? trait.Level : 0;
         public static string GetActionName(uint id) => ActionSheet.TryGetValue(id, out var action) ? (string)action.Name : "UNKNOWN ABILITY";
         public static string GetStatusName(uint id) => StatusSheet.TryGetValue(id, out var status) ? (string)status.Name : "Unknown Status";
 


### PR DESCRIPTION
- ActionWatching
  - Added TraitSheet & GetTraitLevel
- Action
  - Added GetTraitLevel reference.
  - Renamed passed var of LevelChecked from id to actionid to help clarify what's being passed
- ReplaceSkillAttribute
  - Removed duplicate ActionSheet. Now references the one from ActionWatching
- Movement
  - Added Genesis's IsMoving Code from Discord (Based on and Closes #913 )
- CustomCombo
  - Removed CheckMovement(), obsolete. 