### PR TITLE
[AST] Code Cleanup and 6.2 Changes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -170,7 +170,7 @@ namespace XIVSlothCombo.Combos
         #region ASTROLOGIAN
 
         #region DPS
-        [ReplaceSkill(AST.Malefic1, AST.Malefic2, AST.Malefic3, AST.Malefic4, AST.FallMalefic, AST.Combust1, AST.Combust2, AST.Combust3, AST.Gravity, AST.Gravity2)]
+        [ReplaceSkill(AST.Malefic, AST.Malefic2, AST.Malefic3, AST.Malefic4, AST.FallMalefic, AST.Combust, AST.Combust2, AST.Combust3, AST.Gravity, AST.Gravity2)]
         //[ConflictingCombos(AstrologianAlternateDpsFeature)]
         [CustomComboInfo("DPS Feature", "Replaces Malefic or Combust with options below", AST.JobID, 0, "", "")]
         AST_ST_DPS = 1004,
@@ -294,10 +294,6 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(AST_Cards_DrawOnPlay)]
             [CustomComboInfo("Target Focus Feature", "Once you've played your card, switch back to your focus target.", AST.JobID)]
             AST_Cards_DrawOnPlay_ReFocusTarget = 1034,
-
-        [ReplaceSkill(AST.CrownPlay)]
-        [CustomComboInfo("Crown Play to Minor Arcana", "Changes Crown Play to Minor Arcana when a card is not drawn or has Lord Or Lady Buff.", AST.JobID, 17, "", "")]
-        AST_Cards_CrownPlay = 1001,
 
         [ReplaceSkill(AST.Play)]
         //Works With AST_Cards_DrawOnPlay as a feature, or by itself if AST_Cards_DrawOnPlay is disabled.

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -1,105 +1,122 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using Dalamud.Game.ClientState.JobGauge.Enums;
+﻿using Dalamud.Game.ClientState.JobGauge.Enums;
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Game.ClientState.Statuses;
+using System.Collections.Generic;
+using System.Linq;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.PvE
 {
     internal static class AST
     {
-        public const byte JobID = 33;
-        private static ASTGauge Gauge => CustomComboNS.Functions.CustomComboFunctions.GetJobGauge<ASTGauge>();
+        internal const byte JobID = 33;
 
-        public const uint
-            Benefic = 3594,
-            Draw = 3590,
-            /*
-            Balance = 4401,
-            Bole = 4404,
-            Arrow = 4402,
-            Spear = 4403,
-            Ewer = 4405,
-            Spire = 4406,
-            */
-            MinorArcana = 7443,
-            //SleeveDraw = 7448,
-            Malefic4 = 16555,
-            Ascend = 3603,
-            CrownPlay = 25869,
-            Astrodyne = 25870,
-            FallMalefic = 25871,
-            Malefic1 = 3596,
+        internal const uint
+            //DPS
+            Malefic = 3596,
             Malefic2 = 3598,
             Malefic3 = 7442,
-            Play = 17055,
-            LordOfCrowns = 7444,
-            LadyOfCrown = 7445,
-            Divination = 16552,
-            Lightspeed = 3606,
-            Redraw = 3593,
-
-            // AoEs
+            Malefic4 = 16555,
+            FallMalefic = 25871,
             Gravity = 3615,
             Gravity2 = 25872,
 
-            // DoTs
-            Combust3 = 16554,
-            Combust2 = 3608,
-            Combust1 = 3599,
+            //Cards
+            Draw = 3590,
+            Play = 17055,
+            Redraw = 3593,
+            //Obsolete? Left just incase it's needed
+            //Balance = 4401,
+            //Bole = 4404,
+            //Arrow = 4402,
+            //Spear = 4403,
+            //Ewer = 4405,
+            //Spire = 4406,
+            MinorArcana = 7443,
+            //LordOfCrowns = 7444,
+            //LadyOfCrown = 7445,
+            Astrodyne = 25870,
 
-            // Heals
+            //Utility
+            Divination = 16552,
+            Lightspeed = 3606,
+
+            //DoT
+            Combust = 3599,
+            Combust2 = 3608,
+            Combust3 = 16554,
+
+            //Healing
+            Benefic = 3594,
+            Benefic2 = 3610,
+            AspectedBenefic = 3595,
             Helios = 3600,
             AspectedHelios = 3601,
-            CelestialOpposition = 16553,
-            Benefic2 = 3610,
+            Ascend = 3603,
             EssentialDignity = 3614,
+            CelestialOpposition = 16553,
             CelestialIntersection = 16556,
-            AspectedBenefic = 3595,
             Horoscope = 16557,
             Exaltation = 25873;
 
-        private static class Buffs
+        //Action Groups
+        internal static readonly List<uint>
+            MaleficList = new() { Malefic, Malefic2, Malefic3, Malefic4, FallMalefic },
+            GravityList = new() { Gravity, Gravity2 };
+
+        internal static class Buffs
         {
-            public const ushort
+            internal const ushort
+                AspectedBenefic = 835,
+                AspectedHelios = 836,
+                Horoscope = 1890,
+                HoroscopeHelios = 1891,
+                NeutralSect = 1892,
+                NeutralSectShield = 1921,
                 Divination = 1878,
                 LordOfCrownsDrawn = 2054,
                 LadyOfCrownsDrawn = 2055,
-                AspectedHelios = 836,
-                Balance = 913,
-                Bole = 914,
-                Arrow = 915,
-                Spear = 916,
-                Ewer = 917,
-                Spire = 918,
+                ClarifyingDraw = 2713,
+                //The "Buff" that shows when you're holding onto the card
+                BalanceDrawn = 913,
+                BoleDrawn = 914,
+                ArrowDrawn = 915,
+                SpearDrawn = 916,
+                EwerDrawn = 917,
+                SpireDrawn = 918,
+                //The actual buff that buffs players
                 BalanceDamage = 1882,
                 BoleDamage = 1883,
                 ArrowDamage = 1884,
                 SpearDamage = 1885,
                 EwerDamage = 1886,
-                SpireDamage = 1887,
-                Horoscope = 1890,
-                HoroscopeHelios = 1891,
-                AspectedBenefic = 835,
-                NeutralSect = 1892,
-                NeutralSectShield = 1921,
-                ClarifyingDraw = 2713;
+                SpireDamage = 1887;
         }
 
-        public static class Debuffs
+        internal static class Debuffs
         {
-            public const ushort
-                Combust1 = 838,
+            internal const ushort
+                Combust = 838,
                 Combust2 = 843,
                 Combust3 = 1881;
         }
 
-        public static class Config
+        //Debuff Pairs of Actions and Debuff
+        internal static Dictionary<uint, ushort>
+            CombustList = new() {
+                { Combust,  Debuffs.Combust  },
+                { Combust2, Debuffs.Combust2 },
+                { Combust3, Debuffs.Combust3 }
+            };
+
+        private static ASTGauge Gauge => CustomComboFunctions.GetJobGauge<ASTGauge>();
+
+        internal static class Config
         {
-            public const string
+            internal const string
                 AST_LucidDreaming = "ASTLucidDreamingFeature",
                 AST_EssentialDignity = "ASTCustomEssentialDignity",
                 AST_DPS_AltMode = "AST_DPS_AltMode",
@@ -114,42 +131,35 @@ namespace XIVSlothCombo.Combos.PvE
 
             private new GameObject? CurrentTarget;
 
-            private List<GameObject> PartyTargets = new();
+            private readonly List<GameObject> PartyTargets = new();
 
             private GameObject? SelectedRandomMember;
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_Cards_DrawOnPlay;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID == Play)
+                if (actionID is Play)
                 {
-                    bool haveCard = HasEffect(Buffs.Balance) || HasEffect(Buffs.Bole) || HasEffect(Buffs.Arrow) || HasEffect(Buffs.Spear) || HasEffect(Buffs.Ewer) || HasEffect(Buffs.Spire);
-                    CardType cardDrawn = Gauge.DrawnCard;
+                    var haveCard = HasEffect(Buffs.BalanceDrawn) || HasEffect(Buffs.BoleDrawn) || HasEffect(Buffs.ArrowDrawn) || HasEffect(Buffs.SpearDrawn) || HasEffect(Buffs.EwerDrawn) || HasEffect(Buffs.SpireDrawn);
+                    var cardDrawn = Gauge.DrawnCard;
 
-                    if (!Gauge.ContainsSeal(SealType.NONE) &&
-                        IsEnabled(CustomComboPreset.AST_Cards_AstrodyneOnPlay) &&
-                        (Gauge.DrawnCard != CardType.NONE || GetCooldown(Draw).CooldownRemaining > 30)
-                       ) return Astrodyne;
+                    if (IsEnabled(CustomComboPreset.AST_Cards_AstrodyneOnPlay) && LevelChecked(Astrodyne) && !Gauge.ContainsSeal(SealType.NONE) &&
+                        (Gauge.DrawnCard != CardType.NONE || HasCharges(Draw)))
+                        return Astrodyne;
 
                     if (haveCard)
                     {
                         if (HasEffect(Buffs.ClarifyingDraw) && IsEnabled(CustomComboPreset.AST_Cards_Redraw))
                         {
-                            if ((cardDrawn == CardType.BALANCE && Gauge.Seals.Contains(SealType.SUN)) ||
-                                (cardDrawn == CardType.ARROW && Gauge.Seals.Contains(SealType.MOON)) ||
-                                (cardDrawn == CardType.SPEAR && Gauge.Seals.Contains(SealType.CELESTIAL)) ||
-                                (cardDrawn == CardType.BOLE && Gauge.Seals.Contains(SealType.SUN)) ||
-                                (cardDrawn == CardType.EWER && Gauge.Seals.Contains(SealType.MOON)) ||
-                                (cardDrawn == CardType.SPIRE && Gauge.Seals.Contains(SealType.CELESTIAL)))
-
+                            if ((cardDrawn is CardType.BALANCE or CardType.BOLE && Gauge.Seals.Contains(SealType.SUN)) ||
+                                (cardDrawn is CardType.ARROW or CardType.EWER && Gauge.Seals.Contains(SealType.MOON)) ||
+                                (cardDrawn is CardType.SPEAR or CardType.SPIRE && Gauge.Seals.Contains(SealType.CELESTIAL)))
                                 return Redraw;
                         }
                         if (IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay_AutoCardTarget))
                         {
                             if (GetTarget || IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay_TargetLock))
                                 SetTarget();
-
-
                         }
 
                         return OriginalHook(Play);
@@ -161,7 +171,6 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             TargetObject(CurrentTarget);
                         }
-
 
                         if (IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay_ReFocusTarget))
                             TargetObject(TargetType.FocusTarget);
