### PR TITLE
[SGE] DPS Revamp

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2332,62 +2332,62 @@ namespace XIVSlothCombo.Combos
 
         #region Single Target DPS Feature
         [ReplaceSkill(SGE.Dosis, SGE.Dosis2, SGE.Dosis3)]
-        [CustomComboInfo("Single Target DPS Feature", "", SGE.JobID, 100, "", "")]
-        SGE_ST_Dosis = 14100,
+        [CustomComboInfo("Single Target DPS Feature", "Adds various options to Dosis I/II/III.", SGE.JobID, 100, "", "")]
+        SGE_ST_DPS = 14100,
                 
-            [ParentCombo(SGE_ST_Dosis)]
+            [ParentCombo(SGE_ST_DPS)]
             [CustomComboInfo("Lucid Dreaming Option", "Weaves Lucid Dreaming when your MP drops below the specified value.", SGE.JobID, 120, "", "")]
-            SGE_ST_Dosis_Lucid = 14110,
+            SGE_ST_DPS_Lucid = 14110,
 
-            [ParentCombo(SGE_ST_Dosis)]
+            [ParentCombo(SGE_ST_DPS)]
             [CustomComboInfo("Eukrasian Dosis Option", "Automatic DoT Uptime.", SGE.JobID, 110, "", "")]
-            SGE_ST_Dosis_EDosis = 14120,
+            SGE_ST_DPS_EDosis = 14120,
 
-            [ParentCombo(SGE_ST_Dosis)]
-            [CustomComboInfo("Toxikon Option", "Use Toxikon when you have Addersting charges.", SGE.JobID, 112, "", "")]
-            SGE_ST_Dosis_Toxikon = 14130,
+            [ParentCombo(SGE_ST_DPS)]
+            [CustomComboInfo("Movement Options", "Use selected instant cast actions while moving.", SGE.JobID, 112, "", "")]
+            SGE_ST_DPS_Movement = 14130,
 
-            [ParentCombo(SGE_ST_Dosis)]
+            [ParentCombo(SGE_ST_DPS)]
             [CustomComboInfo("Phlegma Option", "Use Phlegma if available and within range.", SGE.JobID, 111, "", "")]
-            SGE_ST_Dosis_Phlegma = 14140,
+            SGE_ST_DPS_Phlegma = 14140,
 
-            [ParentCombo(SGE_ST_Dosis)]
+            [ParentCombo(SGE_ST_DPS)]
             [CustomComboInfo("Kardia Reminder Option", "Adds Kardia when not under the effect.", SGE.JobID, 122, "", "")]
-            SGE_ST_Dosis_Kardia = 14150,
+            SGE_ST_DPS_Kardia = 14150,
 
-            [ParentCombo(SGE_ST_Dosis)]
+            [ParentCombo(SGE_ST_DPS)]
             [CustomComboInfo("Rhizomata Option", "Weaves Rhizomata when Addersgall gauge falls below the specified value.", SGE.JobID, 121, "", "")]
-            SGE_ST_Dosis_Rhizo = 14160,
+            SGE_ST_DPS_Rhizo = 14160,
         #endregion
 
         #region AoE DPS Feature
         [ReplaceSkill(SGE.Phlegma, SGE.Phlegma2, SGE.Phlegma3)]
         [CustomComboInfo("AoE DPS Feature", "", SGE.JobID, 200, "", "")]
-        SGE_AoE_Phlegma = 14200,
+        SGE_AoE_DPS = 14200,
 
-            [ParentCombo(SGE_AoE_Phlegma)]
+            [ParentCombo(SGE_AoE_DPS)]
             [CustomComboInfo("Toxikon - No Phlegma Charges Option", "Use Toxikon when out of Phlegma charges.\nTakes priority over Dyskrasia.", SGE.JobID, 210, "", "")]
-            SGE_AoE_Phlegma_NoPhlegmaToxikon = 14210,
+            SGE_AoE_DPS_NoPhlegmaToxikon = 14210,
 
-            [ParentCombo(SGE_AoE_Phlegma)]
+            [ParentCombo(SGE_AoE_DPS)]
             [CustomComboInfo("Toxikon - Out of Phlegma Range Option", "Use Toxikon when out of Phlemga's Range.\nTakes priority over Dyskrasia.", SGE.JobID, 220, "", "")]
