### PR TITLE
[DNC] Adjustments and extra checks

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -819,6 +819,10 @@ namespace XIVSlothCombo.Combos
             DNC_ST_Simple_Devilment = 4055,
 
             [ParentCombo(DNC_ST_SimpleMode)]
+            [CustomComboInfo("Simple Saber Dance Option", "Includes Saber Dance in the rotation when at or over the Esprit threshold.", DNC.JobID, 3, "", "")]
+            DNC_ST_Simple_SaberDance = 4063,
+
+            [ParentCombo(DNC_ST_SimpleMode)]
             [CustomComboInfo("Simple Flourish Option", "Includes Flourish in the rotation.", DNC.JobID, 3, "", "")]
             DNC_ST_Simple_Flourish = 4056,
 
@@ -883,6 +887,10 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation." +
             "\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 5, "", "")]
             DNC_AoE_Simple_Devilment = 4075,
+
+            [ParentCombo(DNC_AoE_SimpleMode)]
+            [CustomComboInfo("Simple AoE Saber Dance Option", "Includes Saber Dance in the AoE rotation when at or over the Esprit threshold.", DNC.JobID, 6, "", "")]
+            DNC_AoE_Simple_SaberDance = 4082,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
             [CustomComboInfo("Simple AoE Flourish Option", "Includes Flourish in the AoE rotation.", DNC.JobID, 6, "", "")]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -776,7 +776,7 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
         [ConflictingCombos(DNC_CombinedDances, DNC_DanceComboReplacer)]
-        [CustomComboInfo("Dance Step Combo Feature", "Change Standard Step and Technical Step into each dance step while dancing." +
+        [CustomComboInfo("Dance Step Combo Feature", "Change Standard Step and Technical Step into each dance step, while dancing." +
         "\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
         DNC_DanceStepCombo = 4039,
 
@@ -815,7 +815,7 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_ST_SimpleMode)]
             [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation." +
-            "\nWill activate only during Technical Finish if you are Lv70 or above.", DNC.JobID, 2, "", "")]
+            "\nWill activate only during Technical Finish if you're Lv70 or above.", DNC.JobID, 2, "", "")]
             DNC_ST_Simple_Devilment = 4055,
 
             [ParentCombo(DNC_ST_SimpleMode)]
@@ -885,7 +885,7 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_AoE_SimpleMode)]
             [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation." +
-            "\nWill activate only during Technical Finish if you Lv70 or above.", DNC.JobID, 5, "", "")]
+            "\nWill activate only during Technical Finish if you're Lv70 or above.", DNC.JobID, 5, "", "")]
             DNC_AoE_Simple_Devilment = 4075,
 
             [ParentCombo(DNC_AoE_SimpleMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -815,7 +815,8 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_ST_SimpleMode)]
             [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation." +
-            "\nWill activate only during Technical Finish if you're Lv70 or above.", DNC.JobID, 2, "", "")]
+            "\nWill activate only during Technical Finish if you're Lv70 or above." +
+            "\nWill be used on cooldown below Lv70.", DNC.JobID, 2, "", "")]
             DNC_ST_Simple_Devilment = 4055,
 
             [ParentCombo(DNC_ST_SimpleMode)]
@@ -885,7 +886,8 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_AoE_SimpleMode)]
             [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation." +
-            "\nWill activate only during Technical Finish if you're Lv70 or above.", DNC.JobID, 5, "", "")]
+            "\nWill activate only during Technical Finish if you're Lv70 or above." +
+            "\nWill be used on cooldown below Lv70.", DNC.JobID, 5, "", "")]
             DNC_AoE_Simple_Devilment = 4075,
 
             [ParentCombo(DNC_AoE_SimpleMode)]

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -488,7 +488,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
-                        (GetCooldownRemainingTime(TechnicalStep) > 2.5 || IsOffCooldown(TechnicalStep)))
+                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
                         if (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
                             (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50))
@@ -611,7 +611,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
-                        (GetCooldownRemainingTime(TechnicalStep) > 2.5 || IsOffCooldown(TechnicalStep)))
+                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
                         if (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
                             (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -484,7 +484,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
                         ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) && GetCooldownRemainingTime(TechnicalStep) > 2.5) ||
-                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
+                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50)))
                         return SaberDance;
 
                     // ST combos and burst attacks
@@ -604,7 +604,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
                         ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) && GetCooldownRemainingTime(TechnicalStep) > 2.5) ||
-                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
+                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50)))
                         return SaberDance;
 
                     // AoE combos and burst attacks

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -428,7 +428,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Standard Step
                     if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent)) &&
                         IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && ActionReady(StandardStep) &&
-                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish) && GetCooldownRemainingTime(TechnicalStep) > 10) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
+                        ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 10) &&
+                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish)) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
                         return StandardStep;
 
                     // ST Technical Step
