### PR TITLE
[NIN] Added `Dynamic True North Feature` to `Armour Crush`

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1766,7 +1766,7 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(NIN_ST_AdvancedMode_TrueNorth_ArmorCrush)]
         [CustomComboInfo("Dynamic True North", "Only triggers if not in flanking position 0.7 seconds before Armour Crush.", NIN.JobID)]
-        NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic = 10031,
+        NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic = 10067,
 
         [ParentCombo(NIN_ST_AdvancedMode)]
         [CustomComboInfo("Second Wind Option", "Adds Second Wind to Advanced Mode.", NIN.JobID)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1724,6 +1724,10 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Use Before Armor Crush Only", "Only triggers the use of True North before Armor Crush.", NIN.JobID)]
         NIN_ST_AdvancedMode_TrueNorth_ArmorCrush = 10031,
 
+        [ParentCombo(NIN_ST_AdvancedMode_TrueNorth_ArmorCrush)]
+        [CustomComboInfo("Dynamic True North", "Only triggers if not in flanking position 0.7 seconds before Armour Crush.", NIN.JobID)]
+        NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic = 10031,
+
         [ParentCombo(NIN_ST_AdvancedMode)]
         [CustomComboInfo("Second Wind Feature", "Adds Second Wind to Advanced Mode.", NIN.JobID)]
         NIN_ST_AdvancedMode_SecondWind = 10032,

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -169,6 +169,7 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     NINGauge gauge = GetJobGauge<NINGauge>();
                     bool canWeave = CanWeave(SpinningEdge);
+                    var canDelayedWeave = CanWeave(SpinningEdge      , 0.0) && GetCooldown(SpinningEdge).CooldownRemaining < 0.7;
                     bool inTrickBurstSaveWindow = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Cooldowns) && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack) ? GetCooldownRemainingTime(TrickAttack) <= GetOptionValue(Config.Advanced_Trick_Cooldown) : false;
                     bool useBhakaBeforeTrickWindow = GetCooldownRemainingTime(TrickAttack) >= 3;
                     bool inMudraState = HasEffect(Buffs.Mudra);
@@ -231,7 +232,8 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) &&
                             GetRemainingCharges(All.TrueNorth) > 0 &&
                             All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) &&
-                            canWeave)
+                            !(IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic) && OnTargetsFlank()) &&
+                            canDelayedWeave)
                             return OriginalHook(All.TrueNorth);
 
                         return OriginalHook(ArmorCrush);

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -169,7 +169,7 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     NINGauge gauge = GetJobGauge<NINGauge>();
                     bool canWeave = CanWeave(SpinningEdge);
-                    var canDelayedWeave = CanWeave(SpinningEdge      , 0.0) && GetCooldown(SpinningEdge).CooldownRemaining < 0.7;
+                    var canDelayedWeave = CanDelayedWeave(SpinningEdge);
                     bool inTrickBurstSaveWindow = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack_Cooldowns) && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrickAttack) ? GetCooldownRemainingTime(TrickAttack) <= GetOptionValue(Config.Advanced_Trick_Cooldown) : false;
                     bool useBhakaBeforeTrickWindow = GetCooldownRemainingTime(TrickAttack) >= 3;
                     bool inMudraState = HasEffect(Buffs.Mudra);
@@ -232,7 +232,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) &&
                             GetRemainingCharges(All.TrueNorth) > 0 &&
                             All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) &&
-                            !(IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic) && OnTargetsFlank()) &&
+                            !(IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic) && TargetNeedsPositionals() && OnTargetsFlank()) &&
                             canDelayedWeave)
                             return OriginalHook(All.TrueNorth);
 


### PR DESCRIPTION
Given the nature of Ninja and this feature, it doesn't make sense to add it to anything else and it'll most frequently get overridden by other more important oGCDs.
This also changes the standard True North Armour Crush feature to delayed weave, which shouldn't change anything really because it'd weave early and just wait for Armour Crush GCD before anyway.
Separated out from the other branch in the likely event Taur, good boy that he is, doesn't (understandably) want my version defiling his glorious Ninja and implements it in a much better way.