### PR TITLE
[BRD] A little bug on the opener of Simple Bard;

### DIFF
--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -597,15 +597,15 @@ namespace XIVSlothCombo.Combos.PvE
                         float ragingCD = GetCooldownRemainingTime(RagingStrikes);
                         float radiantCD = GetCooldownRemainingTime(RadiantFinale);
 
-                        if (empyrealReady && (!openerFinished || (openerFinished && battleVoiceCD >= 3.5)))
+                        if (empyrealReady && ((!openerFinished && IsOnCooldown(RagingStrikes)) || (openerFinished && battleVoiceCD >= 3.5)))
                             return EmpyrealArrow;
 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
                             (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)) &&
-                            (!openerFinished || (openerFinished && battleVoiceCD >= 3.5)))
+                            ((!openerFinished && IsOnCooldown(RagingStrikes)) || (openerFinished && battleVoiceCD >= 3.5)))
                             return OriginalHook(WanderersMinuet);
 
-                        if (sidewinderReady && (!openerFinished || (openerFinished && battleVoiceCD >= 3.5)))
+                        if (sidewinderReady && ((!openerFinished && IsOnCooldown(RagingStrikes)) || (openerFinished && battleVoiceCD >= 3.5)))
                         {
                             if (IsEnabled(CustomComboPreset.BRD_Simple_Pooling))
                             {
@@ -622,7 +622,7 @@ namespace XIVSlothCombo.Combos.PvE
                             else return Sidewinder;
                         }
 
-                        if (LevelChecked(Bloodletter))
+                        if (LevelChecked(Bloodletter) && ((!openerFinished && IsOnCooldown(RagingStrikes)) || openerFinished))
                         {
                             ushort bloodletterCharges = GetRemainingCharges(Bloodletter);
 
@@ -646,7 +646,6 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (songNone && bloodletterCharges == 3)
                                     return Bloodletter;
                             }
-
                             else if (bloodletterCharges > 0)
                                 return Bloodletter;
                         }


### PR DESCRIPTION
### PVE

   - A little bug on the Simple Bard Opener could make it use `Empyreal Arrow` or `Bloodletter`  before having `Raging Strikes` up, this PR should fix it; 