### PR TITLE
[RDM] Separation of Single and AoE DPS. Variant Support

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -970,7 +970,7 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(DNC_AoE_SimpleMode)]
             [CustomComboInfo("Simple AoE Improvisation Option", "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 10, "", "")]
             DNC_AoE_Simple_Improvisation = 4080,
-        #endregion
+            #endregion
 
         #region Variant
         [Variant]
@@ -2426,156 +2426,153 @@ namespace XIVSlothCombo.Combos
         If more than 10 sub features, use the next feature number if available
         The three digets after RDM.JobID can be used to reorder items in the list
         */
-
-        #region Section 1 - Openers
+        #region Single Target DPS
         [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
-        [CustomComboInfo("Balance Opener Feature [Lv.90]", "Replaces Jolt with the Balance opener ending with Resolution\n**Must move into melee range before melee combo**", RDM.JobID, 110, "", "")]
-        RDM_Balance_Opener = 13110,
+        [CustomComboInfo("Single Target DPS Features","Enables various Single Target options below.", RDM.JobID, 1)]
+        RDM_ST_DPS = 13000,
 
-        [ParentCombo(RDM_Balance_Opener)]
-        [CustomComboInfo("Use Opener at any Mana Option", "Removes 0/0 Mana reqirement to reset opener\n**All other actions must be off cooldown**", RDM.JobID, 111, "", "")]
-        RDM_Balance_Opener_AnyMana = 13111,
+            [ParentCombo(RDM_ST_DPS)]
+            [CustomComboInfo("Balance Opener Option [Lv.90]", "Replaces Jolt with the Balance opener ending with Resolution.\n**Must move into melee range before melee combo**", RDM.JobID, 110)]
+            RDM_Balance_Opener = 13110,
+
+                [ParentCombo(RDM_Balance_Opener)]
+                [CustomComboInfo("Use Opener at any Mana Option", "Removes 0/0 Mana reqirement to reset opener\n**All other actions must be off cooldown**", RDM.JobID, 111)]
+                RDM_Balance_Opener_AnyMana = 13111,
+
+            [ParentCombo(RDM_ST_DPS)]
+            [CustomComboInfo("Verthunder/Veraero Option", "Replace Jolt with Verthunder and Veraero.", RDM.JobID, 210)]
+            RDM_ST_ThunderAero = 13210,
+
+                [ParentCombo(RDM_ST_ThunderAero)]
+                [CustomComboInfo("Acceleration Option", "Add Acceleration when no Verfire/Verstone proc is available.", RDM.JobID, 211)]
+                RDM_ST_ThunderAero_Accel = 13211,
+
+                    [ParentCombo(RDM_ST_ThunderAero_Accel)]
+                    [CustomComboInfo("Include Swiftcast Option", "Add Swiftcast when all Acceleration charges are used.", RDM.JobID, 212)]
+                    RDM_ST_ThunderAero_Accel_Swiftcast = 13212,
+
+            [ParentCombo(RDM_ST_DPS)]
+            [CustomComboInfo("Verfire/Verstone Option", "Replace Jolt with Verfire and Verstone.", RDM.JobID,220)]
+            RDM_ST_FireStone = 13220,
+
+            [ParentCombo(RDM_ST_DPS)]
+            [CustomComboInfo("Weave oGCD Damage Option", "Weave the following oGCD actions.", RDM.JobID, 240)]
+            RDM_ST_oGCD = 13240,
+
+            [ParentCombo(RDM_ST_DPS)]
+            [CustomComboInfo("Single Target Melee Combo Option", "Add the Reposte combo.\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 410)]
+            RDM_ST_MeleeCombo = 13410,
+
+                [ParentCombo(RDM_ST_MeleeCombo)]
+                [CustomComboInfo("Use Manafication and Embolden Option", "Add Manafication and Embolden.\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 411)]
+                RDM_ST_MeleeCombo_ManaEmbolden = 13411,
+
+                    [ParentCombo(RDM_ST_MeleeCombo_ManaEmbolden)]
+                    [CustomComboInfo("Hold for Double Melee Combo Option [Lv.90]", "Hold both actions until you can perform a double melee combo.", RDM.JobID, 412)]
+                    RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo = 13412,
+
+                [ParentCombo(RDM_ST_MeleeCombo)]
+                [CustomComboInfo("Gap close with Corps-a-corps Option", "Use Corp-a-corps when out of melee range and you have enough mana to start the melee combo.", RDM.JobID, 430)]
+                RDM_ST_MeleeCombo_CorpsGapCloser = 13430,
+
+                [ParentCombo(RDM_ST_MeleeCombo)]
+                [CustomComboInfo("Unbalance Mana Option", "Use Acceleration to unbalance mana prior to starting melee combo.", RDM.JobID, 410)]
+                RDM_ST_MeleeCombo_UnbalanceMana = 13440,
+
+            [ParentCombo(RDM_ST_DPS)]
+            [CustomComboInfo("Melee Finisher Option", "Add Verflare/Verholy and other finishing moves.", RDM.JobID, 510)]
+            RDM_ST_MeleeFinisher = 13510,
+
+            [ParentCombo(RDM_ST_DPS)]
+            [CustomComboInfo("Lucid Dreaming Option", "Weaves Lucid Dreaming when your MP drops below the specified value.", RDM.JobID, 610)]
+            RDM_ST_Lucid = 13610,
+        #endregion
+      
+        #region AoE DPS
+        [ReplaceSkill(RDM.Scatter, RDM.Impact)]
+        [CustomComboInfo("AoE DPS Feature", "Enables various AoE Target options below.", RDM.JobID, 310)]
+        RDM_AoE_DPS = 13310,
+
+            [ParentCombo(RDM_AoE_DPS)]
+            [ReplaceSkill(RDM.Scatter, RDM.Impact)]
+            [CustomComboInfo("AoE Acceleration Option", "Use Acceleration for increased damage.", RDM.JobID, 320)]
+            RDM_AoE_Accel = 13320,
+
+                [ParentCombo(RDM_AoE_Accel)]
+                [CustomComboInfo("Include Swiftcast Option", "Add Swiftcast when all Acceleration charges are used or when below level 50.", RDM.JobID, 321)]
+                RDM_AoE_Accel_Swiftcast = 13321,
+
+                [ParentCombo(RDM_AoE_Accel)]
+                [CustomComboInfo("Weave Acceleration Option", "Only use acceleration during weave windows.", RDM.JobID, 322)]
+                RDM_AoE_Accel_Weave = 13322,
+
+            [ParentCombo(RDM_AoE_DPS)]
+            [CustomComboInfo("Weave oGCD Damage Option", "Weave the following oGCD actions:", RDM.JobID, 240)]
+            RDM_AoE_oGCD = 13241,
+
+            [ParentCombo(RDM_AoE_DPS)]
+            [CustomComboInfo("Moulinet Melee Combo Option", "Use Moulinet when over 60/60 mana", RDM.JobID, 420)]
+            RDM_AoE_MeleeCombo = 13420,
+
+                [ParentCombo(RDM_AoE_MeleeCombo)]
+                [CustomComboInfo("Use Manafication and Embolden Option", "Add Manafication and Embolden.\n**Must be in range of Moulinet**", RDM.JobID, 411)]
+                RDM_AoE_MeleeCombo_ManaEmbolden = 13421,
+
+                [ParentCombo(RDM_AoE_MeleeCombo)]
+                [CustomComboInfo("Gap close with Corps-a-corps Option", "Use Corp-a-corps when out of melee range and you have enough mana to start the melee combo.", RDM.JobID, 430)]
+                RDM_AoE_MeleeCombo_CorpsGapCloser = 13422,
+
+                [ParentCombo(RDM_AoE_MeleeCombo)]
+                [CustomComboInfo("Unbalance Mana Option", "Use Acceleration to unbalance mana prior to starting melee combo", RDM.JobID, 410)]
+                RDM_AoE_MeleeCombo_UnbalanceMana = 13423,
+
+            [ParentCombo(RDM_AoE_DPS)]
+            [CustomComboInfo("Melee Finisher Option", "Add Verflare/Verholy and other finishing moves.", RDM.JobID, 510)]
+            RDM_AoE_MeleeFinisher = 13424,
+
+            [ParentCombo(RDM_AoE_DPS)]
+            [CustomComboInfo("Lucid Dreaming Option", "Weaves Lucid Dreaming when your MP drops below the specified value.", RDM.JobID, 610)]
+            RDM_AoE_Lucid = 13425,
         #endregion
 
-        #region Sections 2 to 3 - Rotation
-        [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
-        [CustomComboInfo("Verthunder/Veraero Feature", "Replace Jolt with Verthunder and Veraero", RDM.JobID, 210, "", "")]
-        RDM_ST_ThunderAero = 13210,
-
-        [ParentCombo(RDM_ST_ThunderAero)]
-        [CustomComboInfo("Single Target Acceleration Option", "Add Acceleration when no Verfire/Verstone proc is available", RDM.JobID, 211, "", "")]
-        RDM_ST_ThunderAero_Accel = 13211,
-
-        [ParentCombo(RDM_ST_ThunderAero_Accel)]
-        [CustomComboInfo("Include Swiftcast Option", "Add Swiftcast when all Acceleration charges are used", RDM.JobID, 212, "", "")]
-        RDM_ST_ThunderAero_Accel_Swiftcast = 13212,
-
-        [ReplaceSkill(RDM.Jolt, RDM.Jolt2)]
-        [CustomComboInfo("Verfire/Verstone Feature", "Replace Jolt with Verfire and Verstone", RDM.JobID,220, "", "")]
-        RDM_ST_FireStone = 13220,
-
-        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Fleche, RDM.Riposte, RDM.Moulinet)]
-        [CustomComboInfo("Weave oGCD Damage Feature", "Use oGCD actions on specified action(s)", RDM.JobID, 240, "", "")]
-        RDM_oGCD = 13240,
-
-        [ParentCombo(RDM_oGCD)]
-        [CustomComboInfo("Fleche Option", "Use Fleche on above specified action(s)", RDM.JobID, 241, "", "")]
-        RDM_oGCD_Fleche = 13241,
-
-        [ParentCombo(RDM_oGCD)]
-        [CustomComboInfo("Contra Sixte Option", "Use Contre Sixte on above specified action(s)", RDM.JobID, 242, "", "")]
-        RDM_oGCD_ContraSixte = 13242,
-
-        [ParentCombo(RDM_oGCD)]
-        [CustomComboInfo("Engagement Option", "Use Engagement on above specified action(s) when in melee range", RDM.JobID, 243, "", "")]
-        RDM_oGCD_Engagement = 13243,
-
-        [ParentCombo(RDM_oGCD_Engagement)]
-        [CustomComboInfo("Hold one charge Option", "Pool one charge of Engagement/Displacement for manual use", RDM.JobID, 246, "", "")]
-        RDM_oGCD_Engagement_Pooling = 13246,
-
-        [ParentCombo(RDM_oGCD)]
-        [CustomComboInfo("Corps-a-corps Option", "Use Corps-a-corps on above specified action(s)", RDM.JobID, 244, "", "")]
-        RDM_oGCD_CorpsACorps = 13244,
-
-        [ParentCombo(RDM_oGCD_CorpsACorps)]
-        [CustomComboInfo("Only in Melee Range Option", "Use Corps-a-corps only when in melee range", RDM.JobID, 245, "", "")]
-        RDM_oGCD_CorpsACorps_MeleeRange = 13245,
-
-        [ParentCombo(RDM_oGCD_CorpsACorps)]
-        [CustomComboInfo("Hold one charge Option", "Pool one charge of Corp-a-corps for manual use", RDM.JobID, 247, "", "")]
-        RDM_oGCD_CorpsACorps_Pooling = 13247,
-
-        [ReplaceSkill(RDM.Scatter, RDM.Impact)]
-        [CustomComboInfo("Verthunder II/Veraero II Feature", "Replace Scatter/Impact with Verthunder II or Veraero II", RDM.JobID, 310, "", "")]
-        RDM_AoE_Thunder2Aero2 = 13310,
-
-        [ReplaceSkill(RDM.Scatter, RDM.Impact)]
-        [CustomComboInfo("AoE Acceleration Feature", "Use Acceleration on Scatter/Impact for increased damage", RDM.JobID, 320, "", "")]
-        RDM_AoE_Accel = 13320,
-
-        [ParentCombo(RDM_AoE_Accel)]
-        [CustomComboInfo("Include Swiftcast Option", "Add Swiftcast when all Acceleration charges are used or when below level 50", RDM.JobID, 321, "", "")]
-        RDM_AoE_Accel_Swiftcast = 13321,
-
-        [ParentCombo(RDM_AoE_Accel)]
-        [CustomComboInfo("Weave Acceleration Option", "Only use acceleration during weave windows", RDM.JobID, 322, "", "")]
-        RDM_AoE_Accel_Weave = 13322,
-        #endregion
-
-        # region Sections 4 to 5 - Melee
-        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Riposte)]
-        [CustomComboInfo("Single Target Melee Combo Feature", "Stack Reposte combo on specified action(s)\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 410, "", "")]
-        RDM_ST_MeleeCombo = 13410,
-
-        [ParentCombo(RDM_ST_MeleeCombo)]
-        [CustomComboInfo("Use Manafication and Embolden Option", "Add Manafication and Embolden on specified action(s)\n**Must be in melee range or have Gap close with Corps-a-corps enabled**", RDM.JobID, 411, "", "")]
-        RDM_ST_MeleeCombo_ManaEmbolden = 13411,
-
-        [ParentCombo(RDM_ST_MeleeCombo_ManaEmbolden)]
-        [CustomComboInfo("Hold for Double Melee Combo Option [Lv.90]", "Hold both actions until you can perform a double melee combo", RDM.JobID, 412, "", "")]
-        RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo = 13412,
-
-        [ReplaceSkill(RDM.Scatter, RDM.Impact)]
-        [CustomComboInfo("AoE Melee Combo Feature", "Use Moulinet on Scatter/Impact when over 60/60 mana", RDM.JobID, 420, "", "")]
-        RDM_AoE_MeleeCombo = 13420,
-
-        [ParentCombo(RDM_AoE_MeleeCombo)]
-        [CustomComboInfo("Use Manafication and Embolden Option", "Add Manafication and Embolden to Scatter/Impact\n**Must be in range of Moulinet**", RDM.JobID, 411, "", "")]
-        RDM_AoE_MeleeCombo_ManaEmbolden = 13421,
-
-        [ParentCombo(RDM_ST_MeleeCombo)]
-        [CustomComboInfo("Gap close with Corps-a-corps Option", "Use Corp-a-corps when out of melee range and you have enough mana to start the melee combo", RDM.JobID, 430, "", "")]
-        RDM_ST_MeleeCombo_CorpsGapCloser = 13430,
-
-        [ParentCombo(RDM_ST_MeleeCombo)]
-        [CustomComboInfo("Unbalance Mana Option", "Use Acceleration to unbalance mana prior to starting melee combo", RDM.JobID, 410, "", "")]
-        RDM_ST_MeleeCombo_UnbalanceMana = 13440,
-
-        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Scatter, RDM.Impact, RDM.Riposte, RDM.Moulinet, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3)]
-        [CustomComboInfo("Melee Finisher Feature", "Add Verflare/Verholy and other finishing moves to specified action(s)", RDM.JobID, 510, "", "")]
-        RDM_MeleeFinisher = 13510,
-        #endregion
-
-        #region Sections 6 to 7 - QoL
-        [ReplaceSkill(RDM.Jolt, RDM.Jolt2, RDM.Veraero, RDM.Veraero2, RDM.Veraero3, RDM.Verthunder, RDM.Verthunder2, RDM.Verthunder3, RDM.Scatter, RDM.Impact)]
-        [CustomComboInfo("Lucid Dreaming Feature", "Use Lucid Dreaming on Jolt 1/2, Veraero 1/2/3, Verthunder 1/2/3, and Scatter/Impact when below threshold.", RDM.JobID, 610, "", "")]
-        RDM_Lucid = 13610,
-
+        #region QoL
         [ReplaceSkill(All.Swiftcast)]
         [ConflictingCombos(ALL_Caster_Raise)]
-        [CustomComboInfo("Verraise Feature", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620, "", "")]
+        [CustomComboInfo("Verraise Feature", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620)]
         RDM_Raise = 13620,
         #endregion
 
         #region Sections 8 to 9 - Miscellaneous
         [ReplaceSkill(RDM.Displacement)]
-        [CustomComboInfo("Displacement <> Corps-a-corps Feature", "Replace Displacement with Corps-a-corps when out of range.", RDM.JobID, 810, "", "")]
+        [CustomComboInfo("Displacement <> Corps-a-corps Feature", "Replace Displacement with Corps-a-corps when out of range.", RDM.JobID, 810)]
         RDM_CorpsDisplacement = 13810,
 
         [ReplaceSkill(RDM.Embolden)]
-        [CustomComboInfo("Embolden to Manafication Feature", "Changes Embolden to Manafication when on cooldown.", RDM.JobID, 820, "", "")]
+        [CustomComboInfo("Embolden to Manafication Feature", "Changes Embolden to Manafication when on cooldown.", RDM.JobID, 820)]
         RDM_EmboldenManafication = 13820,
 
         [ReplaceSkill(RDM.MagickBarrier)]
-        [CustomComboInfo("Magick Barrier to Addle Feature", "Changes Magick Barrier to Addle when on cooldown.", RDM.JobID, 820, "", "")]
+        [CustomComboInfo("Magick Barrier to Addle Feature", "Changes Magick Barrier to Addle when on cooldown.", RDM.JobID, 820)]
         RDM_MagickBarrierAddle = 13821,
 
+        [Variant]
+        [VariantParent(RDM_ST_DPS, RDM_AoE_DPS)]
+        [CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown. Replaces Jolts.", RDM.JobID)]
+        RDM_Variant_Rampart = 13830,
 
-        //TODO Revisit once RDM is in a better place. 
-        //[Variant]
-        //[VariantParent(RdmAny)]
-        //[CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown.", RDM.JobID)]
-        //RDM_Variant_Rampart = 13830,
+        [Variant]
+        [VariantParent(RDM_Raise)]
+        [CustomComboInfo("Raise Option", "Turn Swiftcast into Variant Raise whenever you have the Swiftcast or Dualcast buffs.", RDM.JobID)]
+        RDM_Variant_Raise = 13831,
 
-        //[Variant]
-        //[CustomComboInfo("Raise Option", "Turn Swiftcast into Variant Raise whenever you have the Swiftcast buff.", RDM.JobID)]
-        //RDM_Variant_Raise = 13831,
+        [Variant]
+        [VariantParent(RDM_ST_DPS, RDM_AoE_DPS)]
+        [CustomComboInfo("Cure Option", "Use Variant Cure when HP is below set threshold. Replaces Jolts.", RDM.JobID)]
+        RDM_Variant_Cure = 13832,
 
-        //[Variant]
-        //[VariantParent(RdmAny)]
-        //[CustomComboInfo("Cure Option", "Use Variant Cure when HP is below set threshold.", RDM.JobID)]
-        //RDM_Variant_Cure = 13832,
+        [Variant]
+        [CustomComboInfo("Cure on Vercure Option", "Replaces Vercure with Variant Cure.", RDM.JobID)]
+        RDM_Variant_Cure2 = 13833,
         #endregion
 
         #endregion
@@ -3062,7 +3059,7 @@ namespace XIVSlothCombo.Combos
             [CustomComboInfo("Bio / Biolysis Option", "Automatic DoT uptime.", SCH.JobID, 140, "", "")]
             SCH_DPS_Bio = 16150,
 
-        [ParentCombo(SCH_DPS)]
+            [ParentCombo(SCH_DPS)]
             [CustomComboInfo("Dissipation Opener Option", "Use Dissipation at the start of the battle.", SCH.JobID, 170, "", "")]
             SCH_DPS_Dissipation_Opener = 16170,
 

--- a/XIVSlothCombo/Combos/JobHelpers/RDM.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/RDM.cs
@@ -1,0 +1,229 @@
+﻿using XIVSlothCombo.Combos.PvE;
+using XIVSlothCombo.CustomComboNS.Functions;
+
+namespace XIVSlothCombo.Combos.JobHelpers
+{
+    internal class RDM
+    {
+        internal class ManaBalancer : PvE.RDM
+        {
+            internal bool useFire;
+            internal bool useStone;
+            internal bool useThunder;
+            internal bool useAero;
+            internal bool useThunder2;
+            internal bool useAero2;
+
+            internal void CheckBalance()
+            {
+                //SYSTEM_MANA_BALANCING_MACHINE
+                //Machine to decide which ver spell should be used.
+                //Rules:
+                //1.Avoid perfect balancing [NOT DONE]
+                //   - Jolt adds 2/2 mana
+                //   - Scatter/Impact adds 3/3 mana
+                //   - Verstone/Verfire add 5 mana
+                //   - Veraero/Verthunder add 6 mana
+                //   - Veraero2/Verthunder2 add 7 mana
+                //   - Verholy/Verflare add 11 mana
+                //   - Scorch adds 4/4 mana
+                //   - Resolution adds 4/4 mana
+                //2.Stay within difference limit [DONE]
+                //3.Strive to achieve correct mana for double melee combo burst [DONE]
+                static bool HasEffect(ushort id) => CustomComboFunctions.HasEffect(id);
+                static bool LevelChecked(uint id) => CustomComboFunctions.LevelChecked(id);
+                int blackmana = Gauge.BlackMana;
+                int whitemana = Gauge.WhiteMana;
+                //Reset outputs
+                useFire = false;
+                useStone = false;
+                useThunder = false;
+                useAero = false;
+                useThunder2 = false;
+                useAero2 = false;
+
+                //ST
+                if (LevelChecked(Verthunder)
+                    && (HasEffect(Buffs.Dualcast) || HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Acceleration)))
+                {
+                    if (blackmana <= whitemana || HasEffect(Buffs.VerstoneReady)) useThunder = true;
+                    if (whitemana <= blackmana || HasEffect(Buffs.VerfireReady)) useAero = true;
+                    if (!LevelChecked(Veraero)) useThunder = true;
+                }
+                if (!HasEffect(Buffs.Dualcast)
+                    && !HasEffect(All.Buffs.Swiftcast)
+                    && !HasEffect(Buffs.Acceleration))
+                {
+                    if (blackmana <= whitemana && HasEffect(Buffs.VerfireReady)) useFire = true;
+                    if (whitemana <= blackmana && HasEffect(Buffs.VerstoneReady)) useStone = true;
+                    if (!useFire && !useStone && HasEffect(Buffs.VerfireReady)) useFire = true;
+                    if (!useFire && !useStone && HasEffect(Buffs.VerstoneReady)) useStone = true;
+                }
+
+                //AoE
+                if (LevelChecked(Verthunder2)
+                    && !HasEffect(Buffs.Dualcast)
+                    && !HasEffect(All.Buffs.Swiftcast)
+                    && !HasEffect(Buffs.Acceleration))
+                {
+                    if (blackmana <= whitemana || !LevelChecked(Veraero2)) useThunder2 = true;
+                    else useAero2 = true;
+                }
+                //END_SYSTEM_MANA_BALANCING_MACHINE
+            }
+        }
+
+        internal class MeleeFinisher : PvE.RDM
+        { 
+            internal static bool CanUse(in uint lastComboMove, out uint actionID)
+            {
+                static bool HasEffect(ushort id) => CustomComboFunctions.HasEffect(id);
+                static float GetBuffRemainingTime(ushort effectid) => CustomComboFunctions.GetBuffRemainingTime(effectid);
+                static bool LevelChecked(uint id) => CustomComboFunctions.LevelChecked(id);
+                int blackmana = Gauge.BlackMana;
+                int whitemana = Gauge.WhiteMana;
+
+                if (Gauge.ManaStacks >= 3)
+                {
+                    if (blackmana >= whitemana && LevelChecked(Verholy))
+                    {
+                        if ((!HasEffect(Buffs.Embolden) || GetBuffRemainingTime(Buffs.Embolden) < 10)
+                            && !HasEffect(Buffs.VerfireReady)
+                            && (HasEffect(Buffs.VerstoneReady) && GetBuffRemainingTime(Buffs.VerstoneReady) >= 10)
+                            && (blackmana - whitemana <= 18))
+                        {
+                            actionID = Verflare;
+                            return true;
+                        }
+                        actionID = Verholy;
+                        return true;
+                    }
+                    else if (LevelChecked(Verflare))
+                    {
+                        if ((!HasEffect(Buffs.Embolden) || GetBuffRemainingTime(Buffs.Embolden) < 10)
+                            && (HasEffect(Buffs.VerfireReady) && GetBuffRemainingTime(Buffs.VerfireReady) >= 10)
+                            && !HasEffect(Buffs.VerstoneReady)
+                            && LevelChecked(Verholy)
+                            && (whitemana - blackmana <= 18))
+                        {
+                            actionID = Verholy;
+                            return true;
+                        }
+                        actionID = Verflare;
+                        return true;
+                    }
+                }
+                if ((lastComboMove is Verflare or Verholy)
+                    && LevelChecked(Scorch))
+                {
+                    actionID = Scorch;
+                    return true;
+                }
+
+                if (lastComboMove is Scorch
+                    && LevelChecked(Resolution))
+                {
+                    actionID = Resolution;
+                    return true;
+                }
+
+                actionID = 0;
+                return false;
+            }
+        }
+
+        internal class OGCDHelper : PvE.RDM
+        {
+            internal static bool CanUse(in uint actionID, in bool SingleTarget, out uint newActionID)
+            {
+                static ushort GetRemainingCharges(uint actionID) => CustomComboFunctions.GetRemainingCharges(actionID);
+                static float GetCooldownRemainingTime(uint actionID) => CustomComboFunctions.GetCooldownRemainingTime(actionID);
+                static bool LevelChecked(uint id) => CustomComboFunctions.LevelChecked(id);
+                static bool ActionReady(uint id) => CustomComboFunctions.ActionReady(id);
+                static bool CanSpellWeave(uint id) => CustomComboFunctions.CanSpellWeave(id);
+                static bool HasCharges(uint id) => CustomComboFunctions.HasCharges(id);
+                var distance = CustomComboFunctions.GetTargetDistance();
+                
+                uint placeOGCD = 0;
+
+                bool fleche = SingleTarget ? Config.RDM_ST_oGCD_Fleche : Config.RDM_AoE_oGCD_Fleche;
+                bool contra = SingleTarget ? Config.RDM_ST_oGCD_ContraSixte : Config.RDM_AoE_oGCD_ContraSixte;
+                bool engagement = SingleTarget ? Config.RDM_ST_oGCD_Engagement : Config.RDM_AoE_oGCD_Engagement;
+                int engagementPool = (SingleTarget && Config.RDM_ST_oGCD_Engagement_Pooling) || (!SingleTarget && Config.RDM_AoE_oGCD_Engagement_Pooling) ? 1 : 0;
+
+                bool corpacorps = SingleTarget ? Config.RDM_ST_oGCD_CorpACorps : Config.RDM_AoE_oGCD_CorpACorps;
+                int corpsacorpsPool = (SingleTarget && Config.RDM_ST_oGCD_CorpACorps_Pooling) || (!SingleTarget && Config.RDM_ST_oGCD_CorpACorps_Pooling) ? 1 : 0;
+                int corpacorpsRange = (SingleTarget && Config.RDM_ST_oGCD_CorpACorps_Melee) || (!SingleTarget && Config.RDM_ST_oGCD_CorpACorps_Melee) ? 3 : 25;
+
+
+                //Grabs an oGCD to return based on radio options
+                if (engagement
+                    && (GetRemainingCharges(Engagement) > engagementPool
+                        || (GetRemainingCharges(Engagement) == 1 && GetCooldownRemainingTime(Engagement) < 3))
+                    && LevelChecked(Engagement)
+                    && distance <= 3)
+                    placeOGCD = Engagement;
+                if (corpacorps
+                    && (GetRemainingCharges(Corpsacorps) > corpsacorpsPool
+                        || (GetRemainingCharges(Corpsacorps) == 1 && GetCooldownRemainingTime(Corpsacorps) < 3))
+                    && ((GetRemainingCharges(Corpsacorps) >= GetRemainingCharges(Engagement)) || !LevelChecked(Engagement)) // Try to alternate between Corps-a-corps and Engagement
+                    && LevelChecked(Corpsacorps)
+                    && distance <= corpacorpsRange)
+                    placeOGCD = Corpsacorps;
+                if (contra
+                    && ActionReady(ContreSixte))
+                    placeOGCD = ContreSixte;
+                if (fleche && ActionReady(Fleche))
+                    placeOGCD = Fleche;
+
+                if (CanSpellWeave(actionID) && placeOGCD != 0)
+                {
+                    newActionID = placeOGCD;
+                    return true;
+                }
+
+                if (actionID is Fleche && placeOGCD == 0) // All actions are on cooldown, determine the lowest CD to display on Fleche.
+                {
+                    placeOGCD = Fleche;
+                    if (contra
+                        && LevelChecked(ContreSixte)
+                        && GetCooldownRemainingTime(placeOGCD) > GetCooldownRemainingTime(ContreSixte))
+                        placeOGCD = ContreSixte;
+                    if (corpacorps
+                        && LevelChecked(Corpsacorps)
+                        && !HasCharges(Corpsacorps)
+                        && GetCooldownRemainingTime(placeOGCD) > GetCooldownRemainingTime(Corpsacorps))
+                        placeOGCD = Corpsacorps;
+                    if (engagement
+                        && LevelChecked(Engagement)
+                        && GetCooldownRemainingTime(Engagement) == 0
+                        && GetCooldownRemainingTime(placeOGCD) > GetCooldownRemainingTime(Engagement))
+                        placeOGCD = Engagement;
+                }
+                if (actionID is Fleche)
+                {
+                    newActionID = placeOGCD;
+                    return true;
+                }
+
+                newActionID = 0;
+                return false;
+            }
+        }
+
+        internal class RDMLucid : PvE.RDM
+        {
+            internal static bool SafetoUse(in uint lastComboMove)
+            {
+                return
+                    !CustomComboFunctions.HasEffect(Buffs.Dualcast)
+                    && lastComboMove != EnchantedRiposte
+                    && lastComboMove != EnchantedZwerchhau
+                    && lastComboMove != EnchantedRedoublement
+                    && lastComboMove != Verflare
+                    && lastComboMove != Verholy
+                    && lastComboMove != Scorch; // Change abilities to Lucid Dreaming for entire weave window
+            }
+        }
+    }
+}

--- a/XIVSlothCombo/Combos/PvE/ALL.cs
+++ b/XIVSlothCombo/Combos/PvE/ALL.cs
@@ -1,9 +1,10 @@
 ﻿using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.Combos.PvE
 {
-    internal static class All
+    internal class All
     {
         public const byte JobID = 99;
 
@@ -63,6 +64,18 @@ namespace XIVSlothCombo.Combos.PvE
                 Reprisal = 1193,
                 Feint = 1195;
         }
+
+        /// <summary>
+        /// Quick Level, Offcooldown, spellweave, and MP check of Lucid Dreaming
+        /// </summary>
+        /// <param name="actionID">action id to check weave</param>
+        /// <param name="MPThreshold">Player MP less than Threshold check</param>
+        /// <param name="weave">Spell Weave check by default</param>
+        /// <returns></returns>
+        public static bool CanUseLucid(uint actionID, int MPThreshold, bool weave = true) =>
+            CustomComboFunctions.ActionReady(LucidDreaming)
+            && CustomComboFunctions.LocalPlayer.CurrentMp <= MPThreshold
+            && (weave && CustomComboFunctions.CanSpellWeave(actionID));
 
         internal class ALL_IslandSanctuary_Sprint : CustomCombo
         {

--- a/XIVSlothCombo/Combos/PvE/RDM.cs
+++ b/XIVSlothCombo/Combos/PvE/RDM.cs
@@ -1,11 +1,13 @@
 using Dalamud.Game.ClientState.Conditions;
 using Dalamud.Game.ClientState.JobGauge.Types;
-using XIVSlothCombo.Core;
+using System;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
+using static XIVSlothCombo.Combos.JobHelpers.RDM;
 
 namespace XIVSlothCombo.Combos.PvE
 {
-    internal static class RDM
+    internal class RDM
     {
         public const byte JobID = 35;
 
@@ -26,6 +28,7 @@ namespace XIVSlothCombo.Combos.PvE
             Scatter = 7509,
             Verstone = 7511,
             Verfire = 7510,
+            Vercure = 7514,
             Jolt = 7503,
             Jolt2 = 7524,
             Verholy = 7526,
@@ -63,769 +66,675 @@ namespace XIVSlothCombo.Combos.PvE
             // public const short placeholder = 0;
         }
 
-        public static class Levels
-        {
-            public const byte
-                Jolt = 2,
-                Verthunder = 4,
-                Corpsacorps = 6,
-                Veraero = 10,
-                Verthunder2 = 18,
-                Veraero2 = 22,
-                Verfire = 26,
-                Verstone = 30,
-                Verraise = 64,
-                Zwerchhau = 35,
-                Displacement = 40,
-                Acceleration = 50,
-                Redoublement = 50,
-                Moulinet = 52,
-                Vercure = 54,
-                Embolden = 58,
-                Manafication = 60,
-                Jolt2 = 62,
-                Impact = 66,
-                ManaStack = 68,
-                Verflare = 68,
-                Verholy = 70,
-                Fleche = 45,
-                ContreSixte = 56,
-                Engagement = 40,
-                Scorch = 80,
-                Veraero3 = 82,
-                Verthunder3 = 82,
-                MagickBarrier = 86,
-                Resolution = 90;
-        }
+        protected static RDMGauge Gauge => CustomComboFunctions.GetJobGauge<RDMGauge>();
 
         public static class Config
         {
-            public const string RDM_OGCD_OnAction = "RDM_OGCD_OnAction";
-            public const string RDM_ST_MeleeCombo_OnAction = "RDM_ST_MeleeCombo_OnAction";
-            public const string RDM_AoE_MeleeCombo_OnAction = "RDM_AoE_MeleeCombo_OnAction";
-            public const string RDM_MeleeFinisher_OnAction = "RDM_MeleeFinisher_OnAction";
-            public const string RDM_Lucid_Threshold = "RDM_LucidDreaming_Threshold";
-            public const string RDM_MoulinetRange = "RDM_MoulinetRange";
+            public static UserInt
+                RDM_VariantCure = new("RDM_VariantCure"),
+                RDM_ST_Lucid_Threshold = new("RDM_LucidDreaming_Threshold"),
+                RDM_AoE_Lucid_Threshold = new("RDM_AoE_Lucid_Threshold"),
+                RDM_AoE_MoulinetRange = new("RDM_MoulinetRange");
+            public static UserBool
+                RDM_ST_oGCD_OnAction_Adv = new("RDM_ST_oGCD_OnAction_Adv"),
+                RDM_ST_oGCD_Fleche = new("RDM_ST_oGCD_Fleche"),
+                RDM_ST_oGCD_ContraSixte = new("RDM_ST_oGCD_ContraSixte"),
+                RDM_ST_oGCD_Engagement = new("RDM_ST_oGCD_Engagement"),
+                RDM_ST_oGCD_Engagement_Pooling = new("RDM_ST_oGCD_Engagement_Pooling"),
+                RDM_ST_oGCD_CorpACorps = new("RDM_ST_oGCD_CorpACorps"),
+                RDM_ST_oGCD_CorpACorps_Melee = new("RDM_ST_oGCD_CorpACorps_Melee"),
+                RDM_ST_oGCD_CorpACorps_Pooling = new("RDM_ST_oGCD_CorpACorps_Pooling"),
+                RDM_ST_MeleeCombo_Adv = new("RDM_ST_MeleeCombo_Adv"),
+                RDM_ST_MeleeFinisher_Adv = new("RDM_ST_MeleeFinisher_Adv"),
+
+                RDM_AoE_oGCD_OnAction_Adv = new("RDM_AoE_oGCD_OnAction_Adv"),
+                RDM_AoE_oGCD_Fleche = new("RDM_AoE_oGCD_Fleche"),
+                RDM_AoE_oGCD_ContraSixte = new("RDM_AoE_oGCD_ContraSixte"),
+                RDM_AoE_oGCD_Engagement = new("RDM_AoE_oGCD_Engagement"),
+                RDM_AoE_oGCD_Engagement_Pooling = new("RDM_AoE_oGCD_Engagement_Pooling"),
+                RDM_AoE_oGCD_CorpACorps = new("RDM_AoE_oGCD_CorpACorps"),
+                RDM_AoE_oGCD_CorpACorps_Melee = new("RDM_AoE_oGCD_CorpACorps_Melee"),
+                RDM_AoE_oGCD_CorpACorps_Pooling = new("RDM_AoE_oGCD_CorpACorps_Pooling"),
+                RDM_AoE_MeleeCombo_Adv = new("RDM_AoE_MeleeCombo_Adv"),
+                RDM_AoE_MeleeFinisher_Adv = new("RDM_AoE_MeleeFinisher_Adv");                
+            public static UserBoolArray
+                RDM_ST_oGCD_OnAction = new("RDM_ST_oGCD_OnAction"),
+                RDM_ST_MeleeCombo_OnAction = new("RDM_ST_MeleeCombo_OnAction"),
+                RDM_ST_MeleeFinisher_OnAction = new("RDM_ST_MeleeFinisher_OnAction"),
+
+                RDM_AoE_oGCD_OnAction = new("RDM_AoE_oGCD_OnAction"),
+                RDM_AoE_MeleeCombo_OnAction = new("RDM_AoE_MeleeCombo_OnAction"),
+                RDM_AoE_MeleeFinisher_OnAction = new("RDM_AoE_MeleeFinisher_OnAction");
         }
 
-
-        internal class RDM_Main_Combos : CustomCombo
+        internal class RDM_VariantVerCure : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RdmAny;
 
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) =>
+                actionID is Vercure && IsEnabled(CustomComboPreset.RDM_Variant_Cure2) && IsEnabled(Variant.VariantCure)
+                    ? Variant.VariantCure : actionID;
+        }
+
+        internal class RDM_ST_DPS : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_ST_DPS;
+
+            protected internal ManaBalancer manaState = new();
             internal static bool inOpener = false;
             internal static bool readyOpener = false;
             internal static bool openerStarted = false;
             internal static byte step = 0;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-
             {
                 //MAIN_COMBO_VARIABLES
-                RDMGauge gauge = GetJobGauge<RDMGauge>();
-                var moulinetRange = PluginConfiguration.GetCustomIntValue(Config.RDM_MoulinetRange);
-                int black = gauge.BlackMana;
-                int white = gauge.WhiteMana;
-                var radioButtonST = PluginConfiguration.GetCustomIntValue(Config.RDM_ST_MeleeCombo_OnAction);
-                var radioButtonAoE = PluginConfiguration.GetCustomIntValue(Config.RDM_AoE_MeleeCombo_OnAction);
-                var radioButtonMF = PluginConfiguration.GetCustomIntValue(Config.RDM_MeleeFinisher_OnAction);
-                var radioButtonOGCD = PluginConfiguration.GetCustomIntValue(Config.RDM_OGCD_OnAction);
-                var distance = GetTargetDistance();
+                int blackmana = Gauge.BlackMana;
+                int whitemana = Gauge.WhiteMana;
                 //END_MAIN_COMBO_VARIABLES
 
-                //RDM_BALANCE_OPENER
-                if (IsEnabled(CustomComboPreset.RDM_Balance_Opener) && level >= 90 && actionID is Jolt or Jolt2)
+                if (actionID is Jolt or Jolt2)
                 {
-                    bool inCombat = HasCondition(ConditionFlag.InCombat);
-
-                    // Check to start opener
-                    if (openerStarted && lastComboMove is Verthunder3 && HasEffect(Buffs.Dualcast)) { inOpener = true; openerStarted = false; readyOpener = false; }
-                    if ((readyOpener || openerStarted) && !inOpener && LocalPlayer.CastActionId == Verthunder3) { openerStarted = true; return Veraero3; } else { openerStarted = false; }
-
-                    // Reset check for opener
-                    if ((IsEnabled(CustomComboPreset.RDM_Balance_Opener_AnyMana) || (gauge.BlackMana == 0 && gauge.WhiteMana == 0))
-                        && IsOffCooldown(Embolden) && IsOffCooldown(Manafication) && IsOffCooldown(All.Swiftcast)
-                        && GetCooldown(Acceleration).RemainingCharges == 2 && GetCooldown(Corpsacorps).RemainingCharges == 2 && GetCooldown(Engagement).RemainingCharges == 2
-                        && IsOffCooldown(Fleche) && IsOffCooldown(ContreSixte)
-                        && GetTargetHPPercent() == 100 && !inCombat && !inOpener && !openerStarted)
+                    //RDM_BALANCE_OPENER
+                    if (IsEnabled(CustomComboPreset.RDM_Balance_Opener) && level >= 90)
                     {
-                        readyOpener = true;
-                        inOpener = false;
-                        step = 0;
-                        return Verthunder3;
+                        bool inCombat = HasCondition(ConditionFlag.InCombat);
+
+                        // Check to start opener
+                        if (openerStarted && lastComboMove is Verthunder3 && HasEffect(Buffs.Dualcast)) { inOpener = true; openerStarted = false; readyOpener = false; }
+                        if ((readyOpener || openerStarted) && !inOpener && LocalPlayer.CastActionId == Verthunder3) { openerStarted = true; return Veraero3; } else { openerStarted = false; }
+
+                        // Reset check for opener
+                        if ((IsEnabled(CustomComboPreset.RDM_Balance_Opener_AnyMana) || (blackmana == 0 && whitemana == 0))
+                            && IsOffCooldown(Embolden) && IsOffCooldown(Manafication) && IsOffCooldown(All.Swiftcast)
+                            && GetRemainingCharges(Acceleration) == 2 && GetRemainingCharges(Corpsacorps) == 2 && GetRemainingCharges(Engagement) == 2
+                            && IsOffCooldown(Fleche) && IsOffCooldown(ContreSixte)
+                            && GetTargetHPPercent() == 100 && !inCombat && !inOpener && !openerStarted)
+                        {
+                            readyOpener = true;
+                            inOpener = false;
+                            step = 0;
+                            return Verthunder3;
+                        }
+                        else
+                        { readyOpener = false; }
+
+                        // Reset if opener is interrupted, requires step 0 and 1 to be explicit since the inCombat check can be slow
+                        if ((step == 0 && lastComboMove is Verthunder3 && !HasEffect(Buffs.Dualcast))
+                            || (inOpener && step >= 1 && IsOffCooldown(actionID) && !inCombat)) inOpener = false;
+
+                        // Start Opener
+                        if (inOpener)
+                        {
+                            //veraero
+                            //swiftcast
+                            //accel
+                            //verthunder
+                            //verthunder
+                            //embolden
+                            //manafication
+                            //Riposte
+                            //Fleche
+                            //Zwercchau
+                            //Contre-sixte
+                            //Redoublement
+                            //Corps-a-corps
+                            //Engagement
+                            //Verholy
+                            //Corps-a-corps
+                            //Engagement
+                            //Scorch
+                            //Resolution
+
+                            //we do it in steps to be able to control it
+                            if (step == 0)
+                            {
+                                if (lastComboMove == Veraero3) step++;
+                                else return Veraero3;
+                            }
+
+                            if (step == 1)
+                            {
+                                if (IsOnCooldown(All.Swiftcast)) step++;
+                                else return All.Swiftcast;
+                            }
+
+                            if (step == 2)
+                            {
+                                if (GetRemainingCharges(Acceleration) < 2) step++;
+                                else return Acceleration;
+                            }
+
+                            if (step == 3)
+                            {
+                                if (lastComboMove == Verthunder3 && !HasEffect(Buffs.Acceleration)) step++;
+                                else return Verthunder3;
+                            }
+
+                            if (step == 4)
+                            {
+                                if (lastComboMove == Verthunder3 && !HasEffect(All.Buffs.Swiftcast)) step++;
+                                else return Verthunder3;
+                            }
+
+                            if (step == 5)
+                            {
+                                if (IsOnCooldown(Embolden)) step++;
+                                else return Embolden;
+                            }
+
+                            if (step == 6)
+                            {
+                                if (IsOnCooldown(Manafication)) step++;
+                                else return Manafication;
+                            }
+
+                            if (step == 7)
+                            {
+                                if (lastComboMove == Riposte) step++;
+                                else return EnchantedRiposte;
+                            }
+
+                            if (step == 8)
+                            {
+                                if (IsOnCooldown(Fleche)) step++;
+                                else return Fleche;
+                            }
+
+                            if (step == 9)
+                            {
+                                if (lastComboMove == Zwerchhau) step++;
+                                else return EnchantedZwerchhau;
+                            }
+
+                            if (step == 10)
+                            {
+                                if (IsOnCooldown(ContreSixte)) step++;
+                                else return ContreSixte;
+                            }
+
+                            if (step == 11)
+                            {
+                                if (lastComboMove == Redoublement || Gauge.ManaStacks == 3) step++;
+                                else return EnchantedRedoublement;
+                            }
+
+                            if (step == 12)
+                            {
+                                if (GetRemainingCharges(Corpsacorps) < 2) step++;
+                                else return Corpsacorps;
+                            }
+
+                            if (step == 13)
+                            {
+                                if (GetRemainingCharges(Engagement) < 2) step++;
+                                else return Engagement;
+                            }
+
+                            if (step == 14)
+                            {
+                                if (lastComboMove == Verholy) step++;
+                                else return Verholy;
+                            }
+
+                            if (step == 15)
+                            {
+                                if (GetRemainingCharges(Corpsacorps) < 1) step++;
+                                else return Corpsacorps;
+                            }
+
+                            if (step == 16)
+                            {
+                                if (GetRemainingCharges(Engagement) < 1) step++;
+                                else return Engagement;
+                            }
+
+                            if (step == 17)
+                            {
+                                if (lastComboMove == Scorch) step++;
+                                else return Scorch;
+                            }
+
+                            if (step == 18)
+                            {
+                                if (lastComboMove == Resolution) step++;
+                                else return Resolution;
+                            }
+
+                            inOpener = false;
+                        }
                     }
-                    else
-                    { readyOpener = false; }
+                    //END_RDM_BALANCE_OPENER
 
-                    // Reset if opener is interrupted, requires step 0 and 1 to be explicit since the inCombat check can be slow
-                    if ((step == 0 && lastComboMove is Verthunder3 && !HasEffect(Buffs.Dualcast))
-                        || (inOpener && step >= 1 && IsOffCooldown(actionID) && !inCombat)) inOpener = false;
+                    //VARIANTS
+                    if (IsEnabled(CustomComboPreset.RDM_Variant_Cure) &&
+                        IsEnabled(Variant.VariantCure) &&
+                        PlayerHealthPercentageHp() <= GetOptionValue(Config.RDM_VariantCure))
+                        return Variant.VariantCure;
 
-                    // Start Opener
-                    if (inOpener)
-                    {
-                        //veraero
-                        //swiftcast
-                        //accel
-                        //verthunder
-                        //verthunder
-                        //embolden
-                        //manafication
-                        //Riposte
-                        //Fleche
-                        //Zwercchau
-                        //Contre-sixte
-                        //Redoublement
-                        //Corps-a-corps
-                        //Engagement
-                        //Verholy
-                        //Corps-a-corps
-                        //Engagement
-                        //Scorch
-                        //Resolution
-
-                        //we do it in steps to be able to control it
-                        if (step == 0)
-                        {
-                            if (lastComboMove == Veraero3) step++;
-                            else return Veraero3;
-                        }
-
-                        if (step == 1)
-                        {
-                            if (IsOnCooldown(All.Swiftcast)) step++;
-                            else return All.Swiftcast;
-                        }
-
-                        if (step == 2)
-                        {
-                            if (GetRemainingCharges(Acceleration) < 2) step++;
-                            else return Acceleration;
-                        }
-
-                        if (step == 3)
-                        {
-                            if (lastComboMove == Verthunder3 && !HasEffect(Buffs.Acceleration)) step++;
-                            else return Verthunder3;
-                        }
-
-                        if (step == 4)
-                        {
-                            if (lastComboMove == Verthunder3 && !HasEffect(All.Buffs.Swiftcast)) step++;
-                            else return Verthunder3;
-                        }
-
-                        if (step == 5)
-                        {
-                            if (IsOnCooldown(Embolden)) step++;
-                            else return Embolden;
-                        }
-
-                        if (step == 6)
-                        {
-                            if (IsOnCooldown(Manafication)) step++;
-                            else return Manafication;
-                        }
-
-                        if (step == 7)
-                        {
-                            if (lastComboMove == Riposte) step++;
-                            else return EnchantedRiposte;
-                        }
-
-                        if (step == 8)
-                        {
-                            if (IsOnCooldown(Fleche)) step++;
-                            else return Fleche;
-                        }
-
-                        if (step == 9)
-                        {
-                            if (lastComboMove == Zwerchhau) step++;
-                            else return EnchantedZwerchhau;
-                        }
-
-                        if (step == 10)
-                        {
-                            if (IsOnCooldown(ContreSixte)) step++;
-                            else return ContreSixte;
-                        }
-
-                        if (step == 11)
-                        {
-                            if (lastComboMove == Redoublement || gauge.ManaStacks == 3) step++;
-                            else return EnchantedRedoublement;
-                        }
-
-                        if (step == 12)
-                        {
-                            if (GetRemainingCharges(Corpsacorps) < 2) step++;
-                            else return Corpsacorps;
-                        }
-
-                        if (step == 13)
-                        {
-                            if (GetRemainingCharges(Engagement) < 2) step++;
-                            else return Engagement;
-                        }
-
-                        if (step == 14)
-                        {
-                            if (lastComboMove == Verholy) step++;
-                            else return Verholy;
-                        }
-
-                        if (step == 15)
-                        {
-                            if (GetRemainingCharges(Corpsacorps) < 1) step++;
-                            else return Corpsacorps;
-                        }
-
-                        if (step == 16)
-                        {
-                            if (GetRemainingCharges(Engagement) < 1) step++;
-                            else return Engagement;
-                        }
-
-                        if (step == 17)
-                        {
-                            if (lastComboMove == Scorch) step++;
-                            else return Scorch;
-                        }
-
-                        if (step == 18)
-                        {
-                            if (lastComboMove == Resolution) step++;
-                            else return Resolution;
-                        }
-
-                        inOpener = false;
-                    }
+                    if (IsEnabled(CustomComboPreset.RDM_Variant_Rampart) &&
+                        IsEnabled(Variant.VariantRampart) &&
+                        IsOffCooldown(Variant.VariantRampart) &&
+                        CanSpellWeave(actionID))
+                        return Variant.VariantRampart;
                 }
-                //END_RDM_BALANCE_OPENER
 
-                //RDM_ST_MANAFICATIONEMBOLDEN
-                if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden)
-                    && level >= Levels.Embolden
-                    && HasCondition(ConditionFlag.InCombat)
-                    && !HasEffect(Buffs.Dualcast)
-                    && !HasEffect(All.Buffs.Swiftcast)
-                    && !HasEffect(Buffs.Acceleration)
-                    && (GetTargetDistance() <= 3 || (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_CorpsGapCloser)
-                    && GetCooldown(Corpsacorps).RemainingCharges >= 1)))
-                {
-                    if ((radioButtonST == 1 && actionID is Riposte or EnchantedRiposte)
-                        || (radioButtonST == 2 && actionID is Jolt or Jolt2)
-                        || (radioButtonST == 3 && actionID is Riposte or EnchantedRiposte or Jolt or Jolt2))
-                    {
-                        //Situation 1: Manafication first
-                        if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo)
-                            && level >= 90
-                            && gauge.ManaStacks == 0
-                            && lastComboMove is not Verflare
-                            && lastComboMove is not Verholy
-                            && lastComboMove is not Scorch
-                            && System.Math.Max(black, white) <= 50
-                            && (System.Math.Max(black, white) >= 42
-                                || (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_UnbalanceMana) && black == white && black >= 38 && GetCooldown(Acceleration).RemainingCharges > 0))
-                            && System.Math.Min(black, white) >= 31
-                            && IsOffCooldown(Manafication)
-                            && (IsOffCooldown(Embolden) || GetCooldown(Embolden).CooldownRemaining <= 3))
-                        {
-                            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_UnbalanceMana)
-                                && black == white
-                                && black <= 44
-                                && black >= 38
-                                && GetCooldown(Acceleration).RemainingCharges > 0)
-                                return Acceleration;
-
-                            return Manafication;
-                        }
-                        if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo)
-                            && level >= 90
-                            && lastComboMove is Zwerchhau or EnchantedZwerchhau
-                            && System.Math.Max(black, white) >= 57
-                            && System.Math.Min(black, white) >= 46
-                            && GetCooldown(Manafication).CooldownRemaining >= 100
-                            && IsOffCooldown(Embolden))
-                        {
-                            return Embolden;
-                        }
-
-                        //Situation 2: Embolden first
-                        if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo)
-                            && level >= 90
-                            && lastComboMove is Zwerchhau or EnchantedZwerchhau
-                            && System.Math.Max(black, white) <= 57
-                            && System.Math.Min(black, white) <= 46
-                            && (GetCooldown(Manafication).CooldownRemaining <= 7 || IsOffCooldown(Manafication))
-                            && IsOffCooldown(Embolden))
-                        {
-                            return Embolden;
-                        }
-                        if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo)
-                            && level >= 90
-                            && (gauge.ManaStacks == 0 || gauge.ManaStacks == 3)
-                            && lastComboMove is not Verflare 
-                            && lastComboMove is not Verholy 
-                            && lastComboMove is not Scorch
-                            && System.Math.Max(black, white) <= 50
-                            && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden))
-                            && IsOffCooldown(Manafication))
-                        {
-                            return Manafication;
-                        }
-
-                        //Situation 3: Just use them together
-                        if ((IsNotEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo) || level < 90) 
-                            && level >= Levels.Embolden 
-                            && gauge.ManaStacks == 0
-                            && System.Math.Max(black, white) <= 50
-                            && (IsOffCooldown(Manafication) || level < Levels.Manafication)
-                            && IsOffCooldown(Embolden))
-                        {
-                            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_UnbalanceMana)
-                                && black == white
-                                && black <= 44
-                                && GetCooldown(Acceleration).RemainingCharges > 0)
-                                return Acceleration;
-
-                            return Embolden;
-                        }
-                        if ((IsNotEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo) || level < 90) 
-                            && level >= Levels.Manafication 
-                            && (gauge.ManaStacks == 0 || gauge.ManaStacks == 3)
-                            && lastComboMove is not Verflare 
-                            && lastComboMove is not Verholy 
-                            && lastComboMove is not Scorch
-                            && System.Math.Max(black, white) <= 50
-                            && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden))
-                            && IsOffCooldown(Manafication))
-                        {
-                            return Manafication;
-                        }
-
-                        //Situation 4: Level 58 or 59
-                        if (level is < Levels.Manafication and >= Levels.Embolden 
-                            && System.Math.Min(black, white) >= 50 
-                            && IsOffCooldown(Embolden))
-                        {
-                            return Embolden;
-                        }
-                    }
-                }
-                //END_RDM_ST_MANAFICATIONEMBOLDEN
-
-                //RDM_AOE_MANAFICATIONEMBOLDEN
-                if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo_ManaEmbolden)
-                    && ((radioButtonAoE == 1 && actionID is Moulinet or EnchantedMoulinet) || (radioButtonAoE == 2 && actionID is Moulinet or EnchantedMoulinet or Scatter or Impact))
-                    && level >= Levels.Embolden 
-                    && HasCondition(ConditionFlag.InCombat)
-                    && !HasEffect(Buffs.Dualcast) 
-                    && !HasEffect(All.Buffs.Swiftcast) 
-                    && !HasEffect(Buffs.Acceleration)
-                    && ((GetTargetDistance() <= moulinetRange && gauge.ManaStacks == 0) || gauge.ManaStacks > 0))
-                {
-                    //Situation 1: Embolden First (Double)
-                    if (level >= Levels.Manafication
-                        && gauge.ManaStacks == 2
-                        && System.Math.Min(black, white) >= 22
-                        && IsOffCooldown(Manafication)
-                        && IsOffCooldown(Embolden))
-                    {
-                        return Embolden;
-                    }
-                    if (level >= Levels.Manafication 
-                        && ((gauge.ManaStacks == 3 && System.Math.Min(black, white) >= 2) || (gauge.ManaStacks == 0 && System.Math.Min(black, white) >= 10))
-                        && lastComboMove is not Verflare 
-                        && lastComboMove is not Verholy 
-                        && lastComboMove is not Scorch
-                        && System.Math.Max(black, white) <= 50
-                        && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden))
-                        && IsOffCooldown(Manafication))
-                    {
-                        return Manafication;
-                    }
-
-                    //Situation 2: Embolden First (Single)
-                    if (level >= Levels.Manafication 
-                        && gauge.ManaStacks == 0
-                        && lastComboMove is not Verflare 
-                        && lastComboMove is not Verholy 
-                        && lastComboMove is not Scorch
-                        && System.Math.Max(black, white) <= 50 
-                        && System.Math.Min(black, white) >= 10
-                        && IsOffCooldown(Manafication) 
-                        && IsOffCooldown(Embolden))
-                    {
-                        return Embolden;
-                    }
-                    if (level >= Levels.Manafication 
-                        && gauge.ManaStacks == 0 
-                        && lastComboMove is not Verflare 
-                        && lastComboMove is not Verholy 
-                        && lastComboMove is not Scorch
-                        && System.Math.Max(black, white) <= 50 
-                        && System.Math.Min(black, white) >= 10
-                        && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden))
-                        && IsOffCooldown(Manafication))
-                    {
-                        return Manafication;
-                    }
-
-                    //Below Manafication Level
-                    if (level is < Levels.Manafication and >= Levels.Embolden 
-                        && System.Math.Min(black, white) >= 20 
-                        && IsOffCooldown(Embolden))
-                    {
-                        return Embolden;
-                    }
-                }
-                //END_RDM_AOE_MANAFICATIONEMBOLDEN
+                //Lucid Dreaming
+                if (IsEnabled(CustomComboPreset.RDM_ST_Lucid)
+                    && actionID is Jolt or Jolt2
+                    && All.CanUseLucid(actionID, Config.RDM_ST_Lucid_Threshold)
+                    && InCombat()
+                    && RDMLucid.SafetoUse(lastComboMove)) //Don't interupt certain combos
+                    return All.LucidDreaming;
 
                 //RDM_OGCD
