### PR TITLE
GNB 3.0 Rework

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1177,7 +1177,7 @@ namespace XIVSlothCombo.Combos
 
         #region ST
         [ReplaceSkill(GNB.KeenEdge)]
-        [CustomComboInfo("Advanced Gunbreaker", "Replace Solid Barrel with its combo chain and uses Burst Strike to prevent ammo overcap.", GNB.JobID, 0, "", "")]
+        [CustomComboInfo("Advanced Gunbreaker", "Replace Keen Edge with its combo chain and uses Burst Strike to prevent ammo overcap.", GNB.JobID, 0, "", "")]
         GNB_ST_MainCombo = 7001,
 
         #region Gnashing Fang
@@ -1259,8 +1259,8 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         #region AOE
-        [ReplaceSkill(GNB.DemonSlaughter)]
-        [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain.", GNB.JobID, 0, "", "")]
+        [ReplaceSkill(GNB.DemonSlice)]
+        [CustomComboInfo("AoE Combo", "Replace Demon Slice with its combo chain.", GNB.JobID, 0, "", "")]
         GNB_AoE_MainCombo = 7300,
 
         [ConflictingCombos(GNB_NoMercy_Cooldowns)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1172,140 +1172,162 @@ namespace XIVSlothCombo.Combos
 
         #region GUNBREAKER
 
-        [ReplaceSkill(GNB.SolidBarrel)]
-        [CustomComboInfo("Solid Barrel Combo", "Replace Solid Barrel with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Advanced Gunbreaker)", GNB.JobID, 0, "", "")]
-        GNB_ST_MainCombo = 7000,
+        [CustomComboInfo("Skill Speed Support", "Allows for features to support various skill speed rotations.", GNB.JobID, 0)]
+        GNB_ST_SkSSupport = 7000,
 
+        #region ST
+        [ReplaceSkill(GNB.KeenEdge)]
+        [CustomComboInfo("Advanced Gunbreaker", "Replace Solid Barrel with its combo chain and uses Burst Strike to prevent ammo overcap.", GNB.JobID, 0, "", "")]
+        GNB_ST_MainCombo = 7001,
+
+        #region Gnashing Fang
         [ParentCombo(GNB_ST_MainCombo)]
         [CustomComboInfo("Gnashing Fang and Continuation on Main Combo", "Adds Gnashing Fang to the main combo. Gnashing Fang must be started manually and the combo will finish it off.\n Useful for when Gnashing Fang needs to be help due to downtime.", GNB.JobID, 0, "", "")]
-        GNB_ST_Gnashing = 7001,
+        GNB_ST_Gnashing = 7002,
 
+        [ParentCombo(GNB_ST_Gnashing)]
+        [CustomComboInfo("Gnashing Fang Starter", "Begins Gnashing Fang to the main combo.", GNB.JobID, 0, "", "")]
+        GNB_ST_GnashingFang_Starter = 7003,
+        #endregion
+
+        #region Cooldowns
         [ParentCombo(GNB_ST_MainCombo)]
         [CustomComboInfo("Cooldowns on Main Combo", "Adds various cooldowns to the main combo when under No Mercy or when No Mercy is on cooldown", GNB.JobID, 0, "", "")]
-        GNB_ST_MainCombo_CooldownsGroup = 7002,
+        GNB_ST_MainCombo_CooldownsGroup = 7004,
 
         [ParentCombo(GNB_ST_MainCombo_CooldownsGroup)]
         [CustomComboInfo("Double Down on Main Combo", "Adds Double Down to the main combo when under No Mercy buff", GNB.JobID, 0, "", "")]
-        GNB_ST_DoubleDown = 7003,
-
-        [ParentCombo(GNB_ST_MainCombo)]
-        [CustomComboInfo("Rough Divide Option", "Adds Rough Divide to the main combo whenever it's available.", GNB.JobID, 0, "", "")]
-        GNB_ST_RoughDivide = 7004,
+        GNB_ST_DoubleDown = 7005,
 
         [ParentCombo(GNB_ST_MainCombo_CooldownsGroup)]
         [CustomComboInfo("Danger Zone/Blasting Zone on Main Combo", "Adds Danger Zone/Blasting Zone to the main combo", GNB.JobID, 0, "", "")]
-        GNB_ST_BlastingZone = 7005,
-
-        [ReplaceSkill(GNB.DemonSlaughter)]
-        [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain.", GNB.JobID, 0, "", "")]
-        GNB_AoE_MainCombo = 7006,
-
-        [ReplaceSkill(GNB.SolidBarrel, GNB.DemonSlaughter)]
-        [CustomComboInfo("Ammo Overcap Feature", "Uses Burst Strike/Fated Circle on the respective ST/AoE combos when ammo is about to overcap.", GNB.JobID, 0, "", "")]
-        GNB_AmmoOvercap = 7007,
-
-        [ReplaceSkill(GNB.GnashingFang)]
-        [CustomComboInfo("Gnashing Fang Continuation Combo", "Adds Continuation to Gnashing Fang.", GNB.JobID, 0, "", "")]
-        GNB_ST_GnashingFangContinuation = 7008,
-
-        [ParentCombo(GNB_ST_GnashingFangContinuation)]
-        [CustomComboInfo("No Mercy on Gnashing Fang", "Adds No Mercy to Gnashing Fang when it's ready.", GNB.JobID, 0, "", "")]
-        GNB_ST_GnashingFang_NoMercy = 7009,
-
-        [ParentCombo(GNB_ST_GnashingFangContinuation)]
-        [CustomComboInfo("Double Down on Gnashing Fang", "Adds Double Down to Gnashing Fang when No Mercy buff is up.", GNB.JobID, 0, "", "")]
-        GNB_ST_GnashingFang_DoubleDown = 7010,
-
-        [ParentCombo(GNB_ST_GnashingFangContinuation)]
-        [CustomComboInfo("CDs on Gnashing Fang", "Adds Sonic Break/Bow Shock/Blasting Zone on Gnashing Fang, order dependent on No Mercy buff. \nBurst Strike and Hypervelocity added if there's charges while No Mercy buff is up.", GNB.JobID, 0, "", "")]
-        GNB_ST_GnashingFang_Cooldowns = 7011,
-
-        [ReplaceSkill(GNB.BurstStrike)]
-        [CustomComboInfo("Burst Strike Continuation", "Adds Hypervelocity on Burst Strike.", GNB.JobID, 0, "", "")]
-        GNB_ST_BurstStrikeContinuation = 7012,
-
-        [ReplaceSkill(GNB.BurstStrike)]
-        [CustomComboInfo("Burst Strike to Bloodfest Feature", "Replace Burst Strike with Bloodfest if you have no powder gauge.", GNB.JobID, 0, "", "")]
-        GNB_ST_Bloodfest_Overcap = 7013,
+        GNB_ST_BlastingZone = 7006,
 
         [ParentCombo(GNB_ST_MainCombo_CooldownsGroup)]
         [CustomComboInfo("Bloodfest on Main Combo", "Adds Bloodfest to the main combo when ammo is 0.", GNB.JobID, 0, "", "")]
-        GNB_ST_Bloodfest = 7014,
-
-        [ParentCombo(GNB_ST_MainCombo)]
-        [CustomComboInfo("Lightning Shot Uptime", "Adds Lightning Shot to the main combo when you are out of range.", GNB.JobID, 0, "", "")]
-        GNB_RangedUptime = 7015,
-
-        [ConflictingCombos(GNB_NoMercy_Cooldowns)]
-        [ParentCombo(GNB_AoE_MainCombo)]
-        [CustomComboInfo("No Mercy AoE Option", "Adds No Mercy to AoE combo when it's available.", GNB.JobID, 0, "", "")]
-        GNB_AoE_NoMercy = 7016,
-
-        [ParentCombo(GNB_AoE_MainCombo)]
-        [CustomComboInfo("Bow Shock on AoE Feature", "Adds Bow Shock onto the AoE combo when it's off cooldown.", GNB.JobID, 0, "", "")]
-        GNB_AoE_BowShock = 7017,
+        GNB_ST_Bloodfest = 7007,
 
         [ConflictingCombos(GNB_NoMercy_Cooldowns)]
         [ParentCombo(GNB_ST_MainCombo_CooldownsGroup)]
         [CustomComboInfo("No Mercy on Main Combo", "Adds No Mercy to the main combo when at full ammo.", GNB.JobID, 0, "", "")]
-        GNB_ST_NoMercy = 7018,
-
-        [ParentCombo(GNB_ST_Gnashing)]
-        [CustomComboInfo("Gnashing Fang Starter", "Begins Gnashing Fang to the main combo.", GNB.JobID, 0, "", "")]
-        GNB_ST_GnashingFang_Starter = 7019,
+        GNB_ST_NoMercy = 7008,
 
         [ParentCombo(GNB_ST_MainCombo_CooldownsGroup)]
         [CustomComboInfo("Bow Shock on Main Combo", "Adds Bow Shock to the main combo.", GNB.JobID, 0, "", "")]
-        GNB_ST_BowShock = 7020,
+        GNB_ST_BowShock = 7009,
 
         [ParentCombo(GNB_ST_MainCombo_CooldownsGroup)]
         [CustomComboInfo("Sonic Break on Main Combo", "Adds Sonic Break to the main combo.", GNB.JobID, 0, "", "")]
-        GNB_ST_SonicBreak = 7021,
-
-        [ConflictingCombos(GNB_ST_NoMercy, GNB_AoE_NoMercy)]
-        [ReplaceSkill(GNB.NoMercy)]
-        [CustomComboInfo("Cooldowns on No Mercy", "Adds Cooldowns to No Mercy when No Mercy is on cooldown.", GNB.JobID, 0, "", "")]
-        GNB_NoMercy_Cooldowns = 7022,
+        GNB_ST_SonicBreak = 7010,
 
         [ParentCombo(GNB_ST_MainCombo_CooldownsGroup)]
         [CustomComboInfo("Burst Strike on Main Combo", "Adds Burst Strike and Hypervelocity (when available) to the main combo when under No Mercy and Gnashing Fang is over.", GNB.JobID, 0, "", "")]
-        GNB_NoMercy_BurstStrike = 7023,
+        GNB_ST_BurstStrike = 7011,
+        #endregion
 
-        [ParentCombo(GNB_AoE_MainCombo)]
-        [CustomComboInfo("Bloodfest AoE Option", "Adds Bloodfest to AoE combo when it's available. Will dump Ammo through Fated Circle to prepare for Bloodfest.", GNB.JobID, 0, "", "")]
-        GNB_AoE_Bloodfest = 7024,
-
-        [ParentCombo(GNB_AoE_MainCombo)]
-        [CustomComboInfo("Double Down AoE Option", "Adds Double Down to AoE combo when it's available and there is 2 or more ammo.", GNB.JobID, 0, "", "")]
-        GNB_AoE_DoubleDown = 7025,
-
-        [ReplaceSkill(GNB.BurstStrike)]
-        [CustomComboInfo("Double Down on Burst Strike Feature", "Adds Double Down to Burst Strike when under No Mercy and ammo is above 2.", GNB.JobID, 0, "", "")]
-        GNB_BurstStrike_DoubleDown = 7026,
+        #region Rough Divide
+        [ParentCombo(GNB_ST_MainCombo)]
+        [CustomComboInfo("Rough Divide Option", "Adds Rough Divide to the main combo whenever it's available.", GNB.JobID, 0, "", "")]
+        GNB_ST_RoughDivide = 7012,
 
         [ParentCombo(GNB_ST_RoughDivide)]
         [CustomComboInfo("Melee Rough Divide Option", "Uses Rough Divide when under No Mercy, burst cooldowns when available, not moving, and in the target ring (1 yalm).\nWill use as many stacks as selected in the above slider.", GNB.JobID, 0, "", "")]
-        GNB_ST_MeleeRoughDivide = 7027,
+        GNB_ST_MeleeRoughDivide = 7013,
+        #endregion
 
-        [CustomComboInfo("Aurora Protection Feature", "Turns Aurora into Nascent Flash if Aurora's effect is on the player.", GNB.JobID, 0, "", "")]
-        GNB_AuroraProtection = 7028,
+        [ParentCombo(GNB_ST_MainCombo)]
+        [CustomComboInfo("Lightning Shot Uptime", "Adds Lightning Shot to the main combo when you are out of range.", GNB.JobID, 0, "", "")]
+        GNB_ST_RangedUptime = 7014,
+        #endregion
+
+        #region Gnashing Fang
+        [ReplaceSkill(GNB.GnashingFang)]
+        [CustomComboInfo("Gnashing Fang Continuation Combo", "Adds Continuation to Gnashing Fang.", GNB.JobID, 0, "", "")]
+        GNB_GF_Continuation = 7200,
+
+        [ParentCombo(GNB_GF_Continuation)]
+        [CustomComboInfo("No Mercy on Gnashing Fang", "Adds No Mercy to Gnashing Fang when it's ready.", GNB.JobID, 0, "", "")]
+        GNB_GF_NoMercy = 7201,
+
+        [ParentCombo(GNB_GF_Continuation)]
+        [CustomComboInfo("Double Down on Gnashing Fang", "Adds Double Down to Gnashing Fang when No Mercy buff is up.", GNB.JobID, 0, "", "")]
+        GNB_GF_DoubleDown = 7202,
+
+        [ParentCombo(GNB_GF_Continuation)]
+        [CustomComboInfo("CDs on Gnashing Fang", "Adds Bloodfest/Sonic Break/Bow Shock/Blasting Zone on Gnashing Fang, order dependent on No Mercy buff. \nBurst Strike and Hypervelocity added if there's charges while No Mercy buff is up.", GNB.JobID, 0, "", "")]
+        GNB_GF_Cooldowns = 7203,
+        #endregion
+
+        #region AOE
+        [ReplaceSkill(GNB.DemonSlaughter)]
+        [CustomComboInfo("Demon Slaughter Combo", "Replace Demon Slaughter with its combo chain.", GNB.JobID, 0, "", "")]
+        GNB_AoE_MainCombo = 7300,
+
+        [ConflictingCombos(GNB_NoMercy_Cooldowns)]
+        [ParentCombo(GNB_AoE_MainCombo)]
+        [CustomComboInfo("No Mercy AoE Option", "Adds No Mercy to AoE combo when it's available.", GNB.JobID, 0, "", "")]
+        GNB_AoE_NoMercy = 7301,
+
+        [ParentCombo(GNB_AoE_MainCombo)]
+        [CustomComboInfo("Bow Shock on AoE Feature", "Adds Bow Shock onto the AoE combo when it's off cooldown.", GNB.JobID, 0, "", "")]
+        GNB_AoE_BowShock = 7302,
+
+        [ParentCombo(GNB_AoE_MainCombo)]
+        [CustomComboInfo("Bloodfest AoE Option", "Adds Bloodfest to AoE combo when it's available. Will dump Ammo through Fated Circle to prepare for Bloodfest.", GNB.JobID, 0, "", "")]
+        GNB_AoE_Bloodfest = 7303,
+
+        [ParentCombo(GNB_AoE_MainCombo)]
+        [CustomComboInfo("Double Down AoE Option", "Adds Double Down to AoE combo when it's available and there is 2 or more ammo.", GNB.JobID, 0, "", "")]
+        GNB_AoE_DoubleDown = 7304,
 
         [ParentCombo(GNB_AoE_MainCombo)]
         [CustomComboInfo("Danger Zone on AoE Feature", "Adds Danger Zone to the AoE combo when it's off cooldown.", GNB.JobID, 0, "", "")]
-        GNB_AOE_DangerZone = 7029,
+        GNB_AOE_DangerZone = 7305,
 
         [ParentCombo(GNB_AoE_MainCombo)]
         [CustomComboInfo("Sonic Break on AoE Feature", "Adds Sonic Break to the AoE combo when it's off cooldown.", GNB.JobID, 0, "", "")]
-        GNB_AOE_SonicBreak = 7030,
+        GNB_AOE_SonicBreak = 7306,
+
+        [ParentCombo(GNB_AoE_MainCombo)]
+        [CustomComboInfo("Ammo Overcap Feature", "Adds Fated Circle to the AoE combo when about to overcap.", GNB.JobID, 0, "", "")]
+        GNB_AOE_Overcap = 7307,
+        #endregion
+
+        #region Burst Strike
+        [ReplaceSkill(GNB.BurstStrike)]
+        [CustomComboInfo("Burst Strike Features", "Collection of Burst Strike related features.", GNB.JobID, 0, "", "")]
+        GNB_BS = 7400,
+        
+        [ParentCombo(GNB_BS)]
+        [CustomComboInfo("Burst Strike Continuation", "Adds Hypervelocity on Burst Strike.", GNB.JobID, 0, "", "")]
+        GNB_BS_Continuation = 7401,
+
+        [ParentCombo(GNB_BS)]
+        [CustomComboInfo("Burst Strike to Bloodfest Feature", "Replace Burst Strike with Bloodfest if you have no powder gauge.", GNB.JobID, 0, "", "")]
+        GNB_BS_Bloodfest = 7402,
+
+        [ParentCombo(GNB_BS)]
+        [CustomComboInfo("Double Down on Burst Strike Feature", "Adds Double Down to Burst Strike when under No Mercy and ammo is above 2.", GNB.JobID, 0, "", "")]
+        GNB_BS_DoubleDown = 7403,
+        #endregion
+
+        #region No Mercy
+        [ConflictingCombos(GNB_ST_NoMercy, GNB_AoE_NoMercy)]
+        [ReplaceSkill(GNB.NoMercy)]
+        [CustomComboInfo("Cooldowns on No Mercy", "Adds Cooldowns to No Mercy when No Mercy is on cooldown.", GNB.JobID, 0, "", "")]
+        GNB_NoMercy_Cooldowns = 7500,
 
         [ParentCombo(GNB_NoMercy_Cooldowns)]
         [CustomComboInfo("Double Down Option", "Adds Double Down to No Mercy when No Mercy is on cooldown", GNB.JobID, 0, "", "")]
-        GNB_NoMercy_Cooldowns_DD = 7031,
+        GNB_NoMercy_Cooldowns_DD = 7501,
 
         [ParentCombo(GNB_NoMercy_Cooldowns)]
         [CustomComboInfo("Sonic Break/Bow Shock Option", "Adds Sonic Break and Bow Shock to No Mercy when No Mercy is on cooldown", GNB.JobID, 0, "", "")]
-        GNB_NoMercy_Cooldowns_SonicBreakBowShock = 7032,
+        GNB_NoMercy_Cooldowns_SonicBreakBowShock = 7502,
+        #endregion
 
+        [CustomComboInfo("Aurora Protection Feature", "Turns Aurora into Nascent Flash if Aurora's effect is on the player.", GNB.JobID, 0, "", "")]
+        GNB_AuroraProtection = 7600,
         #endregion
 
         #region MACHINIST

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -410,7 +410,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 
-                if (actionID == DemonSlaughter)
+                if (actionID == DemonSlice)
                 {
                     var gauge = GetJobGauge<GNBGauge>();
 

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -10,7 +10,7 @@ namespace XIVSlothCombo.Combos.PvE
 
         public static int MaxCartridges(byte level)
         {
-            return level >= Levels.CartridgeCharge3 ? 3 : 2;
+            return level >= 88 ? 3 : 2;
         }
 
         public const uint
@@ -59,35 +59,12 @@ namespace XIVSlothCombo.Combos.PvE
                 SonicBreak = 1837;
         }
 
-        public static class Levels
-        {
-            public const byte
-                NoMercy = 2,
-                BrutalShell = 4,
-                LightningShot = 15,
-                DangerZone = 18,
-                SolidBarrel = 26,
-                BurstStrike = 30,
-                DemonSlaughter = 40,
-                Aurora = 45,
-                SonicBreak = 54,
-                RoughDivide = 56,
-                GnashingFang = 60,
-                BowShock = 62,
-                Continuation = 70,
-                FatedCircle = 72,
-                Bloodfest = 76,
-                BlastingZone = 80,
-                EnhancedContinuation = 86,
-                CartridgeCharge3 = 88,
-                DoubleDown = 90;
-        }
         public static class Config
         {
             public const string
-                GNB_RoughDivide_HeldCharges = "GnbKeepRoughDivideCharges";
+                GNB_SkS = "GNB_SkS",
+                GNB_RoughDivide_HeldCharges = "GNB_RoughDivide_HeldCharges";
         }
-
 
         internal class GNB_ST_MainCombo : CustomCombo
         {
@@ -95,92 +72,114 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<GNBGauge>();
-                if (actionID == SolidBarrel)
+                if (actionID is KeenEdge)
                 {
+                    var gauge = GetJobGauge<GNBGauge>();
                     var roughDivideChargesRemaining = PluginConfiguration.GetCustomIntValue(Config.GNB_RoughDivide_HeldCharges);
                     var quarterWeave = GetCooldownRemainingTime(actionID) < 1 && GetCooldownRemainingTime(actionID) > 0.6;
+                    int SkSChoice = PluginConfiguration.GetCustomIntValue(Config.GNB_SkS);
+                    bool slowSkS = SkSChoice is 2 && IsEnabled(CustomComboPreset.GNB_ST_SkSSupport);
+                    bool regularSkS = SkSChoice is 0 or 1 || IsNotEnabled(CustomComboPreset.GNB_ST_SkSSupport);
 
-                    if (IsEnabled(CustomComboPreset.GNB_RangedUptime) && !InMeleeRange() && LevelChecked(LightningShot) && HasBattleTarget())
+                    if (IsEnabled(CustomComboPreset.GNB_ST_RangedUptime) && !InMeleeRange() && LevelChecked(LightningShot) && HasBattleTarget())
                         return LightningShot;
 
-                    if (comboTime > 0)
+                    if (IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup) && IsEnabled(CustomComboPreset.GNB_ST_NoMercy) && ActionReady(NoMercy))
                     {
-                        if (quarterWeave && IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup) && IsEnabled(CustomComboPreset.GNB_ST_NoMercy))
+                        if (LevelChecked(BurstStrike))
                         {
-                            if (LevelChecked(NoMercy) && IsOffCooldown(NoMercy))
+                            if (regularSkS && quarterWeave)
                             {
-                                if (LevelChecked(BurstStrike) &&
-                                   ((gauge.Ammo is 1 && IsOffCooldown(Bloodfest) && CombatEngageDuration().TotalSeconds < 30) || //Opener Conditions
+                                if ((gauge.Ammo is 1 && CombatEngageDuration().TotalSeconds < 30 && IsOffCooldown(Bloodfest)) || //Opener Conditions
                                    (CombatEngageDuration().Minutes == 2 && GetCooldownRemainingTime(DoubleDown) < 4) || //2 min delay
-                                   (CombatEngageDuration().Minutes != 2 && gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(GnashingFang) < 4))) //Regular NMGF
+                                   (CombatEngageDuration().Minutes != 2 && gauge.Ammo == MaxCartridges(level) && GetCooldownRemainingTime(GnashingFang) < 4)) //Regular NMGF
                                     return NoMercy;
-                                if (!LevelChecked(BurstStrike)) //no cartridges unlocked
+                            }
+
+                            if (slowSkS && CanWeave(actionID))
+                            {
+                                if ((CombatEngageDuration().TotalSeconds < 30 && lastComboMove is BrutalShell) ||
+                                    gauge.Ammo == MaxCartridges(level) ||
+                                    (CombatEngageDuration().Minutes % 2 == 1 && gauge.Ammo is 2 && WasLastWeaponskill(BurstStrike)))
                                     return NoMercy;
                             }
                         }
 
-                        //oGCDs
-                        if (CanWeave(actionID))
+                        if (!LevelChecked(BurstStrike) && quarterWeave) //no cartridges unlocked
+                            return NoMercy;
+                    }
+
+                    //oGCDs
+                    if (CanWeave(actionID))
+                    {
+                        if (IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
                         {
-                            if (IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
+                            if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && ActionReady(Bloodfest) && gauge.Ammo is 0 && HasEffect(Buffs.NoMercy))
                             {
-                                if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && HasEffect(Buffs.NoMercy) && gauge.Ammo == 0 && IsOffCooldown(Bloodfest) && LevelChecked(Bloodfest) && IsOnCooldown(GnashingFang))
+                                if ((regularSkS && IsOnCooldown(GnashingFang)) || (slowSkS && IsOnCooldown(NoMercy)))
                                     return Bloodfest;
+                            }
 
+
+                            if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && ActionReady(DangerZone))
+                            {
                                 //Blasting Zone outside of NM
-                                if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && LevelChecked(DangerZone) && IsOffCooldown(DangerZone) && !HasEffect(Buffs.NoMercy))
-                                {
-                                    if ((IsOnCooldown(GnashingFang) && gauge.AmmoComboStep != 1 && GetCooldownRemainingTime(NoMercy) > 17) || //Post Gnashing Fang
-                                        !LevelChecked(GnashingFang)) //Pre Gnashing Fang
-                                        return OriginalHook(DangerZone);
-                                }
-
-                                //Ensures Early Weave if available
-                                if (HasEffect(Buffs.NoMercy) && IsOnCooldown(DoubleDown) && IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && IsOffCooldown(DangerZone))
+                                if (!HasEffect(Buffs.NoMercy) && ((IsOnCooldown(GnashingFang) && GetCooldownRemainingTime(NoMercy) > 17) || //Post Gnashing Fang
+                                    !LevelChecked(GnashingFang))) //Pre Gnashing Fang
                                     return OriginalHook(DangerZone);
 
-                                //Continuation
-                                if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && LevelChecked(Continuation) &&
-                                    (HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)))
-                                    return OriginalHook(Continuation);
-
-                                //60s weaves
-                                if (HasEffect(Buffs.NoMercy))
-                                {
-                                    //Post DD
-                                    if (IsOnCooldown(DoubleDown))
-                                    {
-                                        if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && IsOffCooldown(DangerZone))
-                                            return OriginalHook(DangerZone);
-                                        if (IsEnabled(CustomComboPreset.GNB_ST_BowShock) && IsOffCooldown(BowShock))
-                                            return BowShock;
-                                    }
-
-                                    //Pre DD
-                                    if (IsOnCooldown(SonicBreak) && !LevelChecked(DoubleDown))
-                                    {
-                                        if (IsEnabled(CustomComboPreset.GNB_ST_BowShock) && LevelChecked(BowShock) && IsOffCooldown(BowShock))
-                                            return BowShock;
-                                        if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && LevelChecked(DangerZone) && IsOffCooldown(DangerZone))
-                                            return OriginalHook(DangerZone);
-                                    }
-                                }
+                                //Stops DZ Drift
+                                if (HasEffect(Buffs.NoMercy) && ((IsOnCooldown(SonicBreak) && slowSkS) || (IsOnCooldown(DoubleDown) && regularSkS)))
+                                    return OriginalHook(DangerZone);
                             }
 
