### PR TITLE
Post Raid Adjustments

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1972,7 +1972,7 @@ namespace XIVSlothCombo.Combos
         RPR_ST_SliceCombo_Enshroud = 12008,
 
         [ParentCombo(RPR_ST_SliceCombo_Enshroud)]
-        [CustomComboInfo("Enshroud Burst (Double Enshroud) Option", "Uses Enshroud at 50 Shroud during Arcane Circle (mimics the 2-minute Double Enshroud window), but will pool Shroud outside of burst windows.\nBelow level 88, will use Enshroud at 50 gauge.", RPR.JobID, 0, "", "")]
+        [CustomComboInfo("Enshroud Burst (Double Enshroud) Option", "Uses Enshroud at 50 Shroud during Arcane Circle (mimics the 2-minute Double Enshroud window) and will use Enshroud for odd minute bursts.\nBelow level 88, will use Enshroud at 50 gauge.", RPR.JobID, 0, "", "")]
         RPR_ST_SliceCombo_EnshroudPooling = 12009,
 
         [ParentCombo(RPR_ST_SliceCombo_GibbetGallows)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1265,7 +1265,7 @@ namespace XIVSlothCombo.Combos
         GNB_BurstStrike_DoubleDown = 7026,
 
         [ParentCombo(GNB_ST_RoughDivide)]
-        [CustomComboInfo("Melee Rough Divide Option", "Uses Rough Divide when under No Mercy, burst cooldowns when available, and in the target ring (1 yalm).\nWill use as many stacks as selected in the above slider.", GNB.JobID, 0, "", "")]
+        [CustomComboInfo("Melee Rough Divide Option", "Uses Rough Divide when under No Mercy, burst cooldowns when available, not moving, and in the target ring (1 yalm).\nWill use as many stacks as selected in the above slider.", GNB.JobID, 0, "", "")]
         GNB_ST_MeleeRoughDivide = 7027,
 
         [CustomComboInfo("Aurora Protection Feature", "Turns Aurora into Nascent Flash if Aurora's effect is on the player.", GNB.JobID, 0, "", "")]
@@ -2007,6 +2007,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(RPR_ST_SliceCombo_GibbetGallows_Communio)]
         [CustomComboInfo("Communio Movement Option", "Uses Shadow of Death instead of Communio when moving.", RPR.JobID, 0, "", "")]
         RPR_ST_SliceCombo_GibbetGallows_Communio_Movement = 12017,
+
+        [ParentCombo(RPR_ST_SliceCombo)]
+        [CustomComboInfo("Level 90 Opener Option", "Adds the Level 90 Opener to the main combo. Choose which Opener to use below.", RPR.JobID, -1, "", "")]
+        RPR_ST_SliceCombo_Opener = 12018,
         #endregion
 
         #region AoE (Scythe) Combo Section
@@ -2964,11 +2968,11 @@ namespace XIVSlothCombo.Combos
         WAR_InfuriateFellCleave_IRFirst = 18022,
 
         [ParentCombo(WAR_ST_StormsPath_PrimalRend)]
-        [CustomComboInfo("Primal Rend Melee Feature", "Uses Primal Rend when in the target's target ring (1 yalm) and closer otherwise will use it when buff is less than 10 seconds.", WAR.JobID, 0, "", "")]
+        [CustomComboInfo("Primal Rend Melee Feature", "Uses Primal Rend when in the target's target ring (1 yalm) and when not moving otherwise will use it when buff is less than 10 seconds.", WAR.JobID, 0, "", "")]
         WAR_ST_StormsPath_PrimalRend_CloseRange = 18023,
 
         [ParentCombo(WAR_ST_StormsPath_Onslaught)]
-        [CustomComboInfo("Melee Onslaught Option", "Uses Onslaught when under Surging Tempest and in the target ring (1 yalm).\nWill use as many stacks as selected in the above slider.", WAR.JobID, 0, "", "")]
+        [CustomComboInfo("Melee Onslaught Option", "Uses Onslaught when under Surging Tempest and in the target ring (1 yalm) and when not moving.\nWill use as many stacks as selected in the above slider.", WAR.JobID, 0, "", "")]
         WAR_ST_StormsPath_Onslaught_MeleeSpender = 18024,
 
         #endregion

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -284,7 +284,7 @@ namespace XIVSlothCombo.Combos.PvE
                     var DiveOptions = PluginConfiguration.GetCustomIntValue(Config.DRG_AOE_DiveOptions);
 
                     // Piercing Talon Uptime Option
