### PR TITLE
SCH/SGE: Healing Mouseover Electric Boogaloo + Esuna

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2855,7 +2855,7 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID, 2)]
             SCH_ST_Heal_Aetherflow = 16262,
 
-            [ParentCombo(SGE_ST_Heal)]
+            [ParentCombo(SCH_ST_Heal)]
             [CustomComboInfo("Esuna Option", "Applies Esuna to your target if there is a cleansable debuff.", SGE.JobID, 3)]
             SCH_ST_Heal_Esuna = 16265,
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2396,7 +2396,11 @@ namespace XIVSlothCombo.Combos
         SGE_ST_Heal = 14300,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Apply Kardia Option", "Applies Kardia to your target if it's not applied to anyone else.", SGE.JobID, 304, "", "")]
+            [CustomComboInfo("Esuna Option", "Applies Esuna to your target if there is a cleansable debuff.", SGE.JobID, 301, "", "")]
+            SGE_ST_Heal_Esuna = 14301,
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Apply Kardia Option", "Applies Kardia to your target if it's not applied to anyone else.", SGE.JobID, 305, "", "")]
             SGE_ST_Heal_Kardia = 14310,
 
             [ParentCombo(SGE_ST_Heal)]
@@ -2404,7 +2408,7 @@ namespace XIVSlothCombo.Combos
             SGE_ST_Heal_Diagnosis = 14320,
                 
                 [ParentCombo(SGE_ST_Heal_Diagnosis)]
-                [CustomComboInfo("Ignore Shield Check", "Warning, will force the use of Eukrasia Diagnosis, and normal Diagnosis will be unavailable.", SGE.JobID, 313, "", "")]
+                [CustomComboInfo("Ignore Shield Check", "Warning, will force the use of Eukrasia Diagnosis, and normal Diagnosis will be unavailable.", SGE.JobID)]
                 SGE_ST_Heal_Diagnosis_IgnoreShield = 14321,
 
             [ParentCombo(SGE_ST_Heal)]
@@ -2420,7 +2424,7 @@ namespace XIVSlothCombo.Combos
             SGE_ST_Heal_Pepsis = 14350,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Taurochole Option", "Adds Taurochole.", SGE.JobID, 302, "", "")]
+            [CustomComboInfo("Taurochole Option", "Adds Taurochole.", SGE.JobID, 303, "", "")]
             SGE_ST_Heal_Taurochole = 14360,
 
             [ParentCombo(SGE_ST_Heal)]
@@ -2428,7 +2432,7 @@ namespace XIVSlothCombo.Combos
             SGE_ST_Heal_Haima = 14370,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 303, "", "")]
+            [CustomComboInfo("Rhizomata Option", "Adds Rhizomata when Addersgall is 0.", SGE.JobID, 304, "", "")]
             SGE_ST_Heal_Rhizomata = 14380,
 
             [ParentCombo(SGE_ST_Heal)]
@@ -2436,7 +2440,7 @@ namespace XIVSlothCombo.Combos
             SGE_ST_Heal_Krasis = 14390,
 
             [ParentCombo(SGE_ST_Heal)]
-            [CustomComboInfo("Druochole Option", "Applies Druochole.", SGE.JobID, 301, "", "")]
+            [CustomComboInfo("Druochole Option", "Applies Druochole.", SGE.JobID, 302, "", "")]
             SGE_ST_Heal_Druochole = 14400,
             #endregion
 
@@ -2844,19 +2848,23 @@ namespace XIVSlothCombo.Combos
         SCH_ST_Heal = 16260,
 
             [ParentCombo(SCH_ST_Heal)]
-            [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID)]
+            [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value:", SCH.JobID, 1)]
             SCH_ST_Heal_Lucid = 16261,
 
             [ParentCombo(SCH_ST_Heal)]
-            [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID)]
+            [CustomComboInfo("Aetherflow Weave Option", "Use Aetherflow when out of Aetherflow stacks.", SCH.JobID, 2)]
             SCH_ST_Heal_Aetherflow = 16262,
-            
+
+            [ParentCombo(SGE_ST_Heal)]
+            [CustomComboInfo("Esuna Option", "Applies Esuna to your target if there is a cleansable debuff.", SGE.JobID, 3)]
+            SCH_ST_Heal_Esuna = 16265,
+
             [ParentCombo(SCH_ST_Heal)]
