### PR TITLE
[DNC] Semi-rework

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -832,14 +832,19 @@ namespace XIVSlothCombo.Combos
             DNC_ST_Simple_Flourish = 4056,
 
             [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Feathers Option", "Includes Feather usage in the rotation.", DNC.JobID, 4, "", "")]
+            [CustomComboInfo("Simple Feathers Option", "Expends a feather in the next available weave window when capped." +
+            "\nWeaves feathers where possible during Technical Finish." +
+            "\nWeaves feathers outside of burst when target is below set HP percentage (Set to 0 to disable)." +
+            "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 4, "", "")]
             DNC_ST_Simple_Feathers = 4057,
 
+            /*
             [ParentCombo(DNC_ST_Simple_Feathers)]
             [CustomComboInfo("Simple Feather Pooling Option", "Expends a feather in the next available weave window when capped." +
             "\nWeaves feathers where possible during Technical Finish." +
             "\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 4, "", "")]
             DNC_ST_Simple_FeatherPooling = 4058,
+            */
 
             [ParentCombo(DNC_ST_SimpleMode)]
             [CustomComboInfo("Simple Panic Heals Option", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 5, "", "")]
@@ -903,12 +908,16 @@ namespace XIVSlothCombo.Combos
             DNC_AoE_Simple_Flourish = 4076,
 
             [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Feathers Option", "Includes feather usage in the AoE rotation.", DNC.JobID, 7, "", "")]
+            [CustomComboInfo("Simple AoE Feathers Option", "Expends a feather in the next available weave window when capped." +
+            "\nWeaves feathers where possible during Technical Finish." +
+            "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 7, "", "")]
             DNC_AoE_Simple_Feathers = 4077,
 
+            /*
             [ParentCombo(DNC_AoE_Simple_Feathers)]
             [CustomComboInfo("Simple AoE Feather Pooling Option", "Expends a feather in the next available weave window when capped.", DNC.JobID, 8, "", "")]
             DNC_AoE_Simple_FeatherPooling = 4078,
+            */
 
             [ParentCombo(DNC_AoE_SimpleMode)]
             [CustomComboInfo("Simple AoE Panic Heals Option", "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 9, "", "")]

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -437,7 +437,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             int featherBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
                             int minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep)
-                                ? (GetCooldownRemainingTime(TechnicalStep) < 5f?4:3)
+                                ? (GetCooldownRemainingTime(TechnicalStep) < 2.5f ? 4 : 3)
                                 : 0;
 
                             if (HasEffect(Buffs.ThreeFoldFanDance))
@@ -577,7 +577,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers))
                         {
                             int minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep)
-                                ? 3
+                                ? (GetCooldownRemainingTime(TechnicalStep) < 2.5f ? 4 : 3)
                                 : 0;
 
                             if (HasEffect(Buffs.ThreeFoldFanDance))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -449,7 +449,8 @@ namespace XIVSlothCombo.Combos.PvE
                                 return FanDance1;
 
                             // Burst FD1
-                            if (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0))
+                            if ((gauge.Feathers > minFeathers) ||
+                                (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0))
                                 return FanDance1;
                         }
 
@@ -582,7 +583,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
-                            if (LevelChecked(FanDance2) && (gauge.Feathers > minFeathers || (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)))
+
+                            if ((gauge.Feathers > minFeathers ||
+                                (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)) &&
+                                LevelChecked(FanDance2))
                                 return FanDance2;
                         }
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -430,12 +430,6 @@ namespace XIVSlothCombo.Combos.PvE
                         interruptable && !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    // ST Technical Step
-                    if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent)) &&
-                        IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) &&
-                        ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep))
-                        return TechnicalStep;
-
                     if (CanWeave(actionID))
                     {
                         // ST Feathers & Fans
@@ -485,6 +479,12 @@ namespace XIVSlothCombo.Combos.PvE
                             (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
                             return StandardStep;
                     }
+
+                    // ST Technical Step
+                    if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent)) &&
+                        IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) &&
+                        ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep))
+                        return TechnicalStep;
 
                     // ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
@@ -571,12 +571,6 @@ namespace XIVSlothCombo.Combos.PvE
                         interruptable && !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    // AoE Technical Step