-                    if (IsEnabled(CustomComboPreset.DRG_AoE_RangedUptime) && LevelChecked(PiercingTalon) && !InMeleeRange() && HasBattleTarget())
+                    if (IsEnabled(CustomComboPreset.DRG_AoE_RangedUptime) && LevelChecked(PiercingTalon) && GetTargetDistance() > 10 && HasBattleTarget())
                         return PiercingTalon;
 
                     if (CanWeave(actionID))

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -94,10 +94,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is FullThrust)
                 {
-                    // Piercing Talon Uptime Option
-                    if (IsEnabled(CustomComboPreset.DRG_ST_RangedUptime) && LevelChecked(PiercingTalon) && !InMeleeRange() && HasBattleTarget())
-                        return PiercingTalon;
-
                     // Lvl88+ Opener
                     if (!InCombat() && IsEnabled(CustomComboPreset.DRG_ST_Opener) && level >= 88)
                     {
@@ -108,6 +104,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (inOpener)
                             return OriginalHook(TrueThrust);
                     }
+
+                    // Piercing Talon Uptime Option
+                    if (IsEnabled(CustomComboPreset.DRG_ST_RangedUptime) && LevelChecked(PiercingTalon) && !InMeleeRange() && HasBattleTarget())
+                        return PiercingTalon;
 
                     if (InCombat())
                     {

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -149,7 +149,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                             //Blood management before Delirium
                             if (IsEnabled(CustomComboPreset.DRK_Delirium) &&
-                                ((gauge.Blood >= 70 && GetCooldownRemainingTime(BloodWeapon) is > 0 and < 3) || (gauge.Blood >= 50 && GetCooldownRemainingTime(Delirium) > 37 && !HasEffect(Buffs.Delirium))))
+                                ((gauge.Blood >= 60 && GetCooldownRemainingTime(BloodWeapon) is > 0 and < 3) || (gauge.Blood >= 50 && GetCooldownRemainingTime(Delirium) > 37 && !HasEffect(Buffs.Delirium))))
                                 return Bloodspiller;
                         }
 

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -113,7 +113,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (LevelChecked(BurstStrike) &&
                                    ((gauge.Ammo is 0 && lastComboMove is KeenEdge && CombatEngageDuration().TotalSeconds < 6 && IsOffCooldown(Bloodfest)) || //Opener Conditions
                                    (CombatEngageDuration().Minutes == 2 && GetCooldownRemainingTime(DoubleDown) < 4) || //2 min delay
-                                   (CombatEngageDuration().Minutes != 2 && gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(GnashingFang) <= 3))) //Regular NMGF
+                                   (CombatEngageDuration().Minutes != 2 && gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(GnashingFang) < 4))) //Regular NMGF
                                     return NoMercy;
                                 if (!LevelChecked(BurstStrike)) //no cartridges unlocked
                                     return NoMercy;
@@ -132,7 +132,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && LevelChecked(DangerZone) && IsOffCooldown(DangerZone) && !HasEffect(Buffs.NoMercy))
                                 {
                                     if ((IsOnCooldown(GnashingFang) && gauge.AmmoComboStep != 1 && GetCooldownRemainingTime(NoMercy) > 17) || //Post Gnashing Fang
-                                        (!LevelChecked(DangerZone) && IsOnCooldown(NoMercy))) //Pre Gnashing Fang
+                                        !LevelChecked(GnashingFang)) //Pre Gnashing Fang
                                         return OriginalHook(DangerZone);
                                 }
 

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -113,7 +113,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (LevelChecked(BurstStrike) &&
                                    ((gauge.Ammo is 0 && lastComboMove is KeenEdge && CombatEngageDuration().TotalSeconds < 6 && IsOffCooldown(Bloodfest)) || //Opener Conditions
                                    (CombatEngageDuration().Minutes == 2 && GetCooldownRemainingTime(DoubleDown) < 4) || //2 min delay
-                                   (CombatEngageDuration().Minutes != 2 && gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(GnashingFang) < 4))) //Regular NMGF
+                                   (CombatEngageDuration().Minutes != 2 && gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(GnashingFang) <= 3))) //Regular NMGF
                                     return NoMercy;
                                 if (!LevelChecked(BurstStrike)) //no cartridges unlocked
                                     return NoMercy;

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -95,27 +95,27 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
+                var gauge = GetJobGauge<GNBGauge>();
                 if (actionID == SolidBarrel)
                 {
-                    var gauge = GetJobGauge<GNBGauge>();
                     var roughDivideChargesRemaining = PluginConfiguration.GetCustomIntValue(Config.GNB_RoughDivide_HeldCharges);
-                    var quarterWeave = GetCooldown(actionID).CooldownRemaining < 1 && GetCooldown(actionID).CooldownRemaining > 0.2;
+                    var quarterWeave = GetCooldownRemainingTime(actionID) < 1 && GetCooldownRemainingTime(actionID) > 0.6;
 
-                    if (IsEnabled(CustomComboPreset.GNB_RangedUptime) && !InMeleeRange() && level > Levels.LightningShot && HasBattleTarget())
+                    if (IsEnabled(CustomComboPreset.GNB_RangedUptime) && !InMeleeRange() && LevelChecked(LightningShot) && HasBattleTarget())
                         return LightningShot;
 
                     if (comboTime > 0)
                     {
                         if (quarterWeave && IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup) && IsEnabled(CustomComboPreset.GNB_ST_NoMercy))
                         {
-                            if (level >= Levels.NoMercy && IsOffCooldown(NoMercy))
+                            if (LevelChecked(NoMercy) && IsOffCooldown(NoMercy))
                             {
-                                if (level >= Levels.BurstStrike &&
-                                    ((gauge.Ammo == 1 && IsOffCooldown(GnashingFang) && IsOffCooldown(Bloodfest)) || //Opener Conditions
-                                    (gauge.Ammo == 2 && IsOnCooldown(GnashingFang) && GetCooldownRemainingTime(Bloodfest) < 3) || //GFNM windows
-                                    gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(GnashingFang) < 2)) //Regular NMGF
+                                if (LevelChecked(BurstStrike) &&
+                                   ((gauge.Ammo is 0 && lastComboMove is KeenEdge && CombatEngageDuration().TotalSeconds < 6 && IsOffCooldown(Bloodfest)) || //Opener Conditions
+                                   (CombatEngageDuration().Minutes == 2 && GetCooldownRemainingTime(DoubleDown) < 4) || //2 min delay
+                                   (CombatEngageDuration().Minutes != 2 && gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(GnashingFang) < 4))) //Regular NMGF
                                     return NoMercy;
-                                if (level < Levels.BurstStrike) //no cartridges unlocked
+                                if (!LevelChecked(BurstStrike)) //no cartridges unlocked
                                     return NoMercy;
                             }
                         }
@@ -125,17 +125,25 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
                             {
-                                if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && gauge.Ammo == 0 && IsOffCooldown(Bloodfest) && level >= Levels.Bloodfest && IsOnCooldown(GnashingFang))
+                                if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && HasEffect(Buffs.NoMercy) && gauge.Ammo == 0 && IsOffCooldown(Bloodfest) && LevelChecked(Bloodfest) && IsOnCooldown(GnashingFang))
                                     return Bloodfest;
 
                                 //Blasting Zone outside of NM