-            [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or target HP%% below:", SCH.JobID)]
+            [CustomComboInfo("Adloquium Option", "Use Adloquium when missing Galvanize or target HP%% below:", SCH.JobID, 4)]
             SCH_ST_Heal_Adloquium = 16263,
             
             [ParentCombo(SCH_ST_Heal)]
-            [CustomComboInfo("Lustrate Option", "Use Lustrate when target HP%% below:", SCH.JobID)]
+            [CustomComboInfo("Lustrate Option", "Use Lustrate when target HP%% below:", SCH.JobID, 5)]
             SCH_ST_Heal_Lustrate = 16264,
             
 

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -116,11 +116,14 @@ namespace XIVSlothCombo.Combos.PvE
             #endregion
 
             #region Healing
-            internal static int SCH_AoE_LucidOption => PluginConfiguration.GetCustomIntValue(nameof(SCH_AoE_LucidOption));
-            internal static int SCH_AoE_Heal_LucidOption => PluginConfiguration.GetCustomIntValue(nameof(SCH_AoE_Heal_LucidOption));
-            internal static int SCH_ST_Heal_LucidOption => PluginConfiguration.GetCustomIntValue(nameof(SCH_ST_Heal_LucidOption));
-            internal static int SCH_ST_Heal_AdloquiumOption => PluginConfiguration.GetCustomIntValue(nameof(SCH_ST_Heal_AdloquiumOption));
-            internal static int SCH_ST_Heal_LustrateOption => PluginConfiguration.GetCustomIntValue(nameof(SCH_ST_Heal_LustrateOption));
+            internal static UserInt
+                SCH_AoE_LucidOption = new("SCH_AoE_LucidOption"),
+                SCH_AoE_Heal_LucidOption = new("SCH_AoE_Heal_LucidOption"),
+                SCH_ST_Heal_LucidOption = new("SCH_ST_Heal_LucidOption"),
+                SCH_ST_Heal_AdloquiumOption = new("SCH_ST_Heal_AdloquiumOption"),
+                SCH_ST_Heal_LustrateOption = new("SCH_ST_Heal_LustrateOption");
+            internal static UserBool
+                SCH_ST_Heal_UIMouseOver = new("SCH_ST_Heal_UIMouseOver");
             #endregion
 
             #region Utility
@@ -533,11 +536,11 @@ namespace XIVSlothCombo.Combos.PvE
                         return All.LucidDreaming;
 
                     //Grab our target (Soft->Hard->Self)
-                    GameObject? healTarget = null;
-                    GameObject? softTarget = Service.TargetManager.SoftTarget;
-                    if (HasFriendlyTarget(softTarget)) healTarget = softTarget;
-                    if (healTarget is null && HasFriendlyTarget(CurrentTarget)) healTarget = CurrentTarget;
-                    if (healTarget is null) healTarget = LocalPlayer;
+                    GameObject? healTarget = GetHealTarget(Config.SCH_ST_Heal_UIMouseOver);
+
+                    if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
+                        HasCleansableDebuff(healTarget))
+                        return All.Esuna;
 
                     //Check for the Galvanize shield buff. Start applying if it doesn't exist or Target HP is below %
                     if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Adloquium) &&

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -123,6 +123,7 @@ namespace XIVSlothCombo.Combos.PvE
                 SCH_ST_Heal_AdloquiumOption = new("SCH_ST_Heal_AdloquiumOption"),
                 SCH_ST_Heal_LustrateOption = new("SCH_ST_Heal_LustrateOption");
             internal static UserBool
+                SCH_ST_Heal_Adv = new("SCH_ST_Heal_Adv"),
                 SCH_ST_Heal_UIMouseOver = new("SCH_ST_Heal_UIMouseOver");
             #endregion
 
@@ -511,7 +512,7 @@ namespace XIVSlothCombo.Combos.PvE
         }
         
         /*
-        * SCH_AoE_Heal
+        * SCH_ST_Heal
         * Overrides main AoE Healing abiility, Succor
         * Lucid Dreaming and Atherflow weave options
         */
@@ -536,7 +537,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return All.LucidDreaming;
 
                     //Grab our target (Soft->Hard->Self)
-                    GameObject? healTarget = GetHealTarget(Config.SCH_ST_Heal_UIMouseOver);
+                    GameObject? healTarget = GetHealTarget(Config.SCH_ST_Heal_Adv && Config.SCH_ST_Heal_UIMouseOver);
 
                     if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
                         HasCleansableDebuff(healTarget))

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -117,6 +117,8 @@ namespace XIVSlothCombo.Combos.PvE
             #endregion
 
             #region Healing
+            internal static UserBool
+                SGE_ST_Heal_UIMouseOver = new("SGE_ST_Heal_UIMouseOver");
             internal static UserInt
                 SGE_ST_Heal_Zoe = new("SGE_ST_Heal_Zoe"),
                 SGE_ST_Heal_Haima = new("SGE_ST_Heal_Haima"),
@@ -383,12 +385,11 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.Eukrasia))
                         return EukrasianDiagnosis;
 
