### PR TITLE
Unbreaking merge problems

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -500,6 +500,26 @@ namespace XIVSlothCombo.Combos
         [BlueInactive(BLU.SonicBoom, BLU.SharpenedKnife)]
         [CustomComboInfo("Sonic Boom Melee Feature", "Turns Sonic Boom into Sharpened Knife when in melee range.", BLU.JobID)]
         BLU_MeleeCombo = 70016,
+
+        [BlueInactive(BLU.MatraMagic)]
+        [ParentCombo(BLU_PrimalCombo)]
+        [CustomComboInfo("Matra Magic Option", "Adds Matra Magic to the Primal Feature.", BLU.JobID)]
+        BLU_PrimalCombo_Matra = 70017,
+
+        [BlueInactive(BLU.Surpanakha)]
+        [ParentCombo(BLU_PrimalCombo)]
+        [CustomComboInfo("Surpanakha Option", "Adds Surpanakha to the Primal Feature.", BLU.JobID)]
+        BLU_PrimalCombo_Suparnakha = 70018,
+
+        [BlueInactive(BLU.PhantomFlurry)]
+        [ParentCombo(BLU_PrimalCombo)]
+        [CustomComboInfo("Phantom Flurry Option", "Adds Phantom Flurry to the Primal Feature.", BLU.JobID)]
+        BLU_PrimalCombo_PhantomFlurry = 70019,
+
+        [BlueInactive(BLU.Nightbloom, BLU.Bristle)]
+        [ParentCombo(BLU_PrimalCombo)]
+        [CustomComboInfo("Nightbloom Option", "Adds Nightbloom to the Primal Feature.", BLU.JobID)]
+        BLU_PrimalCombo_Nightbloom = 70020,
         #endregion
 
         #region BARD

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1214,6 +1214,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Lightning Shot Uptime", "Adds Lightning Shot to the main combo when you are out of range.", GNB.JobID, 0, "", "")]
         GNB_RangedUptime = 7015,
 
+        [ConflictingCombos(GNB_NoMercy_Cooldowns)]
         [ParentCombo(GNB_AoE_MainCombo)]
         [CustomComboInfo("No Mercy AoE Option", "Adds No Mercy to AoE combo when it's available.", GNB.JobID, 0, "", "")]
         GNB_AoE_NoMercy = 7016,
@@ -1222,6 +1223,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Bow Shock on AoE Feature", "Adds Bow Shock onto the AoE combo when it's off cooldown.", GNB.JobID, 0, "", "")]
         GNB_AoE_BowShock = 7017,
 
+        [ConflictingCombos(GNB_NoMercy_Cooldowns)]
         [ParentCombo(GNB_ST_MainCombo_CooldownsGroup)]
         [CustomComboInfo("No Mercy on Main Combo", "Adds No Mercy to the main combo when at full ammo.", GNB.JobID, 0, "", "")]
         GNB_ST_NoMercy = 7018,
@@ -1238,8 +1240,9 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Sonic Break on Main Combo", "Adds Sonic Break to the main combo.", GNB.JobID, 0, "", "")]
         GNB_ST_SonicBreak = 7021,
 
+        [ConflictingCombos(GNB_ST_NoMercy, GNB_AoE_NoMercy)]
         [ReplaceSkill(GNB.NoMercy)]
-        [CustomComboInfo("Sonic Break/Bow Shock on No Mercy", "Adds Sonic Break and Bow Shock to No Mercy when it is on cooldown.", GNB.JobID, 0, "", "")]
+        [CustomComboInfo("Cooldowns on No Mercy", "Adds Cooldowns to No Mercy when No Mercy is on cooldown.", GNB.JobID, 0, "", "")]
         GNB_NoMercy_Cooldowns = 7022,
 
         [ParentCombo(GNB_ST_MainCombo_CooldownsGroup)]

--- a/XIVSlothCombo/Combos/PvE/BLU.cs
+++ b/XIVSlothCombo/Combos/PvE/BLU.cs
@@ -94,7 +94,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is MoonFlute or Whistle)
+                if (actionID is MoonFlute)
                 {
                     //If Triple Trident is saved for Crit/Det builds
                     if (GetCooldownRemainingTime(TripleTrident) <= 3 && IsSpellActive(TripleTrident))
@@ -130,6 +130,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return RoseOfDestruction;
                     if (IsOffCooldown(FeatherRain) && IsSpellActive(FeatherRain))
                         return FeatherRain;
+                    if (IsOffCooldown(Eruption) && IsSpellActive(Eruption))
+                        return Eruption;
                     if (!HasEffect(Buffs.Bristle) && IsOffCooldown(All.Swiftcast) && IsSpellActive(Bristle))
                         return Bristle;
                     if (IsOffCooldown(All.Swiftcast) && LevelChecked(All.Swiftcast))
@@ -160,6 +162,10 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     if (IsEnabled(CustomComboPreset.BLU_SoloMode) && HasCondition(ConditionFlag.BoundByDuty) && !HasEffect(Buffs.BasicInstinct) && GetPartyMembers().Length == 0 && IsSpellActive(BasicInstinct))
                         return BasicInstinct;
+                    if (!HasEffect(Buffs.Whistle) && IsSpellActive(Whistle) && !WasLastAction(Whistle))
+                        return Whistle;
+                    if (!HasEffect(Buffs.Tingle) && IsSpellActive(Tingle) && !WasLastSpell(Tingle))
+                        return Tingle;
                     if (!HasEffect(Buffs.MoonFlute) && !WasLastSpell(MoonFlute) && IsSpellActive(MoonFlute))
                         return MoonFlute;
                     if (IsEnabled(CustomComboPreset.BLU_Primals))
@@ -168,18 +174,16 @@ namespace XIVSlothCombo.Combos.PvE
                             return RoseOfDestruction;
                         if (IsOffCooldown(FeatherRain) && IsSpellActive(FeatherRain))
                             return FeatherRain;
+                        if (IsOffCooldown(Eruption) && IsSpellActive(Eruption))
+                            return Eruption;
+                        if (IsOffCooldown(MatraMagic) && IsSpellActive(MatraMagic))
+                            return MatraMagic;
                         if (IsOffCooldown(GlassDance) && IsSpellActive(GlassDance))
                             return GlassDance;
-                        if (IsOffCooldown(JKick) && IsSpellActive(JKick))
-                            return JKick;
+                        if (IsOffCooldown(ShockStrike) && IsSpellActive(ShockStrike))
+                            return ShockStrike;
                     }
 
