### PR TITLE
[MNK] Changes to the "Bootshine" replacement function

### DIFF
--- a/XIVSlothCombo/Combos/PvE/MNK.cs
+++ b/XIVSlothCombo/Combos/PvE/MNK.cs
@@ -247,9 +247,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.LeadenFist) &&
                         (HasEffect(Buffs.FormlessFist) ||
                         HasEffect(Buffs.PerfectBalance) ||
-                        HasEffect(Buffs.OpoOpoForm) ||
-                        HasEffect(Buffs.RaptorForm) ||
-                        HasEffect(Buffs.CoerlForm)))
+                        HasEffect(Buffs.OpoOpoForm)))
                         return Bootshine;
 
                     if (level < Levels.DragonKick)


### PR DESCRIPTION
When ST function is OFF and Dragon Kick --> Bootshine Feature function is ON, Dragon Kick was switched to Bootshine in all forms, but now it is switched only in FF and Opo-opo forms.