### PR TITLE
[SCH] Heal combo fixes + internal naming parity

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2799,7 +2799,11 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(SCH.WhisperingDawn)]
         [CustomComboInfo("Fairy Healing Combo", "Change Whispering Dawn into Fey Illumination, Fey Blessing, then Whispering Dawn when used.", SCH.JobID, 240, "", "")]
         SCH_Fairy_Combo = 16240,
-        
+
+            [ParentCombo(SCH_Fairy_Combo)]
+            [CustomComboInfo("Consolation During Seraph", "Adds Consolation Seraph.", SCH.JobID, 240, "", "")]
+            SCH_Fairy_Consolation = 16241,
+
         [ReplaceSkill(SCH.Succor)]
         [CustomComboInfo("AoE Heal Feature", "Replaces Succor with options below", SCH.JobID, 250)]
         SCH_AoE_Heal = 16250,
@@ -2816,8 +2820,7 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Indomitability Option", "Use Indomitability before using Succor", SCH.JobID)]
             SCH_AoE_Heal_Indomitability = 16253,
             
-        [ReplaceSkill(SCH.Physick)]
-        [CustomComboInfo("Heal Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options", SCH.JobID, 260)]
+        [CustomComboInfo("Physick Heal Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options", SCH.JobID, 260)]
         SCH_Heal = 16260,
 
             [ParentCombo(SCH_Heal)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2809,16 +2809,20 @@ namespace XIVSlothCombo.Combos
         SCH_Succor_Combo = 16250,
 
             [ParentCombo(SCH_Succor_Combo)]
-            [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
+            [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming when MP isn't high enough to cast Succor.", SCH.JobID)]
             SCH_Succor_Combo_Lucid = 16251,
 
             [ParentCombo(SCH_Succor_Combo)]
-            [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of aetherflow stacks", SCH.JobID)]
+            [CustomComboInfo("Aetherflow Option", "Use Aetherflow when out of aetherflow stacks.", SCH.JobID)]
             SCH_Succor_Combo_Aetherflow = 16252,
-            
-            [ParentCombo(SCH_Succor_Combo)]
-            [CustomComboInfo("Indomitability Option", "Use Indomitability before using Succor", SCH.JobID)]
-            SCH_Succor_Combo_Indomitability = 16253,
+
+        [ParentCombo(SCH_Succor_Combo_Aetherflow)]
+        [CustomComboInfo("Indomitability Ready Only", "Only uses Aetherflow is Indomitability is ready to use.", SCH.JobID)]
+        SCH_Succor_Combo_Aetherflow_Indomitability = 16253,
+
+        [ParentCombo(SCH_Succor_Combo)]
+            [CustomComboInfo("Indomitability Option", "Use Indomitability before using Succor.", SCH.JobID)]
+            SCH_Succor_Combo_Indomitability = 16254,
 
         [ReplaceSkill(SCH.Physick)]
         [CustomComboInfo("Physick Combo Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options", SCH.JobID, 260)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2802,43 +2802,43 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(SCH_Fairy_Combo)]
             [CustomComboInfo("Consolation During Seraph", "Adds Consolation Seraph.", SCH.JobID, 240, "", "")]
-            SCH_Fairy_Consolation = 16241,
+            SCH_Fairy_Combo_Consolation = 16241,
 
         [ReplaceSkill(SCH.Succor)]
-        [CustomComboInfo("AoE Heal Feature", "Replaces Succor with options below", SCH.JobID, 250)]
-        SCH_AoE_Heal = 16250,
+        [CustomComboInfo("Succor Combo Feature", "Replaces Succor with options below", SCH.JobID, 250)]
+        SCH_Succor_Combo = 16250,
 
-            [ParentCombo(SCH_AoE_Heal)]
+            [ParentCombo(SCH_Succor_Combo)]
             [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
-            SCH_AoE_Heal_Lucid = 16251,
+            SCH_Succor_Combo_Lucid = 16251,
 
-            [ParentCombo(SCH_AoE_Heal)]
+            [ParentCombo(SCH_Succor_Combo)]
             [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of aetherflow stacks", SCH.JobID)]
-            SCH_AoE_Heal_Aetherflow = 16252,
+            SCH_Succor_Combo_Aetherflow = 16252,
             
-            [ParentCombo(SCH_AoE_Heal)]
+            [ParentCombo(SCH_Succor_Combo)]
             [CustomComboInfo("Indomitability Option", "Use Indomitability before using Succor", SCH.JobID)]
-            SCH_AoE_Heal_Indomitability = 16253,
+            SCH_Succor_Combo_Indomitability = 16253,
 
         [ReplaceSkill(SCH.Physick)]
-        [CustomComboInfo("Physick Heal Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options", SCH.JobID, 260)]
-        SCH_Heal = 16260,
+        [CustomComboInfo("Physick Combo Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options", SCH.JobID, 260)]
+        SCH_Physick_Combo = 16260,
 
-            [ParentCombo(SCH_Heal)]
+            [ParentCombo(SCH_Physick_Combo)]
             [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
-            SCH_Heal_Lucid = 16261,
+            SCH_Physick_Combo_Lucid = 16261,
 
-            [ParentCombo(SCH_Heal)]
+            [ParentCombo(SCH_Physick_Combo)]
             [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of aetherflow stacks", SCH.JobID)]
-            SCH_Heal_Aetherflow = 16262,
+            SCH_Physick_Combo_Aetherflow = 16262,
             
-            [ParentCombo(SCH_Heal)]
+            [ParentCombo(SCH_Physick_Combo)]
             [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or Target HP% below", SCH.JobID)]
-            SCH_Heal_Adloquium = 16263,
+            SCH_Physick_Combo_Adloquium = 16263,
             
-            [ParentCombo(SCH_Heal)]
+            [ParentCombo(SCH_Physick_Combo)]
             [CustomComboInfo("Lustrate Option", "Use Lustrate when Target HP% below", SCH.JobID)]
-            SCH_Heal_Lustrate = 16264,
+            SCH_Physick_Combo_Lustrate = 16264,
             
 
         #endregion

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2837,11 +2837,11 @@ namespace XIVSlothCombo.Combos
             SCH_ST_Heal_Aetherflow = 16262,
             
             [ParentCombo(SCH_ST_Heal)]
-            [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or target HP% below:", SCH.JobID)]
+            [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or target HP%% below:", SCH.JobID)]
             SCH_ST_Heal_Adloquium = 16263,
             
             [ParentCombo(SCH_ST_Heal)]
-            [CustomComboInfo("Lustrate Option", "Use Lustrate when target HP% below:", SCH.JobID)]
+            [CustomComboInfo("Lustrate Option", "Use Lustrate when target HP%% below:", SCH.JobID)]
             SCH_ST_Heal_Lustrate = 16264,
             
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2797,11 +2797,11 @@ namespace XIVSlothCombo.Combos
         SCH_Recitation = 16230,
         
         [ReplaceSkill(SCH.WhisperingDawn)]
-        [CustomComboInfo("Fairy Healing Combo", "Change Whispering Dawn into Fey Illumination, Fey Blessing, then Whispering Dawn when used.", SCH.JobID, 240, "", "")]
+        [CustomComboInfo("Fairy Healing Combo Feature", "Change Whispering Dawn into Fey Illumination, Fey Blessing, then Whispering Dawn when used.", SCH.JobID, 240, "", "")]
         SCH_Fairy_Combo = 16240,
 
             [ParentCombo(SCH_Fairy_Combo)]
-            [CustomComboInfo("Consolation During Seraph", "Adds Consolation Seraph.", SCH.JobID, 240, "", "")]
+            [CustomComboInfo("Consolation During Seraph Option", "Adds Consolation during Seraph.", SCH.JobID, 240, "", "")]
             SCH_Fairy_Combo_Consolation = 16241,
 
         [ReplaceSkill(SCH.Succor)]
@@ -2817,7 +2817,7 @@ namespace XIVSlothCombo.Combos
             SCH_AoE_Heal_Aetherflow = 16252,
 
         [ParentCombo(SCH_AoE_Heal_Aetherflow)]
-        [CustomComboInfo("Indomitability Ready Only", "Only uses Aetherflow is Indomitability is ready to use.", SCH.JobID)]
+        [CustomComboInfo("Indomitability Ready Only Option", "Only uses Aetherflow is Indomitability is ready to use.", SCH.JobID)]
         SCH_AoE_Heal_Aetherflow_Indomitability = 16253,
 
             [ParentCombo(SCH_AoE_Heal)]
@@ -2857,11 +2857,11 @@ namespace XIVSlothCombo.Combos
             SCH_Aetherflow_Recite = 16310,
 
                 [ParentCombo(SCH_Aetherflow_Recite)]
-                [CustomComboInfo("On Excogitation Option", "", SCH.JobID, 311, "", "")]
+                [CustomComboInfo("On Excogitation", "", SCH.JobID, 311, "", "")]
                 SCH_Aetherflow_Recite_Excog = 16311,
 
                 [ParentCombo(SCH_Aetherflow_Recite)]
-                [CustomComboInfo("On Indominability Option", "", SCH.JobID, 312, "", "")]
+                [CustomComboInfo("On Indominability", "", SCH.JobID, 312, "", "")]
                 SCH_Aetherflow_Recite_Indom = 16312,
 
             [ParentCombo(SCH_Aetherflow)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2819,7 +2819,8 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(SCH_AoE_Heal)]
             [CustomComboInfo("Indomitability Option", "Use Indomitability before using Succor", SCH.JobID)]
             SCH_AoE_Heal_Indomitability = 16253,
-            
+
+        [ReplaceSkill(SCH.Physick)]
         [CustomComboInfo("Physick Heal Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options", SCH.JobID, 260)]
         SCH_Heal = 16260,
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2805,7 +2805,7 @@ namespace XIVSlothCombo.Combos
             SCH_Fairy_Combo_Consolation = 16241,
 
         [ReplaceSkill(SCH.Succor)]
-        [CustomComboInfo("AoE Heal Feature", "Replaces Succor with options below", SCH.JobID, 250)]
+        [CustomComboInfo("AoE Heal Feature", "Replaces Succor with options below:", SCH.JobID, 250)]
         SCH_AoE_Heal = 16250,
 
             [ParentCombo(SCH_AoE_Heal)]
@@ -2813,7 +2813,7 @@ namespace XIVSlothCombo.Combos
             SCH_AoE_Heal_Lucid = 16251,
 
             [ParentCombo(SCH_AoE_Heal)]
-            [CustomComboInfo("Aetherflow Option", "Use Aetherflow when out of aetherflow stacks.", SCH.JobID)]
+            [CustomComboInfo("Aetherflow Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
             SCH_AoE_Heal_Aetherflow = 16252,
 
         [ParentCombo(SCH_AoE_Heal_Aetherflow)]
@@ -2825,7 +2825,7 @@ namespace XIVSlothCombo.Combos
             SCH_AoE_Heal_Indomitability = 16254,
 
         [ReplaceSkill(SCH.Physick)]
-        [CustomComboInfo("Single Target Heal Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options", SCH.JobID, 260)]
+        [CustomComboInfo("Single Target Heal Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options:", SCH.JobID, 260)]
         SCH_ST_Heal = 16260,
 
             [ParentCombo(SCH_ST_Heal)]
@@ -2833,15 +2833,15 @@ namespace XIVSlothCombo.Combos
             SCH_ST_Heal_Lucid = 16261,
 
             [ParentCombo(SCH_ST_Heal)]
-            [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of aetherflow stacks", SCH.JobID)]
+            [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
             SCH_ST_Heal_Aetherflow = 16262,
             
             [ParentCombo(SCH_ST_Heal)]
-            [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or Target HP% below", SCH.JobID)]
+            [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or target HP% below:", SCH.JobID)]
             SCH_ST_Heal_Adloquium = 16263,
             
             [ParentCombo(SCH_ST_Heal)]
-            [CustomComboInfo("Lustrate Option", "Use Lustrate when Target HP% below", SCH.JobID)]
+            [CustomComboInfo("Lustrate Option", "Use Lustrate when target HP% below:", SCH.JobID)]
             SCH_ST_Heal_Lustrate = 16264,
             
 
@@ -2849,11 +2849,11 @@ namespace XIVSlothCombo.Combos
 
         #region Utilities
         [ReplaceSkill(SCH.EnergyDrain, SCH.Lustrate, SCH.SacredSoil, SCH.Indomitability, SCH.Excogitation)]
-        [CustomComboInfo("Aetherflow Helper Feature", "Change Aetherflow-using skills to Aetherflow, Recitation, or Dissipation as selected", SCH.JobID, 300, "", "")]
+        [CustomComboInfo("Aetherflow Helper Feature", "Change Aetherflow-using skills to Aetherflow, Recitation, or Dissipation as selected.", SCH.JobID, 300, "", "")]
         SCH_Aetherflow = 16300,
 
             [ParentCombo(SCH_Aetherflow)]
-            [CustomComboInfo("Recitation Option", "Prioritizes Recitation usage on Excogitation or Indominability", SCH.JobID, 310, "", "")]
+            [CustomComboInfo("Recitation Option", "Prioritizes Recitation usage on Excogitation or Indomitability.", SCH.JobID, 310, "", "")]
             SCH_Aetherflow_Recite = 16310,
 
                 [ParentCombo(SCH_Aetherflow_Recite)]
@@ -2861,16 +2861,16 @@ namespace XIVSlothCombo.Combos
                 SCH_Aetherflow_Recite_Excog = 16311,
 
                 [ParentCombo(SCH_Aetherflow_Recite)]
-                [CustomComboInfo("On Indominability", "", SCH.JobID, 312, "", "")]
+                [CustomComboInfo("On Indomitability", "", SCH.JobID, 312, "", "")]
                 SCH_Aetherflow_Recite_Indom = 16312,
 
             [ParentCombo(SCH_Aetherflow)]
-            [CustomComboInfo("Dissipation Option", "If Aetherflow itself is on cooldown, show Dissipation instead", SCH.JobID, 320, "", "")]
+            [CustomComboInfo("Dissipation Option", "If Aetherflow is on cooldown, show Dissipation instead.", SCH.JobID, 320, "", "")]
             SCH_Aetherflow_Dissipation = 16320,
 
         [ReplaceSkill(All.Swiftcast)]
         [ConflictingCombos(ALL_Healer_Raise)]
-        [CustomComboInfo("Swiftcast Raise Combo Feature", "Changes Swiftcast to Resurrection while Swiftcast is on cooldown", SCH.JobID, 400, "", "")]
+        [CustomComboInfo("Swiftcast Raise Combo Feature", "Changes Swiftcast to Resurrection while Swiftcast is on cooldown.", SCH.JobID, 400, "", "")]
         SCH_Raise = 16400,
 
         [ReplaceSkill(SCH.WhisperingDawn, SCH.FeyBlessing, SCH.FeyBlessing, SCH.Aetherpact, SCH.Dissipation)]
@@ -2878,11 +2878,11 @@ namespace XIVSlothCombo.Combos
         SCH_FairyReminder = 16500,
 
         [ReplaceSkill(SCH.DeploymentTactics)]
-        [CustomComboInfo("Deployment Tactics Feature", "Deployment Tactics idles as Adloquium until the Party Member has the Galvanize Buff", SCH.JobID, 600, "", "")]
+        [CustomComboInfo("Deployment Tactics Feature", "Changes Deployment Tactics to Adloquium until a party member has the Galvanize buff.", SCH.JobID, 600, "", "")]
         SCH_DeploymentTactics = 16600,
 
             [ParentCombo(SCH_DeploymentTactics)]
-            [CustomComboInfo("Recitation Option", "Adds Recitation when off cooldown to force a critical Galvanize Buff on the Party Member.", SCH.JobID, 601, "", "")]
+            [CustomComboInfo("Recitation Option", "Adds Recitation when off cooldown to force a critical Galvanize buff on a party member.", SCH.JobID, 601, "", "")]
             SCH_DeploymentTactics_Recitation = 16610,
         
         #endregion

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2805,44 +2805,44 @@ namespace XIVSlothCombo.Combos
             SCH_Fairy_Combo_Consolation = 16241,
 
         [ReplaceSkill(SCH.Succor)]
-        [CustomComboInfo("Succor Combo Feature", "Replaces Succor with options below", SCH.JobID, 250)]
-        SCH_Succor_Combo = 16250,
+        [CustomComboInfo("AoE Heal Feature", "Replaces Succor with options below", SCH.JobID, 250)]
+        SCH_AoE_Heal = 16250,
 
-            [ParentCombo(SCH_Succor_Combo)]
+            [ParentCombo(SCH_AoE_Heal)]
             [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming when MP isn't high enough to cast Succor.", SCH.JobID)]
-            SCH_Succor_Combo_Lucid = 16251,
+            SCH_AoE_Heal_Lucid = 16251,
 
-            [ParentCombo(SCH_Succor_Combo)]
+            [ParentCombo(SCH_AoE_Heal)]
             [CustomComboInfo("Aetherflow Option", "Use Aetherflow when out of aetherflow stacks.", SCH.JobID)]
-            SCH_Succor_Combo_Aetherflow = 16252,
+            SCH_AoE_Heal_Aetherflow = 16252,
 
-        [ParentCombo(SCH_Succor_Combo_Aetherflow)]
+        [ParentCombo(SCH_AoE_Heal_Aetherflow)]
         [CustomComboInfo("Indomitability Ready Only", "Only uses Aetherflow is Indomitability is ready to use.", SCH.JobID)]
-        SCH_Succor_Combo_Aetherflow_Indomitability = 16253,
+        SCH_AoE_Heal_Aetherflow_Indomitability = 16253,
 
-        [ParentCombo(SCH_Succor_Combo)]
+            [ParentCombo(SCH_AoE_Heal)]
             [CustomComboInfo("Indomitability Option", "Use Indomitability before using Succor.", SCH.JobID)]
-            SCH_Succor_Combo_Indomitability = 16254,
+            SCH_AoE_Heal_Indomitability = 16254,
 
         [ReplaceSkill(SCH.Physick)]
-        [CustomComboInfo("Physick Combo Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options", SCH.JobID, 260)]
-        SCH_Physick_Combo = 16260,
+        [CustomComboInfo("Single Target Heal Feature", "Change Physick into Adloquium, Lustrate, then Physick with below options", SCH.JobID, 260)]
+        SCH_ST_Heal = 16260,
 
-            [ParentCombo(SCH_Physick_Combo)]
+            [ParentCombo(SCH_ST_Heal)]
             [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
-            SCH_Physick_Combo_Lucid = 16261,
+            SCH_ST_Heal_Lucid = 16261,
 
-            [ParentCombo(SCH_Physick_Combo)]
+            [ParentCombo(SCH_ST_Heal)]
             [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of aetherflow stacks", SCH.JobID)]
-            SCH_Physick_Combo_Aetherflow = 16262,
+            SCH_ST_Heal_Aetherflow = 16262,
             
-            [ParentCombo(SCH_Physick_Combo)]
+            [ParentCombo(SCH_ST_Heal)]
             [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or Target HP% below", SCH.JobID)]
-            SCH_Physick_Combo_Adloquium = 16263,
+            SCH_ST_Heal_Adloquium = 16263,
             
-            [ParentCombo(SCH_Physick_Combo)]
+            [ParentCombo(SCH_ST_Heal)]
             [CustomComboInfo("Lustrate Option", "Use Lustrate when Target HP% below", SCH.JobID)]
-            SCH_Physick_Combo_Lustrate = 16264,
+            SCH_ST_Heal_Lustrate = 16264,
             
 
         #endregion

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -105,10 +105,10 @@ namespace XIVSlothCombo.Combos.PvE
             internal static int SCH_ST_DPS_ChainStratagemOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_ChainStratagemOption));
             internal static float SCH_ST_DPS_EnergyDrain => CustomComboFunctions.GetOptionFloat(nameof(SCH_ST_DPS_EnergyDrain));
             internal static int SCH_AoE_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_AoE_LucidOption));
-            internal static int SCH_Succor_Combo_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Succor_Combo_LucidOption));
-            internal static int SCH_Physick_Combo_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Physick_Combo_LucidOption));
-            internal static int SCH_Physick_Combo_AdloquiumOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Physick_Combo_AdloquiumOption));
-            internal static int SCH_Physick_Combo_LustrateOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Physick_Combo_LustrateOption));
+            internal static int SCH_AoE_Heal_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_AoE_Heal_LucidOption));
+            internal static int SCH_ST_Heal_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_Heal_LucidOption));
+            internal static int SCH_ST_Heal_AdloquiumOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_Heal_AdloquiumOption));
+            internal static int SCH_ST_Heal_LustrateOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_Heal_LustrateOption));
             internal static bool SCH_Aetherflow_Display => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_Aetherflow_Display));
             internal static bool SCH_Aetherflow_Recite_Excog => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_Aetherflow_Recite_Excog));
             internal static bool SCH_Aetherflow_Recite_Indom => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_Aetherflow_Recite_Indom));
