### PR TITLE
Ending MCH 6.2 Changes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1437,8 +1437,8 @@ namespace XIVSlothCombo.Combos
         MCH_ST_Simple_Interrupt = 8021,
 
         [ParentCombo(MCH_ST_SimpleMode)]
-        [CustomComboInfo("Simple Gadget Option", "Adds Automaton Queen or Rook Autoturret uses to the feature, based on your current level.\nAttempts to use Automaton Queen at optimal intervals between :55 to :05 windows.", MCH.JobID, 0, "", "")]
-        MCH_ST_Simple_Gadget = 8022,
+        [CustomComboInfo("Simple Automaton Queen Option", "Includes Automaton Queen in the rotation at x:00 - x:10 intervals outside of opener and 1min Queen", MCH.JobID, 0, "", "")]
+        MCH_ST_QueenThreshold = 8022,
 
         [ParentCombo(MCH_ST_SimpleMode)]
         [CustomComboInfo("Simple Assembling Option", "Pairs reassemble uses with the following skills.\nBefore acquiring Drill it will be used with Clean Shot.", MCH.JobID, 0, "", "")]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1503,6 +1503,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(MCH_AoE_SimpleMode)]
         [CustomComboInfo("Second Wind Option", "Use Second Wind when below the set HP percentage.", MCH.JobID, 0, "", "")]
         MCH_AoE_SecondWind = 8038,
+
+        [ParentCombo(MCH_ST_SimpleMode)]
+        [CustomComboInfo("Level 90 Opener Option", "Adds the Level 90 Opener to the main combo. Choose which Opener to use below.", MCH.JobID, -1, "", "")]
+        MCH_ST_Opener = 8039,
         #endregion
 
         #region MONK

--- a/XIVSlothCombo/Combos/PvE/MCH.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH.cs
@@ -492,19 +492,19 @@ namespace XIVSlothCombo.Combos.PvE
                         if (openerSelection is 0 or 1)
                         { 
                             if (//WasLastAction(Reassemble) &&
-                                IsOnCooldown(ChainSaw) && CanDelayedWeave(actionID, 1.1))
+                                IsOnCooldown(ChainSaw) && CanDelayedWeave(actionID))
                                 return Wildfire;
-                            else if (JustUsed(ChainSaw) && CombatEngageDuration().TotalMinutes >= 2)
+                            else if (JustUsed(ChainSaw) && CanDelayedWeave(actionID) && CombatEngageDuration().TotalMinutes >= 2)
                                 return Wildfire;
                         }
 
                         if (openerSelection is 2)
                         {
                             if (//WasLastAction(Reassemble) &&
-                                IsOffCooldown(ChainSaw) && (CanDelayedWeave(actionID, 1.1) || CanWeave(actionID, 0.6)))
+                                IsOffCooldown(ChainSaw) && CanDelayedWeave(actionID))
                                 return Wildfire;
                             else if (//WasLastAction(Reassemble) &&
-                                (IsOffCooldown(ChainSaw) || GetCooldownRemainingTime(ChainSaw) <= 1.6) && (CanDelayedWeave(actionID) || CanWeave(actionID)) && CombatEngageDuration().TotalMinutes >= 2)
+                                (IsOffCooldown(ChainSaw) || GetCooldownRemainingTime(ChainSaw) <= 1.9) && (CanDelayedWeave(actionID)) && CombatEngageDuration().TotalMinutes >= 2)
                                 return Wildfire;
                         }
                         // 6.2 rotation does not use Wildfire within Hypercharge windows anymore due to minor drifting. Chainsaw and WF should be right next to each other always.
@@ -636,12 +636,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
                     }
