### PR TITLE
Dancer Devilment Priority

### DIFF
--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -425,6 +425,15 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Interrupt) && interruptable)
                         return All.HeadGraze;
 
+                    // Devilment
+                    if (canWeave)
+                    {
+                        bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
+
+                        if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Devilment) && devilmentReady && (techBurst || !LevelChecked(TechnicalStep)))
+                            return Devilment;
+                    }
+
                     // Simple ST Standard (activates dance with no target, or when target is over HP% threshold)
                     if ((!HasTarget() || GetTargetHPPercent() > standardStepBurstThreshold) &&
                         IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && standardStepReady &&
@@ -436,14 +445,11 @@ namespace XIVSlothCombo.Combos.PvE
                         IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) && technicalStepReady && !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
-                    // Devilment & Flourish
+                    // Flourish
                     if (canWeave)
                     {
                         bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
-                        bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
-
-                        if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Devilment) && devilmentReady && (techBurst || !LevelChecked(TechnicalStep)))
-                            return Devilment;
+                        
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Flourish) && flourishReady)
                             return Flourish;
                     }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -425,7 +425,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Interrupt) && interruptable)
                         return All.HeadGraze;
 
-                    // Devilment
+                    // Simple Tech Devilment
                     if (canWeave)
                     {
                         bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
@@ -445,7 +445,7 @@ namespace XIVSlothCombo.Combos.PvE
                         IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) && technicalStepReady && !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
-                    // Flourish
+                    // Simple Tech Flourish
                     if (canWeave)
                     {
                         bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
@@ -554,6 +554,19 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Interrupt) && interruptable)
                         return All.HeadGraze;
 
+
+                    //Simple AOE Tech Devilment
+
+                    if (canWeave)
+                    {
+                        bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
+
+                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Devilment) && devilmentReady &&
+                            (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                            return Devilment;
+
+                    }
+
                     // Simple AoE Standard (activates dance with no target, or when target is over HP% threshold)
                     if ((!HasTarget() || GetTargetHPPercent() > standardStepBurstThreshold) &&
                         IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && standardStepReady &&
@@ -568,12 +581,10 @@ namespace XIVSlothCombo.Combos.PvE
                     if (canWeave)
                     {
                         bool flourishReady = LevelChecked(Flourish) && IsOffCooldown(Flourish) && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) && !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow);
-                        bool devilmentReady = LevelChecked(Devilment) && IsOffCooldown(Devilment);
+                        
 
-                        // Simple AoE Tech Devilment
-                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Devilment) && devilmentReady &&
-                            (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
-                            return Devilment;
+                        // Simple AoE Tech Flourish
+
                         if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Flourish) && flourishReady)
                             return Flourish;
                     }


### PR DESCRIPTION
Standard Step was being prioritized over Devilment in the edge case of Standard Step coming off cooldown while Technical Dancing. 

This is a huge DPS overall and a relatively simple priority fix.
