### PR TITLE
Healer dot thresholds fixed

### DIFF
--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -335,8 +335,8 @@ namespace XIVSlothCombo.Combos.PvE
                             //Grab current DoT via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
                             uint dot = OriginalHook(Combust);
                             Status? dotDebuff = FindTargetEffect(CombustList[dot]);
-                            if (((dotDebuff is null) || (dotDebuff.RemainingTime <= GetOptionFloat(Config.AST_ST_DPS_CombustUptime_Threshold))) &&
-                                (GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_CombustOption)))
+                            if (dotDebuff is null || dotDebuff.RemainingTime <= GetOptionFloat(Config.AST_ST_DPS_CombustUptime_Threshold) &&
+                                GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_CombustOption))
                                 return dot;
 
                             //AlterateMode idles as Malefic

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -111,7 +111,7 @@ namespace XIVSlothCombo.Combos.PvE
             internal static bool SCH_FairyFeature => CustomComboFunctions.GetIntOptionAsBool(nameof(SCH_FairyFeature));
             internal static int SCH_Recitation_Mode => CustomComboFunctions.GetOptionValue(nameof(SCH_Recitation_Mode));
 
-            internal static float SCH_ST_DPS_Bio_Threshold = CustomComboFunctions.GetOptionFloat(nameof(SCH_ST_DPS_Bio_Threshold));
+            internal static string SCH_ST_DPS_Bio_Threshold = "SCH_ST_DPS_Bio_Threshold";
 
         }
 
@@ -349,8 +349,8 @@ namespace XIVSlothCombo.Combos.PvE
                             uint dot = OriginalHook(Bio); //Grab the appropriate DoT Action
                             Status? dotDebuff = FindTargetEffect(BioList[dot]); //Match it with it's Debuff ID, and check for the Debuff
 
-                            if ((dotDebuff is null || dotDebuff?.RemainingTime <= Config.SCH_ST_DPS_Bio_Threshold) &&
-                                (GetTargetHPPercent() > Config.SCH_ST_DPS_BioOption))
+                            if (dotDebuff is null || dotDebuff?.RemainingTime <= GetOptionFloat(Config.SCH_ST_DPS_Bio_Threshold) &&
+                                GetTargetHPPercent() > Config.SCH_ST_DPS_BioOption)
                                 return dot; //Use appropriate DoT Action
                         }
 

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -111,7 +111,7 @@ namespace XIVSlothCombo.Combos.PvE
             internal static int SGE_AoE_Phlegma_Lucid => CustomComboFunctions.GetOptionValue(nameof(SGE_AoE_Phlegma_Lucid));
             internal static int SGE_Eukrasia_Mode => CustomComboFunctions.GetOptionValue(nameof(SGE_Eukrasia_Mode));
 
-            internal static float SGE_ST_Dosis_Threshold = CustomComboFunctions.GetOptionFloat(nameof(SGE_ST_Dosis_Threshold));
+            internal static string SGE_ST_Dosis_Threshold = "SGE_ST_Dosis_Threshold";
 
         }
 
@@ -245,8 +245,8 @@ namespace XIVSlothCombo.Combos.PvE
                             if (DosisList.TryGetValue(OriginalHook(actionID), out ushort dotDebuffID))
                             {
                                 Status? dotDebuff = FindTargetEffect(dotDebuffID);
-                                if (((dotDebuff is null) || (dotDebuff.RemainingTime <= Config.SGE_ST_Dosis_Threshold)) &&
-                                    (GetTargetHPPercent() > Config.SGE_ST_Dosis_EDosisHPPer))
+                                if (dotDebuff is null || dotDebuff.RemainingTime <= GetOptionFloat(Config.SGE_ST_Dosis_Threshold) &&
+                                    GetTargetHPPercent() > Config.SGE_ST_Dosis_EDosisHPPer)
                                     return Eukrasia;
                             }
                         }

--- a/XIVSlothCombo/Combos/PvE/WHM.cs
+++ b/XIVSlothCombo/Combos/PvE/WHM.cs
@@ -229,8 +229,8 @@ namespace XIVSlothCombo.Combos.PvE
                         else DoTDebuff = FindTargetEffect(Debuffs.Aero1);
 
                         // DoT Uptime & HP% threshold