-                    if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent)) &&
-                        IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && ActionReady(TechnicalStep) &&
-                        !HasEffect(Buffs.StandardStep))
-                        return TechnicalStep;
-
                     if (CanWeave(actionID))
                     {
                         // AoE Feathers & Fans
@@ -618,6 +612,12 @@ namespace XIVSlothCombo.Combos.PvE
                             (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
                             return StandardStep;
                     }
+
+                    // AoE Technical Step
+                    if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent)) &&
+                        IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && ActionReady(TechnicalStep) &&
+                        !HasEffect(Buffs.StandardStep))
+                        return TechnicalStep;
 
                     // AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -76,13 +76,6 @@ namespace XIVSlothCombo.Combos.PvE
                 ShieldSamba = 1826;
         }
 
-        /*
-        public static class Debuffs
-        {
-            public const short placeholder = 0;
-        }
-        */
-
         public static class Config
         {
             public const string
@@ -152,18 +145,22 @@ namespace XIVSlothCombo.Combos.PvE
                 // FD 1 --> 3, FD 1 --> 4
                 if (actionID is FanDance1)
                 {
-                    if (HasEffect(Buffs.ThreeFoldFanDance) && IsEnabled(CustomComboPreset.DNC_FanDance_1to3_Combo))
+                    if (IsEnabled(CustomComboPreset.DNC_FanDance_1to3_Combo) &&
+                        HasEffect(Buffs.ThreeFoldFanDance))
                         return FanDance3;
-                    if (HasEffect(Buffs.FourFoldFanDance) && IsEnabled(CustomComboPreset.DNC_FanDance_1to4_Combo))
+                    if (IsEnabled(CustomComboPreset.DNC_FanDance_1to4_Combo) &&
+                        HasEffect(Buffs.FourFoldFanDance))
                         return FanDance4;
                 }
 
                 // FD 2 --> 3, FD 2 --> 4
                 if (actionID is FanDance2)
                 {
-                    if (HasEffect(Buffs.ThreeFoldFanDance) && IsEnabled(CustomComboPreset.DNC_FanDance_2to3_Combo))
+                    if (IsEnabled(CustomComboPreset.DNC_FanDance_2to3_Combo) &&
+                        HasEffect(Buffs.ThreeFoldFanDance))
                         return FanDance3;
-                    if (HasEffect(Buffs.FourFoldFanDance) && IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo))
+                    if (IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo) &&
+                        HasEffect(Buffs.FourFoldFanDance))
                         return FanDance4;
                 }
 
@@ -201,7 +198,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                // Fan Dance 3 & 4 on Flourish when relevant
+                // Fan Dance 3 & 4 on Flourish
                 if (actionID is Flourish && CanWeave(actionID))
                 {
                     if (HasEffect(Buffs.ThreeFoldFanDance))
@@ -342,7 +339,8 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Flourish
-                    if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Flourish) && InCombat() && !gauge.IsDancing &&
+                    if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Flourish) &&
+                        InCombat() && !gauge.IsDancing &&
                         ActionReady(Flourish) &&
                         IsOnCooldown(StandardStep))
                         return Flourish;
@@ -353,7 +351,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Tillana;
 
                     // Tech Step
-                    if (IsOnCooldown(StandardStep) && IsOffCooldown(TechnicalStep) && !gauge.IsDancing && !HasEffect(Buffs.StandardStep))
+                    if (IsOnCooldown(StandardStep) && IsOffCooldown(TechnicalStep) &&
+                        !gauge.IsDancing && !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
                     // Dance steps
@@ -402,15 +401,15 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Dance Fills
                     // ST Standard (Dance) Steps & Fill
-                    if (HasEffect(Buffs.StandardStep) &&
-                        (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_StandardFill)))
+                    if ((IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_StandardFill)) &&
+                        HasEffect(Buffs.StandardStep))
                         return gauge.CompletedSteps < 2
                             ? gauge.NextStep
                             : StandardFinish2;
 
                     // ST Technical (Dance) Steps & Fill
-                    if (HasEffect(Buffs.TechnicalStep) &&
-                        (IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_TechFill)))
+                    if ((IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_TechFill)) &&
+                        HasEffect(Buffs.TechnicalStep))
                         return gauge.CompletedSteps < 4
                             ? gauge.NextStep
                             : TechnicalFinish4;