-                            //Rough Divide Feature
-                            if (CanWeave(actionID) && LevelChecked(RoughDivide) && IsEnabled(CustomComboPreset.GNB_ST_RoughDivide) && GetRemainingCharges(RoughDivide) > roughDivideChargesRemaining && !IsMoving && !HasEffect(Buffs.ReadyToBlast))
+                            //Continuation
+                            if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && LevelChecked(Continuation) &&
+                                (HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)))
+                                return OriginalHook(Continuation);
+
+                            //60s weaves
+                            if (HasEffect(Buffs.NoMercy))
                             {
-                                if (IsNotEnabled(CustomComboPreset.GNB_ST_MeleeRoughDivide) ||
-                                    (IsEnabled(CustomComboPreset.GNB_ST_MeleeRoughDivide) && GetTargetDistance() <= 1 && HasEffect(Buffs.NoMercy) && IsOnCooldown(OriginalHook(DangerZone)) && IsOnCooldown(BowShock)))
-                                    return RoughDivide;
+                                //Post DD
+                                if ((regularSkS && IsOnCooldown(DoubleDown)) || (slowSkS && IsOnCooldown(SonicBreak)))
+                                {
+                                    if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && ActionReady(DangerZone))
+                                        return OriginalHook(DangerZone);
+                                    if (IsEnabled(CustomComboPreset.GNB_ST_BowShock) && ActionReady(BowShock))
+                                        return BowShock;
+                                }
+
+                                //Pre DD
+                                if (IsOnCooldown(SonicBreak) && !LevelChecked(DoubleDown))
+                                {
+                                    if (IsEnabled(CustomComboPreset.GNB_ST_BowShock) && ActionReady(BowShock))
+                                        return BowShock;
+                                    if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && ActionReady(DangerZone))
+                                        return OriginalHook(DangerZone);
+                                }
                             }
                         }
 
