### PR TITLE
[DRK/DRG] Minor changes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1105,8 +1105,8 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         #region Advanced Dragoon AoE
-        [ReplaceSkill(DRG.CoerthanTorment)]
-        [CustomComboInfo("Advanced Dragoon AoE", "Replaces Coerthan Torment with its combo chain", DRG.JobID, 26, "", "")]
+        [ReplaceSkill(DRG.DoomSpike)]
+        [CustomComboInfo("Advanced Dragoon AoE", "Replaces Doom Spike with its combo chain", DRG.JobID, 26, "", "")]
         DRG_AoECombo = 6200,
 
             [ParentCombo(DRG_AoECombo)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1043,7 +1043,7 @@ namespace XIVSlothCombo.Combos
         DRG_STCombo = 6100,
 
             [ParentCombo(DRG_STCombo)]
-            [CustomComboInfo("Level 88+ Opener", "Adds opener to the rotation.\nActivates when Battle Litany and Lance Charge are off cooldown and when True North is used outside of combat. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 0, "", "")]
+            [CustomComboInfo("Level 88+ Opener", "Adds opener to the rotation.\nActivates when Battle Litany and Lance Charge are off cooldown and when True North is used outside of combat or if Elusive Jump is used at the beginning of battle. OPTIONAL: USE REACTION OR MOACTION FOR OPTIMAL TARGETING.", DRG.JobID, 0, "", "")]
             DRG_ST_Opener = 6101,
 
             [ParentCombo(DRG_STCombo)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1038,8 +1038,8 @@ namespace XIVSlothCombo.Combos
         DRG_Jump = 6000,
 
         #region Advanced Dragoon
-        [ReplaceSkill(DRG.FullThrust)]
-        [CustomComboInfo("Advanced Dragoon", "Replaces Full Thrust with the entire ST combo chain.", DRG.JobID, 1, "", "")]
+        [ReplaceSkill(DRG.TrueThrust)]
+        [CustomComboInfo("Advanced Dragoon", "Replaces True Thrust with the entire ST combo chain.", DRG.JobID, 1, "", "")]
         DRG_STCombo = 6100,
 
             [ParentCombo(DRG_STCombo)]

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -102,7 +102,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (LevelChecked(ChaoticSpring)) ChaosDoTDebuff = FindTargetEffect(Debuffs.ChaoticSpring);
                 else ChaosDoTDebuff = FindTargetEffect(Debuffs.ChaosThrust);
 
-                if (actionID is FullThrust)
+                if (actionID is TrueThrust)
                 {
                     // Lvl88+ Opener
                     if (!InCombat() && IsEnabled(CustomComboPreset.DRG_ST_Opener) && level >= 88)

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -13,6 +13,7 @@ namespace XIVSlothCombo.Combos.PvE
         public const uint
             TrueNorth = 7546,
             PiercingTalon = 90,
+            ElusiveJump = 94,
             LanceCharge = 85,
             DragonSight = 7398,
             BattleLitany = 3557,
@@ -120,6 +121,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (InCombat())
                     {
+                        if (CombatEngageDuration().TotalSeconds < 3 && IsOnCooldown(ElusiveJump) && openerReady)
+                            inOpener = true;
+
                         if (inOpener)
                         {
                             if (IsOnCooldown(BattleLitany) && !HasEffect(Buffs.LanceCharge))
@@ -130,27 +134,25 @@ namespace XIVSlothCombo.Combos.PvE
                             {
                                 if (WasLastWeaponskill(Disembowel) && openerOptions is 0 or 1 or 2)
                                 {
-                                    if (IsOffCooldown(LanceCharge))
+                                    if (ActionReady(LanceCharge))
                                         return LanceCharge;
-                                    if (IsOffCooldown(DragonSight))
+                                    if (ActionReady(DragonSight))
                                         return DragonSight;
                                 }
 
                                 if (WasLastWeaponskill(ChaoticSpring))
                                 {
-                                    if (openerOptions is 0 or 1 or 2 && IsOffCooldown(BattleLitany))
+                                    if (openerOptions is 0 or 1 or 2 && ActionReady(BattleLitany))
                                         return BattleLitany;
-                                    if (openerOptions is 2 && IsOffCooldown(Geirskogul))
-                                        return OriginalHook(Geirskogul);
+                                    if (openerOptions is 2 && GetRemainingCharges(SpineshatterDive) > 1)
+                                        return OriginalHook(SpineshatterDive);
                                 }
-                                    
-                                if (WasLastWeaponskill(WheelingThrust))
+
+                                if (WasLastWeaponskill(WheelingThrust) && openerOptions is 0 or 1 or 2)
                                 {
-                                    if (openerOptions is 0 or 1 && IsOffCooldown(Geirskogul))
+                                    if (ActionReady(Geirskogul))
                                         return Geirskogul;
-                                    if (openerOptions is 2 && IsOffCooldown(OriginalHook(Jump)))
-                                        return OriginalHook(Jump);
-                                    if (openerOptions is 0 or 1 or 2 && GetRemainingCharges(LifeSurge) > 0 && !HasEffect(Buffs.LifeSurge))
+                                    if (GetRemainingCharges(LifeSurge) > 0 && !HasEffect(Buffs.LifeSurge))
                                         return LifeSurge;
                                 }
 
@@ -158,43 +160,48 @@ namespace XIVSlothCombo.Combos.PvE
                                 {
                                     if (openerOptions is 0 or 1)
                                     {
-                                        if (IsOffCooldown(OriginalHook(Jump)) && !HasEffect(Buffs.DiveReady))
-                                            return OriginalHook(Jump);
-                                        if (GetRemainingCharges(SpineshatterDive) > 0 && !HasEffect(Buffs.DiveReady))
+                                        if (GetRemainingCharges(SpineshatterDive) < 2 && !WasLastAction(SpineshatterDive))
                                             return SpineshatterDive;
+                                        if (ActionReady(OriginalHook(Jump)) && !HasEffect(Buffs.DiveReady))
+                                            return OriginalHook(Jump);
                                     }
 
-                                    if (openerOptions is 2 && IsOffCooldown(DragonfireDive))
-                                        return DragonfireDive;
+                                    if (openerOptions is 2)
+                                    {
+                                        if (ActionReady(OriginalHook(Jump)))
+                                            return OriginalHook(Jump);
+                                        if (HasEffect(Buffs.DiveReady))
+                                            return MirageDive;
+                                    }
                                 }
 
                                 if (WasLastWeaponskill(RaidenThrust))
                                 {
-                                    if (openerOptions is 0 or 1 && IsOffCooldown(DragonfireDive))
+                                    if (openerOptions is 0 or 1 or 2 && ActionReady(DragonfireDive))
                                         return DragonfireDive;
-                                    if (openerOptions is 2 && GetRemainingCharges(SpineshatterDive) > 0 && !WasLastAction(SpineshatterDive))
-                                        return SpineshatterDive;
-                                }
-                                    
-                                if (WasLastWeaponskill(VorpalThrust) && openerOptions is 0 or 1 or 2)
-                                {
-                                    if (GetRemainingCharges(LifeSurge) > 0 && !HasEffect(Buffs.LifeSurge))
-                                        return LifeSurge;
-                                    if (HasEffect(Buffs.DiveReady))
-                                        return MirageDive;
                                 }
 
-                                if (WasLastWeaponskill(HeavensThrust) && GetRemainingCharges(SpineshatterDive) > 0 && !WasLastAction(SpineshatterDive) && openerOptions is 0 or 1 or 2)
+                                if (WasLastWeaponskill(VorpalThrust))
+                                {
+                                    if (openerOptions is 0 or 1)
+                                    {
+                                        if (GetRemainingCharges(LifeSurge) > 0 && !HasEffect(Buffs.LifeSurge))
+                                            return LifeSurge;
+                                        if (HasEffect(Buffs.DiveReady))
+                                            return MirageDive;
+                                    }
+
+                                    if (openerOptions is 2)
+                                    {
+                                        if (ActionReady(SpineshatterDive))
+                                            return SpineshatterDive;
+                                        if (GetRemainingCharges(LifeSurge) > 0 && !HasEffect(Buffs.LifeSurge))
+                                            return LifeSurge;
+                                    }
+                                }
+
+                                if (WasLastWeaponskill(HeavensThrust) && GetRemainingCharges(SpineshatterDive) > 0 && !WasLastAction(SpineshatterDive) && openerOptions is 0 or 1)
                                     return SpineshatterDive;
-
-                                // healing - please move if not appropriate priority
-                                if (IsEnabled(CustomComboPreset.DRG_ST_ComboHeals))
-                                {
-                                    if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.DRG_STSecondWindThreshold) && LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind))
-                                        return All.SecondWind;
-                                    if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.DRG_STBloodbathThreshold) && LevelChecked(All.Bloodbath) && IsOffCooldown(All.Bloodbath))
-                                        return All.Bloodbath;
-                                }
                             }
                         }
 

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -1,4 +1,5 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
+using Dalamud.Game.ClientState.Statuses;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.Core;
 
@@ -95,6 +96,10 @@ namespace XIVSlothCombo.Combos.PvE
                 bool openerReady = IsOffCooldown(LanceCharge) && IsOffCooldown(BattleLitany);
                 var diveOptions = PluginConfiguration.GetCustomIntValue(Config.DRG_ST_DiveOptions);
                 var openerOptions = PluginConfiguration.GetCustomIntValue(Config.DRG_OpenerOptions);
+
+                Status? ChaosDoTDebuff;
+                if (LevelChecked(ChaoticSpring)) ChaosDoTDebuff = FindTargetEffect(Debuffs.ChaoticSpring);
+                else ChaosDoTDebuff = FindTargetEffect(Debuffs.ChaosThrust);
 
                 if (actionID is FullThrust)
                 {
@@ -196,7 +201,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (!inOpener)
                         {
                             if (CanWeave(actionID))
-                            {                                
+                            {
                                 if (HasEffect(Buffs.PowerSurge))
                                 {
                                     //Wyrmwind Thrust Feature
@@ -241,7 +246,7 @@ namespace XIVSlothCombo.Combos.PvE
                                         //Dives Feature
                                         if (IsEnabled(CustomComboPreset.DRG_ST_Dives) && (IsNotEnabled(CustomComboPreset.DRG_ST_Dives_Melee) || (IsEnabled(CustomComboPreset.DRG_ST_Dives_Melee) && GetTargetDistance() <= 1)))
                                         {
-                                            if (diveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && LevelChecked(Stardiver) && IsOffCooldown(Stardiver) && CanWeave(actionID, 1.3) && IsOnCooldown(DragonfireDive))
+                                            if (diveOptions is 0 or 1 or 2 or 3 && gauge.IsLOTDActive && ActionReady(Stardiver) && IsOnCooldown(DragonfireDive))
                                                 return Stardiver;
 
                                             if (diveOptions is 0 or 1 || //Dives on cooldown
@@ -275,10 +280,14 @@ namespace XIVSlothCombo.Combos.PvE
                             return WheelingThrust;
                         if (comboTime > 0)
                         {
-                            if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(Disembowel) && GetBuffRemainingTime(Buffs.PowerSurge) < 10)
-                                return Disembowel;
-                            if (lastComboMove is Disembowel && LevelChecked(ChaosThrust))
-                                return OriginalHook(ChaosThrust);
+                            if (ChaosDoTDebuff is null || ChaosDoTDebuff.RemainingTime < 6 || GetBuffRemainingTime(Buffs.PowerSurge) < 10)
+                            {
+                                if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(Disembowel))
+                                    return Disembowel;
+                                if (lastComboMove is Disembowel && LevelChecked(ChaosThrust))
+                                    return OriginalHook(ChaosThrust);
+                            }
+
                             if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
                                 return VorpalThrust;
                             if (lastComboMove is VorpalThrust && LevelChecked(FullThrust))

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -316,7 +316,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is CoerthanTorment)
+                if (actionID is DoomSpike)
                 {
                     var gauge = GetJobGauge<DRGGauge>();
                     var DiveOptions = PluginConfiguration.GetCustomIntValue(Config.DRG_AOE_DiveOptions);

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -79,14 +79,17 @@ namespace XIVSlothCombo.Combos.PvE
                             //Mana Features
                             if (IsEnabled(CustomComboPreset.DRK_ManaOvercap))
                             {
-                                if (IsEnabled(CustomComboPreset.DRK_EoSPooling) && GetCooldownRemainingTime(Delirium) >= 50 && (gauge.HasDarkArts || LocalPlayer.CurrentMp > (mpRemaining + 3000)) && LevelChecked(EdgeOfDarkness) && CanDelayedWeave(actionID))
-                                    return OriginalHook(EdgeOfDarkness);
-                                if (gauge.HasDarkArts || LocalPlayer.CurrentMp > 8500 || (gauge.DarksideTimeRemaining < 10 && LocalPlayer.CurrentMp >= 3000))
+                                if ((CombatEngageDuration().TotalSeconds < 7 && gauge.DarksideTimeRemaining == 0 && HasEffect(Buffs.BloodWeapon)) || CombatEngageDuration().TotalSeconds >= 6)
                                 {
-                                    if (LevelChecked(EdgeOfDarkness))
+                                    if (IsEnabled(CustomComboPreset.DRK_EoSPooling) && GetCooldownRemainingTime(Delirium) >= 40 && (gauge.HasDarkArts || LocalPlayer.CurrentMp > (mpRemaining + 3000)) && LevelChecked(EdgeOfDarkness) && CanDelayedWeave(actionID))
                                         return OriginalHook(EdgeOfDarkness);
-                                    if (LevelChecked(FloodOfDarkness) && !LevelChecked(EdgeOfDarkness))
-                                        return FloodOfDarkness;
+                                    if (gauge.HasDarkArts || LocalPlayer.CurrentMp > 8500 || (gauge.DarksideTimeRemaining < 10000 && LocalPlayer.CurrentMp >= 3000))
+                                    {
+                                        if (LevelChecked(EdgeOfDarkness))
+                                            return OriginalHook(EdgeOfDarkness);
+                                        if (LevelChecked(FloodOfDarkness) && !LevelChecked(EdgeOfDarkness))
+                                            return FloodOfDarkness;
+                                    }
                                 }
                             }
 
@@ -143,8 +146,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return Bloodspiller;
 
                             //Delayed Delirium
-                            if (IsEnabled(CustomComboPreset.DRK_DelayedBloodspiller) && GetBuffStacks(Buffs.Delirium) > 0 &&
-                                ((GetBuffStacks(Buffs.BloodWeapon) <= 2 && CombatEngageDuration().TotalSeconds < 30) || CombatEngageDuration().TotalSeconds >= 30))
+                            if (IsEnabled(CustomComboPreset.DRK_DelayedBloodspiller) && GetBuffStacks(Buffs.Delirium) > 0 && IsOnCooldown(BloodWeapon) && GetBuffStacks(Buffs.BloodWeapon) < 2)
                                 return Bloodspiller;
 
                             //Blood management before Delirium

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -79,7 +79,7 @@ namespace XIVSlothCombo.Combos.PvE
                             //Mana Features
                             if (IsEnabled(CustomComboPreset.DRK_ManaOvercap))
                             {
-                                if ((CombatEngageDuration().TotalSeconds < 7 && gauge.DarksideTimeRemaining == 0 && HasEffect(Buffs.BloodWeapon)) || CombatEngageDuration().TotalSeconds >= 6)
+                                if ((CombatEngageDuration().TotalSeconds < 7 && gauge.DarksideTimeRemaining == 0) || CombatEngageDuration().TotalSeconds >= 6)
                                 {
                                     if (IsEnabled(CustomComboPreset.DRK_EoSPooling) && GetCooldownRemainingTime(Delirium) >= 40 && (gauge.HasDarkArts || LocalPlayer.CurrentMp > (mpRemaining + 3000)) && LevelChecked(EdgeOfDarkness) && CanDelayedWeave(actionID))
                                         return OriginalHook(EdgeOfDarkness);
@@ -142,7 +142,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (LevelChecked(Delirium) && IsEnabled(CustomComboPreset.DRK_Bloodspiller) && IsEnabled(CustomComboPreset.DRK_MainComboCDs_Group))
                         {
                             //Regular Delirium
-                            if (GetBuffStacks(Buffs.Delirium) > 0 && (!LevelChecked(LivingShadow) || IsNotEnabled(CustomComboPreset.DRK_DelayedBloodspiller)))
+                            if (GetBuffStacks(Buffs.Delirium) > 0 && IsNotEnabled(CustomComboPreset.DRK_DelayedBloodspiller))
                                 return Bloodspiller;
 
                             //Delayed Delirium

--- a/XIVSlothCombo/Combos/PvE/RPR.cs
+++ b/XIVSlothCombo/Combos/PvE/RPR.cs
@@ -276,7 +276,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GluttonyBloodStalk) && CanWeave(actionID) && !soulReaver && !enshrouded && LevelChecked(BloodStalk) && gauge.Soul >= 50)
                         {
-                            if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && CombatEngageDuration().TotalSeconds < 40 && IsOffCooldown(Gluttony))
+                            if (IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && CombatEngageDuration().TotalSeconds < 40 && ActionReady(Gluttony))
                             {
                                 if (openerChoice is 0 or 1 && gauge.Soul is 50)
                                     return Gluttony;
@@ -284,7 +284,7 @@ namespace XIVSlothCombo.Combos.PvE
                                     return Gluttony;
                             }
 
-                            if ((IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && CombatEngageDuration().TotalSeconds >= 10) || IsNotEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener))
+                            if ((IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && CombatEngageDuration().TotalSeconds >= 10) || IsNotEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) || !LevelChecked(Communio))
                             {
                                 if (IsOffCooldown(Gluttony) && LevelChecked(Gluttony))
                                     return Gluttony;


### PR DESCRIPTION
DRK:
- Change Delirium being dependent on Blood Weapon and instead delays bursts based on Blood Weapon Stacks being less than 2. Addresses #1002.

DRG:
- ST goes into Chaos Thrust/Chaotic Spring combo if the target doesn't have the dot regardless of if the next chain should be Heavens' Thrust/Full Thrust
- Updated Low Ping Opener to reflect 6.2's changes.
- Added Elusive Jump as an opener trigger, requested in #1081
- ST Combo changed to True Thrust, AoE Combo changed to Doom Spike.