### PR TITLE
[Framework] Add `Current Job Level` to debug log

### DIFF
--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -316,6 +316,7 @@ namespace XIVSlothCombo
                                 $"{Service.ClientState.LocalPlayer.ClassJob.GameData.NameEnglish} / " +                         // - EN Name
                                 $"{Service.ClientState.LocalPlayer.ClassJob.GameData.Abbreviation}");                           // - Abbreviation
                             file.WriteLine($"Current Job Index: {Service.ClientState.LocalPlayer.ClassJob.GameData.JobIndex}"); // Job Index
+                            file.WriteLine($"Current Job Level: {Service.ClientState.LocalPlayer.Level}");                      // Job Level
                             file.WriteLine("");
                             file.WriteLine($"Current Zone: {Service.ClientState.TerritoryType}");                               // Current zone location
                             file.WriteLine($"Current Party Size: {Service.PartyList.Length}");                                  // Current party size


### PR DESCRIPTION
Adds a line outputting the currently equipped job level for debugging purposes.