-                    if (!HasEffect(Buffs.Tingle) && IsSpellActive(Tingle) && !WasLastSpell(Tingle))
-                        return Tingle;
-                    if (IsOffCooldown(ShockStrike) && IsEnabled(CustomComboPreset.BLU_Primals) && IsSpellActive(ShockStrike))
-                        return ShockStrike;
-                    if (!HasEffect(Buffs.Whistle) && IsSpellActive(Whistle) && !WasLastAction(Whistle))
-                        return Whistle;
                     if (IsOffCooldown(All.Swiftcast) && LevelChecked(All.Swiftcast))
                         return All.Swiftcast;
                     if (IsSpellActive(FinalSting))
@@ -230,7 +234,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return BadBreath;
                     if (IsOffCooldown(Devour) && HasEffect(Buffs.TankMimicry) && IsSpellActive(Devour))
                         return Devour;
-                    if (IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= 9000 & LevelChecked(All.LucidDreaming))
+                    if (IsOffCooldown(All.LucidDreaming) && LocalPlayer.CurrentMp <= 9000 && LevelChecked(All.LucidDreaming))
                         return All.LucidDreaming;
                 }
 
@@ -244,39 +248,56 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is MagicHammer)
-                {
-                    if (IsOnCooldown(MagicHammer) && IsOffCooldown(All.Addle) && !TargetHasEffect(All.Debuffs.Addle) && !TargetHasEffect(Debuffs.Conked))
-                        return All.Addle;
-                }
-
-                return actionID;
+                return (actionID is MagicHammer && IsOnCooldown(MagicHammer) && IsOffCooldown(All.Addle) && !TargetHasEffect(All.Debuffs.Addle) && !TargetHasEffect(Debuffs.Conked)) ? All.Addle : actionID;
             }
         }
 
         internal class BLU_PrimalCombo : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BLU_PrimalCombo;
+            internal static bool surpanakhaReady = false;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is FeatherRain)
+                if (actionID is FeatherRain or Eruption)
                 {
-                    if (IsOffCooldown(FeatherRain) && IsSpellActive(FeatherRain) &&
-                        (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 30 || IsOffCooldown(Nightbloom)))))
-                        return FeatherRain;
-                    if (IsOffCooldown(ShockStrike) && IsSpellActive(ShockStrike) &&
-                        (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 60 || IsOffCooldown(Nightbloom)))))
-                        return ShockStrike;
-                    if (IsOffCooldown(RoseOfDestruction) && IsSpellActive(RoseOfDestruction) &&
-                        (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 30 || IsOffCooldown(Nightbloom)))))
-                        return RoseOfDestruction;
-                    if (IsOffCooldown(GlassDance) && IsSpellActive(GlassDance) &&
-                        (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 90 || IsOffCooldown(Nightbloom)))))
-                        return GlassDance;
-                    if (IsEnabled(CustomComboPreset.BLU_PrimalCombo_JKick) && IsOffCooldown(JKick) && IsSpellActive(JKick) &&
-                        (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 60 || IsOffCooldown(Nightbloom)))))
-                        return JKick;
+                    if (HasEffect(Buffs.PhantomFlurry))
+                        return OriginalHook(PhantomFlurry);
+
+                    if (!HasEffect(Buffs.PhantomFlurry))
+                    {
+                        if (IsOffCooldown(FeatherRain) && IsSpellActive(FeatherRain) &&
+                            (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 30 || IsOffCooldown(Nightbloom)))))
+                            return FeatherRain;
+                        if (IsOffCooldown(Eruption) && IsSpellActive(Eruption) &&
+                            (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 30 || IsOffCooldown(Nightbloom)))))
+                            return Eruption;
+                        if (IsOffCooldown(ShockStrike) && IsSpellActive(ShockStrike) &&
+                            (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 60 || IsOffCooldown(Nightbloom)))))
+                            return ShockStrike;
+                        if (IsOffCooldown(RoseOfDestruction) && IsSpellActive(RoseOfDestruction) &&
+                            (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 30 || IsOffCooldown(Nightbloom)))))
+                            return RoseOfDestruction;
+                        if (IsOffCooldown(GlassDance) && IsSpellActive(GlassDance) &&
+                            (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 90 || IsOffCooldown(Nightbloom)))))
+                            return GlassDance;
+                        if (IsEnabled(CustomComboPreset.BLU_PrimalCombo_JKick) && IsOffCooldown(JKick) && IsSpellActive(JKick) &&
+                            (IsNotEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) || (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Pool) && (GetCooldownRemainingTime(Nightbloom) > 60 || IsOffCooldown(Nightbloom)))))
+                            return JKick;
+                        if (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Nightbloom) && IsOffCooldown(Nightbloom) && IsSpellActive(Nightbloom))
+                            return Nightbloom;
+                        if (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Matra) && IsOffCooldown(MatraMagic) && IsSpellActive(MatraMagic))
+                            return MatraMagic;
+                        if (IsEnabled(CustomComboPreset.BLU_PrimalCombo_Suparnakha) && IsSpellActive(Surpanakha))
+                        {
+                            if (GetRemainingCharges(Surpanakha) == 4) surpanakhaReady = true;
+                            if (surpanakhaReady && GetRemainingCharges(Surpanakha) > 0) return Surpanakha;
+                            if (GetRemainingCharges(Surpanakha) == 0) surpanakhaReady = false;
+                        }
+
+                        if (IsEnabled(CustomComboPreset.BLU_PrimalCombo_PhantomFlurry) && IsOffCooldown(PhantomFlurry) && IsSpellActive(PhantomFlurry))
+                            return PhantomFlurry;
+                    }
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -169,7 +169,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if (level >= Levels.RoughDivide && IsEnabled(CustomComboPreset.GNB_ST_RoughDivide) && GetRemainingCharges(RoughDivide) > roughDivideChargesRemaining)
                             {
                                 if (IsNotEnabled(CustomComboPreset.GNB_ST_MeleeRoughDivide) ||
-                                    (IsEnabled(CustomComboPreset.GNB_ST_MeleeRoughDivide) && GetTargetDistance() <= 1 && HasEffect(Buffs.NoMercy) && IsOnCooldown(OriginalHook(DangerZone)) && IsOnCooldown(BowShock) && IsOnCooldown(Bloodfest)))
+                                    (IsEnabled(CustomComboPreset.GNB_ST_MeleeRoughDivide) && GetTargetDistance() <= 1 && HasEffect(Buffs.NoMercy) && IsOnCooldown(OriginalHook(DangerZone)) && IsOnCooldown(BowShock)))
                                     return RoughDivide;
                             }
                         }

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -74,6 +74,7 @@ namespace XIVSlothCombo.Combos.PvE
             public const string
                 SAM_ST_KenkiOvercapAmount = "SamKenkiOvercapAmount",
                 SAM_AoE_KenkiOvercapAmount = "SamAOEKenkiOvercapAmount",
