### PR TITLE
[RPR] Add option to hold one charge of True North for use with Gluttony

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2191,11 +2191,11 @@ namespace XIVSlothCombo.Combos
         RPR_Soulsow_Combat = 12062,
 
         [ReplaceSkill(RPR.Gibbet,RPR.Gallows)]
-        [CustomComboInfo("True North Feature (Dynamic)", "Adds True North to Slice when Gibbet/Gallows proc based on position to target, essentially only use True North if needed in the moment.", RPR.JobID, 0, "", "")]
+        [CustomComboInfo("Dynamic True North Feature", "Adds True North to Slice befrore Gibbet/Gallows when you are not in the correct position for the enhanced potency bonus.", RPR.JobID, 0, "", "")]
         RPR_TrueNorthDynamic = 12063,
 
         [ParentCombo(RPR_TrueNorthDynamic)]
-        [CustomComboInfo("Hold True North for Gluttony", "Will hold the last charge of True North for use with Gluttony, even when out of position.", RPR.JobID, 0, "", "")]
+        [CustomComboInfo("Hold True North for Gluttony Option", "Will hold the last charge of True North for use with Gluttony, even when out of position.", RPR.JobID, 0, "", "")]
         RPR_TrueNorthDynamic_HoldCharge = 12064,
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2171,6 +2171,10 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(RPR.Gibbet,RPR.Gallows)]
         [CustomComboInfo("True North Feature (Dynamic)", "Adds True North to Slice when Gibbet/Gallows proc based on position to target, essentially only use True North if needed in the moment.", RPR.JobID, 0, "", "")]
         RPR_TrueNorthDynamic = 12063,
+
+        [ParentCombo(RPR_TrueNorthDynamic)]
+        [CustomComboInfo("Hold one True North charge for Gluttony", "Will not use the last charge of True North, even when out of position, for use with Gluttony.", RPR.JobID, 0, "", "")]
+        RPR_TrueNorthDynamic_HoldCharge = 12064,
         #endregion
 
         #endregion

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2191,11 +2191,11 @@ namespace XIVSlothCombo.Combos
         RPR_Soulsow_Combat = 12062,
 
         [ReplaceSkill(RPR.Gibbet,RPR.Gallows)]
-        [CustomComboInfo("Dynamic True North Feature", "Adds True North to Slice befrore Gibbet/Gallows when you are not in the correct position for the enhanced potency bonus.", RPR.JobID, 0, "", "")]
+        [CustomComboInfo("Dynamic True North Feature", "Adds True North to Slice before Gibbet/Gallows when you are not in the correct position for the enhanced potency bonus.", RPR.JobID, 0, "", "")]
         RPR_TrueNorthDynamic = 12063,
 
         [ParentCombo(RPR_TrueNorthDynamic)]
-        [CustomComboInfo("Hold True North for Gluttony Option", "Will hold the last charge of True North for use with Gluttony, even when out of position.", RPR.JobID, 0, "", "")]
+        [CustomComboInfo("Hold True North for Gluttony Option", "Will hold the last charge of True North for use with Gluttony, even when out of position for Gibbet/Gallows potency bonuses.", RPR.JobID, 0, "", "")]
         RPR_TrueNorthDynamic_HoldCharge = 12064,
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2195,7 +2195,7 @@ namespace XIVSlothCombo.Combos
         RPR_TrueNorthDynamic = 12063,
 
         [ParentCombo(RPR_TrueNorthDynamic)]