-                                if (level >= Levels.DangerZone && IsOffCooldown(DangerZone))
+                                if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && LevelChecked(DangerZone) && IsOffCooldown(DangerZone) && !HasEffect(Buffs.NoMercy))
                                 {
-                                    if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && !HasEffect(Buffs.NoMercy) &&
-                                        ((IsOnCooldown(GnashingFang) && gauge.AmmoComboStep != 1 && GetCooldownRemainingTime(GnashingFang) > 20) || //Post Gnashing Fang
-                                        (level < Levels.GnashingFang) && IsOnCooldown(NoMercy))) //Pre Gnashing Fang
+                                    if ((IsOnCooldown(GnashingFang) && gauge.AmmoComboStep != 1 && GetCooldownRemainingTime(NoMercy) > 17) || //Post Gnashing Fang
+                                        (!LevelChecked(DangerZone) && IsOnCooldown(NoMercy))) //Pre Gnashing Fang
                                         return OriginalHook(DangerZone);
                                 }
+
+                                //Ensures Early Weave if available
+                                if (HasEffect(Buffs.NoMercy) && IsOnCooldown(DoubleDown) && IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && IsOffCooldown(DangerZone))
+                                    return OriginalHook(DangerZone);
+
+                                //Continuation
+                                if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && LevelChecked(Continuation) &&
+                                    (HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)))
+                                    return OriginalHook(Continuation);
 
                                 //60s weaves
                                 if (HasEffect(Buffs.NoMercy))
@@ -150,23 +158,18 @@ namespace XIVSlothCombo.Combos.PvE
                                     }
 
                                     //Pre DD
-                                    if (IsOnCooldown(SonicBreak) && level < Levels.DoubleDown)
+                                    if (IsOnCooldown(SonicBreak) && !LevelChecked(DoubleDown))
                                     {
-                                        if (IsEnabled(CustomComboPreset.GNB_ST_BowShock) && level >= Levels.BowShock && IsOffCooldown(BowShock))
+                                        if (IsEnabled(CustomComboPreset.GNB_ST_BowShock) && LevelChecked(BowShock) && IsOffCooldown(BowShock))
                                             return BowShock;
-                                        if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && level >= Levels.DangerZone && IsOffCooldown(DangerZone))
+                                        if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && LevelChecked(DangerZone) && IsOffCooldown(DangerZone))
                                             return OriginalHook(DangerZone);
                                     }
                                 }
                             }
 
-                            //Continuation
-                            if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && level >= Levels.Continuation &&
-                                (HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)))
-                                return OriginalHook(Continuation);
-
                             //Rough Divide Feature
-                            if (level >= Levels.RoughDivide && IsEnabled(CustomComboPreset.GNB_ST_RoughDivide) && GetRemainingCharges(RoughDivide) > roughDivideChargesRemaining)
+                            if (CanWeave(actionID) && LevelChecked(RoughDivide) && IsEnabled(CustomComboPreset.GNB_ST_RoughDivide) && GetRemainingCharges(RoughDivide) > roughDivideChargesRemaining && !IsMoving && !HasEffect(Buffs.ReadyToBlast))
                             {
                                 if (IsNotEnabled(CustomComboPreset.GNB_ST_MeleeRoughDivide) ||
                                     (IsEnabled(CustomComboPreset.GNB_ST_MeleeRoughDivide) && GetTargetDistance() <= 1 && HasEffect(Buffs.NoMercy) && IsOnCooldown(OriginalHook(DangerZone)) && IsOnCooldown(BowShock)))
@@ -175,9 +178,9 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // 60s window features
-                        if (GetCooldownRemainingTime(NoMercy) > 57 || HasEffect(Buffs.NoMercy) && IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
+                        if ((GetCooldownRemainingTime(NoMercy) > 57 || HasEffect(Buffs.NoMercy)) && IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
                         {
-                            if (level >= Levels.DoubleDown)
+                            if (LevelChecked(DoubleDown))
                             {
                                 if (IsEnabled(CustomComboPreset.GNB_ST_DoubleDown) && IsOffCooldown(DoubleDown) && gauge.Ammo >= 2 && !HasEffect(Buffs.ReadyToRip) && gauge.AmmoComboStep >= 1)
                                     return DoubleDown;
@@ -185,25 +188,25 @@ namespace XIVSlothCombo.Combos.PvE
                                     return SonicBreak;
                             }
 
-                            if (level < Levels.DoubleDown)
+                            if (!LevelChecked(DoubleDown))
                             {
-                                if (IsEnabled(CustomComboPreset.GNB_ST_SonicBreak) && level >= Levels.SonicBreak && IsOffCooldown(SonicBreak) && !HasEffect(Buffs.ReadyToRip) && IsOnCooldown(GnashingFang))
+                                if (IsEnabled(CustomComboPreset.GNB_ST_SonicBreak) && LevelChecked(SonicBreak) && IsOffCooldown(SonicBreak) && !HasEffect(Buffs.ReadyToRip) && IsOnCooldown(GnashingFang))
                                     return SonicBreak;
-
                                 //sub level 54 functionality
-                                if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && level is >= Levels.DangerZone and < Levels.SonicBreak && IsOffCooldown(DangerZone))
+                                if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && LevelChecked(DangerZone) && !LevelChecked(SonicBreak) && IsOffCooldown(DangerZone))
                                     return OriginalHook(DangerZone);
                             }
                         }
 
                         //Pre Gnashing Fang stuff
-                        if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && level >= Levels.GnashingFang)
+                        if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && LevelChecked(GnashingFang))
                         {
                             if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_Starter) && IsOffCooldown(GnashingFang) && gauge.AmmoComboStep == 0 &&