@@ -550,7 +551,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Standard Step
                     if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent)) &&
                         IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && ActionReady(StandardStep) &&
-                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish) && GetCooldownRemainingTime(TechnicalStep) > 10) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
+                        ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 10) &&
+                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish)) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
                         return StandardStep;
 
                     // AoE Technical Step

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -490,10 +490,10 @@ namespace XIVSlothCombo.Combos.PvE
                     if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime is < 2 and > 0)
                         return Fountain;
 
-                    if (HasEffect(Buffs.FlourishingFinish))
-                        return Tillana;
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
+                    if (HasEffect(Buffs.FlourishingFinish))
+                        return Tillana;
 
                     if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
@@ -609,10 +609,10 @@ namespace XIVSlothCombo.Combos.PvE
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime is < 2 and > 0)
                         return Bladeshower;
 
-                    if (HasEffect(Buffs.FlourishingFinish))
-                        return Tillana;
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
+                    if (HasEffect(Buffs.FlourishingFinish))
+                        return Tillana;
 
                     if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -222,32 +222,31 @@ namespace XIVSlothCombo.Combos.PvE
                     DNCGauge? gauge = GetJobGauge<DNCGauge>();
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
-                    bool canWeave = CanWeave(actionID);
-                    int espritThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_ST);
                     #endregion
 
-                    // ST Esprit overcap options
-                    if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) &&
-                        LevelChecked(SaberDance) && gauge.Esprit >= espritThreshold)
+                    // ST Esprit overcap protection
+                    if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) && LevelChecked(SaberDance) &&
+                        gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_ST))
                         return SaberDance;
 
-                    if (canWeave)
+                    if (CanWeave(actionID))
                     {
                         // ST Fan Dance overcap protection
                         if (IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap) &&
-                            gauge.Feathers is 4 && LevelChecked(FanDance1))
+                            LevelChecked(FanDance1) && gauge.Feathers is 4)
                             return FanDance1;
 
                         // ST Fan Dance 3/4 on combo
                         if (IsEnabled(CustomComboPreset.DNC_ST_FanDance34))
                         {
-                            if (HasEffect(Buffs.ThreeFoldFanDance) && LevelChecked(FanDance3))
+                            if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
-                            if (HasEffect(Buffs.FourFoldFanDance) && LevelChecked(FanDance4))
+                            if (HasEffect(Buffs.FourFoldFanDance))
                                 return FanDance4;
                         }
                     }
 
+                    // ST base combos
                     if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
                     if (LevelChecked(ReverseCascade) && symmetry)
@@ -272,20 +271,18 @@ namespace XIVSlothCombo.Combos.PvE
                     DNCGauge? gauge = GetJobGauge<DNCGauge>();
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
-                    bool canWeave = CanWeave(actionID);
-                    int espritThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_AoE);
                     #endregion
 
-                    // AoE Esprit overcap
-                    if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) &&
-                        LevelChecked(SaberDance) && gauge.Esprit >= espritThreshold)
+                    // AoE Esprit overcap protection
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) && LevelChecked(SaberDance) && 
+                        gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_AoE))
                         return SaberDance;
 
-                    if (canWeave)
+                    if (CanWeave(actionID))
                     {
                         // AoE Fan Dance overcap protection
                         if (IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap) &&
-                            gauge.Feathers is 4 && LevelChecked(FanDance2))
+                            LevelChecked(FanDance2) && gauge.Feathers is 4)
                             return FanDance2;
 
                         // AoE Fan Dance 3/4 on combo
@@ -298,6 +295,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
+                    // AoE base combos
                     if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;
                     if (LevelChecked(RisingWindmill) && symmetry)

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -483,7 +483,8 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
-                        ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) && GetCooldownRemainingTime(TechnicalStep) > 2.5) ||
+                        ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) &&
+                        (GetCooldownRemainingTime(TechnicalStep) > 2.5)) || IsOffCooldown(TechnicalStep) ||
                         (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50)))
                         return SaberDance;
 