-        [CustomComboInfo("Hold one True North charge for Gluttony", "Will not use the last charge of True North, even when out of position, for use with Gluttony.", RPR.JobID, 0, "", "")]
+        [CustomComboInfo("Hold True North for Gluttony", "Will hold the last charge of True North for use with Gluttony, even when out of position.", RPR.JobID, 0, "", "")]
         RPR_TrueNorthDynamic_HoldCharge = 12064,
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/RPR.cs
+++ b/XIVSlothCombo/Combos/PvE/RPR.cs
@@ -100,7 +100,13 @@ namespace XIVSlothCombo.Combos.PvE
                 int sodThreshold = PluginConfiguration.GetCustomIntValue(Config.RPR_SoDThreshold);
                 int sodRefreshRange = PluginConfiguration.GetCustomIntValue(Config.RPR_SoDRefreshRange);
                 bool trueNorthReady = GetRemainingCharges(All.TrueNorth) > 0 && !HasEffect(All.Buffs.TrueNorth);
+                bool trueNorthReadyDyn = trueNorthReady;
                 bool opener = IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_Opener) && CombatEngageDuration().TotalSeconds < 30 && LevelChecked(Communio);
+
+				// Prevent the dynamic true north option from using the last charge
+				if( trueNorthReady && IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic) && IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic_HoldCharge) && GetRemainingCharges(All.TrueNorth) < 2 ) {
+					trueNorthReadyDyn = false;
+				}
 
                 // Gibbet and Gallows on Shadow of Death
                 if (actionID is ShadowOfDeath && IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows) && IsEnabled(CustomComboPreset.RPR_ST_SliceCombo_GibbetGallows_OnSoD) && soulReaver && LevelChecked(Gibbet))
@@ -144,14 +150,14 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (HasEffect(Buffs.EnhancedGibbet)) {
                                 // If we are not on the flank, but need to use gibbet, pop true north if not already up
-                                if( IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic) && trueNorthReady && !HasEffect(All.Buffs.TrueNorth) && CanWeave(actionID) && !OnTargetsFlank() ) {
+                                if( IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic) && trueNorthReadyDyn && !HasEffect(All.Buffs.TrueNorth) && CanWeave(actionID) && !OnTargetsFlank() ) {
                                     return All.TrueNorth;
                                 }
                                 return OriginalHook(Gibbet);
                             }
                             if (HasEffect(Buffs.EnhancedGallows)) {
                                 // If we are not on the rear, but need to use gallows, pop true north if not already up
-                                if( IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic) && trueNorthReady && !HasEffect(All.Buffs.TrueNorth) && CanWeave(actionID) && !OnTargetsRear() ) {
+                                if( IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic) && trueNorthReadyDyn && !HasEffect(All.Buffs.TrueNorth) && CanWeave(actionID) && !OnTargetsRear() ) {
                                     return All.TrueNorth;
                                 }
                                 return OriginalHook(Gallows);
@@ -166,13 +172,13 @@ namespace XIVSlothCombo.Combos.PvE
                         if (!HasEffect(Buffs.EnhancedGibbet) && !HasEffect(Buffs.EnhancedGallows) && HasBattleTarget() )
                         {
                             if (positionalChoice is 0 or 1) {
-                                if( IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic) && trueNorthReady && !HasEffect(All.Buffs.TrueNorth) && CanWeave(actionID) && !OnTargetsRear() ) {
+                                if( IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic) && trueNorthReadyDyn && !HasEffect(All.Buffs.TrueNorth) && CanWeave(actionID) && !OnTargetsRear() ) {
                                     return All.TrueNorth;
                                 }
                                 return Gallows;
                             }
                             if (positionalChoice == 2) {
-                                if( IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic) && trueNorthReady && !HasEffect(All.Buffs.TrueNorth) && CanWeave(actionID) && !OnTargetsFlank() ) {
+                                if( IsEnabled(CustomComboPreset.RPR_TrueNorthDynamic) && trueNorthReadyDyn && !HasEffect(All.Buffs.TrueNorth) && CanWeave(actionID) && !OnTargetsFlank() ) {
                                     return All.TrueNorth;
                                 }
                                 return Gibbet;


### PR DESCRIPTION
This PR just adds support for holding a charge of True North so it can be used more effectively after Gluttony (2 back to back positionals) , either by using the older True North option or firing it off manually.