-                    // Set Target. Soft -> Hard -> Self priority, matching normal in-game behavior
-                    GameObject? healTarget = null;
-                    GameObject? softTarget = Service.TargetManager.SoftTarget;
-                    if (HasFriendlyTarget(softTarget)) healTarget = softTarget;
-                    if (healTarget is null && HasFriendlyTarget(CurrentTarget)) healTarget = CurrentTarget;
-                    if (healTarget is null) healTarget = LocalPlayer;
+                    GameObject? healTarget = GetHealTarget(Config.SGE_ST_Heal_UIMouseOver);
+
+                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
+                        HasCleansableDebuff(healTarget))
+                        return All.Esuna;
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && ActionReady(Druochole) &&
                         Gauge.HasAddersgall() &&

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -118,6 +118,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             #region Healing
             internal static UserBool
+                SGE_ST_Heal_Adv = new("SGE_ST_Heal_Adv"),
                 SGE_ST_Heal_UIMouseOver = new("SGE_ST_Heal_UIMouseOver");
             internal static UserInt
                 SGE_ST_Heal_Zoe = new("SGE_ST_Heal_Zoe"),
@@ -357,7 +358,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Eukrasia && HasEffect(Buffs.Eukrasia))
                 {
-                    switch (PluginConfiguration.GetCustomIntValue(Config.SGE_Eukrasia_Mode))
+                    switch ((int)Config.SGE_Eukrasia_Mode)
                     {
                         case 0: return OriginalHook(Dosis);
                         case 1: return OriginalHook(Diagnosis);
@@ -385,7 +386,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.Eukrasia))
                         return EukrasianDiagnosis;
 
-                    GameObject? healTarget = GetHealTarget(Config.SGE_ST_Heal_UIMouseOver);
+                    GameObject? healTarget = GetHealTarget(Config.SGE_ST_Heal_Adv && Config.SGE_ST_Heal_UIMouseOver);
 
                     if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
                         HasCleansableDebuff(healTarget))

--- a/XIVSlothCombo/CustomCombo/Functions/Status.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Status.cs
@@ -119,5 +119,19 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 
             return false;
         }
+
+        public static bool HasCleansableDebuff(GameObject? OurTarget = null)
+        {
+            OurTarget ??= CurrentTarget;
+            if (HasFriendlyTarget(OurTarget) && (OurTarget is BattleChara chara))
+            {
+                foreach (Status status in chara.StatusList)
+                {
+                    if (ActionWatching.StatusSheet.TryGetValue(status.StatusId, out var statusItem) && statusItem.CanDispel)
+                        return true;
+                }
+            }
+            return false;
+        }
     }
 }

--- a/XIVSlothCombo/CustomCombo/Functions/Target.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Target.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Numerics;
+using Dalamud.Game.ClientState.Objects;
 using Dalamud.Game.ClientState.Objects.Enums;
 using Dalamud.Game.ClientState.Objects.Types;
 using XIVSlothCombo.Data;
@@ -101,16 +102,40 @@ namespace XIVSlothCombo.CustomComboNS.Functions
             {
                 //Fallback to CurrentTarget
                 OurTarget = CurrentTarget;
-                if (OurTarget is null) 
+                if (OurTarget is null)
                     return false;
             }
 
             //Humans
-            if (OurTarget.ObjectKind is ObjectKind.Player) 
+            if (OurTarget.ObjectKind is ObjectKind.Player)
                 return true;
             //AI
             if (OurTarget is BattleNpc) return (OurTarget as BattleNpc).BattleNpcKind is not BattleNpcSubKind.Enemy;
             return false;
+        }
+
+        /// <summary> Grabs healable target. Checks Soft Target then Hard Target. If Party UI Mouseover is enabled, find the target and return that. Else return the player. </summary>
+        /// <returns> GameObject of a player target. </returns>
+        public static unsafe GameObject? GetHealTarget(bool checkMOPartyUI = false)
+        {
+            GameObject? healTarget = null;
+            TargetManager tm = Service.TargetManager;
+            
+            if (HasFriendlyTarget(tm.SoftTarget)) healTarget = tm.SoftTarget;
+            if (healTarget is null && HasFriendlyTarget(CurrentTarget)) healTarget = CurrentTarget;
+            //if (checkMO && HasFriendlyTarget(tm.MouseOverTarget)) healTarget = tm.MouseOverTarget;
+            if (checkMOPartyUI)
+            {
+                StructsObject.GameObject* t = PartyTargetingService.UITarget;
+                if (t != null)
+                {
+                    long o = PartyTargetingService.GetObjectID(t);
+                    GameObject? uiTarget =  Service.ObjectTable.Where(x => x.ObjectId == o).First();
+                    if (HasFriendlyTarget(uiTarget)) healTarget = uiTarget;
+                }
+            }
+            healTarget ??= LocalPlayer;
+            return healTarget;
         }
 
         /// <summary> Determines if the enemy can be interrupted if they are currently casting. </summary>

