### PR TITLE
Monk add Meditation builder out of melee range

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1512,8 +1512,12 @@ namespace XIVSlothCombo.Combos
         MNK_ST_Simple_CDs_Brotherhood = 9016,
 
         [ParentCombo(MNK_ST_SimpleMode)]
-        [CustomComboInfo("Meditation on Main Combo", "Adds Meditation to the main combo.", MNK.JobID, 0, "", "")]
+        [CustomComboInfo("Meditation on Main Combo", "Adds Meditation spender to the main combo.", MNK.JobID, 0, "", "")]
         MNK_ST_Simple_Meditation = 9017,
+
+        [ParentCombo(MNK_ST_Simple_Meditation)]
+        [CustomComboInfo("Mediation Uptime Feature", "Replaces Main Combo with Mediation when you are out of range and out of opener/burst.", MNK.JobID, 0, "", "")]
+        MNK_ST_Meditation_Uptime = 9026,
 
         [ParentCombo(MNK_ST_SimpleMode)]
         [CustomComboInfo("Lunar Solar Opener", "Start with the Lunar Solar Opener on the main combo. Requires level 68 for Riddle of Fire.\nA 1.93/1.94 GCD is highly recommended.", MNK.JobID, 0, "", "")]

--- a/XIVSlothCombo/Combos/PvE/MNK.cs
+++ b/XIVSlothCombo/Combos/PvE/MNK.cs
@@ -556,6 +556,11 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Monk Rotation
+                    if (IsEnabled(CustomComboPreset.MNK_ST_Meditation_Uptime) && !InMeleeRange() && gauge.Chakra < 5 && LevelChecked(Meditation))
+                    {
+                        return Meditation;
+                    }
+
                     if ((level >= Levels.DragonKick && HasEffect(Buffs.OpoOpoForm)) || HasEffect(Buffs.FormlessFist))
                     {
                         return HasEffect(Buffs.LeadenFist) ? Bootshine : DragonKick;


### PR DESCRIPTION
#981 inspired me to make my first PR.

Added option to add Meditation chakra builder to Simple Single Target rotation.
![image](https://user-images.githubusercontent.com/105976933/189418741-ac151030-b5c1-4c09-bd41-fde824e0d821.png)

Will only use it out of opener/builder, and out of melee range.
Did not add to AoE due to different AoE melee ranges.