### PR TITLE
Ruin II's Bio feature fixed

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -413,7 +413,7 @@ namespace XIVSlothCombo.Combos.PvE
                     uint dot = OriginalHook(Bio); // Grab the appropriate DoT Action
                     Status? dotDebuff = FindTargetEffect(BioList[dot]); // Match it with it's Debuff ID, and check for the Debuff
 
-                    if ((dotDebuff is null || dotDebuff?.RemainingTime <= Config.SCH_ST_DPS_EnergyDrain) &&
+                    if ((dotDebuff is null || dotDebuff?.RemainingTime <= 3) &&
                         (GetTargetHPPercent() > Config.SCH_ST_DPS_BioOption))
                         return dot; // Use appropriate DoT Action
                 }


### PR DESCRIPTION
Ruin II's Bio debuff refresh changed to 3 second Threshold.