-                    // healing - please move if not appropriate priority
-                    if (IsEnabled(CustomComboPreset.MCH_ST_SecondWind) && CanWeave(actionID, 0.6))
-                    {
-                        if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.MCH_ST_SecondWindThreshold) && LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind))
-                            return All.SecondWind;
-                    }
+
                     // TOOLS & REASSEMBLE
                     if ((IsOffCooldown(AirAnchor) || GetCooldownRemainingTime(AirAnchor) < 1) && level >= Levels.AirAnchor)
                     {
@@ -650,11 +645,12 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (openerSelection is 0 or 1 & opener || 
                                 openerSelection is 2 & opener && WasLastWeaponskill(HeatedCleanShot) || 
-                               !opener && IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_AirAnchor_MaxCharges) && GetRemainingCharges(Reassemble) == GetMaxCharges(Reassemble))
+                               !opener && IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_AirAnchor_MaxCharges) && GetRemainingCharges(Reassemble) == GetMaxCharges(Reassemble) && 
+                               GetCooldownRemainingTime(ChainSaw) <= 3)
                                 //idk why someone would have 2 charges of air anchor, but this could be a pseudo-recovery thing if someone was dead super long??
                                 return Reassemble; // General Purpose Opener & protection if players don't enable Max Charges Reassemble. kinda messy code
 
-                            else if (!IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_AirAnchor_MaxCharges ) && !opener && GetCooldownRemainingTime(ChainSaw) > 2) 
+                            else if (!IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_AirAnchor_MaxCharges ) && !opener && GetCooldownRemainingTime(ChainSaw) <= 3) 
                                 return Reassemble;
 
                         }
@@ -697,12 +693,20 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling) && IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_ChainSaw) && !HasEffect(Buffs.Reassembled) &&
                             GetRemainingCharges(Reassemble) > 0)
                         {
-                            if (IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_ChainSaw_MaxCharges) && GetRemainingCharges(Reassemble) == GetMaxCharges(Reassemble)) return Reassemble;
-                            else if (!IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_ChainSaw_MaxCharges)) return Reassemble;
+                            if (IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_ChainSaw_MaxCharges) && GetRemainingCharges(Reassemble) == GetMaxCharges(Reassemble)) 
+                                return Reassemble;
+                            else if (!IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_ChainSaw_MaxCharges) && CanWeave(actionID, 0.6)) 
+                                return Reassemble;
                         }
                         return ChainSaw;
                     }
-
+                    // healing - please move if not appropriate priority
+                    // Moved 
+                    if (IsEnabled(CustomComboPreset.MCH_ST_SecondWind) && CanWeave(actionID, 0.6))
+                    {
+                        if (PlayerHealthPercentageHp() <= PluginConfiguration.GetCustomIntValue(Config.MCH_ST_SecondWindThreshold) && LevelChecked(All.SecondWind) && IsOffCooldown(All.SecondWind))
+                            return All.SecondWind;
+                    }
                     if (lastComboMove == SplitShot && level >= Levels.SlugShot)
                         return OriginalHook(SlugShot);
 

--- a/XIVSlothCombo/Combos/PvE/MCH.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH.cs
@@ -52,7 +52,8 @@ namespace XIVSlothCombo.Combos.PvE
         {
             public const string
                 MCH_ST_SecondWindThreshold = "MCH_ST_SecondWindThreshold",
-                MCH_AoE_SecondWindThreshold = "MCH_AoE_SecondWindThreshold";
+                MCH_AoE_SecondWindThreshold = "MCH_AoE_SecondWindThreshold",
+                MCH_ST_QueenThreshold = "MCH_ST_QueenThreshold";
         }
 
         public static class Levels
@@ -444,14 +445,16 @@ namespace XIVSlothCombo.Combos.PvE
 
                     }
 