@@ -410,7 +410,6 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Ruin2;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-
                 if (actionID is Ruin2 && LevelChecked(Bio))
                 {
                     uint dot = OriginalHook(Bio); // Grab the appropriate DoT Action
@@ -429,28 +428,28 @@ namespace XIVSlothCombo.Combos.PvE
         * Overrides main AoE Healing abiility, Succor
         * Lucid Dreaming and Atherflow weave options
         */
-        internal class SCH_Succor_Combo : CustomCombo
+        internal class SCH_AoE_Heal : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Succor_Combo;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_Heal;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID is Succor)
                 {
                     // Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_Succor_Combo_Aetherflow) &&
+                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow) &&
                         ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
-                        !(IsEnabled(CustomComboPreset.SCH_Succor_Combo_Aetherflow_Indomitability) && GetCooldownRemainingTime(Indomitability) <= 0.6f) &&
+                        !(IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow_Indomitability) && GetCooldownRemainingTime(Indomitability) <= 0.6f) &&
                             InCombat())
                         return Aetherflow;
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_Succor_Combo_Lucid) &&
+                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid) &&
                         ActionReady(All.LucidDreaming) &&
                         LocalPlayer.CurrentMp < 1000)
                         return All.LucidDreaming;
 
                     // Indomitability
-                    if (IsEnabled(CustomComboPreset.SCH_Succor_Combo_Indomitability) &&
+                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Indomitability) &&
                         ActionReady(Indomitability) &&
                         Gauge.HasAetherflow())
                         return Indomitability;
