### PR TITLE
Changes to Healer DoT refresh timer sliders

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -182,6 +182,10 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Combust Uptime Option", "Adds Combust to the DPS feature if it's not present on current target, or is about to expire.", AST.JobID, 0, "", "")]
             AST_ST_DPS_CombustUptime = 1018,
 
+                [ParentCombo(AST_ST_DPS)]
+                [CustomComboInfo("Overide Refresh Timer Option", "Override the seconds remaining before automatically refreshing the DoT.\nDefaults to 3s when disabled.", AST.JobID, 0, "", "")]
+                AST_ST_DPS_CombustUptime_Adv = 1019,
+
             [ReplaceSkill(AST.Gravity, AST.Gravity2)]
             [ParentCombo(AST_ST_DPS)]
             [CustomComboInfo("AoE DPS Feature", "Every option below (Lucid/AutoDraws/Astrodyne/etc) will also be added to Gravity", AST.JobID, 1, "", "")]
@@ -2343,6 +2347,10 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Eukrasian Dosis Option", "Automatic DoT Uptime.", SGE.JobID, 120, "", "")]
             SGE_ST_Dosis_EDosis = 14120,
 
+                [ParentCombo(SGE_ST_Dosis_EDosis)]
+                [CustomComboInfo("Overide Refresh Timer Option", "Override the seconds remaining before automatically refreshing the DoT.\nDefaults to 3s when disabled.", SGE.JobID, 0, "", "")]
+                SGE_ST_Dosis_EDosis_Adv = 14121,
+
             [ParentCombo(SGE_ST_Dosis)]
             [CustomComboInfo("Toxikon Option", "Use Toxikon when you have Addersting charges.", SGE.JobID, 130, "", "")]
             SGE_ST_Dosis_Toxikon = 14130,
@@ -2769,6 +2777,10 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT uptime.", SCH.JobID, 140, "", "")]
             SCH_DPS_Bio = 16150,
 
+                [ParentCombo(SCH_DPS_Bio)]
+                [CustomComboInfo("Overide Refresh Timer Option", "Override the seconds remaining before automatically refreshing the DoT.\nDefaults to 3s when disabled.", SCH.JobID, 0, "", "")]
+                SCH_DPS_Bio_Adv = 16151,
+
             [ParentCombo(SCH_DPS)]
             [CustomComboInfo("Dissipation Opener Option", "Use Dissipation at the start of the battle.", SCH.JobID, 170, "", "")]
             SCH_DPS_Dissipation_Opener = 16170,
@@ -3124,6 +3136,10 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(WHM_ST_MainCombo)]
             [CustomComboInfo("Aero/Dia Uptime Option", "Adds Aero/Dia to the single target combo if the debuff is not present on current target, or is about to expire.", WHM.JobID, 12, "", "")]
             WHM_ST_MainCombo_DoT = 19013,
+
+                [ParentCombo(WHM_ST_MainCombo_DoT)]
+                [CustomComboInfo("Overide Refresh Timer Option", "Override the seconds remaining before automatically refreshing the DoT.\nDefaults to 3s when disabled.", WHM.JobID, 0, "", "")]
+                WHM_ST_MainCombo_DoT_Adv = 19025,
 
             [ParentCombo(WHM_ST_MainCombo)]
             [CustomComboInfo("Assize Option", "Adds Assize to the single target combo.", WHM.JobID, 13, "", "")]

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -335,7 +335,7 @@ namespace XIVSlothCombo.Combos.PvE
                             //Grab current DoT via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
                             uint dot = OriginalHook(Combust);
                             Status? dotDebuff = FindTargetEffect(CombustList[dot]);
-                            float refreshtimer = IsEnabled(CustomComboPreset.SCH_DPS_Bio_Adv) ? GetOptionFloat(Config.AST_ST_DPS_CombustUptime_Threshold) : 3;
+                            float refreshtimer = IsEnabled(CustomComboPreset.AST_ST_DPS_CombustUptime_Adv) ? GetOptionFloat(Config.AST_ST_DPS_CombustUptime_Threshold) : 3;
 
                             if ((dotDebuff is null || dotDebuff.RemainingTime <= refreshtimer) &&
                                 GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_CombustOption))

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -335,7 +335,9 @@ namespace XIVSlothCombo.Combos.PvE
                             //Grab current DoT via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
                             uint dot = OriginalHook(Combust);
                             Status? dotDebuff = FindTargetEffect(CombustList[dot]);