-                        // 60s window features
-                        if ((GetCooldownRemainingTime(NoMercy) > 57 || HasEffect(Buffs.NoMercy)) && IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
+                        //Rough Divide Feature
+                        if (CanWeave(actionID) && LevelChecked(RoughDivide) && IsEnabled(CustomComboPreset.GNB_ST_RoughDivide) && GetRemainingCharges(RoughDivide) > roughDivideChargesRemaining && !IsMoving && !HasEffect(Buffs.ReadyToBlast))
                         {
-                            if (LevelChecked(DoubleDown))
+                            if (IsNotEnabled(CustomComboPreset.GNB_ST_MeleeRoughDivide) ||
+                                (IsEnabled(CustomComboPreset.GNB_ST_MeleeRoughDivide) && GetTargetDistance() <= 1 && HasEffect(Buffs.NoMercy) && IsOnCooldown(OriginalHook(DangerZone)) && IsOnCooldown(BowShock)))
+                                return RoughDivide;
+                        }
+                    }
+
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && LevelChecked(Continuation) &&
+                        (HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)))
+                        return OriginalHook(Continuation);
+
+                    // 60s window features
+                    if ((GetCooldownRemainingTime(NoMercy) > 57 || HasEffect(Buffs.NoMercy)) && IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
+                    {
+                        if (LevelChecked(DoubleDown) && GetCooldownRemainingTime(GnashingFang) > 20)
+                        {
+                            if (regularSkS)
                             {
                                 if (IsEnabled(CustomComboPreset.GNB_ST_DoubleDown) && IsOffCooldown(DoubleDown) && gauge.Ammo >= 2 && !HasEffect(Buffs.ReadyToRip) && gauge.AmmoComboStep >= 1)
                                     return DoubleDown;
@@ -188,58 +187,66 @@ namespace XIVSlothCombo.Combos.PvE
                                     return SonicBreak;
                             }
 
-                            if (!LevelChecked(DoubleDown))
+                            if (slowSkS)
                             {
-                                if (IsEnabled(CustomComboPreset.GNB_ST_SonicBreak) && LevelChecked(SonicBreak) && IsOffCooldown(SonicBreak) && !HasEffect(Buffs.ReadyToRip) && IsOnCooldown(GnashingFang))
+                                if (IsEnabled(CustomComboPreset.GNB_ST_SonicBreak) && IsOffCooldown(SonicBreak) && !HasEffect(Buffs.ReadyToRip) && gauge.AmmoComboStep >= 1)
                                     return SonicBreak;
-                                //sub level 54 functionality
-                                if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && LevelChecked(DangerZone) && !LevelChecked(SonicBreak) && IsOffCooldown(DangerZone))
-                                    return OriginalHook(DangerZone);
+                                if (IsEnabled(CustomComboPreset.GNB_ST_DoubleDown) && IsOffCooldown(DoubleDown) && gauge.Ammo >= 2 && IsOnCooldown(SonicBreak))
+                                    return DoubleDown;
                             }
                         }
 
-                        //Gnashing Fang stuff
-                        if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && LevelChecked(GnashingFang))
+                        if (!LevelChecked(DoubleDown))
                         {
-                            if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_Starter) && IsOffCooldown(GnashingFang) && gauge.AmmoComboStep == 0 &&
-                                ((gauge.Ammo == MaxCartridges(level) && (GetCooldownRemainingTime(NoMercy) > 50 || HasEffect(Buffs.NoMercy)) && CombatEngageDuration().Minutes != 2) || //Regular 60 second GF/NM timing
-                                (gauge.Ammo == MaxCartridges(level) && (GetCooldownRemainingTime(NoMercy) > 50 || HasEffect(Buffs.NoMercy)) && CombatEngageDuration().Minutes == 2 && GetCooldownRemainingTime(DoubleDown) <= 1) || //2 min delay
-                                (gauge.Ammo == 1 && HasEffect(Buffs.NoMercy) && GetCooldownRemainingTime(DoubleDown) > 50) || //NMDDGF windows/Scuffed windows
-                                (gauge.Ammo > 0 && GetCooldownRemainingTime(NoMercy) > 17 && GetCooldownRemainingTime(NoMercy) < 35) || //Regular 30 second window                                                                        
-                                (gauge.Ammo == 1 && GetCooldownRemainingTime(NoMercy) > 50 && ((IsOffCooldown(Bloodfest) && LevelChecked(Bloodfest)) || !LevelChecked(Bloodfest))))) //Opener Conditions
-                                return GnashingFang;
-                            if (gauge.AmmoComboStep is 1 or 2)
-                                return OriginalHook(GnashingFang);
+                            if (IsEnabled(CustomComboPreset.GNB_ST_SonicBreak) && ActionReady(SonicBreak) && !HasEffect(Buffs.ReadyToRip) && IsOnCooldown(GnashingFang))
+                                return SonicBreak;
+                            //sub level 54 functionality
+                            if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && ActionReady(DangerZone) && !LevelChecked(SonicBreak))
+                                return OriginalHook(DangerZone);
                         }