-            SGE_AoE_Phlegma_OutOfRangeToxikon = 14220,
+            SGE_AoE_DPS_OutOfRangeToxikon = 14220,
 
-            [ParentCombo(SGE_AoE_Phlegma)]
+            [ParentCombo(SGE_AoE_DPS)]
             [CustomComboInfo("Dyskrasia - No Phlegma Charges Option", "Use Dyskrasia when out of Phlegma charges.", SGE.JobID, 230, "", "")]
-            SGE_AoE_Phlegma_NoPhlegmaDyskrasia = 14230,
+            SGE_AoE_DPS_NoPhlegmaDyskrasia = 14230,
 
-            [ParentCombo(SGE_AoE_Phlegma)]
+            [ParentCombo(SGE_AoE_DPS)]
             [CustomComboInfo("Dyskrasia - No-Target Option", "Use Dyskrasia when no target is selected.", SGE.JobID, 240, "", "")]
-            SGE_AoE_Phlegma_NoTargetDyskrasia = 14240,
+            SGE_AoE_DPS_NoTargetDyskrasia = 14240,
 
-            [ParentCombo(SGE_AoE_Phlegma)]
+            [ParentCombo(SGE_AoE_DPS)]
             [CustomComboInfo("Lucid Dreaming Option", "Weaves Lucid Dreaming when your MP falls below the specified value.", SGE.JobID, 250, "", "")]
-            SGE_AoE_Phlegma_Lucid = 14250,
+            SGE_AoE_DPS_Lucid = 14250,
 
-            [ParentCombo(SGE_AoE_Phlegma)]
+            [ParentCombo(SGE_AoE_DPS)]
             [CustomComboInfo("Rhizomata Option", "Weaves Rhizomata when Addersgall gauge falls below the specified value.", SGE.JobID, 121, "", "")]
-            SGE_AoE_Phlegma_Rhizo = 14260,
+            SGE_AoE_DPS_Rhizo = 14260,
         #endregion
 
         #region Diagnosis Simple Single Target Heal

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -98,30 +98,40 @@ namespace XIVSlothCombo.Combos.PvE
         internal static class Config
         {
             #region DPS
-            internal static bool SGE_ST_Dosis_AltMode => CustomComboFunctions.GetIntOptionAsBool(nameof(SGE_ST_Dosis_AltMode));
-            internal static bool SGE_ST_Dosis_Toxikon => CustomComboFunctions.GetIntOptionAsBool(nameof(SGE_ST_Dosis_Toxikon));
-            internal static int SGE_ST_Dosis_EDosisHPPer => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Dosis_EDosisHPPer));
-            internal static bool SGE_ST_Dosis_EDosis_Adv => PluginConfiguration.GetCustomBoolValue(nameof(SGE_ST_Dosis_EDosis_Adv));
-            internal static float SGE_ST_Dosis_EDosisThreshold => CustomComboFunctions.GetOptionFloat(nameof(SGE_ST_Dosis_EDosisThreshold));
-            internal static int SGE_ST_Dosis_Lucid => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Dosis_Lucid));
-            internal static int SGE_ST_Dosis_Rhizo => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Dosis_Rhizo));
+            internal static UserBool
+                SGE_ST_DPS_Adv = new("SGE_ST_DPS_Adv"),
+                SGE_ST_DPS_Adv_D2 = new("SGE_ST_Dosis_AltMode"),
+                SGE_ST_DPS_Adv_GroupInstants = new("SGE_ST_DPS_Adv_GroupInstants"),
+                SGE_ST_DPS_EDosis_Adv = new("SGE_ST_Dosis_EDosis_Adv");
+            internal static UserBoolArray
+                SGE_ST_DPS_Adv_GroupInstants_Addl = new("SGE_ST_DPS_Adv_GroupInstants_Addl"),
+                SGE_ST_DPS_Movement = new("SGE_ST_DPS_Movement");
+            internal static UserInt
+                SGE_ST_DPS_EDosisHPPer = new("SGE_ST_Dosis_EDosisHPPer"),
+                SGE_ST_DPS_Lucid = new("SGE_ST_DPS_Lucid"),
+                SGE_ST_DPS_Rhizo = new("SGE_ST_DPS_Rhizo"),
+                SGE_AoE_DPS_Lucid = new("SGE_AoE_Phlegma_Lucid"),
+                SGE_AoE_DPS_Rhizo = new("SGE_AoE_DPS_Rhizo");
+            internal static UserFloat
+                SGE_ST_DPS_EDosisThreshold = new("SGE_ST_Dosis_EDosisThreshold");
             #endregion
 
             #region Healing