@@ -494,26 +493,26 @@ namespace XIVSlothCombo.Combos.PvE
         * Overrides main AoE Healing abiility, Succor
         * Lucid Dreaming and Atherflow weave options
         */
-        internal class SCH_Physick_Combo : CustomCombo
+        internal class SCH_ST_Heal : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Physick_Combo;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_ST_Heal;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID is Physick)
                 {
                     // Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_Physick_Combo_Aetherflow) &&
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Aetherflow) &&
                         ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
                         InCombat() && CanSpellWeave(actionID))
                         return Aetherflow;
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_Physick_Combo_Lucid) &&
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Lucid) &&
                         ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_Physick_Combo_LucidOption &&
+                        LocalPlayer.CurrentMp <= Config.SCH_ST_Heal_LucidOption &&
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
-                    
+
                     //Grab our target (Soft->Hard->Self)
                     GameObject? healTarget = null;
                     GameObject? softTarget = Service.TargetManager.SoftTarget;
@@ -522,18 +521,18 @@ namespace XIVSlothCombo.Combos.PvE
                     if (healTarget is null) healTarget = LocalPlayer;
 
                     //Check for the Galvanize shield buff. Start applying if it doesn't exist or Target HP is below %
-                    if (IsEnabled(CustomComboPreset.SCH_Physick_Combo_Adloquium) &&
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Adloquium) &&
                         ActionReady(Adloquium) &&