-                if (IsEnabled(CustomComboPreset.RDM_oGCD) 
-                    && level >= Levels.Corpsacorps)
+                if (IsEnabled(CustomComboPreset.RDM_ST_oGCD))
                 {
-                    //Radio Button Settings:
-                    //1: Fleche
-                    //2: Jolt
-                    //3: Impact
-                    //4: Jolt + Impact
-
-                    uint placeOGCD = 0;
-
-                    var corpacorpsRange = 25;
-                    var corpsacorpsPool = 0;
-                    var engagementPool = 0;
-
-                    if (IsEnabled(CustomComboPreset.RDM_oGCD_CorpsACorps_MeleeRange)) corpacorpsRange = 3;
-                    if (IsEnabled(CustomComboPreset.RDM_oGCD_CorpsACorps) && IsEnabled(CustomComboPreset.RDM_oGCD_CorpsACorps_Pooling)) corpsacorpsPool = 1;
-                    if (IsEnabled(CustomComboPreset.RDM_oGCD_Engagement) && IsEnabled(CustomComboPreset.RDM_oGCD_Engagement_Pooling)) engagementPool = 1;
-
-                    if (actionID is Jolt or Jolt2 or Scatter or Impact or Fleche or Riposte or Moulinet)
+                    bool ActionFound = 
+                        ( (!Config.RDM_ST_oGCD_OnAction_Adv && actionID is Jolt or Jolt2) || 
+                          (Config.RDM_ST_oGCD_OnAction_Adv &&
+                            ((Config.RDM_ST_oGCD_OnAction[0] && actionID is Jolt or Jolt2) ||
+                             (Config.RDM_ST_oGCD_OnAction[1] && actionID is Fleche) ||
+                             (Config.RDM_ST_oGCD_OnAction[2] && actionID is Riposte or EnchantedRiposte)
+                            )
+                          )
+                        );
+                    if (ActionFound && LevelChecked(Corpsacorps))
                     {
-                        if (IsEnabled(CustomComboPreset.RDM_oGCD_Engagement) 
-                            && (GetCooldown(Engagement).RemainingCharges > engagementPool
-                                || (GetCooldown(Engagement).RemainingCharges == 1 && GetCooldown(Engagement).CooldownRemaining < 3))
-                            && level >= Levels.Engagement 
-                            && distance <= 3) 
-                            placeOGCD = Engagement;
-                        if (IsEnabled(CustomComboPreset.RDM_oGCD_CorpsACorps) 
-                            && (GetCooldown(Corpsacorps).RemainingCharges > corpsacorpsPool
-                                || (GetCooldown(Corpsacorps).RemainingCharges == 1 && GetCooldown(Corpsacorps).CooldownRemaining < 3))
-                            && ((GetCooldown(Corpsacorps).RemainingCharges >= GetCooldown(Engagement).RemainingCharges) || level < Levels.Engagement) // Try to alternate between Corps-a-corps and Engagement
-                            && level >= Levels.Corpsacorps 
-                            && distance <= corpacorpsRange) 
-                            placeOGCD = Corpsacorps;
-                        if (IsEnabled(CustomComboPreset.RDM_oGCD_ContraSixte) 
-                            && IsOffCooldown(ContreSixte) 
-                            && level >= Levels.ContreSixte) 
-                            placeOGCD = ContreSixte;
-                        if ((radioButtonOGCD == 1 || IsEnabled(CustomComboPreset.RDM_oGCD_Fleche)) 
-                            && IsOffCooldown(Fleche) && level >= Levels.Fleche) 
-                            placeOGCD = Fleche;
-
-                        if ((actionID is Jolt or Jolt2) && (radioButtonOGCD is 2 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
-                        if ((actionID is Scatter or Impact) && (radioButtonOGCD is 3 or 4) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
-                        if ((actionID is Riposte or Moulinet) && (radioButtonOGCD is 5 or 6) && CanSpellWeave(actionID) && placeOGCD != 0) return placeOGCD;
-                        if (actionID is Fleche && radioButtonOGCD is 1 or 6 && placeOGCD == 0) // All actions are on cooldown, determine the lowest CD to display on Fleche.
-                        {
-                            placeOGCD = Fleche;
-                            if (IsEnabled(CustomComboPreset.RDM_oGCD_ContraSixte) 
-                                && level >= Levels.ContreSixte
-                                && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(ContreSixte).CooldownRemaining) 
-                                placeOGCD = ContreSixte;
-                            if (IsEnabled(CustomComboPreset.RDM_oGCD_CorpsACorps) 
-                                && level >= Levels.Corpsacorps
-                                && GetCooldown(Corpsacorps).RemainingCharges == 0
-                                && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Corpsacorps).CooldownRemaining) 
-                                placeOGCD = Corpsacorps;
-                            if (IsEnabled(CustomComboPreset.RDM_oGCD_Engagement) 
-                                && level >= Levels.Engagement
-                                && GetCooldown(Engagement).RemainingCharges == 0
-                                && GetCooldown(placeOGCD).CooldownRemaining > GetCooldown(Engagement).CooldownRemaining) 
-                                placeOGCD = Engagement;
-                        }
-                        if (actionID is Fleche && radioButtonOGCD == 1) return placeOGCD;
+                        if (OGCDHelper.CanUse(actionID, true, out uint oGCDAction)) return oGCDAction;
                     }
                 }
                 //END_RDM_OGCD
 
-                //SYSTEM_MANA_BALANCING_MACHINE
-                //Machine to decide which ver spell should be used.
-                //Rules:
-                //1.Avoid perfect balancing [NOT DONE]
-                //   - Jolt adds 2/2 mana
-                //   - Scatter/Impact adds 3/3 mana
-                //   - Verstone/Verfire add 5 mana
-                //   - Veraero/Verthunder add 6 mana
-                //   - Veraero2/Verthunder2 add 7 mana
-                //   - Verholy/Verflare add 11 mana
-                //   - Scorch adds 4/4 mana
-                //   - Resolution adds 4/4 mana
-                //2.Stay within difference limit [DONE]
-                //3.Strive to achieve correct mana for double melee combo burst [DONE]
-                bool useFire = false;
-                bool useStone = false;
-                bool useThunder = false;
-                bool useAero = false;
-                bool useThunder2 = false;
-                bool useAero2 = false;
-
-                if (level >= Levels.Verthunder 
-                    && (HasEffect(Buffs.Dualcast) || HasEffect(All.Buffs.Swiftcast) || HasEffect(Buffs.Acceleration)))
-                {
-                    if (black <= white || HasEffect(Buffs.VerstoneReady)) useThunder = true;
-                    if (white <= black || HasEffect(Buffs.VerfireReady)) useAero = true;
-                    if (level < Levels.Veraero) useThunder = true;
-                }
-                if (!HasEffect(Buffs.Dualcast) 
-                    && !HasEffect(All.Buffs.Swiftcast) 
-                    && !HasEffect(Buffs.Acceleration))
-                {
-                    if (black <= white && HasEffect(Buffs.VerfireReady)) useFire = true;
-                    if (white <= black && HasEffect(Buffs.VerstoneReady)) useStone = true;
-                    if (!useFire && !useStone && HasEffect(Buffs.VerfireReady)) useFire = true;
-                    if (!useFire && !useStone && HasEffect(Buffs.VerstoneReady)) useStone = true;
-                }
-                if (level >= Levels.Verthunder2 
-                    && !HasEffect(Buffs.Dualcast) 
-                    && !HasEffect(All.Buffs.Swiftcast) 
-                    && !HasEffect(Buffs.Acceleration))
-                {
-                    if (black <= white || level < Levels.Veraero2) useThunder2 = true;
-                    else useAero2 = true;
-                }
-                //END_SYSTEM_MANA_BALANCING_MACHINE
-
                 //RDM_MELEEFINISHER
-                if (IsEnabled(CustomComboPreset.RDM_MeleeFinisher))
+                if (IsEnabled(CustomComboPreset.RDM_ST_MeleeFinisher))
                 {
-                    if ((radioButtonMF == 1 && actionID is Riposte or EnchantedRiposte or Moulinet or EnchantedMoulinet)
-                        || (radioButtonMF == 2 && actionID is Jolt or Jolt2 or Scatter or Impact)
-                        || (radioButtonMF == 3 && actionID is Riposte or EnchantedRiposte or Moulinet or EnchantedMoulinet or Jolt or Jolt2 or Scatter or Impact)
-                        || (radioButtonMF == 4 && actionID is Veraero or Veraero2 or Veraero3 or Verthunder or Verthunder2 or Verthunder3))
-                    {
-                        if (gauge.ManaStacks >= 3)
-                        {
-                            if (black >= white && level >= Levels.Verholy)
-                            {
-                                if ((!HasEffect(Buffs.Embolden) || GetBuffRemainingTime(Buffs.Embolden) < 10)
-                                    && !HasEffect(Buffs.VerfireReady)
-                                    && (HasEffect(Buffs.VerstoneReady) && GetBuffRemainingTime(Buffs.VerstoneReady) >= 10)
-                                    && (black - white <= 18))
-                                    return Verflare;
+                    bool ActionFound =
+                        (!Config.RDM_ST_MeleeFinisher_Adv && actionID is Jolt or Jolt2) ||
+                        (Config.RDM_ST_MeleeFinisher_Adv &&
+                            ((Config.RDM_ST_MeleeFinisher_OnAction[0] && actionID is Jolt or Jolt2) ||
+                             (Config.RDM_ST_MeleeFinisher_OnAction[1] && actionID is Riposte or EnchantedRiposte) || 
+                             (Config.RDM_ST_MeleeFinisher_OnAction[2] && actionID is Veraero or Veraero3 or Verthunder or Verthunder3)));
 
-                                return Verholy;
-                            }
-                            else if (level >= Levels.Verflare)
-                            {
-                                if ((!HasEffect(Buffs.Embolden) || GetBuffRemainingTime(Buffs.Embolden) < 10)
-                                    && (HasEffect(Buffs.VerfireReady) && GetBuffRemainingTime(Buffs.VerfireReady) >= 10)
-                                    && !HasEffect(Buffs.VerstoneReady)
-                                    && level >= Levels.Verholy 
-                                    && (white - black <= 18))
-                                    return Verholy;
-
-                                return Verflare;
-                            }
-                        }
-                        if ((lastComboMove is Verflare or Verholy) 
-                            && level >= Levels.Scorch)
-                            return Scorch;
-
-                        if (lastComboMove is Scorch 
-                            && level >= Levels.Resolution)
-                            return Resolution;
-                    }
+                    if (ActionFound && MeleeFinisher.CanUse(lastComboMove, out uint finisherAction))
+                        return finisherAction;
                 }
                 //END_RDM_MELEEFINISHER
 
                 //RDM_ST_MELEECOMBO
-                if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo) 
+                if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo)
                     && LocalPlayer.IsCasting == false)
                 {
-                    if ((radioButtonST == 1 && actionID is Riposte or EnchantedRiposte)
-                        || (radioButtonST == 2 && actionID is Jolt or Jolt2)
-                        || (radioButtonST == 3 && actionID is Riposte or EnchantedRiposte or Jolt or Jolt2))
+                    bool ActionFound =
+                        (!Config.RDM_ST_MeleeCombo_Adv && actionID is Jolt or Jolt2) ||
+                        (Config.RDM_ST_MeleeCombo_Adv &&
+                            ((Config.RDM_ST_MeleeCombo_OnAction[0] && actionID is Jolt or Jolt2) ||
+                             (Config.RDM_ST_MeleeCombo_OnAction[1] && actionID is Riposte or EnchantedRiposte)));
+
+                    if (ActionFound)
                     {
-                        if ((lastComboMove is Riposte or EnchantedRiposte) 
-                            && level >= Levels.Zwerchhau)
+                        //RDM_ST_MANAFICATIONEMBOLDEN
+                        if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden)
+                            && LevelChecked(Embolden)
+                            && HasCondition(ConditionFlag.InCombat)
+                            && !HasEffect(Buffs.Dualcast)
+                            && !HasEffect(All.Buffs.Swiftcast)
+                            && !HasEffect(Buffs.Acceleration)
+                            && (GetTargetDistance() <= 3 || (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_CorpsGapCloser) && HasCharges(Corpsacorps))))
+                        { 
+                            //Situation 1: Manafication first
+                            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo)
+                                && level >= 90
+                                && Gauge.ManaStacks == 0
+                                && lastComboMove is not Verflare
+                                && lastComboMove is not Verholy
+                                && lastComboMove is not Scorch
+                                && Math.Max(blackmana, whitemana) <= 50
+                                && (Math.Max(blackmana, whitemana) >= 42
+                                    || (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_UnbalanceMana) && blackmana == whitemana && blackmana >= 38 && HasCharges(Acceleration)))
+                                && Math.Min(blackmana, whitemana) >= 31
+                                && IsOffCooldown(Manafication)
+                                && (IsOffCooldown(Embolden) || GetCooldownRemainingTime(Embolden) <= 3))
+                            {
+                                if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_UnbalanceMana)
+                                    && blackmana == whitemana
+                                    && blackmana <= 44
+                                    && blackmana >= 38
+                                    && HasCharges(Acceleration))
+                                    return Acceleration;
+
+                                return Manafication;
+                            }
+                            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo)
+                                && level >= 90
+                                && lastComboMove is Zwerchhau or EnchantedZwerchhau
+                                && Math.Max(blackmana, whitemana) >= 57
+                                && Math.Min(blackmana, whitemana) >= 46
+                                && GetCooldownRemainingTime(Manafication) >= 100
+                                && IsOffCooldown(Embolden))
+                            {
+                                return Embolden;
+                            }
+
+                            //Situation 2: Embolden first
+                            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo)
+                                && level >= 90
+                                && lastComboMove is Zwerchhau or EnchantedZwerchhau
+                                && Math.Max(blackmana, whitemana) <= 57
+                                && Math.Min(blackmana, whitemana) <= 46
+                                && (GetCooldownRemainingTime(Manafication) <= 7 || IsOffCooldown(Manafication))
+                                && IsOffCooldown(Embolden))
+                            {
+                                return Embolden;
+                            }
+                            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo)
+                                && level >= 90
+                                && (Gauge.ManaStacks == 0 || Gauge.ManaStacks == 3)
+                                && lastComboMove is not Verflare
+                                && lastComboMove is not Verholy
+                                && lastComboMove is not Scorch
+                                && Math.Max(blackmana, whitemana) <= 50
+                                && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden))
+                                && IsOffCooldown(Manafication))
+                            {
+                                return Manafication;
+                            }
+
+                            //Situation 3: Just use them together
+                            if ((IsNotEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo) || level < 90)
+                                && ActionReady(Embolden)
+                                && Gauge.ManaStacks == 0
+                                && Math.Max(blackmana, whitemana) <= 50
+                                && (IsOffCooldown(Manafication) || !LevelChecked(Manafication)))
+                            {
+                                if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_UnbalanceMana)
+                                    && blackmana == whitemana
+                                    && blackmana <= 44
+                                    && HasCharges(Acceleration))
+                                    return Acceleration;
+
+                                return Embolden;
+                            }
+                            if ((IsNotEnabled(CustomComboPreset.RDM_ST_MeleeCombo_ManaEmbolden_DoubleCombo) || level < 90)
+                                && ActionReady(Manafication)
+                                && (Gauge.ManaStacks == 0 || Gauge.ManaStacks == 3)
+                                && lastComboMove is not Verflare
+                                && lastComboMove is not Verholy
+                                && lastComboMove is not Scorch
+                                && Math.Max(blackmana, whitemana) <= 50
+                                && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden)))
+                            {
+                                return Manafication;
+                            }
+
+                            //Situation 4: Level 58 or 59
+                            if (!LevelChecked(Manafication) &&
+                                ActionReady(Embolden) &&
+                                Math.Min(blackmana, whitemana) >= 50)
+                            {
+                                return Embolden;
+                            }
+
+                        } //END_RDM_ST_MANAFICATIONEMBOLDEN
+
+                        //Normal Combo
+                        if ((lastComboMove is Riposte or EnchantedRiposte)
+                            && LevelChecked(Zwerchhau))
                             return OriginalHook(Zwerchhau);
 