-                                ((gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(NoMercy) > 55) || //Regular 60 second GF/NM timing
+                                ((gauge.Ammo == MaxCartridges(level) && (GetCooldownRemainingTime(NoMercy) > 50 || HasEffect(Buffs.NoMercy)) && CombatEngageDuration().Minutes != 2) || //Regular 60 second GF/NM timing
+                                (gauge.Ammo == MaxCartridges(level) && (GetCooldownRemainingTime(NoMercy) > 50 || HasEffect(Buffs.NoMercy)) && CombatEngageDuration().Minutes == 2 && GetCooldownRemainingTime(DoubleDown) <= 1) || //2 min delay
+                                (gauge.Ammo == 1 && HasEffect(Buffs.NoMercy) && GetCooldownRemainingTime(DoubleDown) > 50) || //NMDDGF windows/Scuffed windows
                                 (gauge.Ammo > 0 && GetCooldownRemainingTime(NoMercy) > 17 && GetCooldownRemainingTime(NoMercy) < 35) || //Regular 30 second window                                                                        
-                                (gauge.Ammo == 3 && GetCooldownRemainingTime(Bloodfest) < 2 && GetCooldownRemainingTime(NoMercy) < 2) || //3 minute window
-                                (gauge.Ammo == 1 && GetCooldownRemainingTime(NoMercy) > 55 && ((IsOffCooldown(Bloodfest) && level >= Levels.Bloodfest) || level < Levels.Bloodfest)))) //Opener Conditions
+                                (gauge.Ammo == 1 && GetCooldownRemainingTime(NoMercy) > 50 && ((IsOffCooldown(Bloodfest) && LevelChecked(Bloodfest)) || !LevelChecked(Bloodfest))))) //Opener Conditions
                                 return GnashingFang;
                             if (gauge.AmmoComboStep is 1 or 2)
                                 return OriginalHook(GnashingFang);
@@ -211,30 +214,29 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (IsEnabled(CustomComboPreset.GNB_NoMercy_BurstStrike) && IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
                         {
-                            if ((HasEffect(Buffs.NoMercy) || HasEffect(All.Buffs.Medicated)) && gauge.AmmoComboStep == 0 && level >= Levels.BurstStrike)
+                            if (HasEffect(Buffs.NoMercy) && gauge.AmmoComboStep == 0 && LevelChecked(BurstStrike))
                             {
-                                if (level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                                if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
                                     return Hypervelocity;
-                                if (gauge.Ammo != 0 && IsOnCooldown(GnashingFang))
+                                if (gauge.Ammo != 0 && GetCooldownRemainingTime(GnashingFang) > 4)
                                     return BurstStrike;
                             }
 
                             //final check if Burst Strike is used right before No Mercy ends
-                            if (level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                            if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
                                 return Hypervelocity;
                         }
 
                         // Regular 1-2-3 combo with overcap feature
-                        if (lastComboMove == KeenEdge && level >= Levels.BrutalShell)
+                        if (lastComboMove == KeenEdge && LevelChecked(BrutalShell))
                             return BrutalShell;
-                        if (lastComboMove == BrutalShell && level >= Levels.SolidBarrel)
+                        if (lastComboMove == BrutalShell && LevelChecked(SolidBarrel))
                         {
                             if (IsEnabled(CustomComboPreset.GNB_AmmoOvercap))
                             {
-                                if (level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                                if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
                                     return Hypervelocity;
-                                if (level >= Levels.BurstStrike && (gauge.Ammo == MaxCartridges(level) ||
-                                    (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && GetCooldownRemainingTime(Bloodfest) < 6 && gauge.Ammo is not 0 and <= 2 && GetCooldownRemainingTime(NoMercy) > 10 && level >= Levels.Bloodfest))) //Burns Ammo for Bloodfest
+                                if (LevelChecked(BurstStrike) && (gauge.Ammo == MaxCartridges(level)))
                                     return BurstStrike;
                             }
 

--- a/XIVSlothCombo/Combos/PvE/RPR.cs
+++ b/XIVSlothCombo/Combos/PvE/RPR.cs
@@ -97,6 +97,7 @@ namespace XIVSlothCombo.Combos.PvE
                 int sodThreshold = PluginConfiguration.GetCustomIntValue(Config.RPR_SoDThreshold);
                 int sodRefreshRange = PluginConfiguration.GetCustomIntValue(Config.RPR_SoDRefreshRange);
                 bool trueNorthReady = GetRemainingCharges(All.TrueNorth) > 0 && !HasEffect(All.Buffs.TrueNorth);
+                bool opener = IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && CombatEngageDuration().TotalSeconds < 30 && LevelChecked(Communio);
 
                 // Gibbet and Gallows on Shadow of Death
                 if (actionID is ShadowOfDeath && IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows) && IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows_OnSoD) && soulReaver && LevelChecked(Gibbet))
@@ -134,7 +135,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.RPR_TrueNorth) && GetBuffStacks(Buffs.SoulReaver) is 2 && trueNorthReady && CanWeave(actionID))
                         return All.TrueNorth;
 
-                    if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows) && HasEffect(Buffs.SoulReaver) && LevelChecked(Gibbet))
+                    if ((IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows) || opener) && HasEffect(Buffs.SoulReaver) && LevelChecked(Gibbet))
                     {
                         if (positionalChoice is 0 or 1 or 2)
                         {
@@ -178,7 +179,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Stun) && interruptReady)
                         return All.LegSweep;
 