+                    }
 
-                        if (IsEnabled(CustomComboPreset.GNB_NoMercy_BurstStrike) && IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
+                    //Pre Gnashing Fang stuff
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && LevelChecked(GnashingFang))
+                    {
+                        bool activeNoMercy = GetCooldownRemainingTime(NoMercy) > 50 || HasEffect(Buffs.NoMercy);
+                        if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_Starter) && IsOffCooldown(GnashingFang) && gauge.AmmoComboStep == 0 &&
+                            ((gauge.Ammo == MaxCartridges(level) && activeNoMercy && ((CombatEngageDuration().Minutes != 2 && regularSkS) || slowSkS)) || //Regular 60 second GF/NM timing
+                            (gauge.Ammo == MaxCartridges(level) && activeNoMercy && CombatEngageDuration().Minutes == 2 && GetCooldownRemainingTime(DoubleDown) <= 1 && regularSkS) || //2 min delay for regular SkS
+                            (gauge.Ammo == 1 && HasEffect(Buffs.NoMercy) && GetCooldownRemainingTime(DoubleDown) > 50) || //NMDDGF windows/Scuffed windows
+                            (gauge.Ammo > 0 && GetCooldownRemainingTime(NoMercy) > 17 && GetCooldownRemainingTime(NoMercy) < 35) || //Regular 30 second window                                                                        
+                            (gauge.Ammo == 1 && GetCooldownRemainingTime(NoMercy) > 50 && ((IsOffCooldown(Bloodfest) && LevelChecked(Bloodfest)) || !LevelChecked(Bloodfest))))) //Opener Conditions
+                            return GnashingFang;
+                        if (gauge.AmmoComboStep is 1 or 2)
+                            return OriginalHook(GnashingFang);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.GNB_ST_BurstStrike) && IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
+                    {
+                        if (HasEffect(Buffs.NoMercy) && gauge.AmmoComboStep == 0 && LevelChecked(BurstStrike))
                         {
-                            if (HasEffect(Buffs.NoMercy) && gauge.AmmoComboStep == 0 && LevelChecked(BurstStrike))
-                            {
-                                if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
-                                    return Hypervelocity;
-                                if (gauge.Ammo != 0 && GetCooldownRemainingTime(GnashingFang) > 4)
-                                    return BurstStrike;
-                            }
-
-                            //final check if Burst Strike is used right before No Mercy ends
                             if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
                                 return Hypervelocity;
+                            if (gauge.Ammo != 0 && GetCooldownRemainingTime(GnashingFang) > 4)
+                                return BurstStrike;
                         }
 
-                        // Regular 1-2-3 combo with overcap feature
+                        //final check if Burst Strike is used right before No Mercy ends
+                        if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
+                            return Hypervelocity;
+                    }
+
+                    // Regular 1-2-3 combo with overcap feature
+                    if (comboTime > 0)
+                    {
                         if (lastComboMove == KeenEdge && LevelChecked(BrutalShell))
                             return BrutalShell;
                         if (lastComboMove == BrutalShell && LevelChecked(SolidBarrel))
                         {
-                            if (IsEnabled(CustomComboPreset.GNB_AmmoOvercap))
-                            {
-                                if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
-                                    return Hypervelocity;
-                                if (LevelChecked(BurstStrike) && (gauge.Ammo == MaxCartridges(level)))
-                                    return BurstStrike;
-                            }
-
+                            if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
+                                return Hypervelocity;
+                            if (LevelChecked(BurstStrike) && gauge.Ammo == MaxCartridges(level))
+                                return BurstStrike;
                             return SolidBarrel;
                         }
                     }