-                        (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer.ObjectId) is null || GetTargetHPPercent(healTarget) <= Config.SCH_Physick_Combo_AdloquiumOption))
+                        (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer.ObjectId) is null || GetTargetHPPercent(healTarget) <= Config.SCH_ST_Heal_AdloquiumOption))
                     {
                         return Adloquium;
                     }
                     
                     //Cast Lustrate if you have Aetherflow and Target HP is below %
-                    if (IsEnabled(CustomComboPreset.SCH_Physick_Combo_Lustrate) &&
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Lustrate) &&
                         ActionReady(Lustrate) && 
                         Gauge.HasAetherflow() &&
-                        GetTargetHPPercent(healTarget) <= Config.SCH_Physick_Combo_LustrateOption)
+                        GetTargetHPPercent(healTarget) <= Config.SCH_ST_Heal_LustrateOption)
                     {
                         return Lustrate;
                     }

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -105,10 +105,10 @@ namespace XIVSlothCombo.Combos.PvE
             internal static int SCH_ST_DPS_ChainStratagemOption => CustomComboFunctions.GetOptionValue(nameof(SCH_ST_DPS_ChainStratagemOption));
             internal static float SCH_ST_DPS_EnergyDrain => CustomComboFunctions.GetOptionFloat(nameof(SCH_ST_DPS_EnergyDrain));
             internal static int SCH_AoE_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_AoE_LucidOption));