+                SAM_MeikyoChoice = "SAM_MeikyoChoice",
                 SAM_FillerCombo = "SamFillerCombo";
         }
 
@@ -137,6 +138,7 @@ namespace XIVSlothCombo.Combos.PvE
                     var threeSeal = OriginalHook(Iaijutsu) == Setsugekka;
                     var meikyostacks = GetBuffStacks(Buffs.MeikyoShisui);
                     var SamFillerCombo = PluginConfiguration.GetCustomIntValue(Config.SAM_FillerCombo);
+                    var SamMeikyoChoice = PluginConfiguration.GetCustomIntValue(Config.SAM_MeikyoChoice);
                     bool openerReady = GetRemainingCharges(MeikyoShisui) == 1 && IsOffCooldown(Senei) && IsOffCooldown(Ikishoten) && GetRemainingCharges(TsubameGaeshi) == 2;
                     
                     if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_RangedUptime) && Enpi.LevelChecked() && !inEvenFiller && !inOddFiller && !InMeleeRange() && HasBattleTarget())
@@ -188,76 +190,76 @@ namespace XIVSlothCombo.Combos.PvE
                             //oGCDs
                             if (CanSpellWeave(actionID))
                             {
-                                if (gauge.Kaeshi == Kaeshi.NAMIKIRI && gauge.MeditationStacks == 3 && Shoha.LevelChecked())
+                                if (gauge.Kaeshi == Kaeshi.NAMIKIRI && gauge.MeditationStacks == 3)
                                     return Shoha;
 
                                 if (twoSeal && gauge.MeditationStacks == 0 && GetCooldownRemainingTime(Ikishoten) < 110 && IsOnCooldown(Ikishoten))
                                 {
-                                    if (gauge.Kenki >= 10 && IsOffCooldown(Gyoten) && Gyoten.LevelChecked())
+                                    if (gauge.Kenki >= 10 && IsOffCooldown(Gyoten))
                                         return Gyoten;
 
-                                    if (gauge.Kenki >= 25 && Shinten.LevelChecked())
+                                    if (gauge.Kenki >= 25)
                                         return Shinten;
                                 }
 
-                                if (twoSeal && IsOffCooldown(Ikishoten) && Ikishoten.LevelChecked())
+                                if (twoSeal && IsOffCooldown(Ikishoten))
                                     return Ikishoten;
 
                                 if (gauge.Kenki >= 25)
                                 {
-                                    if (oneSeal && GetRemainingCharges(MeikyoShisui) == 0 && oneSeal && Shinten.LevelChecked())
+                                    if (oneSeal && GetRemainingCharges(MeikyoShisui) == 0 && oneSeal)
                                         return Shinten;
 
-                                    if (GetRemainingCharges(MeikyoShisui) == 1 && IsOffCooldown(Senei) && (gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Sen == Sen.NONE) && Senei.LevelChecked())
+                                    if (GetRemainingCharges(MeikyoShisui) == 1 && IsOffCooldown(Senei) && (gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Sen == Sen.NONE))
                                         return Senei;
                                 }
 
-                                if (gauge.Sen == Sen.NONE && GetRemainingCharges(MeikyoShisui) == 1 && MeikyoShisui.LevelChecked())
+                                if (gauge.Sen == Sen.NONE && GetRemainingCharges(MeikyoShisui) == 1)
                                     return MeikyoShisui;
 
-                                if (gauge.Kenki >= 25 && IsOnCooldown(Shoha) && Shinten.LevelChecked())
+                                if (gauge.Kenki >= 25 && IsOnCooldown(Shoha))
                                     return Shinten;
                             }
 
                             //GCDs
                             if ((twoSeal && lastComboMove == Yukikaze) ||
                                 (threeSeal && (GetRemainingCharges(MeikyoShisui) == 1 || !HasEffect(Buffs.OgiNamikiriReady))) ||
-                                (oneSeal && !TargetHasEffect(Debuffs.Higanbana) && GetRemainingCharges(TsubameGaeshi) == 1) && Iaijutsu.LevelChecked())
+                                (oneSeal && !TargetHasEffect(Debuffs.Higanbana) && GetRemainingCharges(TsubameGaeshi) == 1))
                                 return OriginalHook(Iaijutsu);
 
                             if ((gauge.Kaeshi == Kaeshi.NAMIKIRI) ||
-                                (oneSeal && TargetHasEffect(Debuffs.Higanbana) && HasEffect(Buffs.OgiNamikiriReady)) && OgiNamikiri.LevelChecked())
+                                (WasLastWeaponskill(Higanbana) && HasEffect(Buffs.OgiNamikiriReady)))
                                 return OriginalHook(OgiNamikiri);
 
