### PR TITLE
Added missing ID for tanks

### DIFF
--- a/XIVSlothCombo/Combos/PvE/Content/Bozja.cs
+++ b/XIVSlothCombo/Combos/PvE/Content/Bozja.cs
@@ -16,6 +16,7 @@
             LostFlareStar = 22352,
             LostRendArmor = 22353,
             LostSeraphStrike = 22354,
+            LostAethershield = 22355,
             LostDervish = 22356,
             LostBurst = 23909,
             LostRampage = 23910,


### PR DESCRIPTION
some odd reason I added AS as a buff but not the action ID? OOPS