-                    if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_SoD) && LevelChecked(ShadowOfDeath) && !soulReaver && enemyHP > sodThreshold)
+                    if ((IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_SoD) || opener) && LevelChecked(ShadowOfDeath) && !soulReaver && enemyHP > sodThreshold)
                     {
                         if ((IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_SoD_Double) && LevelChecked(PlentifulHarvest) && enshrouded && GetCooldownRemainingTime(ArcaneCircle) < 9 &&
                             ((gauge.LemureShroud is 4 && GetDebuffRemainingTime(Debuffs.DeathsDesign) < 30) || (gauge.LemureShroud is 3 && GetDebuffRemainingTime(Debuffs.DeathsDesign) < 50))) || // Double Enshroud windows
@@ -203,15 +204,15 @@ namespace XIVSlothCombo.Combos.PvE
                         bool arcaneReady = LevelChecked(ArcaneCircle) && IsOffCooldown(ArcaneCircle);
                         bool plentifulReady = LevelChecked(PlentifulHarvest) && HasEffect(Buffs.ImmortalSacrifice);
 
-                        if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_ArcaneCircle) && arcaneReady && CanWeave(actionID))
+                        if ((IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_ArcaneCircle) || opener) && arcaneReady && CanWeave(actionID))
                             return ArcaneCircle;
-                        if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_PlentifulHarvest) && plentifulReady && GetBuffRemainingTime(Buffs.BloodsownCircle) <= 1 && !soulReaver && !enshrouded)
+                        if ((IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_PlentifulHarvest) || opener) && plentifulReady && GetBuffRemainingTime(Buffs.BloodsownCircle) <= 1 && !soulReaver && !enshrouded)
                             return PlentifulHarvest;
                     }
 
                     if (HasBattleTarget() && (deathsDesign || (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_SoD) && enemyHP < sodThreshold)))
                     {
-                        if (!soulReaver && IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Enshroud))
+                        if (!soulReaver && (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Enshroud) || opener))
                         {
                             if (!enshrouded && LevelChecked(Enshroud) && IsOffCooldown(Enshroud) && CanWeave(actionID))
                             {
@@ -230,7 +231,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (enshrouded)
                         {
-                            if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows))
+                            if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows) || opener)
                             {
                                 if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows_Communio) && gauge.LemureShroud is 1 && gauge.VoidShroud is 0 && LevelChecked(Communio))
                                     return !IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows_Communio_Movement) ? Communio : IsMoving ? ShadowOfDeath : Communio;
@@ -254,9 +255,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (!(comboTime > 0) || lastComboMove is InfernalSlice || comboTime > 10)
                         {
-                            if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GluttonyBloodStalk) && !soulReaver && !enshrouded && CanWeave(actionID) && LevelChecked(BloodStalk) && gauge.Soul >= 50)
+                            if ((IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GluttonyBloodStalk) || opener) && CanWeave(actionID) && !soulReaver && !enshrouded && LevelChecked(BloodStalk) && gauge.Soul >= 50)
                             {
-                                if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && CombatEngageDuration().TotalSeconds < 16 && LevelChecked(Communio))
+                                if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && CombatEngageDuration().TotalSeconds < 40 && IsOffCooldown(Gluttony))
                                 {
                                     if (openerChoice is 0 or 1 && gauge.Soul is 50)
                                         return Gluttony;
@@ -264,11 +265,11 @@ namespace XIVSlothCombo.Combos.PvE
                                         return Gluttony;
                                 }
 
-                                if (CombatEngageDuration().TotalSeconds >= 16 || !LevelChecked(Communio))
+                                if (CombatEngageDuration().TotalSeconds >= 10 || !LevelChecked(Communio))
                                 {
                                     if (IsOffCooldown(Gluttony) && LevelChecked(Gluttony))
                                         return Gluttony;
-                                    if (!LevelChecked(Gluttony) || gauge.Soul is 100 || GetCooldownRemainingTime(Gluttony) >= 15)
+                                    if (!LevelChecked(Gluttony) || gauge.Soul is 100 || GetCooldownRemainingTime(Gluttony) >= 25)
                                         return OriginalHook(BloodStalk);
                                 }
                             }
@@ -279,7 +280,7 @@ namespace XIVSlothCombo.Combos.PvE
                             {
                                 if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_SoulSlice) && !enshrouded && !soulReaver && gauge.Soul <= 50)
                                     return SoulSlice;