-                            if (gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Kaeshi == Kaeshi.GOKEN && TsubameGaeshi.LevelChecked())
+                            if (gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Kaeshi == Kaeshi.GOKEN)
                                 return OriginalHook(TsubameGaeshi);
 
                             //1-2-3 Logic
-                            if (lastComboMove == Hakaze && Yukikaze.LevelChecked())
+                            if (lastComboMove == Hakaze)
                                 return Yukikaze;
 
-                            if (twoSeal && gauge.MeditationStacks == 0 && TargetHasEffect(Debuffs.Higanbana) && Hakaze.LevelChecked())
+                            if (twoSeal && gauge.MeditationStacks == 0 && TargetHasEffect(Debuffs.Higanbana))
                                 return Hakaze;
 
-                            if (meikyostacks == 3 && Gekko.LevelChecked())
+                            if (meikyostacks == 3)
                                 return Gekko;
 
-                            if (meikyostacks == 2 && Kasha.LevelChecked())
+                            if (meikyostacks == 2 && !HasEffect(Buffs.OgiNamikiriReady) && gauge.Kaeshi == Kaeshi.NONE)
                                 return Kasha;
 
                             if (meikyostacks == 1)
                             {
-                                if (GetCooldownRemainingTime(Ikishoten) > 110 && Yukikaze.LevelChecked())
+                                if (GetCooldownRemainingTime(Ikishoten) > 110)
                                     return Yukikaze;
 
-                                if (gauge.MeditationStacks == 0 || !HasEffect(Buffs.OgiNamikiriReady) && Gekko.LevelChecked())
+                                if (gauge.MeditationStacks == 0 || !HasEffect(Buffs.OgiNamikiriReady))
                                     return Gekko;
                             }
 
                             if (GetRemainingCharges(TsubameGaeshi) == 0)
                                 inOpener = false;
 
-                            if ((lastComboMove == Yukikaze && oneSeal) || (lastComboMove is Hakaze && (threeSeal || gauge.Sen is Sen.SETSU)) || combatDuration.Seconds > 30)
+                            if ((lastComboMove == Yukikaze && oneSeal) || (lastComboMove is Hakaze && (threeSeal || gauge.Sen is Sen.SETSU)) || CombatEngageDuration().TotalSeconds > 35)
                             {
                                 inOpener = false;
                                 nonOpener = true;
@@ -423,16 +425,41 @@ namespace XIVSlothCombo.Combos.PvE
                                 //oGCDs
                                 if (CanSpellWeave(actionID))
                                 {
-                                    //Senei Features
-                                    if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_Senei) && gauge.Kenki >= 25 && IsOffCooldown(Senei) && Senei.LevelChecked())
+                                    //Meikyo Features
+                                    if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_MeikyoShisui) && MeikyoShisui.LevelChecked() && !meikyoBuff && GetRemainingCharges(MeikyoShisui) > 0)
                                     {
-                                        if (IsNotEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_Senei_Burst))
-                                            return Senei;
-
-                                        if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_Senei_Burst))
+                                        if (CombatEngageDuration().TotalSeconds <= 10 ||
+                                            (CombatEngageDuration().TotalSeconds > 10 &&
+                                            ((SamMeikyoChoice is 0 or 1 && !WasLastWeaponskill(Shifu) && !WasLastWeaponskill(Jinpu) && !(lastComboMove is Hakaze && !gauge.Sen.HasFlag(Sen.SETSU) && HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))) ||
+                                            (SamMeikyoChoice is 2 && (comboTime is 0.0f || WasLastWeaponskill(Yukikaze))))))
                                         {
-                                            if (hasDied || nonOpener || GetCooldownRemainingTime(Ikishoten) <= 100 || ((gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Sen == Sen.NONE) && GetDebuffRemainingTime(Debuffs.Higanbana) <= 10))
+                                            if (IsNotEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_MeikyoShisui_Burst))
+                                                return MeikyoShisui;
+
+                                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_MeikyoShisui_Burst))
+                                            {
+                                                if (hasDied || nonOpener || GetRemainingCharges(MeikyoShisui) == 2 || (gauge.Kaeshi == Kaeshi.NONE && gauge.Sen == Sen.NONE && GetDebuffRemainingTime(Debuffs.Higanbana) <= 15))
+                                                    return MeikyoShisui;
+                                            }
+                                        }
+                                    }
+
+                                    //Senei Features
+                                    if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_Senei) && gauge.Kenki >= 25 && IsOffCooldown(Senei))
+                                    {
+                                        if (Shinten.LevelChecked() && !Senei.LevelChecked() && IsNotEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_Senei_Burst))
+                                            return Shinten;
+
+                                        if (Senei.LevelChecked())
+                                        {
+                                            if (IsNotEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_Senei_Burst))
                                                 return Senei;