-                        if (((DoTDebuff is null) || (DoTDebuff.RemainingTime <= GetOptionFloat(Config.WHM_ST_MainCombo_DoT_Threshold))) &&
-                            (GetTargetHPPercent() > GetOptionValue(Config.WHM_ST_MainCombo_DoT)))
+                        if (DoTDebuff is null || DoTDebuff.RemainingTime <= GetOptionFloat(Config.WHM_ST_MainCombo_DoT_Threshold) &&
+                            GetTargetHPPercent() > GetOptionValue(Config.WHM_ST_MainCombo_DoT))
                             return OriginalHook(Aero1);
                     }
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1076,7 +1076,7 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_DPS_CombustOption, "Stop using at Enemy HP %. Set to Zero to disable this check");
 
             if (preset is CustomComboPreset.AST_ST_DPS_CombustUptime)
-                UserConfig.DrawRoundedSliderFloat(0, 4, AST.Config.AST_ST_DPS_CombustUptime_Threshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check", digits: 1);
+                UserConfig.DrawRoundedSliderFloat(0, 4, AST.Config.AST_ST_DPS_CombustUptime_Threshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check (GCD recommended, ctrl + click bar to type)", digits: 2);
 
             if (preset is CustomComboPreset.AST_DPS_Divination)
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_DPS_DivinationOption, "Stop using at Enemy HP %. Set to Zero to disable this check");
@@ -1464,7 +1464,7 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Dosis_EDosisHPPer), "Stop using at Enemy HP %. Set to Zero to disable this check");
 
             if (preset is CustomComboPreset.SGE_ST_Dosis_EDosis)
-                UserConfig.DrawRoundedSliderFloat(0, 4, nameof(SGE.Config.SGE_ST_Dosis_Threshold), "Seconds remaining before reapplying the DoT.Set to Zero to disable this check", digits: 1);
+                UserConfig.DrawRoundedSliderFloat(0, 4, nameof(SGE.Config.SGE_ST_Dosis_Threshold), "Seconds remaining before reapplying the DoT.Set to Zero to disable this check (GCD recommended, ctrl + click bar to type)", digits: 2);
 
             if (preset is CustomComboPreset.SGE_ST_Dosis_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SGE.Config.SGE_ST_Dosis_Lucid), "MP Threshold", 150, SliderIncrements.Hundreds);
@@ -1573,7 +1573,7 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_DPS_BioOption), "Stop using at Enemy HP %. Set to Zero to disable this check");
 
             if (preset is CustomComboPreset.SCH_DPS_Bio)
-                UserConfig.DrawRoundedSliderFloat(0, 4, nameof(SCH.Config.SCH_ST_DPS_Bio_Threshold), "Seconds remaining before reapplying the DoT. Set to Zero to disable this check", digits: 1);
+                UserConfig.DrawRoundedSliderFloat(0, 4, nameof(SCH.Config.SCH_ST_DPS_Bio_Threshold), "Seconds remaining before reapplying the DoT. Set to Zero to disable this check (GCD recommended, ctrl + click bar to type)", digits: 2);
 
             if (preset is CustomComboPreset.SCH_DPS_ChainStrat)
                 UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_DPS_ChainStratagemOption), "Stop using at Enemy HP %. Set to Zero to disable this check");
@@ -1681,7 +1681,7 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.WHM_ST_MainCombo_DoT)
                 UserConfig.DrawSliderInt(0, 100, WHM.Config.WHM_ST_MainCombo_DoT, "Stop using at Enemy HP %. Set to Zero to disable this check");
             if (preset is CustomComboPreset.WHM_ST_MainCombo_DoT)
-                UserConfig.DrawRoundedSliderFloat(0, 4, WHM.Config.WHM_ST_MainCombo_DoT_Threshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check", digits: 1);
+                UserConfig.DrawRoundedSliderFloat(0, 4, WHM.Config.WHM_ST_MainCombo_DoT_Threshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check (GCD recommended, ctrl + click bar to type)", digits: 2);
             if (preset == CustomComboPreset.WHM_AoE_DPS_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, WHM.Config.WHM_AoE_Lucid, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);
             if (preset == CustomComboPreset.WHM_Afflatus_oGCDHeals)


### PR DESCRIPTION
Sage and Scholar DoT thresholds now updating.
Improved functionality to accept 2 decimal places.
Updated descriptions to recommend GCD and how to type in values.
Cleaned up pointless brackets.