-                    if (CanWeave(actionID) && openerFinished && !gauge.IsRobotActive && IsEnabled(CustomComboPreset.MCH_ST_Simple_Gadget) && (wildfireCDTime >= 2 && !WasLastAbility(Wildfire) || level < Levels.Wildfire))
+                    if (CanWeave(actionID, 0.6) && openerFinished && !gauge.IsRobotActive && IsEnabled(CustomComboPreset.MCH_ST_QueenThreshold) && (wildfireCDTime >= 2 &&
+                        !WasLastAbility(Wildfire) || level < Levels.Wildfire))
                     {
-                        //overflow protection
-                        if (level >= Levels.RookOverdrive && gauge.Battery == 100 && CombatEngageDuration().Seconds < 55)
+                        //queen slider for accurate-ish punches under buff windows
+                        if (IsEnabled(CustomComboPreset.MCH_ST_QueenThreshold) && LevelChecked(AutomatonQueen) && (CombatEngageDuration().Seconds ==
+                            PluginConfiguration.GetCustomIntValue(Config.MCH_ST_QueenThreshold) && gauge.Battery >= 50))
                         {
                             return OriginalHook(RookAutoturret);
                         }
-                        else if (level >= Levels.RookOverdrive && gauge.Battery >= 50 && (CombatEngageDuration().Seconds >= 59 || CombatEngageDuration().Seconds <= 05 || (CombatEngageDuration().Minutes == 0 && !WasLastWeaponskill(OriginalHook(CleanShot))) ))
+                        else if (level >= Levels.RookOverdrive && gauge.Battery >= 50 && (CombatEngageDuration().Minutes == 0 && !WasLastWeaponskill(OriginalHook(CleanShot))))
                         {
                             return OriginalHook(RookAutoturret);
                         }

--- a/XIVSlothCombo/Combos/PvE/MCH.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH.cs
@@ -568,7 +568,41 @@ namespace XIVSlothCombo.Combos.PvE
                             if (UseHypercharge(gauge, wildfireCDTime)) return Hypercharge; 
                         }
                     }