-            internal static int SCH_AoE_Heal_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_AoE_Heal_LucidOption));
-            internal static int SCH_Heal_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Heal_LucidOption));
-            internal static int SCH_Heal_AdloquiumOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Heal_AdloquiumOption));
-            internal static int SCH_Heal_LustrateOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Heal_LustrateOption));
+            internal static int SCH_Succor_Combo_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Succor_Combo_LucidOption));
+            internal static int SCH_Physick_Combo_LucidOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Physick_Combo_LucidOption));
+            internal static int SCH_Physick_Combo_AdloquiumOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Physick_Combo_AdloquiumOption));
+            internal static int SCH_Physick_Combo_LustrateOption => CustomComboFunctions.GetOptionValue(nameof(SCH_Physick_Combo_LustrateOption));
             internal static bool SCH_Aetherflow_Display => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_Aetherflow_Display));
             internal static bool SCH_Aetherflow_Recite_Excog => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_Aetherflow_Recite_Excog));
             internal static bool SCH_Aetherflow_Recite_Indom => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_Aetherflow_Recite_Indom));
@@ -410,6 +410,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Ruin2;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
+
                 if (actionID is Ruin2 && LevelChecked(Bio))
                 {
                     uint dot = OriginalHook(Bio); // Grab the appropriate DoT Action
@@ -428,33 +429,33 @@ namespace XIVSlothCombo.Combos.PvE
         * Overrides main AoE Healing abiility, Succor
         * Lucid Dreaming and Atherflow weave options
         */
-        internal class SCH_AoE_Heal : CustomCombo
+        internal class SCH_Succor_Combo : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_AoE_Heal;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Succor_Combo;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID is Succor)
                 {
                     // Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Aetherflow) &&
+                    if (IsEnabled(CustomComboPreset.SCH_Succor_Combo_Aetherflow) &&
                         ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
                         InCombat() && CanSpellWeave(actionID))
                         return Aetherflow;
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid) &&
+                    if (IsEnabled(CustomComboPreset.SCH_Succor_Combo_Lucid) &&
                         ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_AoE_Heal_LucidOption &&
+                        LocalPlayer.CurrentMp <= Config.SCH_Succor_Combo_LucidOption &&
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
 
                     // Indomitability
-                    if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Indomitability) &&
+                    if (IsEnabled(CustomComboPreset.SCH_Succor_Combo_Indomitability) &&
                         ActionReady(Indomitability) &&
                         Gauge.HasAetherflow())
                         return Indomitability;
                 }