@@ -493,9 +492,9 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // ST Technical Step
-                    if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent)) &&
-                        IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) &&
-                        ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep))
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) && ActionReady(TechnicalStep) &&
+                        (!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent)) &&
+                        !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
                     // ST Saber Dance
@@ -553,15 +552,15 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Dance Fills
                     // AoE Standard (Dance) Steps & Fill
-                    if (HasEffect(Buffs.StandardStep) &&
-                        (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_StandardFill)))
+                    if ((IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_StandardFill)) &&
+                        HasEffect(Buffs.StandardStep))
                         return gauge.CompletedSteps < 2
                             ? gauge.NextStep
                             : StandardFinish2;
 
                     // AoE Technical (Dance) Steps & Fill
-                    if (HasEffect(Buffs.TechnicalStep) &&
-                        (IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_TechFill)))
+                    if ((IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_TechFill)) &&
+                        HasEffect(Buffs.TechnicalStep))
                         return gauge.CompletedSteps < 4
                             ? gauge.NextStep
                             : TechnicalFinish4;
@@ -590,7 +589,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (CanWeave(actionID))
                     {
                         // AoE Feathers & Fans
-                        if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers))
+                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers) && LevelChecked(FanDance1))
                         {
                             int minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep)
                                 ? 3
@@ -638,8 +637,8 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // AoE Technical Step
-                    if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent)) &&
-                        IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && ActionReady(TechnicalStep) &&
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && ActionReady(TechnicalStep) &&
+                        (!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent)) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -418,6 +418,13 @@ namespace XIVSlothCombo.Combos.PvE
                         CanWeave(actionID) && ActionReady(Devilment) && (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
+                    // ST Flourish
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Flourish) &&
+                        CanWeave(actionID, 0.5) && ActionReady(Flourish) &&
+                        !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
+                        !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
+                        return Flourish;
+
                     // ST Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Interrupt) &&
                         interruptable && !HasEffect(Buffs.TechnicalFinish))
@@ -431,13 +438,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (CanWeave(actionID))
                     {
-                        // ST Flourish
-                        if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Flourish) &&
-                            ActionReady(Flourish) &&
-                            !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
-                            !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
-                            return Flourish;
-
                         // ST Feathers & Fans
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Feathers) && LevelChecked(FanDance1))
                         {
@@ -559,6 +559,13 @@ namespace XIVSlothCombo.Combos.PvE
                         (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
+                    // AoE Flourish
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Flourish) &&
+                        CanWeave(actionID, 0.5) && ActionReady(Flourish)
+                        && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
+                        !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
+                        return Flourish;
+
                     // AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Interrupt) &&
                         interruptable && !HasEffect(Buffs.TechnicalFinish))
@@ -569,13 +576,6 @@ namespace XIVSlothCombo.Combos.PvE
                         IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && ActionReady(TechnicalStep) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
-
-                    // AoE Flourish
-                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Flourish) &&
-                        CanWeave(actionID) && ActionReady(Flourish)
-                        && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
-                        !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
-                        return Flourish;
 
                     if (CanWeave(actionID))
                     {

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -425,7 +425,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Flourish
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Flourish) &&
-                        CanWeave(actionID, 0.5) && ActionReady(Flourish) &&
+                        CanDelayedWeave(actionID, 1.25, 0.5) && ActionReady(Flourish) &&
                         !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
                         !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
                         return Flourish;
@@ -576,7 +576,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Flourish
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Flourish) &&
-                        CanWeave(actionID, 0.5) && ActionReady(Flourish)
+                        CanDelayedWeave(actionID, 1.25, 0.5)  && ActionReady(Flourish)
                         && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
                         !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
                         return Flourish;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -394,11 +394,14 @@ namespace XIVSlothCombo.Combos.PvE
                     bool interruptable = CanInterruptEnemy() && ActionReady(All.HeadGraze);
                     #endregion
 
+                    #region Pre-pull
                     // ST Peloton
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Peloton) &&
                         !InCombat() && !HasEffectAny(Buffs.Peloton) && GetBuffRemainingTime(Buffs.StandardStep) > 5)
                         return Peloton;