@@ -180,13 +189,12 @@ namespace XIVSlothCombo.Combos.PvE
                 if (Gauge.DrawnCard.Equals(CardType.NONE)) return false;
                 CardType cardDrawn = Gauge.DrawnCard;
                 if (GetTarget) CurrentTarget = LocalPlayer.TargetObject;
-                //Checks for trusts then normal parties. Buddylist does not include player, so +1
-                int maxPartySize = GetPartySlot(5) == null ? 4 : 8;
 
-                for (int i = 1; i <= maxPartySize; i++)
+                for (int i = 1; i <= 8; i++) //Checking all 8 available slots and skipping nulls & DCs
                 {
-                    GameObject? member = GetPartySlot(i);
-                    if (member == null) continue; //Skip nulls/disconnected people
+                    if (GetPartySlot(i) is not BattleChara member) continue;
+                    //GameObject? member = GetPartySlot(i);
+                    if (member is null) continue; //Skip nulls/disconnected people
 
                     if (FindEffectOnMember(Buffs.BalanceDamage, member) is not null) continue;
                     if (FindEffectOnMember(Buffs.ArrowDamage, member) is not null) continue;
@@ -195,7 +203,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (FindEffectOnMember(Buffs.SpireDamage, member) is not null) continue;
                     if (FindEffectOnMember(Buffs.SpearDamage, member) is not null) continue;
 
-                   
+
                     PartyTargets.Add(member);
                 }
 