-                return OriginalHook(actionID);
+                return actionID;
             }
         }
         
@@ -478,13 +479,13 @@ namespace XIVSlothCombo.Combos.PvE
                     if (ActionReady(FeyBlessing) && !(Gauge.SeraphTimer > 0))
                         return OriginalHook(FeyBlessing);
 
-                    if (IsEnabled(CustomComboPreset.SCH_Fairy_Consolation) && ActionReady(WhisperingDawn))
+                    if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && ActionReady(WhisperingDawn))
                         return OriginalHook(actionID);
 
-                    if (IsEnabled(CustomComboPreset.SCH_Fairy_Consolation) && Gauge.SeraphTimer > 0 && GetRemainingCharges(Consolation) > 0)
+                    if (IsEnabled(CustomComboPreset.SCH_Fairy_Combo_Consolation) && Gauge.SeraphTimer > 0 && GetRemainingCharges(Consolation) > 0)
                     return OriginalHook(Consolation);
                 }
-                return OriginalHook(actionID);
+                return actionID;
             }
         }
         
@@ -493,26 +494,26 @@ namespace XIVSlothCombo.Combos.PvE
         * Overrides main AoE Healing abiility, Succor
         * Lucid Dreaming and Atherflow weave options
         */
-        internal class SCH_Heal : CustomCombo
+        internal class SCH_Physick_Combo : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Heal;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_Physick_Combo;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID is Physick)
                 {
                     // Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_Heal_Aetherflow) &&
+                    if (IsEnabled(CustomComboPreset.SCH_Physick_Combo_Aetherflow) &&
                         ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
                         InCombat() && CanSpellWeave(actionID))
                         return Aetherflow;
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SCH_Heal_Lucid) &&
+                    if (IsEnabled(CustomComboPreset.SCH_Physick_Combo_Lucid) &&
                         ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_Heal_LucidOption &&
+                        LocalPlayer.CurrentMp <= Config.SCH_Physick_Combo_LucidOption &&
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
-
+                    
                     //Grab our target (Soft->Hard->Self)
                     GameObject? healTarget = null;
                     GameObject? softTarget = Service.TargetManager.SoftTarget;
@@ -521,23 +522,23 @@ namespace XIVSlothCombo.Combos.PvE
                     if (healTarget is null) healTarget = LocalPlayer;
 
                     //Check for the Galvanize shield buff. Start applying if it doesn't exist or Target HP is below %
-                    if (IsEnabled(CustomComboPreset.SCH_Heal_Adloquium) &&
+                    if (IsEnabled(CustomComboPreset.SCH_Physick_Combo_Adloquium) &&
                         ActionReady(Adloquium) &&
-                        (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer.ObjectId) is null || GetTargetHPPercent(healTarget) <= Config.SCH_Heal_AdloquiumOption))
+                        (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer.ObjectId) is null || GetTargetHPPercent(healTarget) <= Config.SCH_Physick_Combo_AdloquiumOption))
                     {
                         return Adloquium;
                     }
                     
                     //Cast Lustrate if you have Aetherflow and Target HP is below %