+                    #endregion
 
+                    #region Dance Fills
                     // ST Standard (Dance) Steps & Fill
                     if (HasEffect(Buffs.StandardStep) &&
                         (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_StandardFill)))
@@ -412,7 +415,9 @@ namespace XIVSlothCombo.Combos.PvE
                         return gauge.CompletedSteps < 4
                             ? gauge.NextStep
                             : TechnicalFinish4;
+                    #endregion
 
+                    #region Weaves
                     // ST Devilment
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Devilment) &&
                         CanWeave(actionID) && ActionReady(Devilment) && (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
@@ -471,7 +476,9 @@ namespace XIVSlothCombo.Combos.PvE
                             ActionReady(Improvisation))
                             return Improvisation;
                     }
+                    #endregion
 
+                    #region GCD
                     // ST Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
@@ -519,6 +526,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return ReverseCascade;
                     if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime > 0)
                         return Fountain;
+                    #endregion
                 }
 
                 return actionID;
@@ -540,6 +548,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool interruptable = CanInterruptEnemy() && ActionReady(All.HeadGraze);
                     #endregion
 
+                    #region Dance Fills
                     // AoE Standard (Dance) Steps & Fill
                     if (HasEffect(Buffs.StandardStep) &&
                         (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_StandardFill)))
@@ -553,7 +562,9 @@ namespace XIVSlothCombo.Combos.PvE
                         return gauge.CompletedSteps < 4
                             ? gauge.NextStep
                             : TechnicalFinish4;
+                    #endregion
 
+                    #region Weaves
                     // AoE Devilment
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Devilment) &&
                         CanWeave(actionID) && ActionReady(Devilment) && 
@@ -607,7 +618,9 @@ namespace XIVSlothCombo.Combos.PvE
                             ActionReady(Improvisation))
                             return Improvisation;
                     }
+                    #endregion
 
+                    #region GCD
                     // AoE Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
@@ -655,6 +668,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return RisingWindmill;
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime > 0)
                         return Bladeshower;
+                    #endregion
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -440,23 +440,30 @@ namespace XIVSlothCombo.Combos.PvE
                         // ST Feathers & Fans
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Feathers) && LevelChecked(FanDance1))
                         {
-                            int featherBurstThreshold = PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent);
-                            int minFeathers = IsEnabled(CustomComboPreset.DNC_ST_Simple_FeatherPooling) && LevelChecked(TechnicalStep)
-                                ? (GetCooldownRemainingTime(TechnicalStep) < 2.5f ? 4 : 3)
-                                : 0;
-
+                            // FD3
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
 
-                            // Basic FD1
-                            if ((IsOffCooldown(TechnicalStep) && gauge.Feathers > 3) ||
-                                (GetTargetHPPercent() < featherBurstThreshold && gauge.Feathers > 0))
+                            // FD1 HP% Dump
+                            if (GetTargetHPPercent() <= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent) && gauge.Feathers > 0)
                                 return FanDance1;
 
-                            // Burst FD1
-                            if ((gauge.Feathers > minFeathers) ||
-                                (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0))
+                            if (LevelChecked(TechnicalStep))
+                            {
+                                // Burst FD1
+                                if (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)
+                                    return FanDance1;
+
+                                // FD1 Pooling
+                                if (gauge.Feathers > 3 &&
+                                    (GetCooldownRemainingTime(TechnicalStep) > 2.5f || IsOffCooldown(TechnicalStep)))
+                                    return FanDance1;
+                            }
+
+                            // FD1 Non-pooling & under burst level
+                            if (!LevelChecked(TechnicalStep) && gauge.Feathers > 0)
                                 return FanDance1;
+
                         }
 
                         if (HasEffect(Buffs.FourFoldFanDance))
@@ -485,9 +492,10 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
-                        if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent)) &&
+                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent)) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
+                            IsOffCooldown(StandardStep))
                             return StandardStep;
                     }
 