+
+                                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_Senei_Burst))
+                                            {
+                                                if (hasDied || nonOpener || GetCooldownRemainingTime(Ikishoten) <= 100 || ((gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Sen == Sen.NONE) && GetDebuffRemainingTime(Debuffs.Higanbana) <= 10))
+                                                    return Senei;
+                                            }
                                         }
                                     }
 
@@ -451,19 +478,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                                         if (gauge.Kenki <= 50 && IsOffCooldown(Ikishoten))
                                             return Ikishoten;
-                                    }
-
-                                    //Meikyo Features
-                                    if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_MeikyoShisui) && MeikyoShisui.LevelChecked() && !meikyoBuff && GetRemainingCharges(MeikyoShisui) > 0)
-                                    {
-                                        if (IsNotEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_MeikyoShisui_Burst))
-                                            return MeikyoShisui;
-
-                                        if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_MeikyoShisui_Burst))
-                                        {
-                                            if (hasDied || nonOpener || GetRemainingCharges(MeikyoShisui) == 2 || (gauge.Kaeshi == Kaeshi.NONE && gauge.Sen == Sen.NONE && GetDebuffRemainingTime(Debuffs.Higanbana) <= 15))
-                                                return MeikyoShisui;
-                                        }
                                     }
 
                                     if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_Shoha) && Shoha.LevelChecked() && gauge.MeditationStacks == 3)
@@ -495,50 +509,54 @@ namespace XIVSlothCombo.Combos.PvE
 
                                         if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_OgiNamikiri_Burst))
                                         {
-                                            if (hasDied || nonOpener || (meikyostacks == 1 && GetDebuffRemainingTime(Debuffs.Higanbana) >= 45 && HasEffect(Buffs.MeikyoShisui)) || GetCooldownRemainingTime(Ikishoten) <= 105)
+                                            if (hasDied || nonOpener || (meikyostacks is 1 or 2 && GetDebuffRemainingTime(Debuffs.Higanbana) >= 45 && HasEffect(Buffs.MeikyoShisui)) || GetCooldownRemainingTime(Ikishoten) <= 105)
                                                 return OriginalHook(OgiNamikiri);
                                         }
                                     }
                                 }
                             }
-
-                            if (HasEffect(Buffs.MeikyoShisui))
-                            {
-                                if (!HasEffect(Buffs.Fugetsu) || (gauge.Sen.HasFlag(Sen.GETSU) == false && HasEffect(Buffs.Fuka)))
-                                    return Gekko;
-
-                                if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((gauge.Sen.HasFlag(Sen.KA) == false && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))
-                                    return Kasha;
-
-                                if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && gauge.Sen.HasFlag(Sen.SETSU) == false && Yukikaze.LevelChecked())
-                                    return Yukikaze;
-                            }
                         }
                     }
 
-                    if (comboTime > 0 && !inOpener)
+                    if (!inOpener)
                     {
-                        if (lastComboMove == Hakaze && Jinpu.LevelChecked())
+                        if (HasEffect(Buffs.MeikyoShisui))
                         {
-                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU) && Yukikaze.LevelChecked() && HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
+                            if (!HasEffect(Buffs.Fugetsu) || (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)))
+                                return Gekko;
+
+                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))
+                                return Kasha;
+
+                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU))
                                 return Yukikaze;
-
-                            if ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka)) || !HasEffect(Buffs.Fugetsu))) ||
-                               (Kasha.LevelChecked() && (!HasEffect(Buffs.Fugetsu) || (HasEffect(Buffs.Fuka) && !gauge.Sen.HasFlag(Sen.GETSU)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka))))))
-                                return Jinpu;
-
-                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && LevelChecked(Shifu) &&
-                                ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka))) ||
-                                (Kasha.LevelChecked() && (!HasEffect(Buffs.Fuka) || (HasEffect(Buffs.Fugetsu) && !gauge.Sen.HasFlag(Sen.KA)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)))))))
-                                return Shifu;
                         }
 
-                        if (lastComboMove == Jinpu && Gekko.LevelChecked())
-                            return Gekko;
+                        if (comboTime > 0)
+                        {
+                            if (lastComboMove == Hakaze && Jinpu.LevelChecked())
+                            {
+                                if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU) && Yukikaze.LevelChecked() && HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
+                                    return Yukikaze;
 
-                        if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && lastComboMove == Shifu && Kasha.LevelChecked())
-                            return Kasha;
+                                if ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka)) || !HasEffect(Buffs.Fugetsu))) ||
+                                   (Kasha.LevelChecked() && (!HasEffect(Buffs.Fugetsu) || (HasEffect(Buffs.Fuka) && !gauge.Sen.HasFlag(Sen.GETSU)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka))))))
+                                    return Jinpu;
+
+                                if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && LevelChecked(Shifu) &&
+                                    ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka))) ||
+                                    (Kasha.LevelChecked() && (!HasEffect(Buffs.Fuka) || (HasEffect(Buffs.Fugetsu) && !gauge.Sen.HasFlag(Sen.KA)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)))))))
+                                    return Shifu;
+                            }
+
+                            if (lastComboMove == Jinpu && Gekko.LevelChecked())
+                                return Gekko;
+
+                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && lastComboMove == Shifu && Kasha.LevelChecked())
+                                return Kasha;
+                        }
                     }