@@ -603,7 +604,8 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
-                        ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) && GetCooldownRemainingTime(TechnicalStep) > 2.5) ||
+                        ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) &&
+                        (GetCooldownRemainingTime(TechnicalStep) > 2.5)) || IsOffCooldown(TechnicalStep) ||
                         (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50)))
                         return SaberDance;
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -145,24 +145,21 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                bool FD3Ready = HasEffect(Buffs.ThreeFoldFanDance);
-                bool FD4Ready = HasEffect(Buffs.FourFoldFanDance);
-
                 // FD 1 --> 3, FD 1 --> 4
                 if (actionID is FanDance1)
                 {
-                    if (FD3Ready && IsEnabled(CustomComboPreset.DNC_FanDance_1to3_Combo))
+                    if (HasEffect(Buffs.ThreeFoldFanDance) && IsEnabled(CustomComboPreset.DNC_FanDance_1to3_Combo))
                         return FanDance3;
-                    if (FD4Ready && IsEnabled(CustomComboPreset.DNC_FanDance_1to4_Combo))
+                    if (HasEffect(Buffs.FourFoldFanDance) && IsEnabled(CustomComboPreset.DNC_FanDance_1to4_Combo))
                         return FanDance4;
                 }
 
                 // FD 2 --> 3, FD 2 --> 4
                 if (actionID is FanDance2)
                 {
-                    if (FD3Ready && IsEnabled(CustomComboPreset.DNC_FanDance_2to3_Combo))
+                    if (HasEffect(Buffs.ThreeFoldFanDance) && IsEnabled(CustomComboPreset.DNC_FanDance_2to3_Combo))
                         return FanDance3;
-                    if (FD4Ready && IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo))
+                    if (HasEffect(Buffs.FourFoldFanDance) && IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo))
                         return FanDance4;
                 }
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -426,11 +426,13 @@ namespace XIVSlothCombo.Combos.PvE
                         return All.HeadGraze;
 
                     // ST Standard Step
-                    if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent)) &&
-                        IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && ActionReady(StandardStep) &&
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && ActionReady(StandardStep))
+                    {
+                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent)) &&
                         ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 10) &&
-                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish)) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
+                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish)) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5)) || InCombat())
                         return StandardStep;
+                    }
 
                     // ST Technical Step
                     if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent)) &&
@@ -557,11 +559,14 @@ namespace XIVSlothCombo.Combos.PvE
                         return All.HeadGraze;
 
                     // AoE Standard Step
-                    if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent)) &&
-                        IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && ActionReady(StandardStep) &&
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && ActionReady(StandardStep))
+                    {
+                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent)) &&
                         ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 10) &&
-                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish)) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
+                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish)) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5)) ||
+                        (InCombat() && ActionReady(StandardStep)))
                         return StandardStep;
+                    }
 
                     // AoE Technical Step
                     if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent)) &&

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -568,12 +568,6 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
                         return Flourish;
 
-                    // AoE Saber Dance
-                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
-                        (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) ||
-                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
-                        return SaberDance;
-
                     if (CanWeave(actionID))
                     {
                         // AoE Feathers & Fans
@@ -606,6 +600,12 @@ namespace XIVSlothCombo.Combos.PvE
                             ActionReady(Improvisation))
                             return Improvisation;
                     }
+
+                    // AoE Saber Dance
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
+                        (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) ||
+                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
+                        return SaberDance;
 
                     // AoE combos and burst attacks
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime is < 2 and > 0)

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -98,6 +98,8 @@ namespace XIVSlothCombo.Combos.PvE
             public const string
                 DNCSimpleFeatherBurstPercent = "DNCSimpleFeatherBurstPercent";              // Feather burst    target HP% threshold
             public const string
+                DNCSimpleSaberThreshold = "DNCSimpleSaberThreshold";                        // Saber Dance      Esprit threshold
+            public const string
                 DNCSimplePanicHealWaltzPercent = "DNCSimplePanicHealWaltzPercent";          // Curing Waltz     player HP% threshold
             public const string
                 DNCSimplePanicHealWindPercent = "DNCSimplePanicHealWindPercent";            // Second Wind      player HP% threshold
@@ -108,6 +110,8 @@ namespace XIVSlothCombo.Combos.PvE
                 DNCSimpleSSAoEBurstPercent = "DNCSimpleSSAoEBurstPercent";                  // Standard Step    target HP% threshold
             public const string
                 DNCSimpleTSAoEBurstPercent = "DNCSimpleTSAoEBurstPercent";                  // Technical Step   target HP% threshold
+            public const string
+                DNCSimpleAoESaberThreshold = "DNCSimpleAoESaberThreshold";                  // Saber Dance      Esprit threshold
             public const string
                 DNCSimpleAoEPanicHealWaltzPercent = "DNCSimpleAoEPanicHealWaltzPercent";    // Curing Waltz     player HP% threshold 
             public const string
