### PR TITLE
Minor Tweaks to SCH and SGE

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -171,7 +171,6 @@ namespace XIVSlothCombo.Combos
 
         #region DPS
         [ReplaceSkill(AST.Malefic, AST.Malefic2, AST.Malefic3, AST.Malefic4, AST.FallMalefic, AST.Combust, AST.Combust2, AST.Combust3, AST.Gravity, AST.Gravity2)]
-        //[ConflictingCombos(AstrologianAlternateDpsFeature)]
         [CustomComboInfo("DPS Feature", "Replaces Malefic or Combust with options below", AST.JobID, 0, "", "")]
         AST_ST_DPS = 1004,
 
@@ -2333,7 +2332,6 @@ namespace XIVSlothCombo.Combos
 
         #region Diagnosis Simple Single Target Heal
         [ReplaceSkill(SGE.Diagnosis)]
-        [ConflictingCombos(SGE_Rhizo, SGE_DruoTauro)]
         [CustomComboInfo("Single Target Heal Feature", "Supports soft-targeting.\nOptions below are in priority order", SGE.JobID, 300, "", "")]
         SGE_ST_Heal = 14300,
 
@@ -2369,6 +2367,7 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Haima Option", "Applies Haima.", SGE.JobID, 310, "", "")]
             SGE_ST_Heal_Haima = 14370,
 
+            [ConflictingCombos(SGE_Rhizo)]
             [ParentCombo(SGE_ST_Heal)]
             [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 303, "", "")]
             SGE_ST_Heal_Rhizomata = 14380,
@@ -2377,6 +2376,7 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Krasis Option", "Applies Krasis.", SGE.JobID, 308, "", "")]
             SGE_ST_Heal_Krasis = 14390,
 
+            [ConflictingCombos(SGE_DruoTauro)]
             [ParentCombo(SGE_ST_Heal)]
             [CustomComboInfo("Druochole Option", "Applies Druochole.", SGE.JobID, 301, "", "")]
             SGE_ST_Heal_Druochole = 14400,
@@ -2384,7 +2384,6 @@ namespace XIVSlothCombo.Combos
 
         #region Sage Simple AoE Heal
         [ReplaceSkill(SGE.Prognosis)]
-        [ConflictingCombos(SGE_Rhizo, SGE_DruoTauro)]
         [CustomComboInfo("AoE Heal Feature", "Customize your AoE healing to your liking.", SGE.JobID, 500, "", "")]
         SGE_AoE_Heal = 14500,
             
@@ -2423,15 +2422,15 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(SGE_AoE_Heal)]
             [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 501, "", "")]
             SGE_AoE_Heal_Rhizomata = 14580,
-            #endregion
+        #endregion
 
         #region Misc Healing
-        [ConflictingCombos(SGE_ST_Heal, SGE_AoE_Heal)]
+        [ConflictingCombos(SGE_ST_Heal_Rhizomata)]
         [ReplaceSkill(SGE.Taurochole, SGE.Druochole, SGE.Ixochole, SGE.Kerachole)]
         [CustomComboInfo("Rhizomata Feature", "Replaces Addersgall skills with Rhizomata when empty.", SGE.JobID, 600, "", "")]
         SGE_Rhizo = 14600,
 
-        [ConflictingCombos(SGE_ST_Heal, SGE_AoE_Heal)]
+        [ConflictingCombos(SGE_ST_Heal_Druochole)]
         [ReplaceSkill(SGE.Druochole)]
         [CustomComboInfo("Druochole to Taurochole Feature", "Upgrades Druochole to Taurochole when Taurochole is available.", SGE.JobID, 700, "", "")]
         SGE_DruoTauro = 14700,

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2367,7 +2367,6 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Haima Option", "Applies Haima.", SGE.JobID, 310, "", "")]
             SGE_ST_Heal_Haima = 14370,
 
-            [ConflictingCombos(SGE_Rhizo)]
             [ParentCombo(SGE_ST_Heal)]
             [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 303, "", "")]
             SGE_ST_Heal_Rhizomata = 14380,
@@ -2376,7 +2375,6 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Krasis Option", "Applies Krasis.", SGE.JobID, 308, "", "")]
             SGE_ST_Heal_Krasis = 14390,
 
-            [ConflictingCombos(SGE_DruoTauro)]
             [ParentCombo(SGE_ST_Heal)]
             [CustomComboInfo("Druochole Option", "Applies Druochole.", SGE.JobID, 301, "", "")]
             SGE_ST_Heal_Druochole = 14400,
@@ -2425,12 +2423,10 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         #region Misc Healing
-        [ConflictingCombos(SGE_ST_Heal_Rhizomata)]
         [ReplaceSkill(SGE.Taurochole, SGE.Druochole, SGE.Ixochole, SGE.Kerachole)]
         [CustomComboInfo("Rhizomata Feature", "Replaces Addersgall skills with Rhizomata when empty.", SGE.JobID, 600, "", "")]
         SGE_Rhizo = 14600,
 
-        [ConflictingCombos(SGE_ST_Heal_Druochole)]
         [ReplaceSkill(SGE.Druochole)]
         [CustomComboInfo("Druochole to Taurochole Feature", "Upgrades Druochole to Taurochole when Taurochole is available.", SGE.JobID, 700, "", "")]
         SGE_DruoTauro = 14700,

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -285,7 +285,6 @@ namespace XIVSlothCombo.Combos.PvE
                         //Ruin 2 Movement 
                         if (IsEnabled(CustomComboPreset.SCH_DPS_Ruin2Movement) &&
                             LevelChecked(Ruin2) && InCombat() &&
-                            IsOffCooldown(actionID) && //Check against actionID to stop seizure during cooldown 
                             IsMoving) return OriginalHook(Ruin2); //Who knows in the future
 
                         //AlterateMode idles as Ruin/Broil

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -258,7 +258,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Toxikon
                         bool alwaysShowToxikon = Config.SGE_ST_Dosis_Toxikon;    // False for moving only, True for Show All Times
                         if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) && InCombat() &&
-                            LevelChecked(Toxikon) && IsOffCooldown(actionID) &&  // Cooldown check against original action to stop cooldown animation seizure
+                            LevelChecked(Toxikon) &&
                             ((!alwaysShowToxikon && IsMoving) || alwaysShowToxikon) &&
                             Gauge.HasAddersting())
                             return OriginalHook(Toxikon);


### PR DESCRIPTION
SGE: Removed Conflicting Tags from ST & AOE Heal Features vs Rhizo & Dauro Features
SGE Single Target DPS - Toxikon: Removed base action cooldown check. No Seizure effect with new IsMoving
SCH Single Target DPS - Ruin 2: Removed base action cooldown check. No Seizure effect with new IsMoving