### PR TITLE
Bugfix: [AST] Fixed Single Target Combust Checking

### DIFF
--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -433,7 +433,7 @@ namespace XIVSlothCombo.Combos.PvE
                         //Combust
                         if (IsEnabled(CustomComboPreset.AST_ST_DPS_CombustUptime) &&
                             !GravityList.Contains(actionID) &&
-                            ActionReady(Combust))
+                            LevelChecked(Combust))
                         {
                             //Grab current DoT via OriginalHook, grab it's fellow debuff ID from Dictionary, then check for the debuff
                             uint dot = OriginalHook(Combust);


### PR DESCRIPTION
Replaced ActionReady with LevelChecked per Taurenkey's sleuthing ( Fixes #1231 )

If it was a snake I'd be dead.