-                        if (lastComboMove is Zwerchhau 
-                            && level >= Levels.Redoublement)
+                        if (lastComboMove is Zwerchhau
+                            && LevelChecked(Redoublement))
                             return OriginalHook(Redoublement);
 
-                        if (((System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 50 && level >= Levels.Redoublement)
-                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 35 && level < Levels.Redoublement)
-                            || (System.Math.Min(gauge.WhiteMana, gauge.BlackMana) >= 20 && level < Levels.Zwerchhau))
+                        if (((Math.Min(Gauge.WhiteMana, Gauge.BlackMana) >= 50 && LevelChecked(Redoublement))
+                            || (Math.Min(Gauge.WhiteMana, Gauge.BlackMana) >= 35 && !LevelChecked(Redoublement))
+                            || (Math.Min(Gauge.WhiteMana, Gauge.BlackMana) >= 20 && !LevelChecked(Zwerchhau)))
                             && !HasEffect(Buffs.Dualcast))
                         {
-                            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_CorpsGapCloser) 
-                                && level >= Levels.Corpsacorps && GetCooldown(Corpsacorps).RemainingCharges >= 1 
-                                && distance > 3) 
+                            if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_CorpsGapCloser)
+                                && LevelChecked(Corpsacorps) && HasCharges(Corpsacorps)
+                                && GetTargetDistance() > 3)
                                 return Corpsacorps;
 
                             if (IsEnabled(CustomComboPreset.RDM_ST_MeleeCombo_UnbalanceMana)
-                                && level >= Levels.Acceleration
-                                && black == white
-                                && black >= 50
+                                && LevelChecked(Acceleration)
+                                && blackmana == whitemana
+                                && blackmana >= 50
                                 && !HasEffect(Buffs.Embolden))
                             {
                                 if (HasEffect(Buffs.Acceleration) || WasLastAction(Buffs.Acceleration))
                                 {
-                                    if (useAero && level >= Levels.Veraero3) return Veraero3;
-                                    if (useThunder && level >= Levels.Verthunder3) return Verthunder3;
-                                    if (useAero && level < Levels.Veraero3) return Veraero;
-                                    if (useThunder && level < Levels.Verthunder3) return Verthunder;
+                                    //Run the Mana Balance Computer
+                                    manaState.CheckBalance();
+                                    if (manaState.useAero && LevelChecked(OriginalHook(Veraero))) return OriginalHook(Veraero);
+                                    if (manaState.useThunder && LevelChecked(OriginalHook(Verthunder))) return OriginalHook(Verthunder);
                                 }
 
-                                if (GetCooldown(Acceleration).RemainingCharges > 0)
-                                    return Acceleration;
+                                if (HasCharges(Acceleration)) return Acceleration;
                             }
 
