### PR TITLE
[BLM] Aetherial Manipulation Feature

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -422,6 +422,10 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Thunder 1/3 Option", "Adds Thunder 1/3 when the debuff isn't present or expiring to Advanced BLM.", BLM.JobID, 0, "", "")]
         BLM_TransposeThunderUptime = 2030,
 
+        [ReplaceSkill(BLM.AetherialManipulation)]
+        [CustomComboInfo("Aetherial Manipulation Feature", "Replaces Aetherial Manipulation with Between the Lines when out of active Ley Lines and standing still.", BLM.JobID, 0, "", "")]
+        BLM_AetherialManipulation = 2031,
+
         #endregion
 
         #region BLUE MAGE

--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -28,6 +28,7 @@ namespace XIVSlothCombo.Combos.PvE
             Scathe = 156,
             Freeze = 159,
             Flare = 162,
+            AetherialManipulation = 155,
             LeyLines = 3573,
             Blizzard4 = 3576,
             Fire4 = 3577,
@@ -49,6 +50,7 @@ namespace XIVSlothCombo.Combos.PvE
             internal const ushort
                 Thundercloud = 164,
                 LeyLines = 737,
+                CircleOfPower = 738,
                 Firestarter = 165,
                 Sharpcast = 867,
                 Triplecast = 1211;
@@ -135,6 +137,19 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) => 
                 actionID is LeyLines && HasEffect(Buffs.LeyLines) && LevelChecked(BetweenTheLines) ? BetweenTheLines : actionID;
+        }
+
+        internal class BLM_AetherialManipulation : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BLM_AetherialManipulation;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) =>
+                actionID is AetherialManipulation &&
+                ActionReady(BetweenTheLines) &&
+                HasEffect(Buffs.LeyLines) && 
+                !HasEffect(Buffs.CircleOfPower) &&
+                !IsMoving
+                ? BetweenTheLines : actionID;
         }
 
         internal class BLM_Mana : CustomCombo


### PR DESCRIPTION
Discord Request: New feature to replace Aetherial Manipulation with Between the Lines while Ley Lines is active and player is not moving. Movement check exists in case the player needs to use Aetherial Manipulation to someone too far away outside of Ley Lines.