@@ -251,93 +258,120 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class GNB_ST_GnashingFangContinuation : CustomCombo
+        internal class GNB_GF_Continuation : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_ST_GnashingFangContinuation;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_GF_Continuation;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 if (actionID == GnashingFang)
                 {
                     var gauge = GetJobGauge<GNBGauge>();
+                    int SkSChoice = PluginConfiguration.GetCustomIntValue(Config.GNB_SkS);
+                    bool slowSkS = SkSChoice is 2 && IsEnabled(CustomComboPreset.GNB_ST_SkSSupport);
+                    bool regularSkS = SkSChoice is 0 or 1 || IsNotEnabled(CustomComboPreset.GNB_ST_SkSSupport);
 
-                    if (IsOffCooldown(NoMercy) && CanDelayedWeave(actionID) && IsOffCooldown(GnashingFang) && IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_NoMercy))
+                    if (IsOffCooldown(NoMercy) && CanDelayedWeave(actionID) && IsOffCooldown(GnashingFang) && IsEnabled(CustomComboPreset.GNB_GF_NoMercy))
                         return NoMercy;
-
 
                     if (CanWeave(actionID))
                     {
-                        if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_Cooldowns))
+                        if (IsEnabled(CustomComboPreset.GNB_GF_Cooldowns))
                         {
-                            //Blasting Zone outside of NM
-                            if (level >= Levels.DangerZone && IsOffCooldown(DangerZone))
+                            if (ActionReady(Bloodfest) && gauge.Ammo is 0 && HasEffect(Buffs.NoMercy) && ((regularSkS && IsOnCooldown(GnashingFang)) || (slowSkS && IsOnCooldown(NoMercy))))
+                                return Bloodfest;
+
+                            if (ActionReady(DangerZone))
                             {
-                                if (!HasEffect(Buffs.NoMercy) &&
-                                    ((IsOnCooldown(GnashingFang) && gauge.AmmoComboStep != 1 && GetCooldownRemainingTime(GnashingFang) > 20) || //Post Gnashing Fang
-                                    (level < Levels.GnashingFang) && IsOnCooldown(NoMercy))) //Pre Gnashing Fang
+                                //Blasting Zone outside of NM
+                                if (!HasEffect(Buffs.NoMercy) && ((IsOnCooldown(GnashingFang) && GetCooldownRemainingTime(NoMercy) > 17) || //Post Gnashing Fang
+                                    !LevelChecked(GnashingFang))) //Pre Gnashing Fang
+                                    return OriginalHook(DangerZone);
+
+                                //Stops DZ Drift
+                                if (HasEffect(Buffs.NoMercy) && ((IsOnCooldown(SonicBreak) && slowSkS) || (IsOnCooldown(DoubleDown) && regularSkS)))
                                     return OriginalHook(DangerZone);
                             }
+
+                            //Continuation
+                            if (LevelChecked(Continuation) && (HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)))
+                                return OriginalHook(Continuation);
 
                             //60s weaves
                             if (HasEffect(Buffs.NoMercy))
                             {
                                 //Post DD
-                                if (IsOnCooldown(DoubleDown))
+                                if ((regularSkS && IsOnCooldown(DoubleDown)) || (slowSkS && IsOnCooldown(SonicBreak)))
                                 {
-                                    if (IsOffCooldown(DangerZone))
+                                    if (ActionReady(DangerZone))
                                         return OriginalHook(DangerZone);
-                                    if (IsOffCooldown(BowShock))
+                                    if (ActionReady(BowShock))
                                         return BowShock;
                                 }
 
                                 //Pre DD
-                                if (IsOnCooldown(SonicBreak) && level < Levels.DoubleDown)
+                                if (IsOnCooldown(SonicBreak) && !LevelChecked(DoubleDown))
                                 {
-                                    if (level >= Levels.BowShock && IsOffCooldown(BowShock))
+                                    if (ActionReady(BowShock))
                                         return BowShock;
-                                    if (level >= Levels.DangerZone && IsOffCooldown(DangerZone))
+                                    if (ActionReady(DangerZone))
                                         return OriginalHook(DangerZone);
                                 }
                             }
                         }
 