-                            if (distance <= 3) 
+                            if (GetTargetDistance() <= 3)
                                 return OriginalHook(Riposte);
                         }
                     }
                 }
                 //END_RDM_ST_MELEECOMBO
 
-                //RDM_AOE_MELEECOMBO
-                if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo)
-                    && level >= Levels.Moulinet 
-                    && ((radioButtonAoE == 1 && actionID is Moulinet or EnchantedMoulinet) || (radioButtonAoE == 2 && actionID is Moulinet or EnchantedMoulinet or Scatter or Impact))
-                    && LocalPlayer.IsCasting == false
-                    && !HasEffect(Buffs.Dualcast) 
-                    && !HasEffect(All.Buffs.Swiftcast) 
-                    && !HasEffect(Buffs.Acceleration)
-                    && ((System.Math.Min(gauge.BlackMana, gauge.WhiteMana) + (gauge.ManaStacks * 20) >= 60) || (level < Levels.Verflare && System.Math.Min(gauge.BlackMana, gauge.WhiteMana) >= 20))
-                    && ((GetTargetDistance() <= moulinetRange && gauge.ManaStacks == 0) || gauge.ManaStacks >= 1))
-                    return OriginalHook(EnchantedMoulinet);
-                //END_RDM_AOE_MELEECOMBO
-
                 //RDM_ST_ACCELERATION
