### PR TITLE
[BLM] Cleanup

### DIFF
--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -72,14 +72,14 @@ namespace XIVSlothCombo.Combos.PvE
         }
         internal static class MP
         {
-            internal const uint MaxMP = 10000;
+            internal const int MaxMP = 10000;
+            internal const int Despair = 800; //"ALL MP" spell. Only caring about the absolute minimum.
             internal static int Thunder => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Thunder));
             internal static int ThunderAoE => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Thunder2));
             internal static int Fire => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Fire));
             internal static int FireAoE => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Fire2));
             internal static int Fire3 => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Fire3));
-            internal static int Despair = 800; //"ALL MP" spell. Only caring about the absolute minimum. CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Despair));
-            internal static int Blizzard3 => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Blizzard3));
+            //internal static int Blizzard3 => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Blizzard3));
         }
 
         // Debuff Pairs of Actions and Debuff

--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -65,7 +65,7 @@ namespace XIVSlothCombo.Combos.PvE
 
         internal static class Traits
         {
-            internal static uint
+            internal const uint
                 AspectMasteryIII = 459,
                 EnhancedManafont = 463,
                 EnhancedFreeze = 295;
@@ -463,7 +463,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 }
                                 if (HasEffect(Buffs.Thundercloud))
                                 {
-                                    if (lastComboMove is not Thunder and not Thunder3 and not Thunder2 and not Thunder4 &&
+                                    if (!ThunderList.ContainsKey(lastComboMove) && //Is not 1 2 3 or 4
                                         !TargetHasEffect(Debuffs.Thunder2) && !TargetHasEffect(Debuffs.Thunder4))
                                     {
                                         uint dot = OriginalHook(Thunder); //Grab the appropriate DoT Action
@@ -499,7 +499,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Thunder uptime
                         if (IsEnabled(CustomComboPreset.BLM_Thunder) && Gauge.ElementTimeRemaining >= astralFireRefresh)
                         {
-                            if (lastComboMove is not Thunder and not Thunder3 and not Thunder2 and not Thunder4 && 
+                            if (!ThunderList.ContainsKey(lastComboMove) && 
                                 !TargetHasEffect(Debuffs.Thunder2) && !TargetHasEffect(Debuffs.Thunder4))
                             {
                                 if (HasEffect(Buffs.Thundercloud) || (IsEnabled(CustomComboPreset.BLM_ThunderUptime) && currentMP >= MP.Thunder))
@@ -910,7 +910,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Thunder
                         if (IsEnabled(CustomComboPreset.BLM_Thunder) && Gauge.ElementTimeRemaining >= astralFireRefresh)
                         {
-                            if (lastComboMove is not Thunder and not Thunder3 and not Thunder2 and not Thunder4 &&
+                            if (!ThunderList.ContainsKey(lastComboMove) &&
                                 !TargetHasEffect(Debuffs.Thunder2) && !TargetHasEffect(Debuffs.Thunder4) && thunder3Recast(4))
                             {
                                 if (HasEffect(Buffs.Thundercloud) || (IsEnabled(CustomComboPreset.BLM_ThunderUptime) && currentMP >= MP.Thunder))

--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -529,7 +529,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 }
 
                                 // Use Swiftcast in Astral Fire
-                                if (!IsEnabled(CustomComboPreset.BLM_Simple_Casts_Pooling) && level >= All.Levels.Swiftcast && IsOffCooldown(All.Swiftcast) &&
+                                if (!IsEnabled(CustomComboPreset.BLM_Simple_Casts_Pooling) && ActionReady(All.Swiftcast) &&
                                      Gauge.InAstralFire && currentMP >= MP.Fire * (HasEffect(Buffs.Triplecast) ? 3 : 1))
                                 {
                                     if (LevelChecked(Despair) && currentMP >= MP.Despair)

--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -463,7 +463,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 }
                                 if (HasEffect(Buffs.Thundercloud))
                                 {
-                                    if (lastComboMove is not Thunder or Thunder3 or Thunder2 or Thunder4 &&
+                                    if (lastComboMove is not Thunder and not Thunder3 and not Thunder2 and not Thunder4 &&
                                         !TargetHasEffect(Debuffs.Thunder2) && !TargetHasEffect(Debuffs.Thunder4))
                                     {
                                         uint dot = OriginalHook(Thunder); //Grab the appropriate DoT Action
@@ -499,7 +499,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Thunder uptime
                         if (IsEnabled(CustomComboPreset.BLM_Thunder) && Gauge.ElementTimeRemaining >= astralFireRefresh)
                         {
-                            if (lastComboMove is not Thunder or Thunder3 or Thunder2 or Thunder4 && 
+                            if (lastComboMove is not Thunder and not Thunder3 and not Thunder2 and not Thunder4 && 
                                 !TargetHasEffect(Debuffs.Thunder2) && !TargetHasEffect(Debuffs.Thunder4))
                             {
                                 if (HasEffect(Buffs.Thundercloud) || (IsEnabled(CustomComboPreset.BLM_ThunderUptime) && currentMP >= MP.Thunder))
@@ -910,7 +910,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Thunder
                         if (IsEnabled(CustomComboPreset.BLM_Thunder) && Gauge.ElementTimeRemaining >= astralFireRefresh)
                         {
-                            if (lastComboMove is not Thunder or Thunder3 or Thunder2 or Thunder4 &&
+                            if (lastComboMove is not Thunder and not Thunder3 and not Thunder2 and not Thunder4 &&
                                 !TargetHasEffect(Debuffs.Thunder2) && !TargetHasEffect(Debuffs.Thunder4) && thunder3Recast(4))
                             {
                                 if (HasEffect(Buffs.Thundercloud) || (IsEnabled(CustomComboPreset.BLM_ThunderUptime) && currentMP >= MP.Thunder))

--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -78,7 +78,7 @@ namespace XIVSlothCombo.Combos.PvE
             internal static int Fire => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Fire));
             internal static int FireAoE => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Fire2));
             internal static int Fire3 => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Fire3));
-            internal static int Despair => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Despair));
+            internal static int Despair = 800; //"ALL MP" spell. Only caring about the absolute minimum. CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Despair));
             internal static int Blizzard3 => CustomComboFunctions.GetResourceCost(CustomComboFunctions.OriginalHook(BLM.Blizzard3));
         }
 


### PR DESCRIPTION
Code Cleanup

- Various Trait IDs added.
- Level Constants removed. Substituted with `ActionReady`, `LevelChecked`, and `TraitLevelChecked`
- MP values for various actions will now be pulled from game data instead of constants (except Despair)
- `Gauge` and `HasPolyglotStacks` BLM gauge extension added
- `ThunderList` Dot Debuff Dictionary Added