-            internal static int SGE_ST_Heal_Zoe => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Zoe));
-            internal static int SGE_ST_Heal_Haima => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Haima));
-            internal static int SGE_ST_Heal_Krasis => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Krasis));
-            internal static int SGE_ST_Heal_Pepsis => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Pepsis));
-            internal static int SGE_ST_Heal_Soteria => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Soteria));
-            internal static int SGE_ST_Heal_Diagnosis => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Diagnosis));
-            internal static int SGE_ST_Heal_Druochole => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Druochole));
-            internal static int SGE_ST_Heal_Taurochole => CustomComboFunctions.GetOptionValue(nameof(SGE_ST_Heal_Taurochole));
+            internal static UserInt
+                SGE_ST_Heal_Zoe = new("SGE_ST_Heal_Zoe"),
+                SGE_ST_Heal_Haima = new("SGE_ST_Heal_Haima"),
+                SGE_ST_Heal_Krasis = new("SGE_ST_Heal_Krasis"),
+                SGE_ST_Heal_Pepsis = new("SGE_ST_Heal_Pepsis"),
+                SGE_ST_Heal_Soteria = new("SGE_ST_Heal_Soteria"),
+                SGE_ST_Heal_Diagnosis = new("SGE_ST_Heal_Diagnosis"),
+                SGE_ST_Heal_Druochole = new("SGE_ST_Heal_Druochole"),
+                SGE_ST_Heal_Taurochole = new("SGE_ST_Heal_Taurochole");
             #endregion
 
-            internal static int SGE_AoE_Phlegma_Lucid => CustomComboFunctions.GetOptionValue(nameof(SGE_AoE_Phlegma_Lucid));
-            internal static int SGE_AoE_Phlegma_Rhizo => CustomComboFunctions.GetOptionValue(nameof(SGE_AoE_Phlegma_Rhizo));
-            internal static int SGE_Eukrasia_Mode => CustomComboFunctions.GetOptionValue(nameof(SGE_Eukrasia_Mode));
+            internal static UserInt
+                SGE_Eukrasia_Mode = new("SGE_Eukrasia_Mode");
         }
+
 
         /*
          * SGE_Kardia
@@ -175,28 +185,28 @@ namespace XIVSlothCombo.Combos.PvE
          * Replaces Zero Charges/Stacks of Phlegma with various options
          * Lucid Dreaming, Toxikon, or Dyskrasia
          */
-        internal class SGE_AoE_Phlegma : CustomCombo
+        internal class SGE_AoE_DPS : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_Phlegma;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_AoE_DPS;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (PhlegmaList.Contains(actionID))
                 {
-                    bool NoPhlegmaToxikon = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoPhlegmaToxikon);
-                    bool OutOfRangeToxikon = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_OutOfRangeToxikon);
-                    bool NoPhlegmaDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoPhlegmaDyskrasia);
-                    bool NoTargetDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_NoTargetDyskrasia);
+                    bool NoPhlegmaToxikon = IsEnabled(CustomComboPreset.SGE_AoE_DPS_NoPhlegmaToxikon);
+                    bool OutOfRangeToxikon = IsEnabled(CustomComboPreset.SGE_AoE_DPS_OutOfRangeToxikon);
+                    bool NoPhlegmaDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_DPS_NoPhlegmaDyskrasia);
+                    bool NoTargetDyskrasia = IsEnabled(CustomComboPreset.SGE_AoE_DPS_NoTargetDyskrasia);
                     uint phlegma = OriginalHook(Phlegma); //Level appropriate Phlegma
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Lucid) &&
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Lucid) &&
                         ActionReady(All.LucidDreaming) && CanSpellWeave(Dosis) &&
-                        LocalPlayer.CurrentMp <= Config.SGE_AoE_Phlegma_Lucid)
+                        LocalPlayer.CurrentMp <= Config.SGE_AoE_DPS_Lucid)
                         return All.LucidDreaming;
 
                     // Rhizomata