-                        if ((HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)) && level >= Levels.Continuation)
+                        if (LevelChecked(Continuation) && (HasEffect(Buffs.ReadyToRip) || HasEffect(Buffs.ReadyToTear) || HasEffect(Buffs.ReadyToGouge)))
                             return OriginalHook(Continuation);
                     }
 
-                    if (level >= Levels.DoubleDown)
+                    // 60s window features
+                    if (GetCooldownRemainingTime(NoMercy) > 57 || HasEffect(Buffs.NoMercy))
                     {
-                        if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_DoubleDown) && IsOffCooldown(DoubleDown) && gauge.Ammo >= 2 && !HasEffect(Buffs.ReadyToRip) && gauge.AmmoComboStep >= 1)
-                            return DoubleDown;
-                        if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_Cooldowns) && IsOffCooldown(SonicBreak) && IsOnCooldown(DoubleDown))
-                            return SonicBreak;
-                    }
+                        if (LevelChecked(DoubleDown) && GetCooldownRemainingTime(GnashingFang) > 20)
+                        {
+                            if (regularSkS)
+                            {
+                                if (IsEnabled(CustomComboPreset.GNB_GF_DoubleDown) && IsOffCooldown(DoubleDown) && gauge.Ammo >= 2 && !HasEffect(Buffs.ReadyToRip) && gauge.AmmoComboStep >= 1)
+                                    return DoubleDown;
+                                if (IsEnabled(CustomComboPreset.GNB_GF_Cooldowns) && IsOffCooldown(SonicBreak) && IsOnCooldown(DoubleDown))
+                                    return SonicBreak;
+                            }
 
-                    if (level < Levels.DoubleDown && IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_Cooldowns))
-                    {
-                        if (level >= Levels.SonicBreak && IsOffCooldown(SonicBreak) && !HasEffect(Buffs.ReadyToRip) && IsOnCooldown(GnashingFang))
-                            return SonicBreak;
+                            if (slowSkS)
+                            {
+                                if (IsEnabled(CustomComboPreset.GNB_GF_Cooldowns) && IsOffCooldown(SonicBreak) && !HasEffect(Buffs.ReadyToRip) && gauge.AmmoComboStep >= 1)
+                                    return SonicBreak;
+                                if (IsEnabled(CustomComboPreset.GNB_GF_DoubleDown) && IsOffCooldown(DoubleDown) && gauge.Ammo >= 2 && IsOnCooldown(SonicBreak))
+                                    return DoubleDown;
+                            }
+                        }
 