+
 
                     return Hakaze;
                 }
@@ -693,14 +711,8 @@ namespace XIVSlothCombo.Combos.PvE
                     var gauge = GetJobGauge<SAMGauge>();
                     var SamAOEKenkiOvercapAmount = PluginConfiguration.GetCustomIntValue(Config.SAM_AoE_KenkiOvercapAmount);
 
-                    if (CanWeave(actionID))
-                    {
-                        if (IsEnabled(CustomComboPreset.SAM_AoE_Overcap) && IsNotEnabled(CustomComboPreset.SAM_AoE_OkaCombo_TwoTarget) && gauge.Kenki >= SamAOEKenkiOvercapAmount && Kyuten.LevelChecked())
-                            return Kyuten;
-                            
-                        if (!HasEffect(Buffs.MeikyoShisui) && GetRemainingCharges(MeikyoShisui) > 0 && LevelChecked(MeikyoShisui))
-                            return MeikyoShisui;
-                    }
+                    if (IsEnabled(CustomComboPreset.SAM_AoE_Overcap) && IsNotEnabled(CustomComboPreset.SAM_AoE_OkaCombo_TwoTarget) && gauge.Kenki >= SamAOEKenkiOvercapAmount && Kyuten.LevelChecked() && CanWeave(actionID))
+                        return Kyuten;
 
                     if (HasEffect(Buffs.MeikyoShisui) && IsNotEnabled(CustomComboPreset.SAM_AoE_OkaCombo_TwoTarget))
                         return Oka;
