### PR TITLE
[DRG] Disembowel and chaos thrust changes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1039,7 +1039,7 @@ namespace XIVSlothCombo.Combos
 
         #region Advanced Dragoon
         [ReplaceSkill(DRG.FullThrust)]
-        [CustomComboInfo("Advanced Dragoon", "Replaces Full Thrust with the entire ST combo chain.", DRG.JobID, 1, "", "")]
+        [CustomComboInfo("Advanced Dragoon", "Replaces True Trust with the entire ST combo chain.", DRG.JobID, 1, "", "")]
         DRG_STCombo = 6100,
 
             [ParentCombo(DRG_STCombo)]

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -1,6 +1,7 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.Core;
+using Dalamud.Game.ClientState.JobGauge.Enums;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -95,8 +96,11 @@ namespace XIVSlothCombo.Combos.PvE
                 bool openerReady = IsOffCooldown(LanceCharge) && IsOffCooldown(BattleLitany);
                 var diveOptions = PluginConfiguration.GetCustomIntValue(Config.DRG_ST_DiveOptions);
                 var openerOptions = PluginConfiguration.GetCustomIntValue(Config.DRG_OpenerOptions);
+                var powerSurgeDuration = GetBuffRemainingTime(Buffs.PowerSurge);
+                var chaosThrustDuration = GetDebuffRemainingTime(Debuffs.ChaosThrust);
+                var chaoticSpringDuration = GetDebuffRemainingTime(Debuffs.ChaoticSpring);
 
-                if (actionID is FullThrust)
+                if (actionID is TrueThrust)
                 {
                     // Lvl88+ Opener
                     if (!InCombat() && IsEnabled(CustomComboPreset.DRG_ST_Opener) && level >= 88)
@@ -273,23 +277,34 @@ namespace XIVSlothCombo.Combos.PvE
                             return FangAndClaw;
                         if (HasEffect(Buffs.EnhancedWheelingThrust))
                             return WheelingThrust;
+
                         if (comboTime > 0)
                         {
-                            if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(Disembowel) && GetBuffRemainingTime(Buffs.PowerSurge) < 10)
-                                return Disembowel;
-                            if (lastComboMove is Disembowel && LevelChecked(ChaosThrust))
-                                return OriginalHook(ChaosThrust);
-                            if (lastComboMove is TrueThrust or RaidenThrust && LevelChecked(VorpalThrust))
+                            if ((lastComboMove == TrueThrust || lastComboMove == RaidenThrust) && LevelChecked(Disembowel))
+                            {
+                                if (!TargetHasEffect(Debuffs.ChaosThrust) || (chaosThrustDuration <= 8) )
+                                {
+                                    if (!TargetHasEffect(Debuffs.ChaoticSpring) || (chaoticSpringDuration <= 8))
+                                    {
+                                        return Disembowel;
+                                    }
+                                    return VorpalThrust;
+                                }
                                 return VorpalThrust;
-                            if (lastComboMove is VorpalThrust && LevelChecked(FullThrust))
-                                return OriginalHook(FullThrust);
+                            }   
+                            if (lastComboMove == Disembowel && LevelChecked(ChaosThrust))
+                            {
+                                return OriginalHook(ChaosThrust);
+                            }
+                            if (lastComboMove == VorpalThrust && LevelChecked(FullThrust))
+                            { 
+                            return OriginalHook(FullThrust);
+                            }
                         }
 
                     }
-
                     return OriginalHook(TrueThrust);
                 }
-
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -1,7 +1,6 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.Core;
-using Dalamud.Game.ClientState.JobGauge.Enums;
 
 namespace XIVSlothCombo.Combos.PvE
 {


### PR DESCRIPTION
- Changed Disembowel and Chaos Thrust so its usable on more than 1 target.
- Changed start skill to 1st in chain - True Thrust - instead of 3rd in chain - Full Thrust - .

(works on lvl 90, but need some extra confirmation for below lvl 86 if possible)