-                    if (IsEnabled(CustomComboPreset.SCH_Heal_Lustrate) &&
+                    if (IsEnabled(CustomComboPreset.SCH_Physick_Combo_Lustrate) &&
                         ActionReady(Lustrate) && 
                         Gauge.HasAetherflow() &&
-                        GetTargetHPPercent(healTarget) <= Config.SCH_Heal_LustrateOption)
+                        GetTargetHPPercent(healTarget) <= Config.SCH_Physick_Combo_LustrateOption)
                     {
                         return Lustrate;
                     }
                 }
-                return OriginalHook(actionID);
+                return actionID;
             }
         }
     }

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -445,8 +445,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SCH_Succor_Combo_Lucid) &&
                         ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_Succor_Combo_LucidOption &&
-                        CanSpellWeave(actionID))
+                        LocalPlayer.CurrentMp < 1000)
                         return All.LucidDreaming;
 
                     // Indomitability

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -469,13 +469,20 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is WhisperingDawn)
                 {
+
                     // FeyIllumination
                     if (ActionReady(FeyIllumination))
-                        return FeyIllumination;
-                    
+                        return OriginalHook(FeyIllumination);
+
                     // FeyBlessing
-                    if (ActionReady(FeyBlessing))
-                        return FeyBlessing;
+                    if (ActionReady(FeyBlessing) && !(Gauge.SeraphTimer > 0))
+                        return OriginalHook(FeyBlessing);
+
+                    if (IsEnabled(CustomComboPreset.SCH_Fairy_Consolation) && ActionReady(WhisperingDawn))
+                        return OriginalHook(actionID);
+
+                    if (IsEnabled(CustomComboPreset.SCH_Fairy_Consolation) && Gauge.SeraphTimer > 0 && GetRemainingCharges(Consolation) > 0)
+                    return OriginalHook(Consolation);
                 }
                 return OriginalHook(actionID);
             }
@@ -516,7 +523,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Check for the Galvanize shield buff. Start applying if it doesn't exist or Target HP is below %
                     if (IsEnabled(CustomComboPreset.SCH_Heal_Adloquium) &&
                         ActionReady(Adloquium) &&
-                        (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer.ObjectId) is null || GetTargetHPPercent(healTarget) < Config.SCH_Heal_AdloquiumOption))
+                        (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer.ObjectId) is null || GetTargetHPPercent(healTarget) <= Config.SCH_Heal_AdloquiumOption))
                     {
                         return Adloquium;
                     }

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -523,7 +523,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Check for the Galvanize shield buff. Start applying if it doesn't exist or Target HP is below %
                     if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Adloquium) &&
                         ActionReady(Adloquium) &&
