### PR TITLE
[RPR] SoulSow Internal fixes

### DIFF
--- a/XIVSlothCombo/Combos/PvE/RPR.cs
+++ b/XIVSlothCombo/Combos/PvE/RPR.cs
@@ -507,13 +507,14 @@ namespace XIVSlothCombo.Combos.PvE
                 var soulSowOptions = PluginConfiguration.GetCustomBoolArrayValue(Config.RPR_SoulsowOptions);
                 bool soulsowReady = LevelChecked(Soulsow) && !HasEffect(Buffs.Soulsow);
 
-                return (((actionID is Harpe && soulSowOptions[0] || 
+                return ((soulSowOptions.Length > 0) && ((actionID is Harpe && soulSowOptions[0] || 
                     (actionID is  Slice && soulSowOptions[1]) || 
                     (actionID is SpinningScythe && soulSowOptions[2]) ||
                     (actionID is ShadowOfDeath && soulSowOptions[3]) ||
                     (actionID is BloodStalk && soulSowOptions[4])) && soulsowReady && !InCombat()) ||
                     (IsEnabled(CustomComboPreset.RPR_Soulsow_Combat) && actionID is Harpe && !HasBattleTarget())) ?
                     Soulsow: actionID;
+
             }
         }
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -439,7 +439,12 @@ namespace XIVSlothCombo.Window.Functions
             ImGui.SameLine();
             bool[]? values = PluginConfiguration.GetCustomBoolArrayValue(config);
 
-            if (values.Length == 0) Array.Resize(ref values, totalChoices);
+            if (values.Length == 0 || values.Length != totalChoices)
+            {
+                Array.Resize(ref values, totalChoices);
+                PluginConfiguration.SetCustomBoolArrayValue(config, values);
+                Service.Configuration.Save();
+            }
 
             ImGui.PushStyleColor(ImGuiCol.Text, descriptionColor);
             if (ImGui.Checkbox($"{checkBoxName}###{config}{choice}", ref values[choice]))


### PR DESCRIPTION
Solves various array out of index errors that generate when the option is enabled but no action has been selected (first time user use).
* RPR RPR_Soulsow: Added check to see options is a non-zero array
* UserConfig DrawHorizontalMultiChoice: Better handles first time initialization and resizing.

Closes #1067