### PR TITLE
[GNB] Fix `No Mercy on Gnashing Fang`

### DIFF
--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -261,7 +261,7 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     var gauge = GetJobGauge<GNBGauge>();
 
-                    if (IsOffCooldown(NoMercy) && CanDelayedWeave(actionID) && IsOffCooldown(GnashingFang) && IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_NoMercy))
+                    if (IsOffCooldown(NoMercy) && CanDelayedWeave(SolidBarrel) && IsOffCooldown(GnashingFang) && IsEnabled(CustomComboPreset.GNB_ST_GnashingFang_NoMercy))
                         return NoMercy;
 
 


### PR DESCRIPTION
Option was checking for delayed weave against `Gnashing Fang`.
Now checks against regular GCD action (`Solid Barrel`).