-                        (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer.ObjectId) is null || GetTargetHPPercent(healTarget) <= Config.SCH_ST_Heal_AdloquiumOption))
+                        (FindEffect(Buffs.Galvanize, healTarget, LocalPlayer?.ObjectId) is null || GetTargetHPPercent(healTarget) <= Config.SCH_ST_Heal_AdloquiumOption))
                     {
                         return Adloquium;
                     }

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -439,7 +439,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // Aetherflow
                     if (IsEnabled(CustomComboPreset.SCH_Succor_Combo_Aetherflow) &&
                         ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
-                        InCombat() && CanSpellWeave(actionID))
+                        !(IsEnabled(CustomComboPreset.SCH_Succor_Combo_Aetherflow_Indomitability) && GetCooldownRemainingTime(Indomitability) <= 0.6f) &&
+                            InCombat())
                         return Aetherflow;
 
                     // Lucid Dreaming

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1589,14 +1589,14 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.SCH_AoE_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_AoE_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
                         
-            if (preset is CustomComboPreset.SCH_Physick_Combo_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_Physick_Combo_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
+            if (preset is CustomComboPreset.SCH_ST_Heal_Lucid)
+                UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_ST_Heal_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
             
-            if (preset is CustomComboPreset.SCH_Physick_Combo_Adloquium)
-                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_Physick_Combo_AdloquiumOption), "Start using when below HP %\nSet to 0 to always use Adloquim instead of Physick or 100 to disable this check\nWill still use Adloquim when target doesn't have Galvanize");
+            if (preset is CustomComboPreset.SCH_ST_Heal_Adloquium)
+                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_Heal_AdloquiumOption), "Start using when below HP %\nSet to 0 to always use Adloquim instead of Physick or 100 to disable this check\nWill still use Adloquim when target doesn't have Galvanize");
             
-            if (preset is CustomComboPreset.SCH_Physick_Combo_Lustrate)
-                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_Physick_Combo_LustrateOption), "Start using when below HP %. Set to 100 to disable this check");
+            if (preset is CustomComboPreset.SCH_ST_Heal_Lustrate)
+                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_Heal_LustrateOption), "Start using when below HP %. Set to 100 to disable this check");
 
             if (preset is CustomComboPreset.SCH_FairyReminder)
             {

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1588,10 +1588,7 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset is CustomComboPreset.SCH_AoE_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_AoE_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
-            
-            if (preset is CustomComboPreset.SCH_Succor_Combo_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_Succor_Combo_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
-            
+                        
             if (preset is CustomComboPreset.SCH_Physick_Combo_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_Physick_Combo_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
             

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1593,7 +1593,7 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_ST_Heal_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
             
             if (preset is CustomComboPreset.SCH_ST_Heal_Adloquium)
-                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_Heal_AdloquiumOption), "Start using when below HP %\nSet to 0 to always use Adloquim instead of Physick or 100 to disable this check\nWill still use Adloquim when target doesn't have Galvanize");
+                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_Heal_AdloquiumOption), "Use Adloquium on targets at or below HP % even if they have Galvanize\n0 = Only ever use Adloquium on targets without Galvanize\n100 = Always use Adloquium");
             
             if (preset is CustomComboPreset.SCH_ST_Heal_Lustrate)
                 UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_Heal_LustrateOption), "Start using when below HP %. Set to 100 to disable this check");

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1589,17 +1589,17 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.SCH_AoE_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_AoE_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
             
-            if (preset is CustomComboPreset.SCH_AoE_Heal_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_AoE_Heal_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
+            if (preset is CustomComboPreset.SCH_Succor_Combo_Lucid)
+                UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_Succor_Combo_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
             
-            if (preset is CustomComboPreset.SCH_Heal_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_Heal_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
+            if (preset is CustomComboPreset.SCH_Physick_Combo_Lucid)
+                UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_Physick_Combo_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
             
-            if (preset is CustomComboPreset.SCH_Heal_Adloquium)
-                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_Heal_AdloquiumOption), "Start using when below HP %\nSet to 0 to always use Adloquim instead of Physick or 100 to disable this check\nWill still use Adloquim when target doesn't have Galvanize");
+            if (preset is CustomComboPreset.SCH_Physick_Combo_Adloquium)
+                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_Physick_Combo_AdloquiumOption), "Start using when below HP %\nSet to 0 to always use Adloquim instead of Physick or 100 to disable this check\nWill still use Adloquim when target doesn't have Galvanize");
             
-            if (preset is CustomComboPreset.SCH_Heal_Lustrate)
-                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_Heal_LustrateOption), "Start using when below HP %. Set to 100 to disable this check");
+            if (preset is CustomComboPreset.SCH_Physick_Combo_Lustrate)
+                UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_Physick_Combo_LustrateOption), "Start using when below HP %. Set to 100 to disable this check");
 
             if (preset is CustomComboPreset.SCH_FairyReminder)
             {


### PR DESCRIPTION
Daemeous:
Fix Scholar Healing and Fairy Combos.
Adds Consolation option to Fairy Combo for use under Seraph.
Changed Lucid Dreaming on Succour to be emergency in case of not enough MP.
Added sub-option to only use Aetherflow if Indomitability is ready,
Naming Parity established with Sage.
Clarified descriptions.

Tartarga:
Fixed Adloquium Bar.

