### PR TITLE
[RPR] Regress null error fix

### DIFF
--- a/XIVSlothCombo/Combos/PvE/RPR.cs
+++ b/XIVSlothCombo/Combos/PvE/RPR.cs
@@ -477,7 +477,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                return (actionID is HellsEgress or HellsIngress) && FindEffect(Buffs.Threshold).RemainingTime <= 9
+                return (actionID is HellsEgress or HellsIngress) && FindEffect(Buffs.Threshold)?.RemainingTime <= 9
                     ? Regress
                     : actionID;
             }


### PR DESCRIPTION
RPR Regress's FindEffect was returning null errors in Dalamud when the buff did not exist. Code was checking a cooldown against a null.