-                        //sub level 54 functionality
-                        if (level is >= Levels.DangerZone and < Levels.SonicBreak && IsOffCooldown(DangerZone))
-                            return OriginalHook(DangerZone);
+                        if (!LevelChecked(DoubleDown) && IsEnabled(CustomComboPreset.GNB_GF_Cooldowns))
+                        {
+                            if (ActionReady(SonicBreak) && !HasEffect(Buffs.ReadyToRip) && IsOnCooldown(GnashingFang))
+                                return SonicBreak;
+
+                            //sub level 54 functionality
+                            if (ActionReady(DangerZone) && !LevelChecked(SonicBreak))
+                                return OriginalHook(DangerZone);
+                        }
                     }
 
                     if ((gauge.AmmoComboStep == 0 && IsOffCooldown(GnashingFang)) || gauge.AmmoComboStep is 1 or 2)
                         return OriginalHook(GnashingFang);
 
-                    if (IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_Cooldowns))
+                    if (IsEnabled(CustomComboPreset.GNB_GF_Cooldowns))
                     {
-                        if ((HasEffect(Buffs.NoMercy) || HasEffect(All.Buffs.Medicated)) && gauge.AmmoComboStep == 0 && level >= Levels.BurstStrike)
+                        if (HasEffect(Buffs.NoMercy) && gauge.AmmoComboStep == 0 && LevelChecked(BurstStrike))
                         {
-                            if (level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                            if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
                                 return Hypervelocity;
-                            if (gauge.Ammo != 0 && IsOnCooldown(GnashingFang))
+                            if (gauge.Ammo != 0 && GetCooldownRemainingTime(GnashingFang) > 4)
                                 return BurstStrike;
                         }
 
                         //final check if Burst Strike is used right before No Mercy ends
-                        if (level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
+                        if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast))
                             return Hypervelocity;
                     }
                 }