@@ -710,6 +722,9 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (CanSpellWeave(actionID))
                         {
+                            if (!HasEffect(Buffs.MeikyoShisui) && GetRemainingCharges(MeikyoShisui) > 0 && MeikyoShisui.LevelChecked())
+                                return MeikyoShisui;
+
                             if (Senei.LevelChecked() && gauge.Kenki >= 25 && IsOffCooldown(Senei))
                                 return Senei;
 

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -122,6 +122,8 @@ namespace XIVSlothCombo.Combos.PvE
             internal static bool inEvenFiller = false;
             internal static bool nonOpener = false;
             internal static bool hasDied = false;
+            internal static bool fillerComplete = false;
+            internal static bool fastFillerReady = false;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -269,10 +271,10 @@ namespace XIVSlothCombo.Combos.PvE
                                 hasDied = true;
 
                             //Filler Features
-                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_FillerCombos) && !hasDied && !nonOpener && OgiNamikiri.LevelChecked() && combatDuration.Seconds > 50)
+                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_FillerCombos) && !hasDied && !nonOpener && OgiNamikiri.LevelChecked() && CombatEngageDuration().Minutes > 0)
                             {
-                                bool oddMinute = GetCooldownRemainingTime(Ikishoten) < 60 && gauge.Sen == Sen.NONE && !meikyoBuff && GetDebuffRemainingTime(Debuffs.Higanbana) > 45;
-                                bool evenMinute = !meikyoBuff && GetCooldownRemainingTime(Ikishoten) > 60 && gauge.Sen == Sen.NONE && GetRemainingCharges(TsubameGaeshi) == 0 && GetDebuffRemainingTime(Debuffs.Higanbana) > 42 && gauge.Kenki > 15;
+                                bool oddMinute = CombatEngageDuration().Minutes % 2 == 1 && gauge.Sen == Sen.NONE && !meikyoBuff && GetDebuffRemainingTime(Debuffs.Higanbana) > 45;
+                                bool evenMinute = !meikyoBuff && CombatEngageDuration().Minutes % 2 == 0 && gauge.Sen == Sen.NONE && GetRemainingCharges(TsubameGaeshi) == 0 && GetDebuffRemainingTime(Debuffs.Higanbana) > 42;
 
                                 if (GetDebuffRemainingTime(Debuffs.Higanbana) < 40)
                                 {
@@ -280,6 +282,8 @@ namespace XIVSlothCombo.Combos.PvE
                                     {
                                         inOddFiller = false;
                                         inEvenFiller = false;
+                                        fillerComplete = false;
+                                        fastFillerReady = false;
                                     }
                                 }
 
@@ -288,36 +292,44 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 if (inEvenFiller)
                                 {
-                                    if (hasDied || IsOnCooldown(Hagakure) || (InMeleeRange() && !HasEffect(Buffs.EnhancedEnpi)))
+                                    if (hasDied || fillerComplete)
+                                    {
                                         inEvenFiller = false;
+                                        fillerComplete = false;
+                                    }
 
                                     if (SamFillerCombo == 2)
                                     {
-                                        if (!InMeleeRange() && !HasEffect(Buffs.EnhancedEnpi) && gauge.Kenki >= 10 && Gyoten.LevelChecked())
+                                        if (WasLastAbility(Hagakure))
+                                            fillerComplete = true;
+
+                                        if (WasLastAction(Enpi) && IsOffCooldown(Gyoten))
                                             return Gyoten;
 
-                                        if (HasEffect(Buffs.EnhancedEnpi) && Enpi.LevelChecked())
+                                        if (WasLastAction(Yaten))
                                             return Enpi;
 
-                                        if (gauge.Sen == 0 && gauge.Kenki >= 10 && Yaten.LevelChecked())
+                                        if (gauge.Sen == 0 && gauge.Kenki >= 10 && CanSpellWeave(actionID) && IsOffCooldown(Yaten))
                                             return Yaten;
                                     }
 
                                     if (SamFillerCombo == 3)
                                     {
-                                        if (gauge.Kenki >= 75 && CanWeave(actionID) && Shinten.LevelChecked())
+                                        if (WasLastAbility(Hagakure))
+                                            fillerComplete = true;
+
+                                        if (gauge.Kenki >= 75 && CanWeave(actionID))
                                             return Shinten;
 
-                                        if (gauge.Sen == Sen.SETSU && Hagakure.LevelChecked())
+                                        if (gauge.Sen == Sen.SETSU)
                                             return Hagakure;
 
-                                        if (lastComboMove == Hakaze && Yukikaze.LevelChecked())
+                                        if (lastComboMove == Hakaze)
                                             return Yukikaze;
 
-                                        if (gauge.Sen == 0 && Hakaze.LevelChecked())
+                                        if (gauge.Sen == 0)
                                             return Hakaze;
                                     }
-
                                 }
 
                                 if (!inOddFiller && oddMinute)
@@ -325,67 +337,70 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 if (inOddFiller)
                                 {
-                                    if (hasDied || IsOnCooldown(Hagakure))
+                                    if (hasDied || fillerComplete)
+                                    {
+                                        fastFillerReady = false;
                                         inOddFiller = false;
+                                        fillerComplete = false;
+                                    }
 
                                     if (SamFillerCombo == 1)
                                     {
-                                        if (gauge.Kenki >= 75 && CanWeave(actionID) && Shinten.LevelChecked())
+                                        if (WasLastAbility(Hagakure))
+                                            fillerComplete = true;
+
+                                        if (gauge.Kenki >= 75 && CanWeave(actionID))
                                             return Shinten;
 
-                                        if (gauge.Sen == Sen.SETSU && Hagakure.LevelChecked())
+                                        if (gauge.Sen == Sen.SETSU)
                                             return Hagakure;
 
-                                        if (lastComboMove == Hakaze && Yukikaze.LevelChecked())
+                                        if (lastComboMove == Hakaze)
                                             return Yukikaze;
 
-                                        if (gauge.Sen == 0 && Hakaze.LevelChecked())
+                                        if (gauge.Sen == 0)
                                             return Hakaze;
                                     }
 
                                     if (SamFillerCombo == 2)
                                     {
-                                        if (gauge.Kenki >= 75 && CanWeave(actionID) && Shinten.LevelChecked())
+                                        if (WasLastAbility(Hagakure))
+                                            fillerComplete = true;
+
+                                        if (gauge.Kenki >= 75 && CanWeave(actionID))
                                             return Shinten;
 
-                                        if (gauge.Sen == Sen.GETSU && Hagakure.LevelChecked())
+                                        if (gauge.Sen == Sen.GETSU)
                                             return Hagakure;
 
-                                        if (lastComboMove == Jinpu && Gekko.LevelChecked())
+                                        if (lastComboMove == Jinpu)
                                             return Gekko;
 
-                                        if (lastComboMove == Hakaze && Jinpu.LevelChecked())
+                                        if (lastComboMove == Hakaze)
                                             return Jinpu;
 
-                                        if (gauge.Sen == 0 && Hakaze.LevelChecked())
+                                        if (gauge.Sen == 0)
                                             return Hakaze;
                                     }
 
                                     if (SamFillerCombo == 3)
                                     {
-                                        if (!InMeleeRange() && !HasEffect(Buffs.EnhancedEnpi) && gauge.Kenki >= 10 && Gyoten.LevelChecked())
-                                            return Gyoten;
+                                        if (WasLastAbility(Hagakure))
+                                            fillerComplete = true;
+                                        if (WasLastWeaponskill(Hakaze) && gauge.Sen == Sen.SETSU)
+                                            fastFillerReady = true;
 
-                                        if (gauge.Kenki >= 75 && CanWeave(actionID) && Shinten.LevelChecked())
+                                        if (gauge.Kenki >= 75 && CanWeave(actionID))
                                             return Shinten;
 
-                                        if (gauge.Sen == Sen.GETSU && Hagakure.LevelChecked())
+                                        if (gauge.Sen == Sen.SETSU && WasLastWeaponskill(Yukikaze) && fastFillerReady)
                                             return Hagakure;
 
-                                        if (lastComboMove == Jinpu && Gekko.LevelChecked())
-                                            return Gekko;
+                                        if (lastComboMove == Hakaze)
+                                            return Yukikaze;
 
-                                        if (lastComboMove == Hakaze && Jinpu.LevelChecked())
-                                            return Jinpu;
-
-                                        if (InMeleeRange() && !HasEffect(Buffs.EnhancedEnpi) && IsOnCooldown(Gyoten) && Hakaze.LevelChecked())
+                                        if (gauge.Sen == 0 || gauge.Sen == Sen.SETSU)
                                             return Hakaze;
-
-                                        if (HasEffect(Buffs.EnhancedEnpi) && Enpi.LevelChecked())
-                                            return Enpi;
-
-                                        if (gauge.Sen == 0 && gauge.Kenki >= 10 && Yaten.LevelChecked())
-                                            return Yaten;
                                     }
                                 }
                             }
@@ -505,17 +520,17 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (lastComboMove == Hakaze && Jinpu.LevelChecked())
                         {
+                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU) && Yukikaze.LevelChecked() && HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
+                                return Yukikaze;
+
                             if ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka)) || !HasEffect(Buffs.Fugetsu))) ||