@@ -588,20 +596,53 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (CanWeave(actionID))
                     {
+                        /*
                         // AoE Feathers & Fans
                         if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers) && LevelChecked(FanDance1))
                         {
                             int minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep)
-                                ? 3
+                                ? (GetCooldownRemainingTime(TechnicalStep) < 2.5f ? 4 : 3)
                                 : 0;
 
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
 
-                            if (LevelChecked(FanDance2) &&
-                                (gauge.Feathers > minFeathers ||
-                                (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)))
+                            if ((gauge.Feathers > minFeathers ||
+                                (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)) &&
+                                LevelChecked(FanDance2))
                                 return FanDance2;
+                        }
+                        */
+
+                        // AoE Feathers & Fans
+                        if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers) && LevelChecked(FanDance1))
+                        {
+                            // FD3
+                            if (HasEffect(Buffs.ThreeFoldFanDance))
+                                return FanDance3;
+
+                            if (LevelChecked(FanDance2))
+                            {
+                                if (LevelChecked(TechnicalStep))
+                                {
+                                    // Burst FD2
+                                    if (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)
+                                        return FanDance2;
+
+                                    // FD2 Pooling
+                                    if (gauge.Feathers > 3 &&
+                                        (GetCooldownRemainingTime(TechnicalStep) > 2.5f || IsOffCooldown(TechnicalStep)))
+                                        return FanDance2;
+                                }
+
+                                // FD2 Non-pooling & under burst level
+                                if (!LevelChecked(TechnicalStep) && gauge.Feathers > 0)
+                                    return FanDance2;
+                            }
+
+                            // FD1 Replacement for Lv.30-49
+                            if (!LevelChecked(FanDance2) && gauge.Feathers > 0)
+                                return FanDance1;
                         }
 
                         if (HasEffect(Buffs.FourFoldFanDance))
@@ -630,9 +671,10 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
-                        if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent)) &&
+                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent)) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
+                            IsOffCooldown(StandardStep))
                             return StandardStep;
                     }
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -423,15 +423,6 @@ namespace XIVSlothCombo.Combos.PvE
                         interruptable && !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    // ST Standard Step
-                    if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && ActionReady(StandardStep))
-                    {
-                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent)) &&
-                        ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 10) &&
-                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish)) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5)) || InCombat())
-                        return StandardStep;
-                    }
-
                     // ST Technical Step
                     if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent)) &&
                         IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) &&
@@ -486,6 +477,15 @@ namespace XIVSlothCombo.Combos.PvE
                             return Improvisation;
                     }
 
+                    // ST Standard Step (outside of burst)
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    {
+                        if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent)) &&
+                            ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
+                            return StandardStep;
+                    }
+
                     // ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
@@ -503,6 +503,14 @@ namespace XIVSlothCombo.Combos.PvE
                         return StarfallDance;
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
+
+                    // ST Standard Step (inside of burst)
+                    if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
+                    {
+                        if (GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent) &&
+                            (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
+                            return StandardStep;
+                    }
 
                     if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
@@ -556,16 +564,6 @@ namespace XIVSlothCombo.Combos.PvE
                         interruptable && !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    // AoE Standard Step
-                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && ActionReady(StandardStep))
-                    {
-                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent)) &&
-                        ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 10) &&
-                        ((!HasEffect(Buffs.TechnicalStep) && !HasEffect(Buffs.TechnicalFinish)) || GetBuffRemainingTime(Buffs.TechnicalFinish) > 5)) ||
-                        (InCombat() && ActionReady(StandardStep)))
-                        return StandardStep;
-                    }
-
                     // AoE Technical Step
                     if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent)) &&
                         IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && ActionReady(TechnicalStep) &&
@@ -612,6 +610,15 @@ namespace XIVSlothCombo.Combos.PvE
                             return Improvisation;
                     }
 
+                    // AoE Standard Step (outside of burst)
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    {
+                        if ((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent)) &&
+                            ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
+                            return StandardStep;
+                    }
+
                     // AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
@@ -629,6 +636,14 @@ namespace XIVSlothCombo.Combos.PvE
                         return StarfallDance;
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
+
+                    // AoE Standard Step (inside of burst)
+                    if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
+                    {
+                        if (GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent) &&
+                            (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
+                            return StandardStep;
+                    }
 
                     if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -466,9 +466,12 @@ namespace XIVSlothCombo.Combos.PvE
                         // ST Panic Heals
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_PanicHeals))
                         {
-                            if (ActionReady(CuringWaltz) && PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent))
+                            if (ActionReady(CuringWaltz) &&
+                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent))
                                 return CuringWaltz;