@@ -477,8 +481,9 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // ST Saber Dance
-                    if (LevelChecked(SaberDance) &&
-                        (gauge.Esprit >= 85 || (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
+                        (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
+                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
                         return SaberDance;
 
                     // ST combos and burst attacks
@@ -562,8 +567,9 @@ namespace XIVSlothCombo.Combos.PvE
                         return Flourish;
 
                     // AoE Saber Dance
-                    if (LevelChecked(SaberDance) &&
-                        (gauge.Esprit >= 85 || (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
+                        (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) ||
+                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
                         return SaberDance;
 
                     if (CanWeave(actionID))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -457,9 +457,14 @@ namespace XIVSlothCombo.Combos.PvE
 
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
-                            if (gauge.Feathers > minFeathers ||
-                                (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0) ||
+
+                            // Basic FD1
+                            if ((IsOffCooldown(TechnicalStep) && gauge.Feathers > 3) ||
                                 (GetTargetHPPercent() < featherBurstThreshold && gauge.Feathers > 0))
+                                return FanDance1;
+
+                            // Burst FD1
+                            if (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0))
                                 return FanDance1;
                         }
 
@@ -483,10 +488,12 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
-                        ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) &&
-                        (GetCooldownRemainingTime(TechnicalStep) > 2.5)) || IsOffCooldown(TechnicalStep) ||
-                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50)))
-                        return SaberDance;
+                        (GetCooldownRemainingTime(TechnicalStep) > 2.5 || IsOffCooldown(TechnicalStep)))
+                    {
+                        if (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
+                            (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50))
+                            return SaberDance;
+                    }
 
                     // ST combos and burst attacks
                     if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime is < 2 and > 0)
@@ -604,10 +611,12 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
-                        ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) &&
-                        (GetCooldownRemainingTime(TechnicalStep) > 2.5)) || IsOffCooldown(TechnicalStep) ||
-                        (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50)))
-                        return SaberDance;
+                        (GetCooldownRemainingTime(TechnicalStep) > 2.5 || IsOffCooldown(TechnicalStep)))
+                    {
+                        if (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
+                            (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50))
+                            return SaberDance;
+                    }
 
                     // AoE combos and burst attacks
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime is < 2 and > 0)

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -483,7 +483,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
-                        (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
+                        ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) && GetCooldownRemainingTime(TechnicalStep) > 2.5) ||
                         (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
                         return SaberDance;
 
@@ -603,7 +603,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
-                        (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) ||
+                        ((gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) && GetCooldownRemainingTime(TechnicalStep) > 2.5) ||
                         (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit > 50)))
                         return SaberDance;
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -316,12 +316,10 @@ namespace XIVSlothCombo.Combos.PvE
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Starfall_Devilment;
 
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                return actionID is Devilment && HasEffect(Buffs.FlourishingStarfall)
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) =>
+                actionID is Devilment && HasEffect(Buffs.FlourishingStarfall)
                     ? StarfallDance
                     : actionID;
-            }
         }
 
         internal class DNC_CombinedDances : CustomCombo

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1174,6 +1174,9 @@ namespace XIVSlothCombo.Window.Functions
             if (preset == CustomComboPreset.DNC_ST_Simple_FeatherPooling)
                 UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleFeatherBurstPercent, "Target HP percentage to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
+            if (preset == CustomComboPreset.DNC_ST_Simple_SaberDance)
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCSimpleSaberThreshold, "Esprit", 150, SliderIncrements.Ones);
+
             if (preset == CustomComboPreset.DNC_ST_Simple_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWaltzPercent, "Curing Waltz HP percent", 200, SliderIncrements.Ones);
 
@@ -1189,6 +1192,9 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_TS)
                 UserConfig.DrawSliderInt(0, 10, DNC.Config.DNCSimpleTSAoEBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
+
+            if (preset == CustomComboPreset.DNC_AoE_Simple_SaberDance)
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCSimpleAoESaberThreshold, "Esprit", 150, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWaltzPercent, "Curing Waltz HP percent", 200, SliderIncrements.Ones);


### PR DESCRIPTION
# Changes
• Migrated Simple Modes to `ActionReady()` use
• Added `Simple Saber Dance Option`
• Added `Simple AoE Saber Dance Option`
• Optimised `Esprit` gauge spending near `Technical Step` burst phase
• Added pre-burst protection check to `Saber Dance` use
• Adjusted `Standard Step` priority in differing combat states
• Adjusted `Technical Step` priority in differing combat states
• Adjusted `Devilment` priority in `Simple Dancer (Single Target) Feature`
• Adjusted `Devilment` priority in `Simple Dancer (AoE) Feature`
• Adjusted `Tillana` priority in `Simple Dancer (Single Target) Feature`
• Adjusted `Tillana` priority in `Simple Dancer (AoE) Feature`
• Adjusted `Starfall Dance` priority in `Simple Dancer (Single Target) Feature`
• Adjusted `Starfall Dance` priority in `Simple Dancer (AoE) Feature`
• Adjusted `Saber Dance` priority in `Simple Dancer (AoE) Feature`
• Added `Technical Finish` burst check to `Simple Interrupt Option`
• Added `Technical Finish` burst check to `Simple AoE Interrupt Option`
• Added `Technical Step` cooldown check to `Simple Standard Dance Option`
• Added `Technical Step` cooldown check to `Simple AoE Standard Dance Option`
• Fixed `Standard Step` use when `Technical Step` is excluded from the rotation
• Removed deprecated/unnecessary types from Simple Modes
• Adjusted some option descriptions
• Adjusted comments
• Other tidying