-                                (Kasha.LevelChecked() && (!HasEffect(Buffs.Fugetsu) || (HasEffect(Buffs.Fuka) && gauge.Sen.HasFlag(Sen.GETSU) == false))))
+                               (Kasha.LevelChecked() && (!HasEffect(Buffs.Fugetsu) || (HasEffect(Buffs.Fuka) && !gauge.Sen.HasFlag(Sen.GETSU)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka))))))
                                 return Jinpu;
 
-                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && Shifu.LevelChecked() &&
-                                ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka))) || 
-                                (Kasha.LevelChecked() && (!HasEffect(Buffs.Fuka) || (HasEffect(Buffs.Fugetsu) && gauge.Sen.HasFlag(Sen.KA) == false)))))
+                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && LevelChecked(Shifu) &&
+                                ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka))) ||
+                                (Kasha.LevelChecked() && (!HasEffect(Buffs.Fuka) || (HasEffect(Buffs.Fugetsu) && !gauge.Sen.HasFlag(Sen.KA)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)))))))
                                 return Shifu;
-
-                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && gauge.Sen.HasFlag(Sen.SETSU) == false && Yukikaze.LevelChecked() && HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
-                                return Yukikaze;
                         }
 
                         if (lastComboMove == Jinpu && Gekko.LevelChecked())

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1361,7 +1361,7 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawHorizontalMultiChoice(RPR.Config.RPR_SoulsowOptions, "Slice", "Adds Soulsow to Slice.", 5, 1);
                 UserConfig.DrawHorizontalMultiChoice(RPR.Config.RPR_SoulsowOptions, "Spinning Scythe", "Adds Soulsow to Spinning Scythe", 5, 2);
                 UserConfig.DrawHorizontalMultiChoice(RPR.Config.RPR_SoulsowOptions, "Shadow of Death", "Adds Soulsow to Shadow of Death.", 5, 3);
-                UserConfig.DrawHorizontalMultiChoice(RPR.Config.RPR_SoulsowOptions, "Blood Stalk", "Adds Soulsow to Blood Stalk.", 5, 4);  
+                UserConfig.DrawHorizontalMultiChoice(RPR.Config.RPR_SoulsowOptions, "Blood Stalk", "Adds Soulsow to Blood Stalk.", 5, 4);
             }
             
             #endregion
@@ -1464,6 +1464,12 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.SAM_AoE_Overcap && enabled)
                 UserConfig.DrawSliderInt(0, 85, SAM.Config.SAM_AoE_KenkiOvercapAmount, "Set the Kenki overcap amount for AOE combos.");
+
+            if (preset == CustomComboPreset.SAM_ST_GekkoCombo_CDs_MeikyoShisui && enabled)
+            {
+                UserConfig.DrawHorizontalRadioButton(SAM.Config.SAM_MeikyoChoice, "Use after Hakaze/Sen Applier", "Uses Meikyo Shisui after Hakaze, Gekko, Yukikaze, or Kasha.", 1);
+                UserConfig.DrawHorizontalRadioButton(SAM.Config.SAM_MeikyoChoice,"Use outside of combo chain" ,"Uses Meikyo Shisui outside of a combo chain.", 2);
+            }
 
             //PvP
             if (preset == CustomComboPreset.SAMPvP_BurstMode && enabled)

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1477,7 +1477,7 @@ namespace XIVSlothCombo.Window.Functions
             {
                 UserConfig.DrawHorizontalRadioButton(SAM.Config.SAM_FillerCombo, "2.14+", "2 Filler GCDs", 1);
                 UserConfig.DrawHorizontalRadioButton(SAM.Config.SAM_FillerCombo, "2.06 - 2.08", "3 Filler GCDs. \nWill use Yaten into Enpi as part of filler and Gyoten back into Range.\nHakaze will be delayed by half a GCD after Enpi.", 2);
-                UserConfig.DrawHorizontalRadioButton(SAM.Config.SAM_FillerCombo, "1.99 - 2.01", "4 Filler GCDs. \nWill use Yaten into Enpi as part of filler and Gyoten back into Range. \nHakaze will be delayed by half a GCD after Enpi.", 3);
+                UserConfig.DrawHorizontalRadioButton(SAM.Config.SAM_FillerCombo, "1.99 - 2.01", "4 Filler GCDs. \nUses double Yukikaze loop.", 3);
             }
 
             #endregion


### PR DESCRIPTION
Reimplemented all the code that was lost during the borked merge.

BLU:
Re added BLU_PrimalCombo_Suparnakha, BLU_PrimalCombo_PhantomFlurry, BLU_PrimalCombo_Nightbloom to BLU_PrimalCombo.

SAM:
Re added: 
ST:
Ogi Opener logic tweak to be used before Kasha, 
Meikyo Shisui option now has two choices to use meikyo out of combo or not before Sen Appliers. Meikyo Sticker Spenders able to be used out of combat.
1-2-3 combo logic to use Yukikaze first when both buffs are up. Logic to continue combo when there are 3 sen.
Filler logic unbroken, fast SAM (1.99-2.01) uses double Yukikaze loop for its 4 GCD filler.
Senei option uses Shinten between 70 and 72
Ogi Namikiri being used during the correct even minute burst GCD.

Oka AOE:
Meikyo moved into the two target rotation feature.

GNB:
Re added:
Removed Bloodfest requirement on Rough Divide.
Changed description of GNB_NoMercy_Cooldowns and added ConflictingCombo tags