### PR TITLE
[SAM] Extra Kenki Utilisation in Opener

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -204,11 +204,11 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 if (twoSeal && gauge.MeditationStacks == 0 && GetCooldownRemainingTime(Ikishoten) < 110 && IsOnCooldown(Ikishoten))
                                 {
-                                    if (gauge.Kenki >= 10 && IsOffCooldown(Gyoten))
-                                        return Gyoten;
-
                                     if (gauge.Kenki >= 25)
                                         return Shinten;
+
+                                    if (gauge.Kenki >= 10 && IsOffCooldown(Gyoten))
+                                        return Gyoten;
                                 }
 
                                 if (twoSeal && IsOffCooldown(Ikishoten))


### PR DESCRIPTION
Minor change to Sam Opener that lets you use 10 extra Kenki if you have it from Prepull or a successful Third Eye during the opener (as almost every boss has a big AoE during your opener to use it on)