-                                if (CombatEngageDuration().TotalSeconds < 16 && IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && LevelChecked(Communio))
+                                if (opener)
                                 {
                                     if (openerChoice is 0 or 1 && gauge.Soul <= 50)
                                         return SoulSlice;

--- a/XIVSlothCombo/Combos/PvE/RPR.cs
+++ b/XIVSlothCombo/Combos/PvE/RPR.cs
@@ -76,6 +76,7 @@ namespace XIVSlothCombo.Combos.PvE
                 RPR_PositionalChoice = "RPRPositionChoice",
                 RPR_SoDThreshold = "RPRSoDThreshold",
                 RPR_SoDRefreshRange = "RPRSoDRefreshRange",
+                RPR_OpenerChoice = "RPR_OpenerChoice",
                 RPR_SoulsowOptions = "RPRSoulsowOptions";
         }
 
@@ -92,6 +93,7 @@ namespace XIVSlothCombo.Combos.PvE
                 double playerHP = PlayerHealthPercentageHp();
                 double enemyHP = GetTargetHPPercent();
                 int positionalChoice = PluginConfiguration.GetCustomIntValue(Config.RPR_PositionalChoice);
+                int openerChoice = PluginConfiguration.GetCustomIntValue(Config.RPR_OpenerChoice);
                 int sodThreshold = PluginConfiguration.GetCustomIntValue(Config.RPR_SoDThreshold);
                 int sodRefreshRange = PluginConfiguration.GetCustomIntValue(Config.RPR_SoDRefreshRange);
                 bool trueNorthReady = GetRemainingCharges(All.TrueNorth) > 0 && !HasEffect(All.Buffs.TrueNorth);
@@ -179,9 +181,9 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_SoD) && LevelChecked(ShadowOfDeath) && !soulReaver && enemyHP > sodThreshold)
                     {
                         if ((IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_SoD_Double) && LevelChecked(PlentifulHarvest) && enshrouded && GetCooldownRemainingTime(ArcaneCircle) < 9 &&
-                            ((gauge.LemureShroud is 4 && GetDebuffRemainingTime(Debuffs.DeathsDesign) < 30) || (gauge.LemureShroud is 3 && GetDebuffRemainingTime(Debuffs.DeathsDesign) < 50))) ||    // Double Enshroud windows
-                            (GetDebuffRemainingTime(Debuffs.DeathsDesign) <= sodRefreshRange && IsOffCooldown(ArcaneCircle)) ||                                                                     // Opener condition
-                            (GetDebuffRemainingTime(Debuffs.DeathsDesign) <= sodRefreshRange && IsOnCooldown(ArcaneCircle)))                                                                        // Non-2-minute windows  
+                            ((gauge.LemureShroud is 4 && GetDebuffRemainingTime(Debuffs.DeathsDesign) < 30) || (gauge.LemureShroud is 3 && GetDebuffRemainingTime(Debuffs.DeathsDesign) < 50))) || // Double Enshroud windows
+                            (GetDebuffRemainingTime(Debuffs.DeathsDesign) <= sodRefreshRange && IsOffCooldown(ArcaneCircle)) || // Opener condition
+                            (GetDebuffRemainingTime(Debuffs.DeathsDesign) <= sodRefreshRange && IsOnCooldown(ArcaneCircle))) // Non-2-minute windows  
                             return ShadowOfDeath;
                     }
 
@@ -201,9 +203,9 @@ namespace XIVSlothCombo.Combos.PvE
                         bool arcaneReady = LevelChecked(ArcaneCircle) && IsOffCooldown(ArcaneCircle);
                         bool plentifulReady = LevelChecked(PlentifulHarvest) && HasEffect(Buffs.ImmortalSacrifice);
 
-                        if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_ArcaneCircle) && CanWeave(actionID) && arcaneReady)
+                        if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_ArcaneCircle) && arcaneReady && CanWeave(actionID))
                             return ArcaneCircle;
-                        if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_PlentifulHarvest) && plentifulReady && GetBuffRemainingTime(Buffs.ImmortalSacrifice) < 26 && !soulReaver && !enshrouded)
+                        if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_PlentifulHarvest) && plentifulReady && GetBuffRemainingTime(Buffs.BloodsownCircle) <= 1 && !soulReaver && !enshrouded)
                             return PlentifulHarvest;
                     }
 
@@ -216,11 +218,12 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (IsNotEnabled(CustomComboPreset.RPR_ST_SliceCombo_EnshroudPooling) && gauge.Shroud >= 50)
                                     return Enshroud;
 
-                                if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_EnshroudPooling) &&
-                                    ((!LevelChecked(PlentifulHarvest) && gauge.Shroud >= 50) ||             // Before Plentiful Harvest
-                                    (HasEffectAny(Buffs.ArcaneCircle) && gauge.Shroud >= 50) ||                // Shroud in Arcane Circle
-                                    (gauge.Shroud >= 50 && GetCooldownRemainingTime(ArcaneCircle) < 8) ||   // Prep for double Enshroud
-                                    (!HasEffectAny(Buffs.ArcaneCircle) && gauge.Shroud >= 90)))                // Shroud pooling
+                                if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_EnshroudPooling) && gauge.Shroud >= 50 &&
+                                    (!LevelChecked(PlentifulHarvest) || // Before Plentiful Harvest
+                                    HasEffectAny(Buffs.ArcaneCircle) || // Shroud in Arcane Circle
+                                    GetCooldownRemainingTime(ArcaneCircle) < 8 || // Prep for double Enshroud
+                                    (!HasEffectAny(Buffs.ArcaneCircle) && GetCooldownRemainingTime(ArcaneCircle) is >= 50 and <= 65) || //Natural Odd Minute Shrouds
+                                    (!HasEffectAny(Buffs.ArcaneCircle) && gauge.Soul >= 90))) // Correction for 2 min windows
                                     return Enshroud;
                             }
                         }