-                    if (IsEnabled(CustomComboPreset.SGE_AoE_Phlegma_Rhizo) && CanSpellWeave(Dosis) &&
-                        ActionReady(Rhizomata) && Gauge.Addersgall <= Config.SGE_AoE_Phlegma_Rhizo)
+                    if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Rhizo) && CanSpellWeave(Dosis) &&
+                        ActionReady(Rhizomata) && Gauge.Addersgall <= Config.SGE_AoE_DPS_Rhizo)
                         return Rhizomata;
 
                     // Toxikon
@@ -221,33 +231,42 @@ namespace XIVSlothCombo.Combos.PvE
         }
 
         /*
-         * SGE_ST_Dosis (Single Target Dosis Combo)
+         * SGE_ST_DPS (Single Target DPS Combo)
          * Currently Replaces Dosis with Eukrasia when the debuff on the target is < 3 seconds or not existing
          * Kardia reminder, Lucid Dreaming, & Toxikon optional
          */
-        internal class SGE_ST_Dosis : CustomCombo
+        internal class SGE_ST_DPS : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_Dosis;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ST_DPS;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                bool AlternateMode = Config.SGE_ST_Dosis_AltMode;
-                if ((!AlternateMode && DosisList.ContainsKey(actionID)) ||
-                    (AlternateMode && actionID is Dosis2))
+                bool ActionFound;
+                bool GroupInstants = false;
+
+                if (Config.SGE_ST_DPS_Adv)
+                {
+                    GroupInstants = actionID is Toxikon && Config.SGE_ST_DPS_Adv_GroupInstants;
+                    ActionFound = (!Config.SGE_ST_DPS_Adv_D2 && DosisList.ContainsKey(actionID)) || //not restricted to Dosis 2
+                                  actionID is Dosis2 ||                                             //Dosis 2 is always allowed
+                                  GroupInstants;                                                    //Group Instants on Toxikon
+                } else ActionFound = DosisList.ContainsKey(actionID); //default handling
+
+                if (ActionFound)
                 {
                     // Kardia Reminder
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Kardia) && LevelChecked(Kardia) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Kardia) && LevelChecked(Kardia) &&
                         FindEffect(Buffs.Kardia) is null)
                         return Kardia;
 
                     // Lucid Dreaming
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Lucid) &&
+                    if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Lucid) &&
                         ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) &&
-                        LocalPlayer.CurrentMp <= Config.SGE_ST_Dosis_Lucid)
+                        LocalPlayer.CurrentMp <= Config.SGE_ST_DPS_Lucid)
                         return All.LucidDreaming;
 
                     // Rhizomata
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Rhizo) && CanSpellWeave(actionID) &&
-                        ActionReady(Rhizomata) && Gauge.Addersgall <= Config.SGE_ST_Dosis_Rhizo)
+                    if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Rhizo) && CanSpellWeave(actionID) &&
+                        ActionReady(Rhizomata) && Gauge.Addersgall <= Config.SGE_ST_DPS_Rhizo)
                         return Rhizomata;
 
                     if (HasBattleTarget() && (!HasEffect(Buffs.Eukrasia)))
@@ -255,7 +274,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         // Eukrasian Dosis.
                         // If we're too low level to use Eukrasia, we can stop here.
-                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_EDosis) && LevelChecked(Eukrasia) && InCombat())
+                        if (IsEnabled(CustomComboPreset.SGE_ST_DPS_EDosis) && LevelChecked(Eukrasia) && InCombat())
                         {
                             // Grab current Dosis via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
                             // Using TryGetValue due to edge case where the actionID would be read as Eukrasian Dosis instead of Dosis
@@ -263,28 +282,50 @@ namespace XIVSlothCombo.Combos.PvE
                             if (DosisList.TryGetValue(OriginalHook(actionID), out ushort dotDebuffID))
                             {
                                 Status? dotDebuff = FindTargetEffect(dotDebuffID);
-                                float refreshtimer = Config.SGE_ST_Dosis_EDosis_Adv ? Config.SGE_ST_Dosis_EDosisThreshold : 3;
+                                float refreshtimer = Config.SGE_ST_DPS_EDosis_Adv ? Config.SGE_ST_DPS_EDosisThreshold : 3;
 
                                 if ((dotDebuff is null || dotDebuff.RemainingTime <= refreshtimer) &&
-                                    GetTargetHPPercent() > Config.SGE_ST_Dosis_EDosisHPPer)
+                                    GetTargetHPPercent() > Config.SGE_ST_DPS_EDosisHPPer)
                                     return Eukrasia;
                             }
                         }
 
                         // Phlegma