@@ -346,14 +380,25 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class GNB_ST_BurstStrikeContinuation : CustomCombo
+
+        internal class GNB_BS : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_ST_BurstStrikeContinuation;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_BS;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID == BurstStrike && level >= Levels.EnhancedContinuation && HasEffect(Buffs.ReadyToBlast))
-                    return Hypervelocity;
+                if (actionID is BurstStrike)
+                {
+                    var gauge = GetJobGauge<GNBGauge>();
+
+                    if (IsEnabled(CustomComboPreset.GNB_BS_Continuation) && HasEffect(Buffs.ReadyToBlast) && LevelChecked(Hypervelocity))
+                        return Hypervelocity;
+                    if (IsEnabled(CustomComboPreset.GNB_BS_Bloodfest) && gauge.Ammo is 0 && LevelChecked(Bloodfest) && !HasEffect(Buffs.ReadyToBlast))
+                        return Bloodfest;
+                    if (IsEnabled(CustomComboPreset.GNB_BS_DoubleDown) && HasEffect(Buffs.NoMercy) && GetCooldownRemainingTime(DoubleDown) < 2 && gauge.Ammo >= 2 && LevelChecked(DoubleDown))
+                        return DoubleDown;
+                }
+
                 return actionID;
             }
         }
@@ -364,63 +409,43 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                var gauge = GetJobGauge<GNBGauge>();
+                
                 if (actionID == DemonSlaughter)
                 {
+                    var gauge = GetJobGauge<GNBGauge>();
+
                     if (InCombat())
                     {
                         if (CanWeave(actionID))
                         {
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_NoMercy) && IsOffCooldown(NoMercy) && level >= Levels.NoMercy)
+                            if (IsEnabled(CustomComboPreset.GNB_AoE_NoMercy) && ActionReady(NoMercy))
                                 return NoMercy;
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_BowShock) && level >= Levels.BowShock && IsOffCooldown(BowShock))
+                            if (IsEnabled(CustomComboPreset.GNB_AoE_BowShock) && ActionReady(BowShock))
                                 return BowShock;
-                            if (IsEnabled(CustomComboPreset.GNB_AOE_DangerZone) && IsOffCooldown(DangerZone) && level >= Levels.DangerZone)
+                            if (IsEnabled(CustomComboPreset.GNB_AOE_DangerZone) && ActionReady(DangerZone))
                                 return OriginalHook(DangerZone);
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && gauge.Ammo == 0 && IsOffCooldown(Bloodfest) && level >= Levels.Bloodfest)
+                            if (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && gauge.Ammo == 0 && ActionReady(Bloodfest))
                                 return Bloodfest;
                         }
 
-                        if (IsEnabled(CustomComboPreset.GNB_AOE_SonicBreak) && IsOffCooldown(SonicBreak) && level >= Levels.SonicBreak)
+                        if (IsEnabled(CustomComboPreset.GNB_AOE_SonicBreak) && ActionReady(SonicBreak))
                             return SonicBreak;
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_DoubleDown) && gauge.Ammo >= 2 && IsOffCooldown(DoubleDown) && level >= Levels.DoubleDown)
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_DoubleDown) && gauge.Ammo >= 2 && ActionReady(DoubleDown))
                             return DoubleDown;
-                        if (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && gauge.Ammo != 0 && GetCooldownRemainingTime(Bloodfest) < 6 && level >= Levels.FatedCircle)
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && gauge.Ammo != 0 && GetCooldownRemainingTime(Bloodfest) < 6 && LevelChecked(FatedCircle))
                             return FatedCircle;
 
                     }
 
-                    if (comboTime > 0 && lastComboMove == DemonSlice && level >= Levels.DemonSlaughter)
+                    if (comboTime > 0 && lastComboMove == DemonSlice && LevelChecked(DemonSlaughter))
                     {
-                        return (IsEnabled(CustomComboPreset.GNB_AmmoOvercap) && level >= Levels.FatedCircle && gauge.Ammo == MaxCartridges(level)) ? FatedCircle : DemonSlaughter;
+                        return (IsEnabled(CustomComboPreset.GNB_AOE_Overcap) && LevelChecked(FatedCircle) && gauge.Ammo == MaxCartridges(level)) ? FatedCircle : DemonSlaughter;
                     }
 
                     return DemonSlice;
                 }
 
                 return actionID;
-            }
-        }
-
-        internal class GNB_ST_Bloodfest_Overcap : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_ST_Bloodfest_Overcap;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                var gauge = GetJobGauge<GNBGauge>().Ammo;
-                return (actionID == BurstStrike && gauge == 0 && level >= Levels.Bloodfest && !HasEffect(Buffs.ReadyToBlast)) ? Bloodfest : actionID;
-            }
-        }
-
-        internal class GNB_BurstStrike_DoubleDown : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.GNB_BurstStrike_DoubleDown;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                var gauge = GetJobGauge<GNBGauge>().Ammo;
-                return (actionID is BurstStrike && HasEffect(Buffs.NoMercy) && GetCooldownRemainingTime(DoubleDown) < 2 && gauge >= 2 && LevelChecked(DoubleDown)) ? DoubleDown : actionID;
             }
         }
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1253,6 +1253,12 @@ namespace XIVSlothCombo.Window.Functions
             // ====================================================================================
             #region GUNBREAKER
 
+            if (preset == CustomComboPreset.GNB_ST_SkSSupport && enabled)
+            {
+                UserConfig.DrawHorizontalRadioButton(GNB.Config.GNB_SkS, "< 2.45", "Options are friendly for skill speeds of 2.45 and lower.", 1);
+                UserConfig.DrawHorizontalRadioButton(GNB.Config.GNB_SkS, "2.5", "Options are friendly for 2.5 skill speed.", 2);
+            }
+
             if (preset == CustomComboPreset.GNB_ST_RoughDivide && enabled)
                 UserConfig.DrawSliderInt(0, 1, GNB.Config.GNB_RoughDivide_HeldCharges, "How many charges to keep ready? (0 = Use All)");
 


### PR DESCRIPTION
- Supports <2.45 SkS and 2.5 SkS rotations.
- Cleaned up internals which means config numbers are fucked but I don't care.
- Burst Strike Features grouped together.
- ST and Gnashing Fang combos support both regular and slow GNB rotations.
- ST now on Keen Edge.
- AoE now on Demon Slice.