### PR TITLE
[Bugfix/Framework] ActionWatching LastAction fixes for non-English clients

### DIFF
--- a/XIVSlothCombo/Data/ActionWatching.cs
+++ b/XIVSlothCombo/Data/ActionWatching.cs
@@ -54,15 +54,15 @@ namespace XIVSlothCombo.Data
                 ActionSheet.TryGetValue(header.ActionId, out var sheet);
                 if (sheet != null)
                 {
-                    switch (sheet.ActionCategory.Value.Name)
+                    switch (sheet.ActionCategory.Value.RowId)
                     {
-                        case "Spell":
+                        case 2: //Spell
                             LastSpell = header.ActionId;
                             break;
-                        case "Weaponskill":
+                        case 3: //Weaponskill
                             LastWeaponskill = header.ActionId;
                             break;
-                        case "Ability":
+                        case 4: //Ability
                             LastAbility = header.ActionId;
                             break;
                     }


### PR DESCRIPTION
Checking what type an action is using row ID instead of English strings.

Any weird issues with LastAbility, LastSpell, LastWeaponskill not working might've been related if user's game was not set to English. 