@@ -246,31 +254,12 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class AST_Cards_CrownPlay : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_Cards_CrownPlay;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID == CrownPlay)
-                {
-                    if (LevelChecked(MinorArcana) && Gauge.DrawnCrownCard == CardType.NONE)
-                        return MinorArcana;
-                }
-
-                return actionID;
-            }
-        }
-
         internal class AST_Benefic : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_Benefic;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is Benefic2 && !LevelChecked(Benefic2)) return Benefic;
-                else return actionID;
-            }
+                => actionID is Benefic2 && !LevelChecked(Benefic2) ? Benefic : actionID;
         }
 
         internal class AST_Raise_Alternative : CustomCombo
@@ -278,10 +267,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_Raise_Alternative;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is All.Swiftcast && IsOnCooldown(All.Swiftcast)) return Ascend;
-                else return actionID;
-            }
+                => actionID is All.Swiftcast && IsOnCooldown(All.Swiftcast) ? Ascend : actionID;
         }
 
         internal class AST_ST_DPS : CustomCombo
@@ -290,83 +276,71 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                bool AlternateMode = System.Convert.ToBoolean(GetOptionValue(Config.AST_DPS_AltMode)); //(0 or 1 radio values)
-                if (((!AlternateMode && actionID is FallMalefic or Malefic4 or Malefic3 or Malefic2 or Malefic1) ||
-                     (AlternateMode && actionID is Combust1 or Combust2 or Combust3) ||
-                     (IsEnabled(CustomComboPreset.AST_AoE_DPS) && actionID is Gravity or Gravity2)) &&
+                bool AlternateMode = GetIntOptionAsBool(Config.AST_DPS_AltMode); //(0 or 1 radio values)
+                if (((!AlternateMode && MaleficList.Contains(actionID)) ||
+                     (AlternateMode && CombustList.ContainsKey(actionID)) ||
+                     (IsEnabled(CustomComboPreset.AST_AoE_DPS) && GravityList.Contains(actionID))) &&
                     InCombat())
                 {
+
                     if (IsEnabled(CustomComboPreset.AST_DPS_LightSpeed) &&
-                        LevelChecked(Lightspeed) &&
-                        IsOffCooldown(Lightspeed) &&
+                        ActionReady(Lightspeed) &&
                         GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_LightSpeedOption) &&
-                        CanSpellWeave(actionID)
-                       ) return Lightspeed;
+                        CanSpellWeave(actionID))
+                        return Lightspeed;
 
                     if (IsEnabled(CustomComboPreset.AST_DPS_Lucid) &&
-                        LevelChecked(All.LucidDreaming) &&
-                        IsOffCooldown(All.LucidDreaming) &&
+                        ActionReady(All.LucidDreaming) &&
                         LocalPlayer.CurrentMp <= GetOptionValue(Config.AST_LucidDreaming) &&
-                        CanSpellWeave(actionID)
-                       ) return All.LucidDreaming;
+                        CanSpellWeave(actionID))
+                        return All.LucidDreaming;
 
                     //Divination
                     if (IsEnabled(CustomComboPreset.AST_DPS_Divination) &&
-                        LevelChecked(Divination) &&
-                        IsOffCooldown(Divination) &&
+                        ActionReady(Divination) &&
                         !HasEffect(Buffs.Divination) && //Overwrite protection
                         GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_DivinationOption) &&