-                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Phlegma) && InCombat())
+                        if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Phlegma) && InCombat())
                         {
                             uint phlegma = OriginalHook(Phlegma);
                             if (InActionRange(phlegma) && ActionReady(phlegma)) return phlegma;
                         }
 
-                        // Toxikon
-                        bool alwaysShowToxikon = Config.SGE_ST_Dosis_Toxikon;    // False for moving only, True for Show All Times
-                        if (IsEnabled(CustomComboPreset.SGE_ST_Dosis_Toxikon) && InCombat() &&
-                            LevelChecked(Toxikon) &&
-                            ((!alwaysShowToxikon && IsMoving) || alwaysShowToxikon) &&
-                            Gauge.HasAddersting())
-                            return OriginalHook(Toxikon);
+
+                        // Movement Options
+                        if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Movement) && InCombat() && IsMoving)
+                        {
+                            if (Config.SGE_ST_DPS_Movement.Length == 3)
+                            {
+                                // Toxikon
+                                if (Config.SGE_ST_DPS_Movement[0] && LevelChecked(Toxikon) && Gauge.HasAddersting()) return OriginalHook(Toxikon);
+                                // Dyskrasia
+                                if (Config.SGE_ST_DPS_Movement[1] && LevelChecked(Dyskrasia) && InActionRange(Dyskrasia)) return OriginalHook(Dyskrasia);
+                                // Eukrasia
+                                if (Config.SGE_ST_DPS_Movement[2] && LevelChecked(Eukrasia)) return Eukrasia;
+                            }
+                        }
+                    }
+
+                    //Group Instant GCDs
+                    if (GroupInstants)
+                    {
+                        if (HasEffect(Buffs.Eukrasia)) return OriginalHook(Dosis);
+                        
+                        if (Config.SGE_ST_DPS_Adv_GroupInstants_Addl.Length == 2)
+                        {
+                            // Toxikon
+                            if (Config.SGE_ST_DPS_Adv_GroupInstants_Addl[0] && LevelChecked(Toxikon) && Gauge.HasAddersting()) return OriginalHook(Toxikon);
+                            // Dyskrasia
+                            if (Config.SGE_ST_DPS_Adv_GroupInstants_Addl[1] && LevelChecked(Dyskrasia) && InActionRange(Dyskrasia)) return OriginalHook(Dyskrasia);
+                        }
+                        return Eukrasia;
                     }
                 }
                 return actionID;
