### PR TITLE
[SGE] Add SGE_ST_Toxikon

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2367,8 +2367,8 @@ namespace XIVSlothCombo.Combos
             SGE_ST_Toxikon_Lucid = 141110,
 
             [ParentCombo(SGE_ST_Toxikon)]
-            [CustomComboInfo("Eukrasian Dosis Option", "Use Eukrasian Dosis if DoT is needed or nothing else can be used.", SGE.JobID, 1120, "", "")]
-            SGE_ST_Toxikon_EDosis = 141120,
+            [CustomComboInfo("Eukrasian Dosis Uptime Option", "Use Eukrasian Dosis for DoT uptime.", SGE.JobID, 1120, "", "")]
+            SGE_ST_Toxikon_EDosis_Uptime = 141120,
 
             [ParentCombo(SGE_ST_Toxikon)]
             [CustomComboInfo("Phlegma Option", "Use Phlegma if available and within range.", SGE.JobID, 1130, "", "")]
@@ -2377,6 +2377,10 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(SGE_ST_Toxikon)]
             [CustomComboInfo("Dyskrasia Option", "Use Dyskrasia if Toxikon is not available and within range.", SGE.JobID, 1140, "", "")]
             SGE_ST_Toxikon_Dyskrasia  = 141140,
+
+            [ParentCombo(SGE_ST_Toxikon)]
+            [CustomComboInfo("Eukrasian Dosis Option", "Use Eukrasian Dosis if no other skills can be used.", SGE.JobID, 1150, "", "")]
+            SGE_ST_Toxikon_EDosis = 141150,
             
             #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2357,6 +2357,29 @@ namespace XIVSlothCombo.Combos
             
             #endregion
 
+        #region Single Target No Cast DPS Feature
+        [ReplaceSkill(SGE.Toxikon, SGE.Toxikon2)]
+        [CustomComboInfo("Single Target No Cast DPS Feature, put spells with no cast time on Toxikon", "", SGE.JobID, 1100, "", "")]
+        SGE_ST_Toxikon = 141100,
+                
+            [ParentCombo(SGE_ST_Toxikon)]
+            [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming to Toxikon when MP drops below slider value.", SGE.JobID, 1110, "", "")]
+            SGE_ST_Toxikon_Lucid = 141110,
+
+            [ParentCombo(SGE_ST_Toxikon)]
+            [CustomComboInfo("Eukrasian Dosis Option", "Use Eukrasian Dosis if DoT is needed or nothing else can be used.", SGE.JobID, 1120, "", "")]
+            SGE_ST_Toxikon_EDosis = 141120,
+
+            [ParentCombo(SGE_ST_Toxikon)]
+            [CustomComboInfo("Phlegma Option", "Use Phlegma if available and within range.", SGE.JobID, 1130, "", "")]
+            SGE_ST_Toxikon_Phlegma = 141130,
+
+            [ParentCombo(SGE_ST_Toxikon)]
+            [CustomComboInfo("Dyskrasia Option", "Use Dyskrasia if Toxikon is not available and within range.", SGE.JobID, 1140, "", "")]
+            SGE_ST_Toxikon_Dyskrasia  = 141140,
+            
+            #endregion
+
         #region AoE DPS Feature
         [ReplaceSkill(SGE.Phlegma, SGE.Phlegma2, SGE.Phlegma3)]
         [CustomComboInfo("AoE DPS Feature", "", SGE.JobID, 200, "", "")]

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -296,7 +296,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return All.LucidDreaming;
 
                     // Eukrasia.
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Toxikon_EDosis) && LevelChecked(Eukrasia) && HasBattleTarget())
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Toxikon_EDosis_Uptime) && LevelChecked(Eukrasia) && HasBattleTarget())
                     {
                         // Grab current Dosis via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
                         // Using TryGetValue due to edge case where the actionID would be read as Eukrasian Dosis instead of Dosis


### PR DESCRIPTION
* SGE_ST_Toxikon: group spells with no cast time in one button, so that you can spam it when you are moving.