-                if (IsEnabled(CustomComboPreset.RDM_ST_ThunderAero) && IsEnabled(CustomComboPreset.RDM_ST_ThunderAero_Accel) 
-                    && actionID is Jolt or Jolt2 
-                    && HasCondition(ConditionFlag.InCombat) 
-                    && LocalPlayer.IsCasting == false 
-                    && gauge.ManaStacks == 0
-                    && lastComboMove is not Verflare 
-                    && lastComboMove is not Verholy 
+                if (IsEnabled(CustomComboPreset.RDM_ST_ThunderAero) && IsEnabled(CustomComboPreset.RDM_ST_ThunderAero_Accel)
+                    && actionID is Jolt or Jolt2
+                    && HasCondition(ConditionFlag.InCombat)
+                    && LocalPlayer.IsCasting == false
+                    && Gauge.ManaStacks == 0
+                    && lastComboMove is not Verflare
+                    && lastComboMove is not Verholy
                     && lastComboMove is not Scorch
-                    && !HasEffect(Buffs.VerfireReady) 
-                    && !HasEffect(Buffs.VerstoneReady) 
-                    && !HasEffect(Buffs.Acceleration) 
-                    && !HasEffect(Buffs.Dualcast) 
+                    && !HasEffect(Buffs.VerfireReady)
+                    && !HasEffect(Buffs.VerstoneReady)
+                    && !HasEffect(Buffs.Acceleration)
+                    && !HasEffect(Buffs.Dualcast)
                     && !HasEffect(All.Buffs.Swiftcast))
                 {
-                    if (level >= Levels.Acceleration 
-                        && GetCooldown(Acceleration).RemainingCharges > 0 
+                    if (ActionReady(Acceleration)
                         && GetCooldown(Acceleration).ChargeCooldownRemaining < 54.5)
                         return Acceleration;
-                    if (IsEnabled(CustomComboPreset.RDM_ST_ThunderAero_Accel_Swiftcast) 
-                        && ActionReady(All.Swiftcast) 
-                        && GetCooldown(Acceleration).RemainingCharges == 0)
+                    if (IsEnabled(CustomComboPreset.RDM_ST_ThunderAero_Accel_Swiftcast)
+                        && ActionReady(All.Swiftcast)
+                        && !HasCharges(Acceleration))
                         return All.Swiftcast;
                 }
                 //END_RDM_ST_ACCELERATION
 
+                //RDM_VERFIREVERSTONE
+                if (IsEnabled(CustomComboPreset.RDM_ST_FireStone)
+                    && actionID is Jolt or Jolt2
+                    && !HasEffect(Buffs.Acceleration)
+                    && !HasEffect(Buffs.Dualcast))
+                {
+                    //Run the Mana Balance Computer
+                    manaState.CheckBalance();
+                    if (manaState.useFire) return Verfire;
+                    if (manaState.useStone) return Verstone;
+                }
+                //END_RDM_VERFIREVERSTONE
+
+                //RDM_VERTHUNDERVERAERO
+                if (IsEnabled(CustomComboPreset.RDM_ST_ThunderAero)
+                    && actionID is Jolt or Jolt2)
+                {
+                    //Run the Mana Balance Computer
+                    manaState.CheckBalance();
+                    if (manaState.useThunder) return OriginalHook(Verthunder);
+                    if (manaState.useAero) return OriginalHook(Veraero);
+                }
+                //END_RDM_VERTHUNDERVERAERO
+
+                //NO_CONDITIONS_MET
+                if (!LevelChecked(Jolt)) return Riposte;
+                return actionID;
+            }
+        }
+
+        internal class RDM_AoE_DPS : CustomCombo
+        {
+            protected internal ManaBalancer manaState = new();
+            protected internal MeleeFinisher meleeFinisher = new();
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_AoE_DPS;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                int black = Gauge.BlackMana;
+                int white = Gauge.WhiteMana;
+
+                // LUCID
+                if (IsEnabled(CustomComboPreset.RDM_AoE_Lucid)
+                    && actionID is Scatter or Impact
+                    && All.CanUseLucid(actionID, Config.RDM_AoE_Lucid_Threshold)
+                    && InCombat()
+                    && RDMLucid.SafetoUse(lastComboMove))
+                    return All.LucidDreaming;
+
+                //RDM_OGCD
+                if (IsEnabled(CustomComboPreset.RDM_AoE_oGCD)
+                    && LevelChecked(Corpsacorps) &&
+                    actionID is Scatter or Impact &&
+                    OGCDHelper.CanUse(actionID, false, out uint oGCDAction)) return oGCDAction;
+
+                //RDM_MELEEFINISHER
+                if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeFinisher))
+                {
+                    bool ActionFound =
+                        (!Config.RDM_AoE_MeleeFinisher_Adv && actionID is Scatter or Impact) ||
+                        (Config.RDM_AoE_MeleeFinisher_Adv &&
+                            ((Config.RDM_AoE_MeleeFinisher_OnAction[0] && actionID is Scatter or Impact) ||
+                             (Config.RDM_AoE_MeleeFinisher_OnAction[1] && actionID is Moulinet or EnchantedMoulinet) ||
+                             (Config.RDM_AoE_MeleeFinisher_OnAction[2] && actionID is Veraero2 or Verthunder2)));
+
+                    if (ActionFound && MeleeFinisher.CanUse(lastComboMove, out uint finisherAction))
+                        return finisherAction;
+                }
+                    //END_RDM_MELEEFINISHER
+
+                //RDM_AOE_MELEECOMBO
+                if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo))
+                {
+                    bool ActionFound =
+                        (!Config.RDM_ST_MeleeCombo_Adv && actionID is Scatter or Impact) ||
+                        (Config.RDM_ST_MeleeCombo_Adv &&
+                            ((Config.RDM_AoE_MeleeCombo_OnAction[0] && actionID is Scatter or Impact) ||
+                                (Config.RDM_AoE_MeleeCombo_OnAction[1] && actionID is Moulinet or EnchantedMoulinet)));
+
+                    if (ActionFound)
+                    {
+                        //RDM_AOE_MANAFICATIONEMBOLDEN
+                        if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo_ManaEmbolden))
+                        {
+                            if (HasCondition(ConditionFlag.InCombat)
+                                && !HasEffect(Buffs.Dualcast)
+                                && !HasEffect(All.Buffs.Swiftcast)
+                                && !HasEffect(Buffs.Acceleration)
+                                && ((GetTargetDistance() <= Config.RDM_AoE_MoulinetRange && Gauge.ManaStacks == 0) || Gauge.ManaStacks > 0))
+                            {
+                                if (ActionReady(Manafication))
+                                {
+                                    //Situation 1: Embolden First (Double)
+                                    if (Gauge.ManaStacks == 2
+                                        && Math.Min(black, white) >= 22
+                                        && IsOffCooldown(Embolden))
+                                    {
+                                        return Embolden;
+                                    }
+                                    if (((Gauge.ManaStacks == 3 && Math.Min(black, white) >= 2) || (Gauge.ManaStacks == 0 && Math.Min(black, white) >= 10))
+                                        && lastComboMove is not Verflare
+                                        && lastComboMove is not Verholy
+                                        && lastComboMove is not Scorch
+                                        && Math.Max(black, white) <= 50
+                                        && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden)))
+                                    {
+                                        return Manafication;
+                                    }
+
+                                    //Situation 2: Embolden First (Single)
+                                    if (Gauge.ManaStacks == 0
+                                        && lastComboMove is not Verflare
+                                        && lastComboMove is not Verholy
+                                        && lastComboMove is not Scorch
+                                        && Math.Max(black, white) <= 50
+                                        && Math.Min(black, white) >= 10
+                                        && IsOffCooldown(Embolden))
+                                    {
+                                        return Embolden;
+                                    }
+                                    if (Gauge.ManaStacks == 0
+                                        && lastComboMove is not Verflare
+                                        && lastComboMove is not Verholy
+                                        && lastComboMove is not Scorch
+                                        && Math.Max(black, white) <= 50
+                                        && Math.Min(black, white) >= 10
+                                        && (HasEffect(Buffs.Embolden) || WasLastAction(Embolden)))
+                                    {
+                                        return Manafication;
+                                    }
+                                }
+
+                                //Below Manafication Level
+                                if (ActionReady(Embolden) && !LevelChecked(Manafication)
+                                    && Math.Min(black, white) >= 20)
+                                {
+                                    return Embolden;
+                                }
+                            }
+                            //END_RDM_AOE_MANAFICATIONEMBOLDEN
+                        }
+
+                        if (LevelChecked(Moulinet)
+                            && LocalPlayer.IsCasting == false
+                            && !HasEffect(Buffs.Dualcast)
+                            && !HasEffect(All.Buffs.Swiftcast)
+                            && !HasEffect(Buffs.Acceleration)
+                            && ((Math.Min(Gauge.BlackMana, Gauge.WhiteMana) + (Gauge.ManaStacks * 20) >= 60) || (!LevelChecked(Verflare) && Math.Min(Gauge.BlackMana, Gauge.WhiteMana) >= 20))
+                            && ((GetTargetDistance() <= Config.RDM_AoE_MoulinetRange && Gauge.ManaStacks == 0) || Gauge.ManaStacks >= 1))
+                            return OriginalHook(EnchantedMoulinet);
+                    }
+                }
+                //END_RDM_AOE_MELEECOMBO
+
                 //RDM_AoE_ACCELERATION
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Accel) 
-                    && actionID is Scatter or Impact 
-                    && LocalPlayer.IsCasting == false 
-                    && gauge.ManaStacks == 0
-                    && lastComboMove is not Verflare 
-                    && lastComboMove is not Verholy 
-                    && lastComboMove is not Scorch 
+                if (IsEnabled(CustomComboPreset.RDM_AoE_Accel)
+                    && actionID is Scatter or Impact
+                    && LocalPlayer.IsCasting == false
+                    && Gauge.ManaStacks == 0
+                    && lastComboMove is not Verflare
+                    && lastComboMove is not Verholy
+                    && lastComboMove is not Scorch
                     && !WasLastAction(Embolden)
                     && (IsNotEnabled(CustomComboPreset.RDM_AoE_Accel_Weave) || CanSpellWeave(actionID))
-                    && !HasEffect(Buffs.Acceleration) 
-                    && !HasEffect(Buffs.Dualcast) 
+                    && !HasEffect(Buffs.Acceleration)
+                    && !HasEffect(Buffs.Dualcast)
                     && !HasEffect(All.Buffs.Swiftcast))
                 {
-                    if (level >= Levels.Acceleration 
-                        && GetCooldown(Acceleration).RemainingCharges > 0
+                    //if (level >= Levels.Acceleration
+                    //    && GetCooldown(Acceleration).RemainingCharges > 0
+                    //    && GetCooldown(Acceleration).ChargeCooldownRemaining < 54.5)
+                    if (ActionReady(Acceleration) //check for level and 1 charge minimum
                         && GetCooldown(Acceleration).ChargeCooldownRemaining < 54.5)
                         return Acceleration;
-                    if (IsEnabled(CustomComboPreset.RDM_AoE_Accel_Swiftcast) 
-                        && ActionReady(All.Swiftcast) 
-                        && GetCooldown(Acceleration).RemainingCharges == 0
+                    if (IsEnabled(CustomComboPreset.RDM_AoE_Accel_Swiftcast)
+                        && ActionReady(All.Swiftcast)
+                        && !HasCharges(Acceleration)
                         && GetCooldown(Acceleration).ChargeCooldownRemaining < 54.5)
                         return All.Swiftcast;
                 }
                 //END_RDM_AoE_ACCELERATION
 
-                //RDM_VERFIREVERSTONE
-                if (IsEnabled(CustomComboPreset.RDM_ST_FireStone) 
-                    && actionID is Jolt or Jolt2
-                    && !HasEffect(Buffs.Acceleration) 
-                    && !HasEffect(Buffs.Dualcast))
-                {
-                    if (useFire) return Verfire;
-                    if (useStone) return Verstone;
-                }
-                //END_RDM_VERFIREVERSTONE
-
-                //RDM_VERTHUNDERVERAERO
-                if (IsEnabled(CustomComboPreset.RDM_ST_ThunderAero) 
-                    && actionID is Jolt or Jolt2)
-                {
-                    if (useThunder) return OriginalHook(Verthunder);
-                    if (useAero) return OriginalHook(Veraero);
-                }
-                //END_RDM_VERTHUNDERVERAERO
-
                 //RDM_VERTHUNDERIIVERAEROII
-                if (IsEnabled(CustomComboPreset.RDM_AoE_Thunder2Aero2) 
-                    && actionID is Scatter or Impact)
+                if (actionID is Scatter or Impact)
                 {
-                    if (useThunder2) return Verthunder2;
-                    if (useAero2) return Veraero2;
+                    manaState.CheckBalance();
+                    if (manaState.useThunder2) return OriginalHook(Verthunder2);
+                    if (manaState.useAero2) return OriginalHook(Veraero2);
                 }
                 //END_RDM_VERTHUNDERIIVERAEROII
 
-
-                //NO_CONDITIONS_MET
-                if (level < Levels.Jolt && actionID is Jolt or Jolt2) { return Riposte; }
-                return actionID;
-            }
-        }
-
-        internal class RDM_Lucid : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Lucid;
-
-            internal static bool showLucid = false;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is Jolt or Jolt2 or Veraero or Veraero2 or Veraero3 or Verthunder or Verthunder2 or Verthunder3 or Scatter or Impact)
-                {
-                    var lucidThreshold = PluginConfiguration.GetCustomIntValue(Config.RDM_Lucid_Threshold);
-
-                    if (LevelChecked(All.LucidDreaming) && LocalPlayer.CurrentMp <= lucidThreshold) // Check to show Lucid Dreaming
-                    {
-                        showLucid = true;
-                    }
-
-                    if (showLucid && CanSpellWeave(actionID) 
-                        && HasCondition(ConditionFlag.InCombat) 
-                        && IsOffCooldown(All.LucidDreaming) 
-                        && !HasEffect(Buffs.Dualcast)
-                        && lastComboMove != EnchantedRiposte 
-                        && lastComboMove != EnchantedZwerchhau
-                        && lastComboMove != EnchantedRedoublement 
-                        && lastComboMove != Verflare
-                        && lastComboMove != Verholy 
-                        && lastComboMove != Scorch) // Change abilities to Lucid Dreaming for entire weave window
-                    {
-                        return All.LucidDreaming;
-                    }
-                    showLucid = false;
-                }
                 return actionID;
             }
         }
