### PR TITLE
[AST] 6.2 Changes Only

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -206,7 +206,7 @@ namespace XIVSlothCombo.Combos
             AST_DPS_Astrodyne = 1009,
 
             [ParentCombo(AST_ST_DPS)]
-            [CustomComboInfo("Crown Card Draw Weave Option", "Adds Auto Crown Card Draw", AST.JobID, 7, "", "")]
+            [CustomComboInfo("Minor Arcana Weave Option", "Adds Minor Arcana", AST.JobID, 7, "", "")]
             AST_DPS_AutoCrownDraw = 1012,
 
             [ParentCombo(AST_ST_DPS)]
@@ -294,10 +294,6 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(AST_Cards_DrawOnPlay)]
             [CustomComboInfo("Target Focus Feature", "Once you've played your card, switch back to your focus target.", AST.JobID)]
             AST_Cards_DrawOnPlay_ReFocusTarget = 1034,
-
-        [ReplaceSkill(AST.CrownPlay)]
-        [CustomComboInfo("Crown Play to Minor Arcana", "Changes Crown Play to Minor Arcana when a card is not drawn or has Lord Or Lady Buff.", AST.JobID, 17, "", "")]
-        AST_Cards_CrownPlay = 1001,
 
         [ReplaceSkill(AST.Play)]
         //Works With AST_Cards_DrawOnPlay as a feature, or by itself if AST_Cards_DrawOnPlay is disabled.

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -29,7 +29,6 @@ namespace XIVSlothCombo.Combos.PvE
             //SleeveDraw = 7448,
             Malefic4 = 16555,
             Ascend = 3603,
-            CrownPlay = 25869,
             Astrodyne = 25870,
             FallMalefic = 25871,
             Malefic1 = 3596,
@@ -246,22 +245,6 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class AST_Cards_CrownPlay : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_Cards_CrownPlay;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID == CrownPlay)
-                {
-                    if (LevelChecked(MinorArcana) && Gauge.DrawnCrownCard == CardType.NONE)
-                        return MinorArcana;
-                }
-
-                return actionID;
-            }
-        }
-
         internal class AST_Benefic : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.AST_Benefic;
@@ -334,20 +317,12 @@ namespace XIVSlothCombo.Combos.PvE
                         CanSpellWeave(actionID)
                        ) return Draw;
 
-                    //Minor Arcana
-                    if (IsEnabled(CustomComboPreset.AST_DPS_AutoCrownDraw) &&
-                        LevelChecked(MinorArcana) &&
-                        Gauge.DrawnCrownCard == CardType.NONE &&
-                        IsOffCooldown(MinorArcana) &&
-                        CanSpellWeave(actionID)
-                       ) return MinorArcana;
-
-                    //Lord of Crowns
-                    if (IsEnabled(CustomComboPreset.AST_DPS_LazyLord) &&
-                        LevelChecked(CrownPlay) &&
-                        Gauge.DrawnCrownCard is CardType.LORD &&
-                        CanSpellWeave(actionID)
-                       ) return LordOfCrowns;
+                   //Minor Arcana / Lord of Crowns
+                    if (ActionReady(OriginalHook(MinorArcana)) &&
+                        ((IsEnabled(CustomComboPreset.AST_DPS_AutoCrownDraw) && Gauge.DrawnCrownCard is CardType.NONE) ||
+                        (IsEnabled(CustomComboPreset.AST_DPS_LazyLord) && Gauge.DrawnCrownCard is CardType.LORD && HasBattleTarget())) &&
+                        CanSpellWeave(actionID))
+                        return OriginalHook(MinorArcana);
 
                     //Combust
                     if (IsEnabled(CustomComboPreset.AST_ST_DPS_CombustUptime) &&
@@ -386,10 +361,10 @@ namespace XIVSlothCombo.Combos.PvE
                         return Helios;
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_LazyLady) &&
-                        LevelChecked(CrownPlay) &&
+                        LevelChecked(MinorArcana) &&
                         InCombat() &&
-                        Gauge.DrawnCrownCard == CardType.LADY
-                       ) return LadyOfCrown;
+                        Gauge.DrawnCrownCard is CardType.LADY)
+                        return OriginalHook(MinorArcana);
 
                     if (IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_CelestialOpposition) &&
                         LevelChecked(CelestialOpposition) &&


### PR DESCRIPTION
Removed `Crown Play to Minor Arcana` (deprecated)
Combined `Minor Arcana` / `Lord of Crowns` in `DPS Feature`
Updated `Aspected Helios Feature` for 6.2 changes
Updated feature/option descriptions