### PR TITLE
[Framework] Upgraded InActionRange for Radius math of Self Targetting actions

### DIFF
--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -59,9 +59,8 @@ namespace XIVSlothCombo.CustomComboNS.Functions
                         //GetTargetDistance measures hitbox to hitbox (correct usage for ranged abilities so far)
                         //But attacks from player must include personal space (0.5y).
                         if (radius > 0)
-                        {
-                            //Don't nest this if with above. GTD's invalid target return is 0.
-                            if (GetTargetDistance() > 0) return GetTargetDistance() <= (radius - 0.5f); else return false;
+                        {   //Do not nest with above
+                            if (HasTarget()) return GetTargetDistance() <= (radius - 0.5f); else return false;
                         }
                         else return true; //Self use targets (Second Wind) have no radius
                     }

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -42,13 +42,32 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         public static bool InActionRange(uint id)
         {
             int range = ActionWatching.GetActionRange(id);
-            return range switch
+            switch (range)
             {
-                -2 => false,//Doesn't exist in ActionWatching
-                -1 => InMeleeRange(),//In the Sheet, all Melee skills appear to be -1
-                0 => true,//In the Sheet, all self use abilities appear to be 0 (ie no range restriction)
-                _ => GetTargetDistance() <= range,
-            };
+                case -2:
+                    return false; //Error catch, Doesn't exist in ActionWatching
+                case -1:
+                    return InMeleeRange();//In the Sheet, all Melee skills appear to be -1
+                case 0: //Self Use Skills (Second Wind) or attacks (Art of War, Dyskrasia)
+                    {
+                        //NOTES: HOUSING DUMMIES ARE FUCKING CURSED BASTARDS THAT DON'T REGISTER ATTACKS CORRECTLY WITH SELF RADIUS ATTACKS
+                        //Use Explorer Mode dungeon, field map dummies, or let Thancred tank.
+
+                        //Check if there is a radius
+                        float radius = ActionWatching.GetActionEffectRange(id);
+                        //Player has a 0.5y radius inside hitbox.
+                        //GetTargetDistance measures hitbox to hitbox (correct usage for ranged abilities so far)
+                        //But attacks from player must include personal space (0.5y).
+                        if (radius > 0)
+                        {
+                            //Don't nest this if with above. GTD's invalid target return is 0.
+                            if (GetTargetDistance() > 0) return GetTargetDistance() <= (radius - 0.5f); else return false;
+                        }
+                        else return true; //Self use targets (Second Wind) have no radius
+                    }
+                default:
+                    return GetTargetDistance() <= range;
+            }
         } 
 
         /// <summary> Returns the level of a trait. </summary>

--- a/XIVSlothCombo/Data/ActionWatching.cs
+++ b/XIVSlothCombo/Data/ActionWatching.cs
@@ -171,7 +171,7 @@ namespace XIVSlothCombo.Data
 
         public static int GetLevel(uint id) => ActionSheet.TryGetValue(id, out var action) && action.ClassJobCategory is not null ? action.ClassJobLevel : 255;
         public static int GetActionRange(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.Range : -2; // 0 & -1 are valid numbers. -2 is our failure code for InActionRange
-        public static int GetActionRadius(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.EffectRange : -1; //-1 is our failure code for.
+        public static int GetActionEffectRange(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.EffectRange : -1;
         public static int GetTraitLevel(uint id) => TraitSheet.TryGetValue(id, out var trait) ? trait.Level : 255;
         public static string GetActionName(uint id) => ActionSheet.TryGetValue(id, out var action) ? (string)action.Name : "UNKNOWN ABILITY";
         public static string GetStatusName(uint id) => StatusSheet.TryGetValue(id, out var status) ? (string)status.Name : "Unknown Status";

--- a/XIVSlothCombo/Data/ActionWatching.cs
+++ b/XIVSlothCombo/Data/ActionWatching.cs
@@ -171,6 +171,7 @@ namespace XIVSlothCombo.Data
 
         public static int GetLevel(uint id) => ActionSheet.TryGetValue(id, out var action) && action.ClassJobCategory is not null ? action.ClassJobLevel : 255;
         public static int GetActionRange(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.Range : -2; // 0 & -1 are valid numbers. -2 is our failure code for InActionRange
+        public static int GetActionRadius(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.EffectRange : -1; //-1 is our failure code for.
         public static int GetTraitLevel(uint id) => TraitSheet.TryGetValue(id, out var trait) ? trait.Level : 255;
         public static string GetActionName(uint id) => ActionSheet.TryGetValue(id, out var action) ? (string)action.Name : "UNKNOWN ABILITY";
         public static string GetStatusName(uint id) => StatusSheet.TryGetValue(id, out var status) ? (string)status.Name : "Unknown Status";


### PR DESCRIPTION
**[Framework]**
Added `GetActionEffectRange()` to grab a zero-range action's radius
Added logic and notes to `InActionRange()` for radius checking