@@ -314,7 +355,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Eukrasia && HasEffect(Buffs.Eukrasia))
                 {
-                    switch (Config.SGE_Eukrasia_Mode)
+                    switch (PluginConfiguration.GetCustomIntValue(Config.SGE_Eukrasia_Mode))
                     {
                         case 0: return OriginalHook(Dosis);
                         case 1: return OriginalHook(Diagnosis);

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -301,7 +301,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Movement Options
                         if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Movement) && InCombat() && IsMoving)
                         {
-                            if (Config.SGE_ST_DPS_Movement.Length == 3)
+                            if (Config.SGE_ST_DPS_Movement.Count == 3)
                             {
                                 // Toxikon
                                 if (Config.SGE_ST_DPS_Movement[0] && LevelChecked(Toxikon) && Gauge.HasAddersting()) return OriginalHook(Toxikon);
@@ -318,7 +318,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (HasEffect(Buffs.Eukrasia)) return OriginalHook(Dosis);
                         
-                        if (Config.SGE_ST_DPS_Adv_GroupInstants_Addl.Length == 2)
+                        if (Config.SGE_ST_DPS_Adv_GroupInstants_Addl.Count == 2)
                         {
                             // Toxikon
                             if (Config.SGE_ST_DPS_Adv_GroupInstants_Addl[0] && LevelChecked(Toxikon) && Gauge.HasAddersting()) return OriginalHook(Toxikon);

--- a/XIVSlothCombo/CustomCombo/Functions/Config.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Config.cs
@@ -13,4 +13,38 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 
         public static float GetOptionFloat(string SliderID) => PluginConfiguration.GetCustomFloatValue(SliderID);
     }
+
+    internal class UserData
+    {
+        protected string pName;
+        public UserData(string v) => pName = v;
+        public static implicit operator string(UserData o) => (o.pName);
+    }
+
+    internal class UserFloat : UserData
+    {
+        public UserFloat(string v) : base(v) { }
+        public static implicit operator float(UserFloat o) => PluginConfiguration.GetCustomFloatValue(o.pName);
+    }
+
+    internal class UserInt : UserData
+    {
+        public UserInt(string v) : base(v) { }
+        public static implicit operator int(UserInt o) => PluginConfiguration.GetCustomIntValue(o.pName);
+    }
+
+    internal class UserBool : UserData
+    {
+        public UserBool(string v) : base(v) { }
+        public static implicit operator bool(UserBool o) => PluginConfiguration.GetCustomBoolValue(o.pName);
+    }
+
+    internal class UserBoolArray : UserData
+    {
+        public UserBoolArray(string v) : base(v) { }
+        public int Length => PluginConfiguration.GetCustomBoolArrayValue(this.pName).Length;
+        public bool this[int index] => PluginConfiguration.GetCustomBoolArrayValue(this.pName)[index];
+        public static implicit operator bool[](UserBoolArray o) => PluginConfiguration.GetCustomBoolArrayValue(o.pName);
+    }
+
 }

--- a/XIVSlothCombo/CustomCombo/Functions/Config.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Config.cs
@@ -42,7 +42,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
     internal class UserBoolArray : UserData
     {
         public UserBoolArray(string v) : base(v) { }
-        public int Length => PluginConfiguration.GetCustomBoolArrayValue(this.pName).Length;
+        public int Count => PluginConfiguration.GetCustomBoolArrayValue(this.pName).Length;
         public bool this[int index] => PluginConfiguration.GetCustomBoolArrayValue(this.pName)[index];
         public static implicit operator bool[](UserBoolArray o) => PluginConfiguration.GetCustomBoolArrayValue(o.pName);
     }

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1478,13 +1478,13 @@ namespace XIVSlothCombo.Window.Functions
             {
                 UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_DPS_Adv, "Advanced Action Options", "Change how Dosis actions are handled", isConditionalChoice: true);
 
-                if (PluginConfiguration.GetCustomBoolValue(SGE.Config.SGE_ST_DPS_Adv))
+                if (SGE.Config.SGE_ST_DPS_Adv)
                 {
                     ImGui.Indent();
                     UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_DPS_Adv_D2, "Apply all selected options to Dosis II", "Dosis I & III will behave normally.");
                     UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_DPS_Adv_GroupInstants, "Instant Actions on Toxikon", "Adds instant GCDs and oGCDs to Toxikon.\nDefaults to Eukrasia.", isConditionalChoice: true);
 
-                    if (PluginConfiguration.GetCustomBoolValue(SGE.Config.SGE_ST_DPS_Adv_GroupInstants))
+                    if (SGE.Config.SGE_ST_DPS_Adv_GroupInstants)
                     {
                         ImGui.Indent();
                         ImGui.Spacing();//Not sure why I need this, indenting did not work without it
@@ -1501,7 +1501,7 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_DPS_EDosisHPPer, "Stop using at Enemy HP %. Set to Zero to disable this check");
 
                 UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_DPS_EDosis_Adv, "Advanced Options", "", isConditionalChoice: true);
