### PR TITLE
[SMN] Add Energy Drain to AoE Combo if too low level to use Energy Siphon.

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -190,19 +190,17 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID == Painflare)
+                var gauge = GetJobGauge<SMNGauge>();
+                if (actionID == Painflare && !gauge.HasAetherflowStacks)
                 {
-                    var gauge = GetJobGauge<SMNGauge>();
-
-                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
+                    if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
                         return Ruin4;
 
-                    if (LevelChecked(EnergyDrain) && !LevelChecked(EnergySiphon) && !gauge.HasAetherflowStacks)
-                        return EnergyDrain;
-                    
-                    if (LevelChecked(EnergySiphon) && !gauge.HasAetherflowStacks)
+                    if (LevelChecked(EnergySiphon))
                         return EnergySiphon;
-
+                    
+                    if (LevelChecked(EnergyDrain))
+                        return EnergyDrain;
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -415,7 +415,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         
                         // ED/ES
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain) && (!inOpener || DemiAttackCount >= burstDelay))
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain) && (!LevelChecked(DreadwyrmTrance) || (!inOpener || DemiAttackCount >= burstDelay)))
                         {
                             if ((STCombo || (AoECombo && !LevelChecked(EnergySiphon))) && LevelChecked(EnergyDrain))
                                 return EnergyDrain;

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -197,7 +197,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
                         return Ruin4;
 
-                    if (!LevelChecked(EnergySiphon) && !gauge.HasAetherflowStacks)
+                    if (LevelChecked(EnergyDrain) && !LevelChecked(EnergySiphon) && !gauge.HasAetherflowStacks)
                         return EnergyDrain;
                     
                     if (LevelChecked(EnergySiphon) && !gauge.HasAetherflowStacks)
@@ -228,7 +228,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (!gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain))
                         {
-                            if ((STCombo && LevelChecked(EnergyDrain)) || (AoECombo && !LevelChecked(EnergySiphon)))
+                            if ((STCombo || (AoECombo && !LevelChecked(EnergySiphon))) && LevelChecked(EnergyDrain))
                                 return EnergyDrain;
 
                             if (AoECombo && LevelChecked(EnergySiphon))
@@ -419,7 +419,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // ED/ES
                         if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain) && (!inOpener || DemiAttackCount >= burstDelay))
                         {
-                            if ((STCombo && LevelChecked(EnergyDrain)) || (AoECombo && !LevelChecked(EnergySiphon)))
+                            if ((STCombo || (AoECombo && !LevelChecked(EnergySiphon))) && LevelChecked(EnergyDrain))
                                 return EnergyDrain;
 
                             if (AoECombo && LevelChecked(EnergySiphon))

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -191,7 +191,8 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 var gauge = GetJobGauge<SMNGauge>();
-                if (actionID == Painflare && !gauge.HasAetherflowStacks)
+                
+                if (actionID == Painflare && LevelChecked(Painflare) && !gauge.HasAetherflowStacks)
                 {
                     if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
                         return Ruin4;

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -197,6 +197,9 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.FurtherRuin) && IsOnCooldown(EnergySiphon) && !gauge.HasAetherflowStacks && IsEnabled(CustomComboPreset.SMN_ESPainflare_Ruin4))
                         return Ruin4;
 
+                    if (!LevelChecked(EnergySiphon) && !gauge.HasAetherflowStacks)
+                        return EnergyDrain;
+                    
                     if (LevelChecked(EnergySiphon) && !gauge.HasAetherflowStacks)
                         return EnergySiphon;
 
@@ -223,12 +226,12 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsOffCooldown(SearingLight) && LevelChecked(SearingLight) && OriginalHook(Ruin) == AstralImpulse)
                             return SearingLight;
 
-                        if (!gauge.HasAetherflowStacks)
+                        if (!gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain))
                         {
-                            if (STCombo && LevelChecked(EnergyDrain) && IsOffCooldown(EnergyDrain))
+                            if ((STCombo && LevelChecked(EnergyDrain)) || (AoECombo && !LevelChecked(EnergySiphon)))
                                 return EnergyDrain;
 
-                            if (AoECombo && LevelChecked(EnergySiphon) && IsOffCooldown(EnergySiphon))
+                            if (AoECombo && LevelChecked(EnergySiphon))
                                 return EnergySiphon;
                         }
                         
@@ -414,12 +417,12 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         
                         // ED/ES
-                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && (!inOpener || DemiAttackCount >= burstDelay))
+                        if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_EDFester) && !gauge.HasAetherflowStacks && IsOffCooldown(EnergyDrain) && (!inOpener || DemiAttackCount >= burstDelay))
                         {
-                            if (STCombo && LevelChecked(EnergyDrain) && IsOffCooldown(EnergyDrain))
+                            if ((STCombo && LevelChecked(EnergyDrain)) || (AoECombo && !LevelChecked(EnergySiphon)))
                                 return EnergyDrain;
 
-                            if (AoECombo && LevelChecked(EnergySiphon) && IsOffCooldown(EnergySiphon))
+                            if (AoECombo && LevelChecked(EnergySiphon))
                                 return EnergySiphon;
                         }
                         


### PR DESCRIPTION
# SMN
- Adds Energy Drain to `Simple Summoner`, `Advanced Summoner`, and `Energy Siphon to Painflare Feature` for their respective AoE button if you're high enough level to use Painflare, but too low to use Energy Siphon.
- Small bugfix for ED/ES following burst delay settings prior to unlocking a demi.