-                            if (ActionReady(All.SecondWind) && PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent))
+
+                            if (ActionReady(All.SecondWind) &&
+                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent))
                                 return All.SecondWind;
                         }
 
@@ -608,9 +611,12 @@ namespace XIVSlothCombo.Combos.PvE
                         // AoE Panic Heals
                         if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_PanicHeals))
                         {
-                            if (ActionReady(CuringWaltz) && PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent))
+                            if (ActionReady(CuringWaltz) &&
+                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent))
                                 return CuringWaltz;
-                            if (ActionReady(All.SecondWind) && PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent))
+
+                            if (ActionReady(All.SecondWind) &&
+                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent))
                                 return All.SecondWind;
                         }
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -504,14 +504,14 @@ namespace XIVSlothCombo.Combos.PvE
                             return SaberDance;
                     }
 
-                    // ST combos and burst attacks
-                    if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime is < 2 and > 0)
-                        return Fountain;
-
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
+
+                    // ST combos and burst attacks
+                    if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime is < 2 and > 0)
+                        return Fountain;
 
                     // ST Standard Step (inside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
@@ -646,14 +646,14 @@ namespace XIVSlothCombo.Combos.PvE
                             return SaberDance;
                     }
 
-                    // AoE combos and burst attacks
-                    if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime is < 2 and > 0)
-                        return Bladeshower;
-
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
+
+                    // AoE combos and burst attacks
+                    if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime is < 2 and > 0)
+                        return Bladeshower;
 
                     // AoE Standard Step (inside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -391,7 +391,6 @@ namespace XIVSlothCombo.Combos.PvE
                     DNCGauge? gauge = GetJobGauge<DNCGauge>();
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
-                    bool interruptable = CanInterruptEnemy() && ActionReady(All.HeadGraze);
                     #endregion
 
                     #region Pre-pull
@@ -420,7 +419,8 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Weaves
                     // ST Devilment
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Devilment) &&
-                        CanWeave(actionID) && ActionReady(Devilment) && (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                        CanWeave(actionID) && ActionReady(Devilment) &&
+                        (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
                     // ST Flourish
@@ -432,7 +432,8 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_Interrupt) &&
-                        interruptable && !HasEffect(Buffs.TechnicalFinish))
+                        CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
+                        !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
                     if (CanWeave(actionID))
@@ -545,7 +546,6 @@ namespace XIVSlothCombo.Combos.PvE
                     DNCGauge? gauge = GetJobGauge<DNCGauge>();
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
-                    bool interruptable = CanInterruptEnemy() && ActionReady(All.HeadGraze);
                     #endregion
 
                     #region Dance Fills
@@ -567,7 +567,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Weaves
                     // AoE Devilment
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Devilment) &&
-                        CanWeave(actionID) && ActionReady(Devilment) && 
+                        CanWeave(actionID) && ActionReady(Devilment) &&
                         (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
@@ -580,7 +580,8 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_Interrupt) &&
-                        interruptable && !HasEffect(Buffs.TechnicalFinish))
+                        CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
+                        !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
                     if (CanWeave(actionID))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -593,15 +593,15 @@ namespace XIVSlothCombo.Combos.PvE
                         if (LevelChecked(FanDance1) && IsEnabled(CustomComboPreset.DNC_AoE_Simple_Feathers))
                         {
                             int minFeathers = IsEnabled(CustomComboPreset.DNC_AoE_Simple_FeatherPooling) && LevelChecked(TechnicalStep)
-                                ? (GetCooldownRemainingTime(TechnicalStep) < 2.5f ? 4 : 3)
+                                ? 3
                                 : 0;
 
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
 
-                            if ((gauge.Feathers > minFeathers ||
-                                (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)) &&
-                                LevelChecked(FanDance2))
+                            if (LevelChecked(FanDance2) &&
+                                (gauge.Feathers > minFeathers ||
+                                (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)))
                                 return FanDance2;
                         }
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1164,56 +1164,56 @@ namespace XIVSlothCombo.Window.Functions
             }
 
             if (preset == CustomComboPreset.DNC_ST_EspritOvercap)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_ST, "Esprit", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_ST, "Esprit", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DNC_AoE_EspritOvercap)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_AoE, "Esprit", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_AoE, "Esprit", 150, SliderIncrements.Fives);
 
             #region Simple ST Sliders
 
             if (preset == CustomComboPreset.DNC_ST_Simple_SS)
