### PR TITLE
[RDM] Single Target oGCD on Reprise

### DIFF
--- a/XIVSlothCombo/Combos/PvE/RDM.cs
+++ b/XIVSlothCombo/Combos/PvE/RDM.cs
@@ -44,6 +44,7 @@ namespace XIVSlothCombo.Combos.PvE
             EnchantedMoulinet = 7530,
             Corpsacorps = 7506,
             Displacement = 7515,
+            Reprise = 16529,
             MagickBarrier = 25857,
 
             //Buffs
@@ -336,7 +337,8 @@ namespace XIVSlothCombo.Combos.PvE
                           (Config.RDM_ST_oGCD_OnAction_Adv &&
                             ((Config.RDM_ST_oGCD_OnAction[0] && actionID is Jolt or Jolt2) ||
                              (Config.RDM_ST_oGCD_OnAction[1] && actionID is Fleche) ||
-                             (Config.RDM_ST_oGCD_OnAction[2] && actionID is Riposte or EnchantedRiposte)
+                             (Config.RDM_ST_oGCD_OnAction[2] && actionID is Riposte) ||
+                             (Config.RDM_ST_oGCD_OnAction[3] && actionID is Reprise)
                             )
                           )
                         );

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1557,9 +1557,10 @@ namespace XIVSlothCombo.Window.Functions
                 if (RDM.Config.RDM_ST_oGCD_OnAction_Adv)
                 {
                     ImGui.Indent();ImGui.Spacing();
-                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Jolts", "", 3, 0, descriptionColor: ImGuiColors.DalamudYellow);
-                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Fleche", "", 3, 1, descriptionColor: ImGuiColors.DalamudYellow);
-                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Riposte", "", 3, 2, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Jolts", "", 4, 0, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Fleche", "", 4, 1, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Riposte", "", 4, 2, descriptionColor: ImGuiColors.DalamudYellow);
+                    UserConfig.DrawHorizontalMultiChoice(RDM.Config.RDM_ST_oGCD_OnAction, "Reprise", "", 4, 3, descriptionColor: ImGuiColors.DalamudYellow);
                     ImGui.Unindent();
                 }
 


### PR DESCRIPTION
Added Reprise as an optional action to attach Single Target's oGCD Weave to