@@ -251,17 +254,39 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (!(comboTime > 0) || lastComboMove is InfernalSlice || comboTime > 10)
                         {
-                            if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GluttonyBloodStalk) && !soulReaver && !enshrouded && gauge.Soul >= 50 && CanWeave(actionID) && LevelChecked(BloodStalk))
+                            if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GluttonyBloodStalk) && !soulReaver && !enshrouded && CanWeave(actionID) && LevelChecked(BloodStalk) && gauge.Soul >= 50)
                             {
-                                return gauge.Soul >= 50 && IsOffCooldown(Gluttony) && LevelChecked(Gluttony)
-                                    ? Gluttony
-                                    : OriginalHook(BloodStalk);
+                                if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && CombatEngageDuration().TotalSeconds < 16 && LevelChecked(Communio))
+                                {
+                                    if (openerChoice is 0 or 1 && gauge.Soul is 50)
+                                        return Gluttony;
+                                    if (openerChoice is 2 && WasLastAbility(Communio) && gauge.Soul is 100)
+                                        return Gluttony;
+                                }
+
+                                if (CombatEngageDuration().TotalSeconds >= 16 || !LevelChecked(Communio))
+                                {
+                                    if (IsOffCooldown(Gluttony) && LevelChecked(Gluttony))
+                                        return Gluttony;
+                                    if (!LevelChecked(Gluttony) || gauge.Soul is 100 || GetCooldownRemainingTime(Gluttony) >= 15)
+                                        return OriginalHook(BloodStalk);
+                                }
                             }
 
                             bool soulSliceReady = LevelChecked(SoulSlice) && GetRemainingCharges(SoulSlice) > 0;
 
-                            if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_SoulSlice) && !enshrouded && !soulReaver && gauge.Soul <= 50 && soulSliceReady)
-                                return SoulSlice;
+                            if (soulSliceReady && !enshrouded && !soulReaver)
+                            {
+                                if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_SoulSlice) && !enshrouded && !soulReaver && gauge.Soul <= 50)
+                                    return SoulSlice;
+                                if (CombatEngageDuration().TotalSeconds < 16 && IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && LevelChecked(Communio))
+                                {
+                                    if (openerChoice is 0 or 1 && gauge.Soul <= 50)
+                                        return SoulSlice;
+                                    if (openerChoice is 2)
+                                        return SoulSlice;
+                                }
+                            }
                         }
                     }
 

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -78,7 +78,6 @@ namespace XIVSlothCombo.Combos.PvE
                 SAM_FillerCombo = "SamFillerCombo";
         }
 
-
         internal class SAM_ST_YukikazeCombo : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SAM_ST_YukikazeCombo;
