### PR TITLE
[RDM] Various Fixes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2529,9 +2529,9 @@ namespace XIVSlothCombo.Combos
                 [CustomComboInfo("Gap close with Corps-a-corps Option", "Use Corp-a-corps when out of melee range and you have enough mana to start the melee combo.", RDM.JobID, 430)]
                 RDM_AoE_MeleeCombo_CorpsGapCloser = 13422,
 
-                [ParentCombo(RDM_AoE_MeleeCombo)]
-                [CustomComboInfo("Unbalance Mana Option", "Use Acceleration to unbalance mana prior to starting melee combo", RDM.JobID, 410)]
-                RDM_AoE_MeleeCombo_UnbalanceMana = 13423,
+                //[ParentCombo(RDM_AoE_MeleeCombo)]
+                //[CustomComboInfo("Unbalance Mana Option", "Use Acceleration to unbalance mana prior to starting melee combo", RDM.JobID, 410)]
+                //RDM_AoE_MeleeCombo_UnbalanceMana = 13423,
 
             [ParentCombo(RDM_AoE_DPS)]
             [CustomComboInfo("Melee Finisher Option", "Add Verflare/Verholy and other finishing moves.", RDM.JobID, 510)]

--- a/XIVSlothCombo/Combos/JobHelpers/RDM.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/RDM.cs
@@ -5,6 +5,16 @@ namespace XIVSlothCombo.Combos.JobHelpers
 {
     internal class RDM
     {
+        static bool HasEffect(ushort id) => CustomComboFunctions.HasEffect(id);
+        static float GetBuffRemainingTime(ushort effectid) => CustomComboFunctions.GetBuffRemainingTime(effectid);
+        static bool LevelChecked(uint id) => CustomComboFunctions.LevelChecked(id);
+        static float GetActionCastTime(uint actionID) => CustomComboFunctions.GetActionCastTime(actionID);
+        static ushort GetRemainingCharges(uint actionID) => CustomComboFunctions.GetRemainingCharges(actionID);
+        static float GetCooldownRemainingTime(uint actionID) => CustomComboFunctions.GetCooldownRemainingTime(actionID);
+        static bool ActionReady(uint id) => CustomComboFunctions.ActionReady(id);
+        static bool CanSpellWeave(uint id) => CustomComboFunctions.CanSpellWeave(id);
+        static bool HasCharges(uint id) => CustomComboFunctions.HasCharges(id);
+
         internal class ManaBalancer : PvE.RDM
         {
             internal bool useFire;
@@ -30,8 +40,6 @@ namespace XIVSlothCombo.Combos.JobHelpers
                 //   - Resolution adds 4/4 mana
                 //2.Stay within difference limit [DONE]
                 //3.Strive to achieve correct mana for double melee combo burst [DONE]
-                static bool HasEffect(ushort id) => CustomComboFunctions.HasEffect(id);
-                static bool LevelChecked(uint id) => CustomComboFunctions.LevelChecked(id);
                 int blackmana = Gauge.BlackMana;
                 int whitemana = Gauge.WhiteMana;
                 //Reset outputs
@@ -54,10 +62,16 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     && !HasEffect(All.Buffs.Swiftcast)
                     && !HasEffect(Buffs.Acceleration))
                 {
-                    if (blackmana <= whitemana && HasEffect(Buffs.VerfireReady)) useFire = true;
-                    if (whitemana <= blackmana && HasEffect(Buffs.VerstoneReady)) useStone = true;
-                    if (!useFire && !useStone && HasEffect(Buffs.VerfireReady)) useFire = true;
-                    if (!useFire && !useStone && HasEffect(Buffs.VerstoneReady)) useStone = true;
+                    //Checking the time remaining instead of just the effect, to stop last second bad casts
+                    bool VerFireReady = GetBuffRemainingTime(Buffs.VerfireReady) >= GetActionCastTime(Verfire);
+                    bool VerStoneReady = GetBuffRemainingTime(Buffs.VerstoneReady) >= GetActionCastTime(Verstone);
+
+                    //Prioritize mana balance
+                    if (blackmana <= whitemana && VerFireReady) useFire = true;
+                    if (whitemana <= blackmana && VerStoneReady) useStone = true;
+                    //Else use the action if we can
+                    if (!useFire && !useStone && VerFireReady) useFire = true;
+                    if (!useFire && !useStone && VerStoneReady) useStone = true;
                 }
 
                 //AoE
@@ -77,9 +91,6 @@ namespace XIVSlothCombo.Combos.JobHelpers
         { 
             internal static bool CanUse(in uint lastComboMove, out uint actionID)
             {
-                static bool HasEffect(ushort id) => CustomComboFunctions.HasEffect(id);
-                static float GetBuffRemainingTime(ushort effectid) => CustomComboFunctions.GetBuffRemainingTime(effectid);
-                static bool LevelChecked(uint id) => CustomComboFunctions.LevelChecked(id);
                 int blackmana = Gauge.BlackMana;
                 int whitemana = Gauge.WhiteMana;
 
@@ -136,12 +147,6 @@ namespace XIVSlothCombo.Combos.JobHelpers
         {
             internal static bool CanUse(in uint actionID, in bool SingleTarget, out uint newActionID)
             {
-                static ushort GetRemainingCharges(uint actionID) => CustomComboFunctions.GetRemainingCharges(actionID);
-                static float GetCooldownRemainingTime(uint actionID) => CustomComboFunctions.GetCooldownRemainingTime(actionID);
-                static bool LevelChecked(uint id) => CustomComboFunctions.LevelChecked(id);
-                static bool ActionReady(uint id) => CustomComboFunctions.ActionReady(id);
-                static bool CanSpellWeave(uint id) => CustomComboFunctions.CanSpellWeave(id);
-                static bool HasCharges(uint id) => CustomComboFunctions.HasCharges(id);
                 var distance = CustomComboFunctions.GetTargetDistance();
                 
                 uint placeOGCD = 0;

--- a/XIVSlothCombo/Combos/PvE/RDM.cs
+++ b/XIVSlothCombo/Combos/PvE/RDM.cs
@@ -610,19 +610,21 @@ namespace XIVSlothCombo.Combos.PvE
                              (Config.RDM_AoE_MeleeFinisher_OnAction[1] && actionID is Moulinet or EnchantedMoulinet) ||
                              (Config.RDM_AoE_MeleeFinisher_OnAction[2] && actionID is Veraero2 or Verthunder2)));
 
+
                     if (ActionFound && MeleeFinisher.CanUse(lastComboMove, out uint finisherAction))
                         return finisherAction;
                 }
-                    //END_RDM_MELEEFINISHER
+                //END_RDM_MELEEFINISHER
 
                 //RDM_AOE_MELEECOMBO
                 if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo))
                 {
                     bool ActionFound =
-                        (!Config.RDM_ST_MeleeCombo_Adv && actionID is Scatter or Impact) ||
-                        (Config.RDM_ST_MeleeCombo_Adv &&
+                        (!Config.RDM_AoE_MeleeCombo_Adv && actionID is Scatter or Impact) ||
+                        (Config.RDM_AoE_MeleeCombo_Adv &&
                             ((Config.RDM_AoE_MeleeCombo_OnAction[0] && actionID is Scatter or Impact) ||
                                 (Config.RDM_AoE_MeleeCombo_OnAction[1] && actionID is Moulinet or EnchantedMoulinet)));
+
 
                     if (ActionFound)
                     {
@@ -692,9 +694,17 @@ namespace XIVSlothCombo.Combos.PvE
                             && !HasEffect(Buffs.Dualcast)
                             && !HasEffect(All.Buffs.Swiftcast)
                             && !HasEffect(Buffs.Acceleration)
-                            && ((Math.Min(Gauge.BlackMana, Gauge.WhiteMana) + (Gauge.ManaStacks * 20) >= 60) || (!LevelChecked(Verflare) && Math.Min(Gauge.BlackMana, Gauge.WhiteMana) >= 20))
-                            && ((GetTargetDistance() <= Config.RDM_AoE_MoulinetRange && Gauge.ManaStacks == 0) || Gauge.ManaStacks >= 1))
-                            return OriginalHook(EnchantedMoulinet);
+                            && ((Math.Min(Gauge.BlackMana, Gauge.WhiteMana) + (Gauge.ManaStacks * 20) >= 60) || 
+                                (!LevelChecked(Verflare) && Math.Min(Gauge.BlackMana, Gauge.WhiteMana) >= 20)))
+                        {
+                            if (IsEnabled(CustomComboPreset.RDM_AoE_MeleeCombo_CorpsGapCloser)
+                                && ActionReady(Corpsacorps)
+                                && GetTargetDistance() > Config.RDM_AoE_MoulinetRange)
+                                return Corpsacorps;
+
+                            if ((GetTargetDistance() <= Config.RDM_AoE_MoulinetRange && Gauge.ManaStacks == 0) || Gauge.ManaStacks >= 1)
+                            return OriginalHook(Moulinet);
+                        }
                     }
                 }
                 //END_RDM_AOE_MELEECOMBO