@@ -843,10 +752,14 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_Raise;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is All.Swiftcast && level >= Levels.Verraise)
+                if (actionID is All.Swiftcast)
                 {
-                    if (GetCooldown(All.Swiftcast).CooldownRemaining > 0 ||     // Condition 1: Swiftcast is on cooldown
-                        HasEffect(Buffs.Dualcast))                              // Condition 2: Swiftcast is available, but we have Dualcast)
+                    if (HasEffect(All.Buffs.Swiftcast) && IsEnabled(CustomComboPreset.SMN_Variant_Raise) && IsEnabled(Variant.VariantRaise))
+                        return Variant.VariantRaise;
+
+                    if (LevelChecked(Verraise) &&
+                        (GetCooldownRemainingTime(All.Swiftcast) > 0 ||     // Condition 1: Swiftcast is on cooldown
+                        HasEffect(Buffs.Dualcast)))                              // Condition 2: Swiftcast is available, but we have Dualcast)
                         return Verraise;
                 }
 
@@ -858,48 +771,30 @@ namespace XIVSlothCombo.Combos.PvE
         internal class RDM_CorpsDisplacement : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_CorpsDisplacement;
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                var distance = GetTargetDistance();
-
-                if (actionID is Displacement 
-                    && level >= Levels.Displacement 
-                    && HasTarget() 
-                    && distance >= 5)
-                    return Corpsacorps;
-
-                return actionID;
-            }
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) => 
+                actionID is Displacement
+                && LevelChecked(Displacement)
+                && HasTarget()
+                && GetTargetDistance() >= 5 ? Corpsacorps : actionID;
         }
 
         internal class RDM_EmboldenManafication : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_EmboldenManafication;
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is Embolden 
-                    && level >= Levels.Manafication 
-                    && IsOnCooldown(Embolden) 
-                    && IsOffCooldown(Manafication))
-                    return Manafication;
-
-                return actionID;
-            }
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) => 
+                actionID is Embolden
+                && IsOnCooldown(Embolden)
+                && ActionReady(Manafication) ? Manafication : actionID;
         }
 
         internal class RDM_MagickBarrierAddle : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.RDM_MagickBarrierAddle;
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is MagickBarrier
-                    && (IsOnCooldown(MagickBarrier) || level < Levels.MagickBarrier)
-                    && ActionReady(All.Addle)
-                    && !TargetHasEffectAny(All.Debuffs.Addle))
-                    return All.Addle;
-
-                return actionID;
-            }
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) => 
+                actionID is MagickBarrier
+                && (IsOnCooldown(MagickBarrier) || !LevelChecked(MagickBarrier))
+                && ActionReady(All.Addle)
+                && !TargetHasEffectAny(All.Debuffs.Addle) ? All.Addle : actionID;
         }
     }
 }

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -11,6 +11,7 @@ using XIVSlothCombo.Combos.PvP;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.Services;
 using Dalamud.Interface;