-
+                    //Gauss & Rico Suave
+                    if (CanWeave(actionID, 0.6) && IsEnabled(CustomComboPreset.MCH_ST_Simple_GaussRicochet))
+                    {
+                        Dalamud.Logging.PluginLog.Log("Tier 1 check");
+                        if (openerSelection is 1 && opener && IsEnabled(CustomComboPreset.MCH_ST_Opener) && CombatEngageDuration().TotalSeconds < 3.5 && WasLastWeaponskill(AirAnchor))
+                        {
+                            Dalamud.Logging.PluginLog.Log("Tier 2 check");
+                            if (HasCharges(GaussRound) && (level < Levels.Ricochet || GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
+                                return GaussRound;
+                            else if (HasCharges(Ricochet) && level >= Levels.Ricochet)
+                                return Ricochet;
+                        }
+                        if (openerSelection is 2 && opener && JustUsed(HeatedSplitShot))
+                        {
+                            if (HasCharges(GaussRound) && (level < Levels.Ricochet || GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
+                            {
+                                return GaussRound;
+                            }
+                            else if (HasCharges(Ricochet) && level >= Levels.Ricochet)
+                            {
+                                return Ricochet;
+                            }
+                        }
+                        else
+                        {
+                            if (HasCharges(GaussRound) && (level < Levels.Ricochet || GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
+                            {
+                                return GaussRound;
+                            }
+                            else if (HasCharges(Ricochet) && level >= Levels.Ricochet)
+                            {
+                                return Ricochet;
+                            }
+                        }
+                    }
                     // healing - please move if not appropriate priority
                     if (IsEnabled(CustomComboPreset.MCH_ST_SecondWind) && CanWeave(actionID, 0.6))
                     {
@@ -634,39 +668,6 @@ namespace XIVSlothCombo.Combos.PvE
                             else if (!IsEnabled(CustomComboPreset.MCH_ST_Simple_Assembling_ChainSaw_MaxCharges)) return Reassemble;
                         }
                         return ChainSaw;
-                    }
-                    //Gauss & Rico Suave
-                    if (CanWeave(actionID, 0.5) && IsEnabled(CustomComboPreset.MCH_ST_Simple_GaussRicochet))
-                    {
-                        if (openerSelection is 1 && opener && IsEnabled(CustomComboPreset.MCH_ST_Opener) && CombatEngageDuration().TotalSeconds < 3.5 && WasLastWeaponskill(AirAnchor))
-                        {
-                            if (HasCharges(GaussRound) && (level < Levels.Ricochet || GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
-                                return GaussRound; 
-                            else if (HasCharges(Ricochet) && level >= Levels.Ricochet)
-                                return Ricochet; 
-                        }
-                        if (openerSelection is 2 && opener && JustUsed(HeatedSplitShot))
-                        {
-                            if (HasCharges(GaussRound) && (level < Levels.Ricochet || GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
-                            { 
-                                return GaussRound; 
-                            }
-                            else if (HasCharges(Ricochet) && level >= Levels.Ricochet)
-                            { 
-                                return Ricochet; 
-                            }
-                        }
-                        else 
-                        {
-                            if (HasCharges(GaussRound) && (level < Levels.Ricochet || GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
-                            { 
-                                return GaussRound; 
-                            }
-                            else if (HasCharges(Ricochet) && level >= Levels.Ricochet)
-                            { 
-                                return Ricochet; 
-                            }
-                        }
                     }
 
                     if (openerSelection is 2 && !inCombat && opener && HasBattleTarget()) //this code is kinda all over the place right now. can you tell?

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1286,6 +1286,9 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.MCH_AoE_SecondWind)
                 UserConfig.DrawSliderInt(0, 100, MCH.Config.MCH_AoE_SecondWindThreshold, "Second Wind HP percentage threshold", 150, SliderIncrements.Ones);
+
+            if (preset == CustomComboPreset.MCH_ST_QueenThreshold)
+                UserConfig.DrawSliderInt(01, 10, MCH.Config.MCH_ST_QueenThreshold, "0:xx Seconds", 150, SliderIncrements.Ones);
             #endregion
             // ====================================================================================
             #region MONK

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1289,11 +1289,17 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.MCH_ST_QueenThreshold)
                 UserConfig.DrawSliderInt(01, 10, MCH.Config.MCH_ST_QueenThreshold, "0:xx Seconds", 150, SliderIncrements.Ones);
-            #endregion
-            // ====================================================================================
-            #region MONK
 
-            if (preset == CustomComboPreset.MNK_ST_SimpleMode)
+            if (preset == CustomComboPreset.MCH_ST_Opener && enabled)
+            {
+                UserConfig.DrawHorizontalRadioButton(MCH.Config.MCH_OpenerSelection, "General Purpose Opener", "Uses General Purpose Opener from 6.2. ", 1);
+                UserConfig.DrawHorizontalRadioButton(MCH.Config.MCH_OpenerSelection, "Delayed Tools Opener", "Uses Delayed Tools Opener starting from Heated Split Shot. ", 2);
+            }
+                #endregion
+                // ====================================================================================
+                #region MONK
+
+                if (preset == CustomComboPreset.MNK_ST_SimpleMode)
                 UserConfig.DrawRoundedSliderFloat(5.0f, 10.0f, MNK.Config.MNK_Demolish_Apply, "Seconds remaining before refreshing Demolish.");
 
             if (preset == CustomComboPreset.MNK_ST_SimpleMode)

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1288,7 +1288,7 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 100, MCH.Config.MCH_AoE_SecondWindThreshold, "Second Wind HP percentage threshold", 150, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.MCH_ST_QueenThreshold)
-                UserConfig.DrawSliderInt(01, 10, MCH.Config.MCH_ST_QueenThreshold, "0:xx Seconds", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(01, 10, MCH.Config.MCH_ST_QueenThreshold, " :xx Seconds ", 150, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.MCH_ST_Opener && enabled)
             {


### PR DESCRIPTION
Needed to PR due to variant updates.

General Opener option does not entirely work. 
Delayed Tools opener rotation works somewhat. If Heated Split Shot is not the first GCD, turn off&on Sloth. (There was an issue here with Reassemble which I could not figure out. )

Please use Air Anchor and Chain Saw with Reassemble on Delayed Tools opener and **not** Max Charges. Maybe removing Max Charges code would eliminate the previous issue. 

Barrel Stabilizer should be after Drill always.
Queen issues will happen if not lv90, lv90 opener option not used, and delayed tools opener not chosen. 
Stopped midway through Queen issues. I cannot find a solution to a non-combat-time based Queen. Ultimately, I came to two solutions on my own: either use before Chain Saw is up or use Queen at 50 battery (this effectively makes all your party's rdps much lower, but this isn't a parsing plugin after all). These solutions are not reflected.

Wildfire should happen before Chain Saw and after Reassemble. ie. Reassem, Wildfire, Chain Saw.