@@ -130,7 +129,6 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID == Gekko)
                 {
-                    Dalamud.Logging.PluginLog.Debug($"In Opener: {inOpener} Non Opener: {nonOpener}");
                     var gauge = GetJobGauge<SAMGauge>();
                     var SamKenkiOvercapAmount = PluginConfiguration.GetCustomIntValue(Config.SAM_ST_KenkiOvercapAmount);
                     var meikyoBuff = HasEffect(Buffs.MeikyoShisui);
@@ -208,14 +206,14 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 if (gauge.Kenki >= 25)
                                 {
-                                    if (oneSeal && GetRemainingCharges(MeikyoShisui) == 0 && oneSeal)
+                                    if (oneSeal && GetRemainingCharges(MeikyoShisui) == 0)
                                         return Shinten;
 
                                     if (GetRemainingCharges(MeikyoShisui) == 1 && IsOffCooldown(Senei) && (gauge.Kaeshi == Kaeshi.SETSUGEKKA || gauge.Sen == Sen.NONE))
                                         return Senei;
                                 }
 
-                                if (gauge.Sen == Sen.NONE && GetRemainingCharges(MeikyoShisui) == 1 && GetRemainingCharges(TsubameGaeshi) == 1)
+                                if (gauge.Sen == Sen.NONE && GetRemainingCharges(MeikyoShisui) == 1 && GetRemainingCharges(TsubameGaeshi) == 1 && !HasEffect(Buffs.MeikyoShisui))
                                     return MeikyoShisui;
 
                                 if (gauge.Kenki >= 25 && IsOnCooldown(Shoha))
@@ -276,10 +274,10 @@ namespace XIVSlothCombo.Combos.PvE
                             //Filler Features
                             if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_FillerCombos) && !hasDied && !nonOpener && OgiNamikiri.LevelChecked() && CombatEngageDuration().Minutes > 0)
                             {
-                                bool oddMinute = CombatEngageDuration().Minutes % 2 == 1 && gauge.Sen == Sen.NONE && !meikyoBuff && GetDebuffRemainingTime(Debuffs.Higanbana) > 45;
-                                bool evenMinute = !meikyoBuff && CombatEngageDuration().Minutes % 2 == 0 && gauge.Sen == Sen.NONE && GetRemainingCharges(TsubameGaeshi) == 0 && GetDebuffRemainingTime(Debuffs.Higanbana) > 42;
+                                bool oddMinute = CombatEngageDuration().Minutes % 2 == 1 && gauge.Sen == Sen.NONE && !meikyoBuff && GetDebuffRemainingTime(Debuffs.Higanbana) >= 48 && GetDebuffRemainingTime(Debuffs.Higanbana) <= 51;
+                                bool evenMinute = !meikyoBuff && CombatEngageDuration().Minutes % 2 == 0 && gauge.Sen == Sen.NONE && GetRemainingCharges(TsubameGaeshi) == 0 && GetDebuffRemainingTime(Debuffs.Higanbana) >= 44 && GetDebuffRemainingTime(Debuffs.Higanbana) <= 47;
 
-                                if (GetDebuffRemainingTime(Debuffs.Higanbana) < 40)
+                                if (GetDebuffRemainingTime(Debuffs.Higanbana) < 42)
                                 {
                                     if (inOddFiller || inEvenFiller)
                                     {
@@ -303,7 +301,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                                     if (SamFillerCombo == 2)
                                     {
-                                        if (WasLastAbility(Hagakure))
+                                        if (WasLastAbility(Gyoten))
                                             fillerComplete = true;
 
                                         if (WasLastAction(Enpi) && IsOffCooldown(Gyoten))
@@ -628,7 +626,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             //Dumps Kenki in preparation for Ikishoten
                             if (gauge.Kenki > 50 && GetCooldownRemainingTime(Ikishoten) < 10)
-                                return Guren;
+                                return Kyuten;
 
                             if (gauge.Kenki <= 50 && IsOffCooldown(Ikishoten))
                                 return Ikishoten;

--- a/XIVSlothCombo/Combos/PvE/WAR.cs
+++ b/XIVSlothCombo/Combos/PvE/WAR.cs
@@ -115,14 +115,14 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_Onslaught) && level >= Levels.Onslaught && GetRemainingCharges(Onslaught) > onslaughtChargesRemaining)
                             {
                                 if (IsNotEnabled(CustomComboPreset.WAR_ST_StormsPath_Onslaught_MeleeSpender) ||
-                                    (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_Onslaught_MeleeSpender) && GetTargetDistance() <= 1 && (GetCooldownRemainingTime(InnerRelease) > 40 || level < Levels.InnerRelease)))
+                                    (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_Onslaught_MeleeSpender) && !IsMoving && GetTargetDistance() <= 1 && (GetCooldownRemainingTime(InnerRelease) > 40 || level < Levels.InnerRelease)))
                                     return Onslaught;
                             }
                         }
 
                         if (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_PrimalRend) && HasEffect(Buffs.PrimalRendReady) && level >= Levels.PrimalRend)
                         {
-                            if (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_PrimalRend_CloseRange) && (GetTargetDistance() <= 1 || GetBuffRemainingTime(Buffs.PrimalRendReady) <= 10))
+                            if (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_PrimalRend_CloseRange) && !IsMoving && (GetTargetDistance() <= 1 || GetBuffRemainingTime(Buffs.PrimalRendReady) <= 10))
                                 return PrimalRend;
                             if (IsNotEnabled(CustomComboPreset.WAR_ST_StormsPath_PrimalRend_CloseRange))
                                 return PrimalRend;

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1363,7 +1363,13 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawHorizontalMultiChoice(RPR.Config.RPR_SoulsowOptions, "Shadow of Death", "Adds Soulsow to Shadow of Death.", 5, 3);
                 UserConfig.DrawHorizontalMultiChoice(RPR.Config.RPR_SoulsowOptions, "Blood Stalk", "Adds Soulsow to Blood Stalk.", 5, 4);
             }
-            
+
+            if (preset == CustomComboPreset.RPR_ST_SliceCombo_Opener && enabled)
+            {
+                UserConfig.DrawHorizontalRadioButton(RPR.Config.RPR_OpenerChoice, "Early Gluttony Opener ", "Uses Early Gluttony Opener.", 1);
+                UserConfig.DrawHorizontalRadioButton(RPR.Config.RPR_OpenerChoice, "Early Enshroud Opener", "Uses Early Enshroud Opener. Will Clip CD if not at 2.48-2.49.", 2);
+            }
+
             #endregion
             // ====================================================================================
             #region RED MAGE

--- a/XIVSlothCombo/XIVSlothCombo.csproj
+++ b/XIVSlothCombo/XIVSlothCombo.csproj
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<Authors>Aki, k-kz, ele-starshade, damolitionn, Taurenkey, Augporto, grimgal</Authors>
 		<Company>-</Company>
-		<Version>3.0.17.0</Version>
+		<Version>3.0.17.1</Version>
 		<!-- This is the version that will be used when pushing to the repo.-->
 		<Description>XIVCombo for lazy players</Description>
 		<Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>


### PR DESCRIPTION
GNB (Thoroughly tested through the tier):
- Bloodfest cartridge management removed.
- Adjusted opener for 1NM23GF Opener.
- Adjusted timing for 1GCD GF delay at 2 min window.
- Removed GFNM logic from 6.1.
- Added !IsMoving check to melee Rough Divide option.
- Adjusted 30 sec Danger Zones when forced to delay the skill.
- Adjusted Bloodfest burst windows with 6.2 changes.

DRK:
- Reduced Blood overcap management during Blood Weapon from 70 to 60.

DRG:
- Bugfix where Piercing Talon would deactivate the opener if it was the first ability used in combat.
- Fixed Piercing Talon Option on AOE.

RPR:
- Added Opener option that allows for Early Enshroud and Early Gluttony Openers.
- Adjusted Soul management so that Soul is pooled for Gluttony so as to stop Gluttony drift.
- Adjusted Enshroud windows for natural odd/even Enshrouds.

SAM:
- Bugfix where Enpi would deactivate the opener if it was the first ability used in combat.
- Various adjustments the opener.
- Tightened the windows that begin and end the filler windows.
- Fixed Meikyo Burst option.

WAR:
- Added !IsMoving to melee Primal Rend and Onslaught options.