+using Dalamud.Interface.Style;
 
 namespace XIVSlothCombo.Window.Functions
 {
@@ -1518,42 +1519,115 @@ namespace XIVSlothCombo.Window.Functions
             // ====================================================================================
             #region RED MAGE
 
-            if (preset == CustomComboPreset.RDM_oGCD)
+            if (preset is CustomComboPreset.RDM_ST_oGCD)
             {
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_OGCD_OnAction, "-Fleche", "", 1);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_OGCD_OnAction, "-Jolt\n-Jolt II", "Select for one button rotation", 2);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_OGCD_OnAction, "-Scatter\n-Impact", "Select for one button rotation", 3);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_OGCD_OnAction, "-Jolt\n-Jolt II\n-Scatter\n-Impact", "Select for one button rotation", 4);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_OGCD_OnAction, "-Riposte\n-Moulinet", "", 5);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_OGCD_OnAction, "-Fleche\n-Riposte\n-Moulinet", "", 6);
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_OnAction_Adv, "Advanced Action Options.", "Changes which action this option will replace.", isConditionalChoice: true);
+                if (RDM.Config.RDM_ST_oGCD_OnAction_Adv)
+                {
+                    ImGui.Indent();ImGui.Spacing();
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Jolts", "", 3, 0, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Fleche", "", 3, 1, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Riposte", "", 3, 2, descriptionColor: ImGuiColors.DalamudYellow);
+                    ImGui.Unindent();
+                }
+
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_Fleche, "Fleche", "");
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_ContraSixte, "Contra Sixte", "");
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_Engagement, "Engagement", "", isConditionalChoice: true);
+                if (RDM.Config.RDM_ST_oGCD_Engagement)
+                {
+                    ImGui.Indent(); ImGui.Spacing();
+                    UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_Engagement_Pooling, "Pool one charge for manual use.", "");
+                    ImGui.Unindent();
+                }
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_CorpACorps, "Corp-a-Corps", "", isConditionalChoice: true);
+                if (RDM.Config.RDM_ST_oGCD_CorpACorps)
+                {
+                    ImGui.Indent();ImGui.Spacing();
+                    UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_CorpACorps_Melee, "Use only in melee range.", "");
+                    UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_oGCD_CorpACorps_Pooling, "Pool one charge for manual use.", "");
+                    ImGui.Unindent();
+                }
             }
 
