### PR TITLE
BTN/MIN Request

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3146,8 +3146,13 @@ namespace XIVSlothCombo.Combos
 
         #region DOL
 
+        [ReplaceSkill(DOL.AgelessWords, DOL.SolidReason)] 
         [CustomComboInfo("[BTN/MIN] Eureka Feature", "Replaces Ageless Words and Solid Reason with Wise to the World when available", DOL.JobID)]
         DOL_Eureka = 51001,
+
+        [ReplaceSkill(DOL.ArborCall, DOL.ArborCall2, DOL.LayOfTheLand, DOL.LayOfTheLand2)]
+        [CustomComboInfo("[BTN/MIN] Locate & Truth Feature", "Replaces Lay of the Lands or Arbor Calls with Prospect/Triangulate and Truth of Mountains/Forests if not active.", DOL.JobID)]
+        DOL_NodeSearchingBuffs = 51012,
 
         [ReplaceSkill(DOL.Cast)]
         [CustomComboInfo("[FSH] Cast to Hook Feature", "Replaces Cast with Hook when fishing", DOL.JobID)]
@@ -3195,7 +3200,7 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(FSH_Swim)]
             [CustomComboInfo("Chum to Baited Breath Option", "Replaces Chum with Baited Breath when diving.", DOL.JobID)]
             FSH_Chum_BaitedBreath = 51011,
-
+        
         #endregion
 
         #endregion

--- a/XIVSlothCombo/Combos/PvE/DOL.cs
+++ b/XIVSlothCombo/Combos/PvE/DOL.cs
@@ -14,6 +14,14 @@ namespace XIVSlothCombo.Combos.PvE
             SolidReason = 232,
             MinWiseToTheWorld = 26521,
             BtnWiseToTheWorld = 26522,
+            Prospect = 227,
+            LayOfTheLand = 228,
+            LayOfTheLand2 = 291,
+            TruthOfMountains = 238,
+            Triangulate = 210,
+            ArborCall = 211,
+            ArborCall2 = 290,
+            TruthOfForests = 221, 
             //FSH
             Cast = 289,
             Hook = 296,
@@ -39,6 +47,10 @@ namespace XIVSlothCombo.Combos.PvE
         internal static class Buffs
         {
             internal const ushort
+                TruthOfForests = 221,
+                TruthOfMountains = 222,
+                Triangulate = 217,
+                Prospect = 225,
                 EurekaMoment = 2765;
         }
 
@@ -55,6 +67,21 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is SolidReason && HasEffect(Buffs.EurekaMoment)) return MinWiseToTheWorld;
                 if (actionID is AgelessWords && HasEffect(Buffs.EurekaMoment)) return BtnWiseToTheWorld;
+                return actionID;
+            }
+        }
+
+        internal class DOL_NodeSearchingBuffs : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DOL_NodeSearchingBuffs;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                //MIN
+                if (actionID is DOL.LayOfTheLand && !HasEffect(Buffs.Prospect)) return DOL.Prospect;
+                if (actionID is DOL.LayOfTheLand2 && LevelChecked(TruthOfMountains) && !HasEffect(Buffs.TruthOfMountains)) return DOL.TruthOfMountains;
+                //BTN
+                if (actionID is DOL.ArborCall && !HasEffect(Buffs.Triangulate)) return DOL.Triangulate;
+                if (actionID is DOL.ArborCall2 && LevelChecked(TruthOfForests) && !HasEffect(Buffs.TruthOfForests)) return DOL.TruthOfForests;
                 return actionID;
             }
         }


### PR DESCRIPTION
Added feature request from Discord, where Arbor Call (I & II) become Triangulate & Truth of Forests, and Lay of the Land (I & II) become Prospect & Truth of Mountains if the buffs are not active