-                if (PluginConfiguration.GetCustomBoolValue(SGE.Config.SGE_ST_DPS_EDosis_Adv))
+                if (SGE.Config.SGE_ST_DPS_EDosis_Adv)
                 {
                     ImGui.Indent();
                     UserConfig.DrawRoundedSliderFloat(0, 4, SGE.Config.SGE_ST_DPS_EDosisThreshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -439,6 +439,7 @@ namespace XIVSlothCombo.Window.Functions
             ImGui.SameLine();
             bool[]? values = PluginConfiguration.GetCustomBoolArrayValue(config);
 
+            //If new saved options or amount of choices changed, resize and save
             if (values.Length == 0 || values.Length != totalChoices)
             {
                 Array.Resize(ref values, totalChoices);
@@ -1473,72 +1474,90 @@ namespace XIVSlothCombo.Window.Functions
             // ====================================================================================
             #region SAGE
 
-            if (preset is CustomComboPreset.SGE_ST_Dosis)
+            if (preset is CustomComboPreset.SGE_ST_DPS)
             {
-                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_ST_Dosis_AltMode), "On All Dosis Actions", "", 0);
-                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_ST_Dosis_AltMode), "On Dosis II", "Alternative DPS Mode. Leaves Dosis & Dosis III alone for normal DPS", 1);
-            }
+                UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_DPS_Adv, "Advanced Action Options", "Change how Dosis actions are handled", isConditionalChoice: true);
 
-            if (preset is CustomComboPreset.SGE_ST_Dosis_EDosis)
-            {
-                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Dosis_EDosisHPPer), "Stop using at Enemy HP %. Set to Zero to disable this check");
-
-                UserConfig.DrawAdditionalBoolChoice(nameof(SGE.Config.SGE_ST_Dosis_EDosis_Adv), "Advanced Options", "", isConditionalChoice: true);
-                if (PluginConfiguration.GetCustomBoolValue(nameof(SGE.Config.SGE_ST_Dosis_EDosis_Adv)))
+                if (PluginConfiguration.GetCustomBoolValue(SGE.Config.SGE_ST_DPS_Adv))
                 {
                     ImGui.Indent();
-                    UserConfig.DrawRoundedSliderFloat(0, 4, nameof(SGE.Config.SGE_ST_Dosis_EDosisThreshold), "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);
+                    UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_DPS_Adv_D2, "Apply all selected options to Dosis II", "Dosis I & III will behave normally.");
+                    UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_DPS_Adv_GroupInstants, "Instant Actions on Toxikon", "Adds instant GCDs and oGCDs to Toxikon.\nDefaults to Eukrasia.", isConditionalChoice: true);
+
+                    if (PluginConfiguration.GetCustomBoolValue(SGE.Config.SGE_ST_DPS_Adv_GroupInstants))
+                    {
+                        ImGui.Indent();
+                        ImGui.Spacing();//Not sure why I need this, indenting did not work without it
+                        UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Adv_GroupInstants_Addl, "Add Toxikon", "Use Toxikon when Addersting is available.", 2, 0);
+                        UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Adv_GroupInstants_Addl, "Add Dyskrasia", "Use Dyskrasia when in range of a selected enemy target.", 2, 1);
+                        ImGui.Unindent();
+                    }
                     ImGui.Unindent();
                 }
             }
 
-            if (preset is CustomComboPreset.SGE_ST_Dosis_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, nameof(SGE.Config.SGE_ST_Dosis_Lucid), "MP Threshold", 150, SliderIncrements.Hundreds);
-
-            if (preset is CustomComboPreset.SGE_ST_Dosis_Rhizo)
-                UserConfig.DrawSliderInt(0, 1, nameof(SGE.Config.SGE_ST_Dosis_Rhizo), "Addersgall Threshold", 150, SliderIncrements.Ones);
-
-            if (preset is CustomComboPreset.SGE_ST_Dosis_Toxikon)
+            if (preset is CustomComboPreset.SGE_ST_DPS_EDosis)
             {
-                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_ST_Dosis_Toxikon), "Show when moving only", "", 0);
-                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_ST_Dosis_Toxikon), "Show at all times", "", 1);
+                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_DPS_EDosisHPPer, "Stop using at Enemy HP %. Set to Zero to disable this check");
+
+                UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_DPS_EDosis_Adv, "Advanced Options", "", isConditionalChoice: true);
+                if (PluginConfiguration.GetCustomBoolValue(SGE.Config.SGE_ST_DPS_EDosis_Adv))
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawRoundedSliderFloat(0, 4, SGE.Config.SGE_ST_DPS_EDosisThreshold, "Seconds remaining before reapplying the DoT. Set to Zero to disable this check.", digits: 1);
+                    ImGui.Unindent();
+                }
             }
 