-            if (preset == CustomComboPreset.RDM_ST_MeleeCombo)
+            if (preset is CustomComboPreset.RDM_ST_MeleeCombo)
             {
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_ST_MeleeCombo_OnAction, "-Riposte", "", 1);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_ST_MeleeCombo_OnAction, "-Jolt\n-Jolt II", "Select for one button rotation", 2);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_ST_MeleeCombo_OnAction, "-Riposte\n-Jolt\n-Jolt II", "Select for one button rotation", 3);
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_MeleeCombo_Adv, "Advanced Action Options", "Changes which action this option will replace.", isConditionalChoice: true);
+                if (RDM.Config.RDM_ST_MeleeCombo_Adv)
+                {
+                    ImGui.Indent(); ImGui.Spacing();
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_MeleeCombo_OnAction, "Jolts", "", 2, 0, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_MeleeCombo_OnAction, "Riposte", "", 2, 1, descriptionColor: ImGuiColors.DalamudYellow);
+                    ImGui.Unindent();
+                }
             }
 
-            if (preset == CustomComboPreset.RDM_AoE_MeleeCombo)
+            if (preset is CustomComboPreset.RDM_ST_MeleeFinisher)
             {
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_AoE_MeleeCombo_OnAction, "-Moulinet", "", 1);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_AoE_MeleeCombo_OnAction, "-Moulinet\n-Scatter\n-Impact", "Select for one button rotation", 2);
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_ST_MeleeFinisher_Adv, "Advanced Action Options", "Changes which action this option will replace.", isConditionalChoice: true);
+                if (RDM.Config.RDM_ST_MeleeFinisher_Adv)
+                {
+                    ImGui.Indent(); ImGui.Spacing();
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_MeleeFinisher_OnAction, "Jolts", "", 3, 0, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_MeleeFinisher_OnAction, "Riposte", "", 3, 1, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_MeleeFinisher_OnAction, "VerAero & VerThunder", "", 3, 2, descriptionColor: ImGuiColors.DalamudYellow);
+                    ImGui.Unindent();
+                }
             }
 
-            if (preset == CustomComboPreset.RDM_MeleeFinisher)
+            if (preset is CustomComboPreset.RDM_ST_Lucid)
+                UserConfig.DrawSliderInt(0, 10000, RDM.Config.RDM_ST_Lucid_Threshold, "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);
+
+            // AoE
+            if (preset is CustomComboPreset.RDM_AoE_oGCD)
             {
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "-Riposte\n-Moulinet", "", 1);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "-Jolt\n-Jolt II\n-Scatter\n-Impact", "Select for one button rotation", 2);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "-Riposte\n-Moulinet\n-Jolt\n-Jolt II\n-Scatter\n-Impact", "Select for one button rotation", 3);
-                UserConfig.DrawHorizontalRadioButton(RDM.Config.RDM_MeleeFinisher_OnAction, "-Veraero 1/2/3\n-Verthunder 1/2/3", "", 4);
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_oGCD_Fleche, "Fleche", "");
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_oGCD_ContraSixte, "Contra Sixte", "");
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_oGCD_Engagement, "Engagement", "", isConditionalChoice: true);
+                if (RDM.Config.RDM_AoE_oGCD_Engagement)
+                {
+                    ImGui.Indent(); ImGui.Spacing();
+                    UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_oGCD_Engagement_Pooling, "Pool one charge for manual use.", "");
+                    ImGui.Unindent();
+                }
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_oGCD_CorpACorps, "Corp-a-Corps", "", isConditionalChoice: true);
+                if (RDM.Config.RDM_AoE_oGCD_CorpACorps)
+                {
+                    ImGui.Indent(); ImGui.Spacing();
+                    UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_oGCD_CorpACorps_Melee, "Use only in melee range.", "");
+                    UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_oGCD_CorpACorps_Pooling, "Pool one charge for manual use.", "");
+                    ImGui.Unindent();
+                }
             }
 
-            if (preset == CustomComboPreset.RDM_Lucid && enabled)
-                UserConfig.DrawSliderInt(0, 10000, RDM.Config.RDM_Lucid_Threshold, "Add Lucid Dreaming when below this MP", 300, SliderIncrements.Hundreds);
+            if (preset is CustomComboPreset.RDM_AoE_MeleeCombo)
+            {
+                UserConfig.DrawSliderInt(3, 8, RDM.Config.RDM_AoE_MoulinetRange, "Range to use first Moulinet; no range restrictions after first Moulinet", sliderIncrement: SliderIncrements.Ones);
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_MeleeCombo_Adv, "Advanced Action Options", "Changes which action this option will replace.", isConditionalChoice: true);
+                if (RDM.Config.RDM_AoE_MeleeCombo_Adv)
+                {
+                    ImGui.Indent(); ImGui.Spacing();
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_AoE_MeleeCombo_OnAction, "Scatter/Impact", "", 2, 0, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_AoE_MeleeCombo_OnAction, "Moulinet", "", 2, 1, descriptionColor: ImGuiColors.DalamudYellow);
+                    ImGui.Unindent();
+                }
+            }
 
-            if (preset == CustomComboPreset.RDM_AoE_MeleeCombo && enabled)
-                UserConfig.DrawSliderInt(3, 8, RDM.Config.RDM_MoulinetRange, "Range to use first Moulinet; no range restrictions after first Moulinet", 150, SliderIncrements.Ones);
+            if (preset is CustomComboPreset.RDM_AoE_MeleeFinisher)
+            {
+                UserConfig.DrawAdditionalBoolChoice(RDM.Config.RDM_AoE_MeleeFinisher_Adv, "Advanced Action Options", "Changes which action this option will replace.", isConditionalChoice: true);
+                if (RDM.Config.RDM_AoE_MeleeFinisher_Adv)
+                {
+                    ImGui.Indent(); ImGui.Spacing();
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_AoE_MeleeFinisher_OnAction, "Scatter/Impact", "", 3, 0, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_AoE_MeleeFinisher_OnAction, "Moulinet", "", 3, 1, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_AoE_MeleeFinisher_OnAction, "VerAero II & VerThunder II", "", 3, 2, descriptionColor: ImGuiColors.DalamudYellow);
+                    ImGui.Unindent();
+                }
+            }
+
+            if (preset is CustomComboPreset.RDM_AoE_Lucid)
+                UserConfig.DrawSliderInt(0, 10000, RDM.Config.RDM_AoE_Lucid_Threshold, "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);
 
             #endregion
             // ====================================================================================


### PR DESCRIPTION
RDM
* No existing functionality should have been lost, just redone visually. 
* RDM Helper file added. Holds a lot of the shared code for ST & AoE (Melee Finishers, oGCD, Mana Calculator, Lucid Dreaming) 
* RDM DPS Options by default work as a single button full operation
  *  Options to change Action binding under an "Advanced Action Options" menu.
* Melee Manification routines nested under Melee Combo routine. 
* Variant Abilities Enabled

ALL
* Added a LucidDreaming helper for the common checks (level, offcooldown, mp, etc).