### PR TITLE
Fix "GetAttackType" for non-English clients

### DIFF
--- a/XIVSlothCombo/Data/ActionWatching.cs
+++ b/XIVSlothCombo/Data/ActionWatching.cs
@@ -244,11 +244,11 @@ namespace XIVSlothCombo.Data
         {
             if (!ActionSheet.TryGetValue(id, out var action)) return ActionAttackType.Unknown;
 
-            return action.ActionCategory.Value.Name.RawString switch
+            return action.ActionCategory.Row switch
             {
-                "Spell" => ActionAttackType.Spell,
-                "Weaponskill" => ActionAttackType.Weaponskill,
-                "Ability" => ActionAttackType.Ability,
+                2 => ActionAttackType.Spell,
+                3 => ActionAttackType.Weaponskill,
+                4 => ActionAttackType.Ability,
                 _ => ActionAttackType.Unknown
             };
         }


### PR DESCRIPTION
Past me was a baka and coded stuff as a string instead of by key. Fixed now.