-                        CanSpellWeave(actionID)
-                       ) return Divination;
+                        CanSpellWeave(actionID))
+                        return Divination;
 
                     //Astrodyne
                     if (IsEnabled(CustomComboPreset.AST_DPS_Astrodyne) &&
                         LevelChecked(Astrodyne) &&
                         !Gauge.ContainsSeal(SealType.NONE) &&
-                        CanSpellWeave(actionID)
-                        ) return Astrodyne;
+                        CanSpellWeave(actionID))
+                        return Astrodyne;
 
                     //Card Draw
                     if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
-                        LevelChecked(Draw) &&
-                        Gauge.DrawnCard.Equals(CardType.NONE) &&
-                        GetCooldown(Draw).RemainingCharges > 0 &&
-                        CanSpellWeave(actionID)
-                       ) return Draw;
+                        ActionReady(Draw) &&
+                        Gauge.DrawnCard is CardType.NONE &&
+                        CanSpellWeave(actionID))
+                        return Draw;
 
-                    //Minor Arcana
-                    if (IsEnabled(CustomComboPreset.AST_DPS_AutoCrownDraw) &&
-                        LevelChecked(MinorArcana) &&
-                        Gauge.DrawnCrownCard == CardType.NONE &&
-                        IsOffCooldown(MinorArcana) &&
-                        CanSpellWeave(actionID)
-                       ) return MinorArcana;
+                    //Minor Arcana / Lord of Crowns
+                    if (ActionReady(MinorArcana) &&
+                        ((IsEnabled(CustomComboPreset.AST_DPS_AutoCrownDraw) && Gauge.DrawnCrownCard is CardType.NONE) ||
+                        (IsEnabled(CustomComboPreset.AST_DPS_LazyLord) && Gauge.DrawnCrownCard is CardType.LORD && HasBattleTarget())) &&
+                        CanSpellWeave(actionID))
+                        return OriginalHook(MinorArcana);
 