-                            if (dotDebuff is null || dotDebuff.RemainingTime <= GetOptionFloat(Config.AST_ST_DPS_CombustUptime_Threshold) &&
+                            float refreshtimer = IsEnabled(CustomComboPreset.SCH_DPS_Bio_Adv) ? GetOptionFloat(Config.AST_ST_DPS_CombustUptime_Threshold) : 3;
+
+                            if ((dotDebuff is null || dotDebuff.RemainingTime <= refreshtimer) &&
                                 GetTargetHPPercent() > GetOptionValue(Config.AST_DPS_CombustOption))
                                 return dot;
 

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -350,8 +350,9 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             uint dot = OriginalHook(Bio); //Grab the appropriate DoT Action
                             Status? dotDebuff = FindTargetEffect(BioList[dot]); //Match it with it's Debuff ID, and check for the Debuff
+                            float refreshtimer = IsEnabled(CustomComboPreset.SCH_DPS_Bio_Adv) ? Config.SCH_ST_DPS_Bio_Threshold : 3;
 
-                            if (dotDebuff is null || dotDebuff?.RemainingTime <= Config.SCH_ST_DPS_Bio_Threshold &&
+                            if ((dotDebuff is null || dotDebuff?.RemainingTime <= refreshtimer) &&
                                 GetTargetHPPercent() > Config.SCH_ST_DPS_BioOption)
                                 return dot; //Use appropriate DoT Action
                         }

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -244,7 +244,9 @@ namespace XIVSlothCombo.Combos.PvE
                             if (DosisList.TryGetValue(OriginalHook(actionID), out ushort dotDebuffID))
                             {
                                 Status? dotDebuff = FindTargetEffect(dotDebuffID);
-                                if (dotDebuff is null || dotDebuff.RemainingTime <= Config.SGE_ST_Dosis_Threshold &&
+                                float refreshtimer = IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis_Adv) ? Config.SGE_ST_Dosis_Threshold : 3;
+
+                                if ((dotDebuff is null || dotDebuff.RemainingTime <= refreshtimer) &&
                                     GetTargetHPPercent() > Config.SGE_ST_Dosis_EDosisHPPer)
                                     return Eukrasia;
                             }

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1075,7 +1075,7 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.AST_ST_DPS_CombustUptime)
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_DPS_CombustOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
 
-            if (preset is CustomComboPreset.AST_ST_DPS_CombustUptime)
+            if (preset is CustomComboPreset.AST_ST_DPS_CombustUptime_Adv)
                 UserConfig.DrawRoundedSliderFloat(0, 4, AST.Config.AST_ST_DPS_CombustUptime_Threshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);
 
             if (preset is CustomComboPreset.AST_DPS_Divination)
@@ -1463,7 +1463,7 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.SGE_ST_Dosis_EDosis)
                 UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Dosis_EDosisHPPer), "Stop using at Enemy HP %. Set to Zero to disable this check");
 
-            if (preset is CustomComboPreset.SGE_ST_Dosis_EDosis)
+            if (preset is CustomComboPreset.SGE_ST_Dosis_EDosis_Adv)
                 UserConfig.DrawRoundedSliderFloat(0, 4, nameof(SGE.Config.SGE_ST_Dosis_Threshold), "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);
 
             if (preset is CustomComboPreset.SGE_ST_Dosis_Lucid)
@@ -1577,7 +1577,7 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.SCH_DPS_Bio)
                 UserConfig.DrawSliderInt(0, 100, nameof(SCH.Config.SCH_ST_DPS_BioOption), "Stop using at Enemy HP%. Set to Zero to disable this check.");
 
-            if (preset is CustomComboPreset.SCH_DPS_Bio)
+            if (preset is CustomComboPreset.SCH_DPS_Bio_Adv)
                 UserConfig.DrawRoundedSliderFloat(0, 4, nameof(SCH.Config.SCH_ST_DPS_Bio_Threshold), "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);
 
             if (preset is CustomComboPreset.SCH_DPS_ChainStrat)
@@ -1696,7 +1696,7 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.WHM_ST_MainCombo_DoT)
                 UserConfig.DrawSliderInt(0, 100, WHM.Config.WHM_ST_MainCombo_DoT, "Stop using at Enemy HP %. Set to Zero to disable this check.");
             
-            if (preset is CustomComboPreset.WHM_ST_MainCombo_DoT)
+            if (preset is CustomComboPreset.WHM_ST_MainCombo_DoT_Adv)
                 UserConfig.DrawRoundedSliderFloat(0, 4, WHM.Config.WHM_ST_MainCombo_DoT_Threshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);
             
             if (preset == CustomComboPreset.WHM_AoE_DPS_Lucid)


### PR DESCRIPTION
* Healer DoT Refresh Sliders are activated by a sub option now. Default to 3s if not enabled
* WHM: Added DoT Debuff dictionary from other healers for quicker DoT Debuff checking, instead of level checks