--- a/XIVSlothCombo/CustomCombo/Functions/Action.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Action.cs
@@ -36,6 +36,11 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns></returns>
         public static int GetLevel(uint id) => ActionWatching.GetLevel(id);
 
+        /// <summary> Get the Cast time of an action. </summary>
+        /// <param name="id"> Action ID to check. </param>
+        /// <returns> Returns the cast time of an action. </returns>
+        internal static unsafe float GetActionCastTime(uint id) => ActionWatching.GetActionCastTime(id);
+
         /// <summary> Checks if the player is in range to use an action. Best used with actions with irregular ranges.</summary>
         /// <param name="id"> ID of the action. </param>
         /// <returns></returns>

--- a/XIVSlothCombo/Data/ActionWatching.cs
+++ b/XIVSlothCombo/Data/ActionWatching.cs
@@ -222,6 +222,7 @@ namespace XIVSlothCombo.Data
         }
 
         public static int GetLevel(uint id) => ActionSheet.TryGetValue(id, out var action) && action.ClassJobCategory is not null ? action.ClassJobLevel : 255;
+        public static float GetActionCastTime(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.Cast100ms / (float)10 : 0;
         public static int GetActionRange(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.Range : -2; // 0 & -1 are valid numbers. -2 is our failure code for InActionRange
         public static int GetActionEffectRange(uint id) => ActionSheet.TryGetValue(id, out var action) ? action.EffectRange : -1;
         public static int GetTraitLevel(uint id) => TraitSheet.TryGetValue(id, out var trait) ? trait.Level : 255;


### PR DESCRIPTION
[RDM]
- Disabled AoE Unbalance Mana Option in UI. Never existed prior to code reorganization, just an accidental addition to the UI. May write it up in RDM at some point.
- AoE Corp-a-Corps: Also an accidental mistake from reorganization. Logic added to make this UI element actually do what it's supposed to do.

[Framework] Added GetActionCastTime. Pulls cast time from Action Sheet

[RDM Helper]
- ManaBalancer.CheckBalance: Replaced HasEffect checks for Verstone and Verfire with buff time remaining checks against their cast time. Stops Casting of VerStone/VerFire under 2 seconds of the buff remaining.
- Combined all forwarding functions under the root class