-                    //Lord of Crowns
-                    if (IsEnabled(CustomComboPreset.AST_DPS_LazyLord) &&
-                        LevelChecked(CrownPlay) &&
-                        Gauge.DrawnCrownCard is CardType.LORD &&
-                        CanSpellWeave(actionID)
-                       ) return LordOfCrowns;
-
-                    //Combust
-                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_CombustUptime) &&
-                        actionID is not Gravity and not Gravity2 &&
-                        LevelChecked(Combust1) &&
-                        HasBattleTarget())
+                    if (HasBattleTarget())
                     {
-                        //Determine which Combust debuff to check
-                        Status? CombustDebuffID;
-                        if (LevelChecked(Combust3)) CombustDebuffID = FindTargetEffect(Debuffs.Combust3);
-                        else if (LevelChecked(Combust2)) CombustDebuffID = FindTargetEffect(Debuffs.Combust2);
-                        else CombustDebuffID = FindTargetEffect(Debuffs.Combust1);
+                        //Combust
+                        if (IsEnabled(CustomComboPreset.AST_ST_DPS_CombustUptime) &&
+                            !GravityList.Contains(actionID) &&
+                            LevelChecked(Combust))
+                        {
+                            //Grab current DoT via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
+                            uint dot = OriginalHook(Combust);
+                            Status? dotDebuff = FindTargetEffect(CombustList[dot]);
+                            if (((dotDebuff is null) || (dotDebuff.RemainingTime <= 3)) &&
+                                (GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_CombustOption)))
+                                return dot;
 
-                        if ((CombustDebuffID is null || CombustDebuffID?.RemainingTime <= 3) &&
-                            (GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_CombustOption))
-                           ) return OriginalHook(Combust1);
-
-                        //AlterateMode idles as Malefic
-                        if (AlternateMode) return OriginalHook(Malefic1);
+                            //AlterateMode idles as Malefic
+                            if (AlternateMode) return OriginalHook(Malefic);
+                        }
                     }
                 }
                 return actionID;
@@ -386,21 +360,19 @@ namespace XIVSlothCombo.Combos.PvE
                         return Helios;
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_LazyLady) &&
-                        LevelChecked(CrownPlay) &&
+                        LevelChecked(MinorArcana) &&
                         InCombat() &&
