### PR TITLE
Fixed Sage AoE Phlega Lucid Weaving.

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -179,7 +179,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) &&
-                        ActionReady(All.LucidDreaming) && CanSpellWeave(Dyskrasia) &&
+                        ActionReady(All.LucidDreaming) && CanSpellWeave(Dosis) &&
                         LocalPlayer.CurrentMp <= Config.SGE_AoE_Phlegma_Lucid)
                         return All.LucidDreaming;
 

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -179,7 +179,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) &&
-                        ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) &&
+                        ActionReady(All.LucidDreaming) && CanSpellWeave(Dyskrasia) &&
                         LocalPlayer.CurrentMp <= Config.SGE_AoE_Phlegma_Lucid)
                         return All.LucidDreaming;
 


### PR DESCRIPTION
Using Dosis, a regular GCD ability, instead of Phlegma, an ability with charges to compare for spellweaving.