-                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleSSBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleSSBurstPercent, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_ST_Simple_TS)
-                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleTSBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleTSBurstPercent, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_ST_Simple_FeatherPooling)
-                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleFeatherBurstPercent, "Target HP percentage to dump all pooled feathers below", 75, SliderIncrements.Ones);
+            if (preset == CustomComboPreset.DNC_ST_Simple_Feathers)
+                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleFeatherBurstPercent, "Target HP% to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_ST_Simple_SaberDance)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCSimpleSaberThreshold, "Esprit", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCSimpleSaberThreshold, "Esprit", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DNC_ST_Simple_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWaltzPercent, "Curing Waltz HP percent", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWaltzPercent, "Curing Waltz HP%", 200, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_ST_Simple_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWindPercent, "Second Wind HP percent", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWindPercent, "Second Wind HP%", 200, SliderIncrements.Ones);
 
             #endregion
 
             #region Simple AoE Sliders
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_SS)
-                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNCSimpleSSAoEBurstPercent, "Target HP percentage to stop using Standard Step below", 75, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNCSimpleSSAoEBurstPercent, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_TS)
-                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNCSimpleTSAoEBurstPercent, "Target HP percentage to stop using Technical Step below", 75, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNCSimpleTSAoEBurstPercent, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_SaberDance)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCSimpleAoESaberThreshold, "Esprit", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCSimpleAoESaberThreshold, "Esprit", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWaltzPercent, "Curing Waltz HP percent", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWaltzPercent, "Curing Waltz HP%", 200, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWindPercent, "Second Wind HP percent", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWindPercent, "Second Wind HP%", 200, SliderIncrements.Ones);
 
             #endregion
 
             #region PvP Sliders
 
             if (preset == CustomComboPreset.DNCPvP_BurstMode_CuringWaltz)
-                UserConfig.DrawSliderInt(0, 90, DNCPvP.Config.DNCPvP_WaltzThreshold, "Caps at 90 to prevent waste.###DNCPvP", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 90, DNCPvP.Config.DNCPvP_WaltzThreshold, "Curing Waltz HP% - caps at 90 to prevent waste.", 150, SliderIncrements.Ones);
 
             #endregion
 
@@ -1917,6 +1917,7 @@ namespace XIVSlothCombo.Window.Functions
     {
         public const uint
             Ones = 1,
+            Fives = 5,
             Tens = 10,
             Hundreds = 100,
             Thousands = 1000;


### PR DESCRIPTION
The code now knows its Jetes from its Pirouettes, and its Emboites from its Entrechats.

## **[Framework]**
Added `Fives` increments to sliders

## **[DNC]**
Adjusted single-target `Standard Step` conditions
Adjusted AoE `Standard Step` conditions
Improved ability to weave `Flourish` between dances at higher latencies
Fixed `Standard Step` execution delaying `Flourish`
Prevented `Fan Dance III` from weaving after flourish immediately before burst
Reduced pre-burst overcap potential for `Simple Feather Pooling Option`
Added pre-burst protection to `Simple AoE Feather Pooling Option`
Rewrote all code relating to `Fan Dance` usage in Simple modes
Split and simplified `Fan Dance` code for readability
Fixed `Simple Standard Dance Option` use when in combat
Fixed `Simple AoE Standard Dance Option` use when in combat
Consolidated `Simple Feather Pooling Option`
Consolidated `Simple AoE Feather Pooling Option`
Optimised `Fourfold Feather` AoE use between Lv.30-49
Adjusted config descriptions
Other tidying (readability, regioning)

##

If your latency is *truly* terrible, you might suffer a bit with this, now.
But seriously, if it's that bad just start using a latency mitigation tool.
Duh.