-                        Gauge.DrawnCrownCard == CardType.LADY
-                       ) return LadyOfCrown;
+                        Gauge.DrawnCrownCard is CardType.LADY)
+                        return OriginalHook(MinorArcana);
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_CelestialOpposition) &&
-                        LevelChecked(CelestialOpposition) &&
-                        IsOffCooldown(CelestialOpposition)
-                       ) return CelestialOpposition;
+                        ActionReady(CelestialOpposition))
+                        return CelestialOpposition;
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Horoscope))
                     {
-                        if (LevelChecked(Horoscope) &&
-                            IsOffCooldown(Horoscope)
-                           ) return Horoscope;
+                        if (ActionReady(Horoscope))
+                            return Horoscope;
 
                         if ((LevelChecked(AspectedHelios) && !HasEffect(Buffs.AspectedHelios))
                              || HasEffect(Buffs.Horoscope)
@@ -419,20 +391,16 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
+        //Works With AST_Cards_DrawOnPlay as a feature, or by itself if AST_Cards_DrawOnPlay is disabled.
+        //Do not do ConflictingCombos with AST_Cards_DrawOnPlay
         internal class AST_Cards_AstrodyneOnPlay : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_Cards_AstrodyneOnPlay;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID == Play && !IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay))
-                {
-                    if (!Gauge.ContainsSeal(SealType.NONE))
-                        return Astrodyne;
-                }
-                return actionID;
-
-            }
+                => actionID is Play && !IsEnabled(CustomComboPreset.AST_Cards_DrawOnPlay) && !Gauge.ContainsSeal(SealType.NONE)
+                    ? Astrodyne
+                    : actionID;
         }
 
         internal class AST_ST_SimpleHeals : CustomCombo
@@ -448,25 +416,22 @@ namespace XIVSlothCombo.Combos.PvE
                         Status? NeutralSectShield = FindTargetEffect(Buffs.NeutralSectShield);
                         Status? NeutralSectBuff = FindTargetEffect(Buffs.NeutralSect);
                         if ((aspectedBeneficHoT is null) || (aspectedBeneficHoT.RemainingTime <= 3)
-                            || ((NeutralSectShield is null) && (NeutralSectBuff is not null))
-                           ) return AspectedBenefic;
+                            || ((NeutralSectShield is null) && (NeutralSectBuff is not null)))
+                            return AspectedBenefic;
                     }
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity) &&
-                        LevelChecked(EssentialDignity) &&
-                        GetCooldown(EssentialDignity).RemainingCharges > 0 &&
-                        GetTargetHPPercent() <= GetOptionValue(Config.AST_EssentialDignity)
-                       ) return EssentialDignity;
+                        ActionReady(EssentialDignity) &&
+                        GetTargetHPPercent() <= GetOptionValue(Config.AST_EssentialDignity))
+                        return EssentialDignity;
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Exaltation) &&
-                        LevelChecked(Exaltation) &&
-                        IsOffCooldown(Exaltation)
-                       ) return Exaltation;
+                        ActionReady(Exaltation))
+                        return Exaltation;
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_CelestialIntersection) &&
-                        LevelChecked(CelestialIntersection) &&
-                        GetCooldown(CelestialIntersection).RemainingCharges > 0
-                       ) return CelestialIntersection;
+                        ActionReady(CelestialIntersection))
+                        return CelestialIntersection;
                 }
                 return actionID;
             }


### PR DESCRIPTION
Everything but 6.2 changes to Crown Play / Minor Arcana / X of Crowns was tested weeks back. Marking as "ready" for beta merging.

AST
- Sorting of Action IDs
- Malefic1 -> Malefic
- Malefic Action Group and Combust Dictionary added
- CrownPlay Action Removed
- Lord/Lady action IDs commented out. OriginalHook-ing should do the trick
- CrownPlay to Minor Arcana Feature Removed (6.2 change. Minor Archana goes straight to card)
- LevelChecked/ActionReady everything else