--- a/XIVSlothCombo/CustomCombo/Functions/Target.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Target.cs
@@ -114,7 +114,8 @@ namespace XIVSlothCombo.CustomComboNS.Functions
             return false;
         }
 
-        /// <summary> Grabs healable target. Checks Soft Target then Hard Target. If Party UI Mouseover is enabled, find the target and return that. Else return the player. </summary>
+        /// <summary> Grabs healable target. Checks Soft Target then Hard Target. 
+        /// If Party UI Mouseover is enabled, find the target and return that. Else return the player. </summary>
         /// <returns> GameObject of a player target. </returns>
         public static unsafe GameObject? GetHealTarget(bool checkMOPartyUI = false)
         {

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1530,8 +1530,18 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 1, SGE.Config.SGE_AoE_DPS_Rhizo, "Addersgall Threshold", 150, SliderIncrements.Ones);
 
             if (preset is CustomComboPreset.SGE_ST_Heal)
-                UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_Heal_UIMouseOver, "Party UI Mouseover Checking", 
-                                                    "Check party member's HP by using mouseover on the party list.\nDoes not target the party member.");
+            {
+                UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_Heal_Adv, "Advanced Options", "", isConditionalChoice: true);
+                if (SGE.Config.SGE_ST_Heal_Adv)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_Heal_UIMouseOver, 
+                        "Party UI Mouseover Checking",
+                        "Check party member's HP & Debuffs by using mouseover on the party list.\n" +
+                        "To be used in conjunction with Redirect/Reaction/etc");
+                    ImGui.Unindent();
+                }
+            }
 
             if (preset is CustomComboPreset.SGE_ST_Heal_Soteria)
                 UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Soteria, "Use Soteria when Target HP is at or below set percentage");
@@ -1660,8 +1670,18 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_AoE_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
 
             if (preset is CustomComboPreset.SCH_ST_Heal)
-                UserConfig.DrawAdditionalBoolChoice(SCH.Config.SCH_ST_Heal_UIMouseOver, "Party UI Mouseover Checking",
-                                                    "Check party member's HP by using mouseover on the party list.\nDoes not target the party member.");
+            {
+                UserConfig.DrawAdditionalBoolChoice(SCH.Config.SCH_ST_Heal_Adv, "Advanced Options", "", isConditionalChoice: true);
+                if (SCH.Config.SCH_ST_Heal_Adv)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawAdditionalBoolChoice(SCH.Config.SCH_ST_Heal_UIMouseOver,
+                        "Party UI Mouseover Checking",
+                        "Check party member's HP & Debuffs by using mouseover on the party list.\n" +
+                        "To be used in conjunction with Redirect/Reaction/etc");
+                    ImGui.Unindent();
+                }
+            }
 
             if (preset is CustomComboPreset.SCH_ST_Heal_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_ST_Heal_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1529,6 +1529,10 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.SGE_AoE_DPS_Rhizo)
                 UserConfig.DrawSliderInt(0, 1, SGE.Config.SGE_AoE_DPS_Rhizo, "Addersgall Threshold", 150, SliderIncrements.Ones);
 
+            if (preset is CustomComboPreset.SGE_ST_Heal)
+                UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_Heal_UIMouseOver, "Party UI Mouseover Checking", 
+                                                    "Check party member's HP by using mouseover on the party list.\nDoes not target the party member.");
+
             if (preset is CustomComboPreset.SGE_ST_Heal_Soteria)
                 UserConfig.DrawSliderInt(0, 100, SGE.Config.SGE_ST_Heal_Soteria, "Use Soteria when Target HP is at or below set percentage");
 
@@ -1654,7 +1658,11 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset is CustomComboPreset.SCH_AoE_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_AoE_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
-                        
+
+            if (preset is CustomComboPreset.SCH_ST_Heal)
+                UserConfig.DrawAdditionalBoolChoice(SCH.Config.SCH_ST_Heal_UIMouseOver, "Party UI Mouseover Checking",
+                                                    "Check party member's HP by using mouseover on the party list.\nDoes not target the party member.");
+
             if (preset is CustomComboPreset.SCH_ST_Heal_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, nameof(SCH.Config.SCH_ST_Heal_LucidOption), "MP Threshold", 150, SliderIncrements.Hundreds);
             


### PR DESCRIPTION
SCH/SGE Single Target Heal
- Targeting code moved to function GetHealTarget
- Optional "Party UI Mouseover Target Checking" added. Does not apply actions to the target. Rejoice ye Redirect/Reaction/moAction healers.
- Esuna Option Added. Detects cleanable debuffs

Framework
- Status: HasCleansableDebuff added. Used for Esuna checking
- Target: GetHealTarget added. Optional checking the Party UI Mouseover Target added by passed parameter.