### PR TITLE
[Framework] Update `ShieldValue`

### DIFF
--- a/XIVSlothCombo/Extensions/BattleCharaExtensions.cs
+++ b/XIVSlothCombo/Extensions/BattleCharaExtensions.cs
@@ -1,9 +1,4 @@
 ﻿using Dalamud.Game.ClientState.Objects.Types;
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace XIVSlothCombo.Extensions
 {
@@ -12,7 +7,7 @@ namespace XIVSlothCombo.Extensions
         public unsafe static uint RawShieldValue(this BattleChara chara)
         {
             FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara* baseVal = (FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara*)chara.Address;
-            var value = baseVal->Character.ShieldValue;
+            var value = baseVal->Character.CharacterData.ShieldValue;
             var rawValue = chara.MaxHp / 100 * value;
 
             return rawValue;
@@ -21,7 +16,7 @@ namespace XIVSlothCombo.Extensions
         public unsafe static byte ShieldPercentage(this BattleChara chara)
         {
             FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara* baseVal = (FFXIVClientStructs.FFXIV.Client.Game.Character.BattleChara*)chara.Address;
-            var value = baseVal->Character.ShieldValue;
+            var value = baseVal->Character.CharacterData.ShieldValue;
 
             return value;
         }


### PR DESCRIPTION
Apparently `Character.ShieldValue` became obsolete at some point