-            if (preset is CustomComboPreset.SGE_AoE_Phlegma_Lucid)
-                UserConfig.DrawSliderInt(4000, 9500, nameof(SGE.Config.SGE_AoE_Phlegma_Lucid), "MP Threshold", 150, SliderIncrements.Hundreds);
+            if (preset is CustomComboPreset.SGE_ST_DPS_Lucid)
+                UserConfig.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_DPS_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
 
-            if (preset is CustomComboPreset.SGE_AoE_Phlegma_Rhizo)
-                UserConfig.DrawSliderInt(0, 1, nameof(SGE.Config.SGE_AoE_Phlegma_Rhizo), "Addersgall Threshold", 150, SliderIncrements.Ones);
+
+            if (preset is CustomComboPreset.SGE_ST_DPS_Rhizo)
+                UserConfig.DrawSliderInt(0, 1, SGE.Config.SGE_ST_DPS_Rhizo, "Addersgall Threshold", 150, SliderIncrements.Ones);
+
+            if (preset is CustomComboPreset.SGE_ST_DPS_Movement)
+            {
+                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, "Toxikon", "Use Toxikon when Addersting is available.", 3, 0);
+                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, "Dyskrasia", "Use Dyskrasia when in range of a selected enemy target.", 3, 1);
+                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, "Eukrasia", "Use Eukrasia.", 3, 2);
+            }
+
+            if (preset is CustomComboPreset.SGE_AoE_DPS_Lucid)
+                UserConfig.DrawSliderInt(4000, 9500, SGE.Config.SGE_AoE_DPS_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);
+
+            if (preset is CustomComboPreset.SGE_AoE_DPS_Rhizo)
+                UserConfig.DrawSliderInt(0, 1, SGE.Config.SGE_AoE_DPS_Rhizo, "Addersgall Threshold", 150, SliderIncrements.Ones);
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Soteria)
-                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Soteria), "Use Soteria when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Soteria, "Use Soteria when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Zoe)
-                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Zoe), "Use Zoe when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Zoe, "Use Zoe when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Pepsis)
-                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Pepsis), "Use Pepsis when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Pepsis, "Use Pepsis when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Taurochole)
-                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Taurochole), "Use Taurochole when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Taurochole, "Use Taurochole when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Haima)
-                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Haima), "Use Haima when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Haima, "Use Haima when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Krasis)
-                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Krasis), "Use Krasis when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Krasis, "Use Krasis when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Druochole)
-                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Druochole), "Use Druochole when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Druochole, "Use Druochole when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Diagnosis)
-                UserConfig.DrawSliderInt(0, 100, nameof(SGE.Config.SGE_ST_Heal_Diagnosis), "Use Diagnosis when Target HP is at or below set percentage");
+                UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Diagnosis, "Use Diagnosis when Target HP is at or below set percentage");
 
             if (preset is CustomComboPreset.SGE_Eukrasia)
             {
-                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_Eukrasia_Mode), "Eukrasian Dosis", "", 0);
-                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_Eukrasia_Mode), "Eukrasian Diagnosis", "", 1);
-                UserConfig.DrawRadioButton(nameof(SGE.Config.SGE_Eukrasia_Mode), "Eukrasian Prognosis", "", 2);
+                UserConfig.DrawRadioButton(SGE.Config.SGE_Eukrasia_Mode, "Eukrasian Dosis", "", 0);
+                UserConfig.DrawRadioButton(SGE.Config.SGE_Eukrasia_Mode, "Eukrasian Diagnosis", "", 1);
+                UserConfig.DrawRadioButton(SGE.Config.SGE_Eukrasia_Mode, "Eukrasian Prognosis", "", 2);
             }
 
             #endregion


### PR DESCRIPTION
@k-kz for your sanity
Your #1062 should be merged first, then #1053 (both are part of this, but just to be safe)

**[Framework]**
Fixed `DrawHorizontalMultiChoice` failing if userdata was did not already exist or not an expected array size
New UserConfig class helpers added

**[SGE]**
Restructured `Alternative DPS Mode` to `Advanced Action Options`
Added `Advanced Action Option` on `Toxikon` (concept from #1042)
Renamed `Toxikon Option` to `Movement Options`
Added use of `Toxikon`, `Dyskrasia` and `Eukrasia` to `Movement Options`
Internal Name cleanup (`SGE_ST_Dosis -> SGE_ST_DPS`, `SGE_AoE_Phlegma -> SGE_AoE_DPS`)