### PR TITLE
[DNC] Simple/Advanced Modes Rework

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -704,291 +704,371 @@ namespace XIVSlothCombo.Combos
 
         #region DANCER
 
-        #region Single Target Multibutton
         [ReplaceSkill(DNC.Cascade)]
-        [ConflictingCombos(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Single Target Multibutton Feature", "Single target combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
-        DNC_ST_MultiButton = 4000,
+        [ConflictingCombos(DNC_AdvST, DNC_LegacyFeatures)]
+        [CustomComboInfo("Simple Dancer (Single Target) Feature",
+        "Single button, single target." +
+        "\nIncludes songs, flourishes and overprotections." +
+        "\nConflicts with all other non-simple features except 'Dance Step Solver Feature'.", DNC.JobID, 0, "", "")]
+        DNC_ST_SimpleMode = 4000,
 
-            [ParentCombo(DNC_ST_MultiButton)]
-            [CustomComboInfo("ST Esprit Overcap Option", "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0, "", "")]
-            DNC_ST_EspritOvercap = 4001,
-
-            [ParentCombo(DNC_ST_MultiButton)]
-            [CustomComboInfo("Fan Dance Overcap Protection Option", "Adds Fan Dance 1 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
-            DNC_ST_FanDanceOvercap = 4003,
-
-            [ParentCombo(DNC_ST_MultiButton)]
-            [CustomComboInfo("Fan Dance Option", "Adds Fan Dance 3/4 when available.", DNC.JobID, 0, "", "")]
-            DNC_ST_FanDance34 = 4004,
-            #endregion
-
-        #region AoE Multibutton
-        [ReplaceSkill(DNC.Windmill)]
-        [ConflictingCombos(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("AoE Multibutton Feature", "AoE combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
-        DNC_AoE_MultiButton = 4010,
-
-            [ParentCombo(DNC_AoE_MultiButton)]
-            [CustomComboInfo("AoE Esprit Overcap Option", "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0, "", "")]
-            DNC_AoE_EspritOvercap = 4011,
-
-            [ParentCombo(DNC_AoE_MultiButton)]
-            [CustomComboInfo("AoE Fan Dance Overcap Protection Option", "Adds Fan Dance 2 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
-            DNC_AoE_FanDanceOvercap = 4013,
-
-            [ParentCombo(DNC_AoE_MultiButton)]
-            [CustomComboInfo("AoE Fan Dance Option", "Adds Fan Dance 3/4 when available.", DNC.JobID, 0, "", "")]
-            DNC_AoE_FanDance34 = 4014,
-            #endregion
-
-        #region Dance Features
-        [ConflictingCombos(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Dance Features", "Features and options involving Standard Step and Technical Step.\nCollapsing this category does NOT disable the features inside.", DNC.JobID, 0, "", "")]
-        DNC_Dance_Menu = 4020,
-
-            #region Combined Dance Feature
-            [ReplaceSkill(DNC.StandardStep)]
-            [ParentCombo(DNC_Dance_Menu)]
-            [ConflictingCombos(DNC_DanceStepCombo, DNC_DanceComboReplacer, DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Combined Dance Feature", "Standard And Technical Dance on one button (SS)." +
-            "\nStandard > Technical." +
-            "\nThis combos out into Tillana and Starfall Dance.", DNC.JobID, 0, "", "")]
-            DNC_CombinedDances = 4022,
-
-                [ParentCombo(DNC_CombinedDances)]
-                [CustomComboInfo("Devilment Plus Option", "Adds Devilment right after Technical finish.", DNC.JobID, 0, "", "")]
-                DNC_CombinedDances_Devilment = 4023,
-
-                [ParentCombo(DNC_CombinedDances)]
-                [CustomComboInfo("Flourish Plus Option", "Adds Flourish to the Combined Dance Feature.", DNC.JobID, 0, "", "")]
-                DNC_CombinedDances_Flourish = 4024,
-                #endregion
-
-            [ParentCombo(DNC_Dance_Menu)]
-            [ConflictingCombos(DNC_DanceStepCombo, DNC_CombinedDances, DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Custom Dance Step Feature",
-            "Change custom actions into dance steps while dancing." +
-            "\nThis helps ensure you can still dance with combos on, without using auto dance." +
-            "\nYou can change the respective actions by inputting action IDs below for each dance step." +
-            "\nThe defaults are Cascade, Flourish, Fan Dance and Fan Dance II. If set to 0, they will reset to these actions." +
-            "\nYou can get Action IDs with Garland Tools by searching for the action and clicking the cog.", DNC.JobID, 0, "", "")]
-            DNC_DanceComboReplacer = 4025,
-            #endregion
-
-        #region Flourishing Features
-        [ConflictingCombos(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Flourishing Features", "Features and options involving Fourfold Feathers and Flourish." +
-        "\nCollapsing this category does NOT disable the features inside.", DNC.JobID, 0, "", "")]
-        DNC_FlourishingFeatures_Menu = 4030,
-
-            [ReplaceSkill(DNC.Flourish)]
-            [ParentCombo(DNC_FlourishingFeatures_Menu)]
-            [ConflictingCombos(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Flourishing Fan Dance Feature", "Replace Flourish with Fan Dance 3 & 4 during weave-windows, when Flourish is on cooldown.", DNC.JobID, 0, "", "")]
-            DNC_FlourishingFanDances = 4032,
-            #endregion
-
-        #region Fan Dance Combo Features
-        [ParentCombo(DNC_FlourishingFeatures_Menu)]
-        [ConflictingCombos(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Fan Dance Combo Feature", "Options for Fan Dance combos." +
-        "\nFan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0, "", "")]
-        DNC_FanDanceCombos = 4033,
-
-            [ReplaceSkill(DNC.FanDance1)]
-            [ParentCombo(DNC_FanDanceCombos)]
-            [CustomComboInfo("Fan Dance 1 -> 3 Option", "Changes Fan Dance 1 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
-            DNC_FanDance_1to3_Combo = 4034,
-
-            [ReplaceSkill(DNC.FanDance1)]
-            [ParentCombo(DNC_FanDanceCombos)]
-            [CustomComboInfo("Fan Dance 1 -> 4 Option", "Changes Fan Dance 1 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
-            DNC_FanDance_1to4_Combo = 4035,
-
-            [ReplaceSkill(DNC.FanDance2)]
-            [ParentCombo(DNC_FanDanceCombos)]
-            [CustomComboInfo("Fan Dance 2 -> 3 Option", "Changes Fan Dance 2 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
-            DNC_FanDance_2to3_Combo = 4036,
-
-            [ReplaceSkill(DNC.FanDance2)]
-            [ParentCombo(DNC_FanDanceCombos)]
-            [CustomComboInfo("Fan Dance 2 -> 4 Option", "Changes Fan Dance 2 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
-            DNC_FanDance_2to4_Combo = 4037,
-            #endregion
-
-        // Devilment --> Starfall
-        [ReplaceSkill(DNC.Devilment)]
-        [ConflictingCombos(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Devilment to Starfall Feature", "Change Devilment into Starfall Dance after use.", DNC.JobID, 0, "", "")]
-        DNC_Starfall_Devilment = 4038,
-
-        [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
-        [ConflictingCombos(DNC_CombinedDances, DNC_DanceComboReplacer)]
-        [CustomComboInfo("Dance Step Combo Feature", "Change Standard Step and Technical Step into each dance step, while dancing." +
-        "\nWorks with Simple Dancer and Simple Dancer AoE.", DNC.JobID, 0, "", "")]
-        DNC_DanceStepCombo = 4039,
-
-        #region Simple Dancer (Single Target)
+        #region Advanced Dancer (Single Target)
         [ReplaceSkill(DNC.Cascade)]
-        [ConflictingCombos(DNC_ST_MultiButton, DNC_AoE_MultiButton, DNC_CombinedDances, DNC_DanceComboReplacer, DNC_FlourishingFeatures_Menu, DNC_Starfall_Devilment)]
-        [CustomComboInfo("Simple Dancer (Single Target) Feature", "Single button, single target. Includes songs, flourishes and overprotections." +
-        "\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
-        DNC_ST_SimpleMode = 4050,
+        [ConflictingCombos(DNC_ST_SimpleMode, DNC_LegacyFeatures)]
+        [CustomComboInfo("Advanced Dancer (Single Target) Feature",
+        "Single button, single target." +
+        "\nIncludes songs, flourishes and overprotections." +
+        "\nComplete with options for Advanced use." +
+        "\nConflicts with all other non-advanced features except 'Dance Step Solver Feature'.", DNC.JobID, 0, "", "")]
+        DNC_AdvST = 4001,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Interrupt Option", "Includes an interrupt in the rotation (if applicable to your current target).", DNC.JobID, 5, "", "")]
-            DNC_ST_Simple_Interrupt = 4051,
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Interrupt Option",
+            "Includes an interrupt in the rotation (if applicable to your current target).", DNC.JobID, 5, "", "")]
+            DNC_AdvST_Interrupt = 4002,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [ConflictingCombos(DNC_ST_Simple_StandardFill)]
-            [CustomComboInfo("Simple Standard Dance Option", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 1, "", "")]
-            DNC_ST_Simple_SS = 4052,
+            [ParentCombo(DNC_AdvST)]
+            [ConflictingCombos(DNC_AdvST_StandardFill)]
+            [CustomComboInfo("Standard Dance Option",
+            "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 1, "", "")]
+            DNC_AdvST_SS = 4003,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [ConflictingCombos(DNC_ST_Simple_SS)]
-            [CustomComboInfo("Simple Standard Fill Option", "Adds ONLY Standard dance steps and Standard Finish to the rotation." +
+            [ParentCombo(DNC_AdvST)]
+            [ConflictingCombos(DNC_AdvST_SS)]
+            [CustomComboInfo("Standard Fill Option",
+            "Adds ONLY Standard dance steps and Standard Finish to the rotation." +
             "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 1, "", "")]
-            DNC_ST_Simple_StandardFill = 4061,
+            DNC_AdvST_StandardFill = 4004,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [ConflictingCombos(DNC_ST_Simple_TechFill)]
-            [CustomComboInfo("Simple Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 2, "", "")]
-            DNC_ST_Simple_TS = 4053,
+            [ParentCombo(DNC_AdvST)]
+            [ConflictingCombos(DNC_AdvST_TechFill)]
+            [CustomComboInfo("Technical Dance Option",
+            "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 2, "", "")]
+            DNC_AdvST_TS = 4005,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [ConflictingCombos(DNC_ST_Simple_TS)]
-            [CustomComboInfo("Simple Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the rotation." +
+            [ParentCombo(DNC_AdvST)]
+            [ConflictingCombos(DNC_AdvST_TS)]
+            [CustomComboInfo("Technical Fill Option",
+            "Adds ONLY Technical dance steps and Technical Finish to the rotation." +
             "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 2, "", "")]
-            DNC_ST_Simple_TechFill = 4054,
+            DNC_AdvST_TechFill = 4006,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Tech Devilment Option", "Includes Devilment in the rotation." +
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Technical Devilment Option",
+            "Includes Devilment in the rotation." +
             "\nWill activate only during Technical Finish if you're Lv70 or above." +
             "\nWill be used on cooldown below Lv70.", DNC.JobID, 2, "", "")]
-            DNC_ST_Simple_Devilment = 4055,
+            DNC_AdvST_Devilment = 4007,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Saber Dance Option", "Includes Saber Dance in the rotation when at or over the Esprit threshold.", DNC.JobID, 3, "", "")]
-            DNC_ST_Simple_SaberDance = 4063,
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Saber Dance Option",
+            "Includes Saber Dance in the rotation when at or over the Esprit threshold.", DNC.JobID, 3, "", "")]
+            DNC_AdvST_SaberDance = 4008,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Flourish Option", "Includes Flourish in the rotation.", DNC.JobID, 3, "", "")]
-            DNC_ST_Simple_Flourish = 4056,
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Flourish Option",
+            "Includes Flourish in the rotation.", DNC.JobID, 3, "", "")]
+            DNC_AdvST_Flourish = 4009,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Feathers Option", "Expends a feather in the next available weave window when capped." +
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Feathers Option",
+            "Expends a feather in the next available weave window when capped." +
             "\nWeaves feathers where possible during Technical Finish." +
             "\nWeaves feathers outside of burst when target is below set HP percentage (Set to 0 to disable)." +
             "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 4, "", "")]
-            DNC_ST_Simple_Feathers = 4057,
+            DNC_AdvST_Feathers = 4010,
 
-            /*
-            [ParentCombo(DNC_ST_Simple_Feathers)]
-            [CustomComboInfo("Simple Feather Pooling Option", "Expends a feather in the next available weave window when capped." +
-            "\nWeaves feathers where possible during Technical Finish." +
-            "\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 4, "", "")]
-            DNC_ST_Simple_FeatherPooling = 4058,
-            */
+                /*
+                [ParentCombo(DNC_AdvST_Feathers)]
+                [CustomComboInfo("Simple Feather Pooling Option",
+                "Expends a feather in the next available weave window when capped." +
+                "\nWeaves feathers where possible during Technical Finish." +
+                "\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 4, "", "")]
+                DNC_ST_Simple_FeatherPooling = 4011,
+                */
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Panic Heals Option", "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 5, "", "")]
-            DNC_ST_Simple_PanicHeals = 4059,
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Panic Heals Option",
+            "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 5, "", "")]
+            DNC_AdvST_PanicHeals = 4012,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Improvisation Option", "Includes Improvisation in the rotation when available.", DNC.JobID, 5, "", "")]
-            DNC_ST_Simple_Improvisation = 4060,
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Improvisation Option",
+            "Includes Improvisation in the rotation when available.", DNC.JobID, 5, "", "")]
+            DNC_AdvST_Improvisation = 4013,
 
-            [ParentCombo(DNC_ST_SimpleMode)]
-            [CustomComboInfo("Simple Peloton Opener Option", "Uses Peloton when you are out of combat, do not already have the Peloton buff and are performing Standard Step with greater than 5s remaining of your dance." +
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Peloton Opener Option",
+            "Uses Peloton when you are out of combat, do not already have the Peloton buff and are performing Standard Step with greater than 5s remaining of your dance." +
             "\nWill not override Dance Step Combo Feature.", DNC.JobID, 5, "", "")]
-            DNC_ST_Simple_Peloton = 4062,
-            #endregion
+            DNC_AdvST_Peloton = 4014,
+        #endregion
 
-        #region Simple Dancer (AoE)
         [ReplaceSkill(DNC.Windmill)]
-        [ConflictingCombos(DNC_ST_MultiButton, DNC_AoE_MultiButton, DNC_CombinedDances, DNC_DanceComboReplacer, DNC_FlourishingFeatures_Menu, DNC_Starfall_Devilment)]
-        [CustomComboInfo("Simple Dancer (AoE) Feature", "Single button, AoE. Includes songs, flourishes and overprotections." +
-        "\nConflicts with all other non-simple toggles, except 'Dance Step Combo'.", DNC.JobID, 0, "", "")]
-        DNC_AoE_SimpleMode = 4070,
+        [ConflictingCombos(DNC_AdvAoE, DNC_LegacyFeatures)]
+        [CustomComboInfo("Simple Dancer (AoE) Feature",
+        "Single button, AoE." +
+        "\nIncludes songs, flourishes and overprotections." +
+        "\nConflicts with all other non-simple features except 'Dance Step Solver Feature'.", DNC.JobID, 0, "", "")]
+        DNC_AoE_SimpleMode = 4020,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Interrupt Option", "Includes an interrupt in the AoE rotation (if your current target can be interrupted).", DNC.JobID, 0, "", "")]
-            DNC_AoE_Simple_Interrupt = 4071,
+        #region Advanced Dancer (AoE)
+        [ReplaceSkill(DNC.Windmill)]
+        [ConflictingCombos(DNC_AoE_SimpleMode, DNC_LegacyFeatures)]
+        [CustomComboInfo("Advanced Dancer (AoE) Feature",
+        "Single button, AoE." +
+        "\nIncludes songs, flourishes and overprotections." +
+        "\nComplete with options for Advanced use." +
+        "\nConflicts with all other non-advanced features except 'Dance Step Solver Feature'.", DNC.JobID, 0, "", "")]
+        DNC_AdvAoE = 4021,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [ConflictingCombos(DNC_AoE_Simple_StandardFill)]
-            [CustomComboInfo("Simple AoE Standard Dance Option", "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 1, "", "")]
-            DNC_AoE_Simple_SS = 4072,
+            [ParentCombo(DNC_AdvAoE)]
+            [CustomComboInfo("AoE Interrupt Option",
+            "Includes an interrupt in the AoE rotation (if your current target can be interrupted).", DNC.JobID, 0, "", "")]
+            DNC_AdvAoE_Interrupt = 4022,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [ConflictingCombos(DNC_AoE_Simple_SS)]
-            [CustomComboInfo("Simple AoE Standard Fill Option", "Adds ONLY Standard dance steps and Standard Finish to the AoE rotation." +
+            [ParentCombo(DNC_AdvAoE)]
+            [ConflictingCombos(DNC_AdvAoE_StandardFill)]
+            [CustomComboInfo("AoE Standard Dance Option",
+            "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 1, "", "")]
+            DNC_AdvAoE_SS = 4023,
+
+            [ParentCombo(DNC_AdvAoE)]
+            [ConflictingCombos(DNC_AdvAoE_SS)]
+            [CustomComboInfo("AoE Standard Fill Option",
+            "Adds ONLY Standard dance steps and Standard Finish to the AoE rotation." +
             "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 2, "", "")]
-            DNC_AoE_Simple_StandardFill = 4081,
+            DNC_AdvAoE_StandardFill = 4024,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [ConflictingCombos(DNC_AoE_Simple_TechFill)]
-            [CustomComboInfo("Simple AoE Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the AoE rotation.", DNC.JobID, 3, "", "")]
-            DNC_AoE_Simple_TS = 4073,
+            [ParentCombo(DNC_AdvAoE)]
+            [ConflictingCombos(DNC_AdvAoE_TechFill)]
+            [CustomComboInfo("AoE Technical Dance Option",
+            "Includes Technical Step, all dance steps and Technical Finish in the AoE rotation.", DNC.JobID, 3, "", "")]
+            DNC_AdvAoE_TS = 4025,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [ConflictingCombos(DNC_AoE_Simple_TS)]
-            [CustomComboInfo("Simple AoE Tech Fill Option", "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation." +
+            [ParentCombo(DNC_AdvAoE)]
+            [ConflictingCombos(DNC_AdvAoE_TS)]
+            [CustomComboInfo("AoE Tech Fill Option",
+            "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation." +
             "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 4, "", "")]
-            DNC_AoE_Simple_TechFill = 4074,
+            DNC_AdvAoE_TechFill = 4026,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Tech Devilment Option", "Includes Devilment in the AoE rotation." +
+            [ParentCombo(DNC_AdvAoE)]
+            [CustomComboInfo("AoE Tech Devilment Option",
+            "Includes Devilment in the AoE rotation." +
             "\nWill activate only during Technical Finish if you're Lv70 or above." +
             "\nWill be used on cooldown below Lv70.", DNC.JobID, 5, "", "")]
-            DNC_AoE_Simple_Devilment = 4075,
+            DNC_AdvAoE_Devilment = 4027,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Saber Dance Option", "Includes Saber Dance in the AoE rotation when at or over the Esprit threshold.", DNC.JobID, 6, "", "")]
-            DNC_AoE_Simple_SaberDance = 4082,
+            [ParentCombo(DNC_AdvAoE)]
+            [CustomComboInfo("Saber Dance Option",
+            "Includes Saber Dance in the AoE rotation when at or over the Esprit threshold.", DNC.JobID, 6, "", "")]
+            DNC_AdvAoE_SaberDance = 4028,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Flourish Option", "Includes Flourish in the AoE rotation.", DNC.JobID, 6, "", "")]
-            DNC_AoE_Simple_Flourish = 4076,
+            [ParentCombo(DNC_AdvAoE)]
+            [CustomComboInfo("AoE Flourish Option",
+            "Includes Flourish in the AoE rotation.", DNC.JobID, 6, "", "")]
+            DNC_AdvAoE_Flourish = 4029,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Feathers Option", "Expends a feather in the next available weave window when capped." +
+            [ParentCombo(DNC_AdvAoE)]
+            [CustomComboInfo("AoE Feathers Option",
+            "Expends a feather in the next available weave window when capped." +
             "\nWeaves feathers where possible during Technical Finish." +
             "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 7, "", "")]
-            DNC_AoE_Simple_Feathers = 4077,
+            DNC_AdvAoE_Feathers = 4030,
 
-            /*
-            [ParentCombo(DNC_AoE_Simple_Feathers)]
-            [CustomComboInfo("Simple AoE Feather Pooling Option", "Expends a feather in the next available weave window when capped.", DNC.JobID, 8, "", "")]
-            DNC_AoE_Simple_FeatherPooling = 4078,
-            */
+                /*
+                [ParentCombo(DNC_AdvAoE_Feathers)]
+                [CustomComboInfo("AoE Feather Pooling Option",
+                "Expends a feather in the next available weave window when capped.", DNC.JobID, 8, "", "")]
+                DNC_AoE_Simple_FeatherPooling = 4031,
+                */
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Panic Heals Option", "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 9, "", "")]
-            DNC_AoE_Simple_PanicHeals = 4079,
+            [ParentCombo(DNC_AdvAoE)]
+            [CustomComboInfo("AoE Panic Heals Option",
+            "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 9, "", "")]
+            DNC_AdvAoE_PanicHeals = 4032,
 
-            [ParentCombo(DNC_AoE_SimpleMode)]
-            [CustomComboInfo("Simple AoE Improvisation Option", "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 10, "", "")]
-            DNC_AoE_Simple_Improvisation = 4080,
+            [ParentCombo(DNC_AdvAoE)]
+            [CustomComboInfo("AoE Improvisation Option",
+            "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 10, "", "")]
+            DNC_AdvAoE_Improvisation = 4033,
+        #endregion
+
+        [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
+        [ConflictingCombos(DNC_Dance_Menu)]
+        [CustomComboInfo("Dance Step Solver Feature",
+        "Change Standard Step and Technical Step into each dance step while dancing." +
+        "\nWorks with Simple/Advanced Dancer Single Target and AoE." +
+        "\nWorks with Legacy Features.", DNC.JobID, 0, "", "")]
+        DNC_DanceStepSolver = 4034,
+
+        #region Legacy Features (L)
+        [ConflictingCombos(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
+        [CustomComboInfo("Legacy Features",
+        "Deprecated features more closely resembling traditional XIVCombo implementation.", DNC.JobID, 0, "", "")]
+        DNC_LegacyFeatures = 4100,
+
+            #region Single Target Multibutton (L)
+            [ReplaceSkill(DNC.Cascade)]
+            [ParentCombo(DNC_LegacyFeatures)]
+            [ConflictingCombos()]
+            [CustomComboInfo("Single Target Multibutton Feature (Legacy)",
+            "Single target combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
+            DNC_ST_MultiButton = 4110,
+
+                [ParentCombo(DNC_ST_MultiButton)]
+                [CustomComboInfo("ST Esprit Overcap Option",
+                "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0, "", "")]
+                DNC_ST_EspritOvercap = 4111,
+
+                [ParentCombo(DNC_ST_MultiButton)]
+                [CustomComboInfo("Fan Dance Overcap Protection Option",
+                "Adds Fan Dance 1 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
+                DNC_ST_FanDanceOvercap = 4112,
+
+                [ParentCombo(DNC_ST_MultiButton)]
+                [CustomComboInfo("Fan Dance Option",
+                "Adds Fan Dance 3/4 when available.", DNC.JobID, 0, "", "")]
+                DNC_ST_FanDance34 = 4113,
             #endregion
 
-        #region Variant
-        [Variant]
-        [VariantParent(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown.", DNC.JobID)]
-        DNC_Variant_Rampart = 4083,
+            #region AoE Multibutton (L)
+            [ReplaceSkill(DNC.Windmill)]
+            [ParentCombo(DNC_LegacyFeatures)]
+            [ConflictingCombos()]
+            [CustomComboInfo("AoE Multibutton Feature (Legacy)",
+            "AoE combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
+            DNC_AoE_MultiButton = 4120,
 
-        [Variant]
-        [VariantParent(DNC_ST_SimpleMode, DNC_AoE_SimpleMode)]
-        [CustomComboInfo("Cure Option", "Use Variant Cure when HP is below set threshold.", DNC.JobID)]
-        DNC_Variant_Cure = 4084,
+                [ParentCombo(DNC_AoE_MultiButton)]
+                [CustomComboInfo("AoE Esprit Overcap Option",
+                "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0, "", "")]
+                DNC_AoE_EspritOvercap = 4121,
 
+                [ParentCombo(DNC_AoE_MultiButton)]
+                [CustomComboInfo("AoE Fan Dance Overcap Protection Option",
+                "Adds Fan Dance 2 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
+                DNC_AoE_FanDanceOvercap = 4122,
+
+                [ParentCombo(DNC_AoE_MultiButton)]
+                [CustomComboInfo("AoE Fan Dance Option",
+                "Adds Fan Dance 3/4 when available.", DNC.JobID, 0, "", "")]
+                DNC_AoE_FanDance34 = 4123,
+            #endregion
+
+            #region Dance Features (L)
+            [ParentCombo(DNC_LegacyFeatures)]
+            [ConflictingCombos(DNC_DanceStepSolver)]
+            [CustomComboInfo("Dance Features (Legacy)",
+            "Features and options for Standard Step and Technical Step.", DNC.JobID, 0, "", "")]
+            DNC_Dance_Menu = 4130,
+
+                #region Combined Dance Feature
+                [ReplaceSkill(DNC.StandardStep)]
+                [ParentCombo(DNC_Dance_Menu)]
+                [ConflictingCombos(DNC_DanceComboReplacer)]
+                [CustomComboInfo("Combined Dance Feature",
+                "Standard And Technical Dance on one button." +
+                "\nStandard > Technical." +
+                "\nThis combos out into Tillana and Starfall Dance.", DNC.JobID, 0, "", "")]
+                DNC_CombinedDances = 4131,
+
+                    [ParentCombo(DNC_CombinedDances)]
+                    [CustomComboInfo("Devilment Plus Option",
+                    "Adds Devilment right after Technical finish.", DNC.JobID, 0, "", "")]
+                    DNC_CombinedDances_Devilment = 4132,
+
+                    [ParentCombo(DNC_CombinedDances)]
+                    [CustomComboInfo("Flourish Plus Option",
+                    "Adds Flourish to the Combined Dance Feature.", DNC.JobID, 0, "", "")]
+                    DNC_CombinedDances_Flourish = 4133,
+                #endregion
+
+                [ParentCombo(DNC_Dance_Menu)]
+                [ConflictingCombos(DNC_CombinedDances)]
+                [CustomComboInfo("Custom Dance Step Feature",
+                "Change custom actions into dance steps while dancing." +
+                "\nThis helps ensure you can still dance with combos on, without using auto dance." +
+                "\nYou can change the respective actions by inputting action IDs below for each dance step." +
+                "\nThe defaults are Cascade, Flourish, Fan Dance and Fan Dance II. If set to 0, they will reset to these actions." +
+                "\nYou can get Action IDs with Garland Tools by searching for the action and clicking the cog.", DNC.JobID, 0, "", "")]
+                DNC_DanceComboReplacer = 4134,
+        #endregion
+
+            #region Flourishing Features (L)
+            [ParentCombo(DNC_LegacyFeatures)]
+            [ConflictingCombos()]
+            [CustomComboInfo("Flourishing Features (Legacy)",
+            "Features and options for Fourfold Feathers and Flourish.", DNC.JobID, 0, "", "")]
+            DNC_FlourishingFeatures_Menu = 4140,
+
+                [ReplaceSkill(DNC.Flourish)]
+                [ParentCombo(DNC_FlourishingFeatures_Menu)]
+                [ConflictingCombos()]
+                [CustomComboInfo("Flourishing Fan Dance Feature",
+                "Replace Flourish with Fan Dance 3 & 4 during weave-windows, when Flourish is on cooldown.", DNC.JobID, 0, "", "")]
+                DNC_FlourishingFanDances = 4141,
+
+                [ParentCombo(DNC_FlourishingFeatures_Menu)]
+                [ConflictingCombos()]
+                [CustomComboInfo("Fan Dance Combo Feature (Legacy)",
+                "Options for Fan Dance combos." +
+                "\nFan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0, "", "")]
+                DNC_FanDanceCombos = 4142,
+
+                    [ReplaceSkill(DNC.FanDance1)]
+                    [ParentCombo(DNC_FanDanceCombos)]
+                    [CustomComboInfo("Fan Dance 1 -> 3 Option",
+                    "Changes Fan Dance 1 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
+                    DNC_FanDance_1to3_Combo = 4143,
+
+                    [ReplaceSkill(DNC.FanDance1)]
+                    [ParentCombo(DNC_FanDanceCombos)]
+                    [CustomComboInfo("Fan Dance 1 -> 4 Option",
+                    "Changes Fan Dance 1 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
+                    DNC_FanDance_1to4_Combo = 4144,
+
+                    [ReplaceSkill(DNC.FanDance2)]
+                    [ParentCombo(DNC_FanDanceCombos)]
+                    [CustomComboInfo("Fan Dance 2 -> 3 Option",
+                    "Changes Fan Dance 2 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
+                    DNC_FanDance_2to3_Combo = 4145,
+
+                    [ReplaceSkill(DNC.FanDance2)]
+                    [ParentCombo(DNC_FanDanceCombos)]
+                    [CustomComboInfo("Fan Dance 2 -> 4 Option",
+                    "Changes Fan Dance 2 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
+                    DNC_FanDance_2to4_Combo = 4146,
+            #endregion
+
+            #region Devilment --> Starfall (L)
+            [ReplaceSkill(DNC.Devilment)]
+            [ParentCombo(DNC_LegacyFeatures)]
+            [ConflictingCombos()]
+            [CustomComboInfo("Devilment to Starfall Feature (Legacy)",
+            "Change Devilment into Starfall Dance after use.", DNC.JobID, 0, "", "")]
+            DNC_Starfall_Devilment = 4150,
+            #endregion
 
         #endregion
 
-        // Last value = 4084
+        #region Variant
+        [Variant]
+        [VariantParent(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
+        [CustomComboInfo("Rampart Option",
+        "Use Variant Rampart on cooldown.", DNC.JobID)]
+        DNC_Variant_Rampart = 4200,
 
+        [Variant]
+        [VariantParent(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
+        [CustomComboInfo("Cure Option",
+        "Use Variant Cure when HP is below set threshold.", DNC.JobID)]
+        DNC_VariantCure = 4201,
+
+        #endregion
+
+        // Last value = 4201
         #endregion
 
         #region DARK KNIGHT

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -724,7 +724,7 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Interrupt Option",
-            "Includes an interrupt in the rotation (if applicable to your current target).", DNC.JobID, 5, "", "")]
+            "Includes Head Graze in the rotation during the second weave window (if applicable to your current target).", DNC.JobID, 5, "", "")]
             DNC_AdvST_Interrupt = 4002,
 
             [ParentCombo(DNC_AdvST)]
@@ -735,7 +735,7 @@ namespace XIVSlothCombo.Combos
 
                 [ParentCombo(DNC_AdvST_SS)]
                 [CustomComboInfo("Standard Dance Burst Option",
-                "Includes Standard Step (and all steps) in the burst at low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.", DNC.JobID, 1, "", "")]
+                "Includes Standard Step (and all steps) in the burst with low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.", DNC.JobID, 1, "", "")]
                 DNC_AdvST_SS_Burst = 4004,
 
             [ParentCombo(DNC_AdvST)]
@@ -829,7 +829,7 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Interrupt Option",
-            "Includes an interrupt in the AoE rotation (if your current target can be interrupted).", DNC.JobID, 0, "", "")]
+            "Includes Head Graze in the AoE rotation during the second weave window (if applicable to your current target).", DNC.JobID, 0, "", "")]
             DNC_AdvAoE_Interrupt = 4022,
 
             [ParentCombo(DNC_AdvAoE)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -723,47 +723,31 @@ namespace XIVSlothCombo.Combos
         DNC_AdvST = 4001,
 
             [ParentCombo(DNC_AdvST)]
-            [ConflictingCombos(DNC_AdvST_StandardFill)]
             [CustomComboInfo("Standard Dance Option",
-            "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0)]
+            "Includes Standard Step in the rotation.", DNC.JobID, 0)]
             DNC_AdvST_SS = 4002,
 
             [ParentCombo(DNC_AdvST)]
-            [ConflictingCombos(DNC_AdvST_SS)]
-            [CustomComboInfo("Standard Fill Option",
-            "Adds ONLY Standard dance steps and Standard Finish to the rotation." +
-            "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 0)]
-            DNC_AdvST_StandardFill = 4003,
-
-            [ParentCombo(DNC_AdvST)]
-            [ConflictingCombos(DNC_AdvST_TechFill)]
             [CustomComboInfo("Technical Dance Option",
-            "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 0)]
-            DNC_AdvST_TS = 4004,
+            "Includes Technical Step in the rotation.", DNC.JobID, 0)]
+            DNC_AdvST_TS = 4003,
 
             [ParentCombo(DNC_AdvST)]
-            [ConflictingCombos(DNC_AdvST_TS)]
-            [CustomComboInfo("Technical Fill Option",
-            "Adds ONLY Technical dance steps and Technical Finish to the rotation." +
-            "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 0)]
-            DNC_AdvST_TechFill = 4005,
-
-            [ParentCombo(DNC_AdvST)]
-            [CustomComboInfo("Technical Devilment Option",
+            [CustomComboInfo("Devilment Option",
             "Includes Devilment in the rotation." +
             "\nWill activate only during Technical Finish if you're Lv70 or above." +
             "\nWill be used on cooldown below Lv70.", DNC.JobID, 0)]
-            DNC_AdvST_Devilment = 4006,
+            DNC_AdvST_Devilment = 4004,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Saber Dance Option",
             "Includes Saber Dance in the rotation when at or over the Esprit threshold.", DNC.JobID, 0)]
-            DNC_AdvST_SaberDance = 4007,
+            DNC_AdvST_SaberDance = 4005,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Flourish Option",
             "Includes Flourish in the rotation.", DNC.JobID, 0)]
-            DNC_AdvST_Flourish = 4008,
+            DNC_AdvST_Flourish = 4006,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Feathers Option",
@@ -771,7 +755,7 @@ namespace XIVSlothCombo.Combos
             "\nWeaves feathers where possible during Technical Finish." +
             "\nWeaves feathers outside of burst when target is below set HP percentage (Set to 0 to disable)." +
             "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 0)]
-            DNC_AdvST_Feathers = 4009,
+            DNC_AdvST_Feathers = 4007,
 
                 /*
                 [ParentCombo(DNC_AdvST_Feathers)]
@@ -779,30 +763,30 @@ namespace XIVSlothCombo.Combos
                 "Expends a feather in the next available weave window when capped." +
                 "\nWeaves feathers where possible during Technical Finish." +
                 "\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 0)]
-                DNC_ST_Simple_FeatherPooling = 4010,
+                DNC_ST_Simple_FeatherPooling = 4008,
                 */
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Panic Heals Option",
             "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages." +
             "\nSet to 0 to disable.", DNC.JobID, 0)]
-            DNC_AdvST_PanicHeals = 4010,
+            DNC_AdvST_PanicHeals = 4009,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Peloton Opener Option",
             "Uses Peloton when you are out of combat, do not already have the Peloton buff and are performing Standard Step with greater than 5s remaining of your dance." +
             "\nWill not override Dance Step Combo Feature.", DNC.JobID, 0)]
-            DNC_AdvST_Peloton = 4011,
+            DNC_AdvST_Peloton = 4010,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Interrupt Option",
             "Includes Head Graze in the rotation during the second weave window (if applicable to your current target).", DNC.JobID, 0)]
-            DNC_AdvST_Interrupt = 4012,
+            DNC_AdvST_Interrupt = 4011,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Improvisation Option",
             "Includes Improvisation in the rotation when available.", DNC.JobID, 0)]
-            DNC_AdvST_Improvisation = 4013,
+            DNC_AdvST_Improvisation = 4012,
         #endregion
 
         [ReplaceSkill(DNC.Windmill)]
@@ -824,77 +808,61 @@ namespace XIVSlothCombo.Combos
         DNC_AdvAoE = 4021,
 
             [ParentCombo(DNC_AdvAoE)]
-            [ConflictingCombos(DNC_AdvAoE_StandardFill)]
             [CustomComboInfo("AoE Standard Dance Option",
-            "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0)]
+            "Includes Standard Step in the AoE rotation.", DNC.JobID, 0)]
             DNC_AdvAoE_SS = 4022,
 
             [ParentCombo(DNC_AdvAoE)]
-            [ConflictingCombos(DNC_AdvAoE_SS)]
-            [CustomComboInfo("AoE Standard Fill Option",
-            "Adds ONLY Standard dance steps and Standard Finish to the AoE rotation." +
-            "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 0)]
-            DNC_AdvAoE_StandardFill = 4023,
-
-            [ParentCombo(DNC_AdvAoE)]
-            [ConflictingCombos(DNC_AdvAoE_TechFill)]
             [CustomComboInfo("AoE Technical Dance Option",
-            "Includes Technical Step, all dance steps and Technical Finish in the AoE rotation.", DNC.JobID, 0)]
-            DNC_AdvAoE_TS = 4024,
-
-            [ParentCombo(DNC_AdvAoE)]
-            [ConflictingCombos(DNC_AdvAoE_TS)]
-            [CustomComboInfo("AoE Tech Fill Option",
-            "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation." +
-            "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 0)]
-            DNC_AdvAoE_TechFill = 4025,
+            "Includes Technical Step in the AoE rotation.", DNC.JobID, 0)]
+            DNC_AdvAoE_TS = 4023,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Tech Devilment Option",
             "Includes Devilment in the AoE rotation." +
             "\nWill activate only during Technical Finish if you're Lv70 or above." +
             "\nWill be used on cooldown below Lv70.", DNC.JobID, 0)]
-            DNC_AdvAoE_Devilment = 4026,
+            DNC_AdvAoE_Devilment = 4024,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Saber Dance Option",
             "Includes Saber Dance in the AoE rotation when at or over the Esprit threshold.", DNC.JobID, 0)]
-            DNC_AdvAoE_SaberDance = 4027,
+            DNC_AdvAoE_SaberDance = 4025,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Flourish Option",
             "Includes Flourish in the AoE rotation.", DNC.JobID, 0)]
-            DNC_AdvAoE_Flourish = 4028,
+            DNC_AdvAoE_Flourish = 4026,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Feathers Option",
             "Expends a feather in the next available weave window when capped." +
             "\nWeaves feathers where possible during Technical Finish." +
             "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 0)]
-            DNC_AdvAoE_Feathers = 4029,
+            DNC_AdvAoE_Feathers = 4027,
 
                 /*
                 [ParentCombo(DNC_AdvAoE_Feathers)]
                 [CustomComboInfo("AoE Feather Pooling Option",
                 "Expends a feather in the next available weave window when capped.", DNC.JobID, 0)]
-                DNC_AoE_Simple_FeatherPooling = 4030,
+                DNC_AoE_Simple_FeatherPooling = 4028,
                 */
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Panic Heals Option",
             "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages." +
             "\nSet to 0 to disable.", DNC.JobID, 0)]
-            DNC_AdvAoE_PanicHeals = 4030,
+            DNC_AdvAoE_PanicHeals = 4029,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Interrupt Option",
             "Includes Head Graze in the AoE rotation during the second weave window (if applicable to your current target).", DNC.JobID, 0)]
-            DNC_AdvAoE_Interrupt = 4031,
+            DNC_AdvAoE_Interrupt = 4030,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Improvisation Option",
             "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 0)]
-            DNC_AdvAoE_Improvisation = 4032,
+            DNC_AdvAoE_Improvisation = 4031,
         #endregion
 
         [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -818,7 +818,7 @@ namespace XIVSlothCombo.Combos
             DNC_AdvAoE_TS = 4023,
 
             [ParentCombo(DNC_AdvAoE)]
-            [CustomComboInfo("AoE Tech Devilment Option",
+            [CustomComboInfo("AoE Devilment Option",
             "Includes Devilment in the AoE rotation." +
             "\nWill activate only during Technical Finish if you're Lv70 or above." +
             "\nWill be used on cooldown below Lv70.", DNC.JobID, 0)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -838,66 +838,71 @@ namespace XIVSlothCombo.Combos
             "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 1, "", "")]
             DNC_AdvAoE_SS = 4023,
 
+                [ParentCombo(DNC_AdvAoE_SS)]
+                [CustomComboInfo("AoE Standard Dance Burst Option",
+                "Includes Standard Step (and all steps) in the burst at low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.", DNC.JobID, 1, "", "")]
+                DNC_AdvAoE_SS_Burst = 4024,
+
             [ParentCombo(DNC_AdvAoE)]
             [ConflictingCombos(DNC_AdvAoE_SS)]
             [CustomComboInfo("AoE Standard Fill Option",
             "Adds ONLY Standard dance steps and Standard Finish to the AoE rotation." +
             "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 2, "", "")]
-            DNC_AdvAoE_StandardFill = 4024,
+            DNC_AdvAoE_StandardFill = 4025,
 
             [ParentCombo(DNC_AdvAoE)]
             [ConflictingCombos(DNC_AdvAoE_TechFill)]
             [CustomComboInfo("AoE Technical Dance Option",
             "Includes Technical Step, all dance steps and Technical Finish in the AoE rotation.", DNC.JobID, 3, "", "")]
-            DNC_AdvAoE_TS = 4025,
+            DNC_AdvAoE_TS = 4026,
 
             [ParentCombo(DNC_AdvAoE)]
             [ConflictingCombos(DNC_AdvAoE_TS)]
             [CustomComboInfo("AoE Tech Fill Option",
             "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation." +
             "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 4, "", "")]
-            DNC_AdvAoE_TechFill = 4026,
+            DNC_AdvAoE_TechFill = 4027,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Tech Devilment Option",
             "Includes Devilment in the AoE rotation." +
             "\nWill activate only during Technical Finish if you're Lv70 or above." +
             "\nWill be used on cooldown below Lv70.", DNC.JobID, 5, "", "")]
-            DNC_AdvAoE_Devilment = 4027,
+            DNC_AdvAoE_Devilment = 4028,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("Saber Dance Option",
             "Includes Saber Dance in the AoE rotation when at or over the Esprit threshold.", DNC.JobID, 6, "", "")]
-            DNC_AdvAoE_SaberDance = 4028,
+            DNC_AdvAoE_SaberDance = 4029,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Flourish Option",
             "Includes Flourish in the AoE rotation.", DNC.JobID, 6, "", "")]
-            DNC_AdvAoE_Flourish = 4029,
+            DNC_AdvAoE_Flourish = 4030,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Feathers Option",
             "Expends a feather in the next available weave window when capped." +
             "\nWeaves feathers where possible during Technical Finish." +
             "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 7, "", "")]
-            DNC_AdvAoE_Feathers = 4030,
+            DNC_AdvAoE_Feathers = 4031,
 
                 /*
                 [ParentCombo(DNC_AdvAoE_Feathers)]
                 [CustomComboInfo("AoE Feather Pooling Option",
                 "Expends a feather in the next available weave window when capped.", DNC.JobID, 8, "", "")]
-                DNC_AoE_Simple_FeatherPooling = 4031,
+                DNC_AoE_Simple_FeatherPooling = 4032,
                 */
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Panic Heals Option",
             "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 9, "", "")]
-            DNC_AdvAoE_PanicHeals = 4032,
+            DNC_AdvAoE_PanicHeals = 4033,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Improvisation Option",
             "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 10, "", "")]
-            DNC_AdvAoE_Improvisation = 4033,
+            DNC_AdvAoE_Improvisation = 4034,
         #endregion
 
         [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
@@ -906,7 +911,7 @@ namespace XIVSlothCombo.Combos
         "Change Standard Step and Technical Step into each dance step while dancing." +
         "\nWorks with Simple/Advanced Dancer Single Target and AoE." +
         "\nWorks with Legacy Features.", DNC.JobID, 0, "", "")]
-        DNC_DanceStepSolver = 4034,
+        DNC_DanceStepSolver = 4040,
 
         #region Legacy Features (L)
         [ConflictingCombos(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -733,42 +733,47 @@ namespace XIVSlothCombo.Combos
             "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 1, "", "")]
             DNC_AdvST_SS = 4003,
 
+                [ParentCombo(DNC_AdvST_SS)]
+                [CustomComboInfo("Standard Dance Burst Option",
+                "Includes Standard Step (and all steps) in the burst at low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.", DNC.JobID, 1, "", "")]
+                DNC_AdvST_SS_Burst = 4004,
+
             [ParentCombo(DNC_AdvST)]
             [ConflictingCombos(DNC_AdvST_SS)]
             [CustomComboInfo("Standard Fill Option",
             "Adds ONLY Standard dance steps and Standard Finish to the rotation." +
             "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 1, "", "")]
-            DNC_AdvST_StandardFill = 4004,
+            DNC_AdvST_StandardFill = 4005,
 
             [ParentCombo(DNC_AdvST)]
             [ConflictingCombos(DNC_AdvST_TechFill)]
             [CustomComboInfo("Technical Dance Option",
             "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 2, "", "")]
-            DNC_AdvST_TS = 4005,
+            DNC_AdvST_TS = 4006,
 
             [ParentCombo(DNC_AdvST)]
             [ConflictingCombos(DNC_AdvST_TS)]
             [CustomComboInfo("Technical Fill Option",
             "Adds ONLY Technical dance steps and Technical Finish to the rotation." +
             "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 2, "", "")]
-            DNC_AdvST_TechFill = 4006,
+            DNC_AdvST_TechFill = 4007,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Technical Devilment Option",
             "Includes Devilment in the rotation." +
             "\nWill activate only during Technical Finish if you're Lv70 or above." +
             "\nWill be used on cooldown below Lv70.", DNC.JobID, 2, "", "")]
-            DNC_AdvST_Devilment = 4007,
+            DNC_AdvST_Devilment = 4008,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Saber Dance Option",
             "Includes Saber Dance in the rotation when at or over the Esprit threshold.", DNC.JobID, 3, "", "")]
-            DNC_AdvST_SaberDance = 4008,
+            DNC_AdvST_SaberDance = 4009,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Flourish Option",
             "Includes Flourish in the rotation.", DNC.JobID, 3, "", "")]
-            DNC_AdvST_Flourish = 4009,
+            DNC_AdvST_Flourish = 4010,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Feathers Option",
@@ -776,7 +781,7 @@ namespace XIVSlothCombo.Combos
             "\nWeaves feathers where possible during Technical Finish." +
             "\nWeaves feathers outside of burst when target is below set HP percentage (Set to 0 to disable)." +
             "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 4, "", "")]
-            DNC_AdvST_Feathers = 4010,
+            DNC_AdvST_Feathers = 4011,
 
                 /*
                 [ParentCombo(DNC_AdvST_Feathers)]
@@ -784,24 +789,24 @@ namespace XIVSlothCombo.Combos
                 "Expends a feather in the next available weave window when capped." +
                 "\nWeaves feathers where possible during Technical Finish." +
                 "\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 4, "", "")]
-                DNC_ST_Simple_FeatherPooling = 4011,
+                DNC_ST_Simple_FeatherPooling = 4012,
                 */
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Panic Heals Option",
             "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 5, "", "")]
-            DNC_AdvST_PanicHeals = 4012,
+            DNC_AdvST_PanicHeals = 4013,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Improvisation Option",
             "Includes Improvisation in the rotation when available.", DNC.JobID, 5, "", "")]
-            DNC_AdvST_Improvisation = 4013,
+            DNC_AdvST_Improvisation = 4014,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Peloton Opener Option",
             "Uses Peloton when you are out of combat, do not already have the Peloton buff and are performing Standard Step with greater than 5s remaining of your dance." +
             "\nWill not override Dance Step Combo Feature.", DNC.JobID, 5, "", "")]
-            DNC_AdvST_Peloton = 4014,
+            DNC_AdvST_Peloton = 4015,
         #endregion
 
         [ReplaceSkill(DNC.Windmill)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -709,7 +709,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Dancer (Single Target) Feature",
         "Single button, single target." +
         "\nIncludes songs, flourishes and overprotections." +
-        "\nConflicts with all other non-simple features except 'Dance Step Solver Feature'.", DNC.JobID, 0, "", "")]
+        "\nConflicts with all other non-simple features except 'Dance Step Solver Feature'.", DNC.JobID, 0)]
         DNC_ST_SimpleMode = 4000,
 
         #region Advanced Dancer (Single Target)
@@ -719,94 +719,90 @@ namespace XIVSlothCombo.Combos
         "Single button, single target." +
         "\nIncludes songs, flourishes and overprotections." +
         "\nComplete with options for Advanced use." +
-        "\nConflicts with all other non-advanced features except 'Dance Step Solver Feature'.", DNC.JobID, 0, "", "")]
+        "\nConflicts with all other non-advanced features except 'Dance Step Solver Feature'.", DNC.JobID, 0)]
         DNC_AdvST = 4001,
-
-            [ParentCombo(DNC_AdvST)]
-            [CustomComboInfo("Interrupt Option",
-            "Includes Head Graze in the rotation during the second weave window (if applicable to your current target).", DNC.JobID, 5, "", "")]
-            DNC_AdvST_Interrupt = 4002,
 
             [ParentCombo(DNC_AdvST)]
             [ConflictingCombos(DNC_AdvST_StandardFill)]
             [CustomComboInfo("Standard Dance Option",
-            "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 1, "", "")]
-            DNC_AdvST_SS = 4003,
-
-                [ParentCombo(DNC_AdvST_SS)]
-                [CustomComboInfo("Standard Dance Burst Option",
-                "Includes Standard Step (and all steps) in the burst with low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.", DNC.JobID, 1, "", "")]
-                DNC_AdvST_SS_Burst = 4004,
+            "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 0)]
+            DNC_AdvST_SS = 4002,
 
             [ParentCombo(DNC_AdvST)]
             [ConflictingCombos(DNC_AdvST_SS)]
             [CustomComboInfo("Standard Fill Option",
             "Adds ONLY Standard dance steps and Standard Finish to the rotation." +
-            "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 1, "", "")]
-            DNC_AdvST_StandardFill = 4005,
+            "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 0)]
+            DNC_AdvST_StandardFill = 4003,
 
             [ParentCombo(DNC_AdvST)]
             [ConflictingCombos(DNC_AdvST_TechFill)]
             [CustomComboInfo("Technical Dance Option",
-            "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 2, "", "")]
-            DNC_AdvST_TS = 4006,
+            "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 0)]
+            DNC_AdvST_TS = 4004,
 
             [ParentCombo(DNC_AdvST)]
             [ConflictingCombos(DNC_AdvST_TS)]
             [CustomComboInfo("Technical Fill Option",
             "Adds ONLY Technical dance steps and Technical Finish to the rotation." +
-            "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 2, "", "")]
-            DNC_AdvST_TechFill = 4007,
+            "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 0)]
+            DNC_AdvST_TechFill = 4005,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Technical Devilment Option",
             "Includes Devilment in the rotation." +
             "\nWill activate only during Technical Finish if you're Lv70 or above." +
-            "\nWill be used on cooldown below Lv70.", DNC.JobID, 2, "", "")]
-            DNC_AdvST_Devilment = 4008,
+            "\nWill be used on cooldown below Lv70.", DNC.JobID, 0)]
+            DNC_AdvST_Devilment = 4006,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Saber Dance Option",
-            "Includes Saber Dance in the rotation when at or over the Esprit threshold.", DNC.JobID, 3, "", "")]
-            DNC_AdvST_SaberDance = 4009,
+            "Includes Saber Dance in the rotation when at or over the Esprit threshold.", DNC.JobID, 0)]
+            DNC_AdvST_SaberDance = 4007,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Flourish Option",
-            "Includes Flourish in the rotation.", DNC.JobID, 3, "", "")]
-            DNC_AdvST_Flourish = 4010,
+            "Includes Flourish in the rotation.", DNC.JobID, 0)]
+            DNC_AdvST_Flourish = 4008,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Feathers Option",
             "Expends a feather in the next available weave window when capped." +
             "\nWeaves feathers where possible during Technical Finish." +
             "\nWeaves feathers outside of burst when target is below set HP percentage (Set to 0 to disable)." +
-            "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 4, "", "")]
-            DNC_AdvST_Feathers = 4011,
+            "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 0)]
+            DNC_AdvST_Feathers = 4009,
 
                 /*
                 [ParentCombo(DNC_AdvST_Feathers)]
                 [CustomComboInfo("Simple Feather Pooling Option",
                 "Expends a feather in the next available weave window when capped." +
                 "\nWeaves feathers where possible during Technical Finish." +
-                "\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 4, "", "")]
-                DNC_ST_Simple_FeatherPooling = 4012,
+                "\nWeaves feathers outside of burst when target is below set HP percentage.", DNC.JobID, 0)]
+                DNC_ST_Simple_FeatherPooling = 4010,
                 */
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Panic Heals Option",
-            "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages.", DNC.JobID, 5, "", "")]
-            DNC_AdvST_PanicHeals = 4013,
-
-            [ParentCombo(DNC_AdvST)]
-            [CustomComboInfo("Improvisation Option",
-            "Includes Improvisation in the rotation when available.", DNC.JobID, 5, "", "")]
-            DNC_AdvST_Improvisation = 4014,
+            "Includes Curing Waltz and Second Wind in the rotation when available and your HP is below the set percentages." +
+            "\nSet to 0 to disable.", DNC.JobID, 0)]
+            DNC_AdvST_PanicHeals = 4010,
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Peloton Opener Option",
             "Uses Peloton when you are out of combat, do not already have the Peloton buff and are performing Standard Step with greater than 5s remaining of your dance." +
-            "\nWill not override Dance Step Combo Feature.", DNC.JobID, 5, "", "")]
-            DNC_AdvST_Peloton = 4015,
+            "\nWill not override Dance Step Combo Feature.", DNC.JobID, 0)]
+            DNC_AdvST_Peloton = 4011,
+
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Interrupt Option",
+            "Includes Head Graze in the rotation during the second weave window (if applicable to your current target).", DNC.JobID, 0)]
+            DNC_AdvST_Interrupt = 4012,
+
+            [ParentCombo(DNC_AdvST)]
+            [CustomComboInfo("Improvisation Option",
+            "Includes Improvisation in the rotation when available.", DNC.JobID, 0)]
+            DNC_AdvST_Improvisation = 4013,
         #endregion
 
         [ReplaceSkill(DNC.Windmill)]
@@ -814,7 +810,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Dancer (AoE) Feature",
         "Single button, AoE." +
         "\nIncludes songs, flourishes and overprotections." +
-        "\nConflicts with all other non-simple features except 'Dance Step Solver Feature'.", DNC.JobID, 0, "", "")]
+        "\nConflicts with all other non-simple features except 'Dance Step Solver Feature'.", DNC.JobID, 0)]
         DNC_AoE_SimpleMode = 4020,
 
         #region Advanced Dancer (AoE)
@@ -824,85 +820,81 @@ namespace XIVSlothCombo.Combos
         "Single button, AoE." +
         "\nIncludes songs, flourishes and overprotections." +
         "\nComplete with options for Advanced use." +
-        "\nConflicts with all other non-advanced features except 'Dance Step Solver Feature'.", DNC.JobID, 0, "", "")]
+        "\nConflicts with all other non-advanced features except 'Dance Step Solver Feature'.", DNC.JobID, 0)]
         DNC_AdvAoE = 4021,
-
-            [ParentCombo(DNC_AdvAoE)]
-            [CustomComboInfo("AoE Interrupt Option",
-            "Includes Head Graze in the AoE rotation during the second weave window (if applicable to your current target).", DNC.JobID, 0, "", "")]
-            DNC_AdvAoE_Interrupt = 4022,
 
             [ParentCombo(DNC_AdvAoE)]
             [ConflictingCombos(DNC_AdvAoE_StandardFill)]
             [CustomComboInfo("AoE Standard Dance Option",
-            "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 1, "", "")]
-            DNC_AdvAoE_SS = 4023,
-
-                [ParentCombo(DNC_AdvAoE_SS)]
-                [CustomComboInfo("AoE Standard Dance Burst Option",
-                "Includes Standard Step (and all steps) in the burst at low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.", DNC.JobID, 1, "", "")]
-                DNC_AdvAoE_SS_Burst = 4024,
+            "Includes Standard Step (and all steps) in the AoE rotation.", DNC.JobID, 0)]
+            DNC_AdvAoE_SS = 4022,
 
             [ParentCombo(DNC_AdvAoE)]
             [ConflictingCombos(DNC_AdvAoE_SS)]
             [CustomComboInfo("AoE Standard Fill Option",
             "Adds ONLY Standard dance steps and Standard Finish to the AoE rotation." +
-            "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 2, "", "")]
-            DNC_AdvAoE_StandardFill = 4025,
+            "\nStandard Step itself must be initiated manually when using this option.", DNC.JobID, 0)]
+            DNC_AdvAoE_StandardFill = 4023,
 
             [ParentCombo(DNC_AdvAoE)]
             [ConflictingCombos(DNC_AdvAoE_TechFill)]
             [CustomComboInfo("AoE Technical Dance Option",
-            "Includes Technical Step, all dance steps and Technical Finish in the AoE rotation.", DNC.JobID, 3, "", "")]
-            DNC_AdvAoE_TS = 4026,
+            "Includes Technical Step, all dance steps and Technical Finish in the AoE rotation.", DNC.JobID, 0)]
+            DNC_AdvAoE_TS = 4024,
 
             [ParentCombo(DNC_AdvAoE)]
             [ConflictingCombos(DNC_AdvAoE_TS)]
             [CustomComboInfo("AoE Tech Fill Option",
             "Adds ONLY Technical dance steps and Technical Finish to the AoE rotation." +
-            "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 4, "", "")]
-            DNC_AdvAoE_TechFill = 4027,
+            "\nTechnical Step itself must be initiated manually when using this option.", DNC.JobID, 0)]
+            DNC_AdvAoE_TechFill = 4025,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Tech Devilment Option",
             "Includes Devilment in the AoE rotation." +
             "\nWill activate only during Technical Finish if you're Lv70 or above." +
-            "\nWill be used on cooldown below Lv70.", DNC.JobID, 5, "", "")]
-            DNC_AdvAoE_Devilment = 4028,
+            "\nWill be used on cooldown below Lv70.", DNC.JobID, 0)]
+            DNC_AdvAoE_Devilment = 4026,
 
             [ParentCombo(DNC_AdvAoE)]
-            [CustomComboInfo("Saber Dance Option",
-            "Includes Saber Dance in the AoE rotation when at or over the Esprit threshold.", DNC.JobID, 6, "", "")]
-            DNC_AdvAoE_SaberDance = 4029,
+            [CustomComboInfo("AoE Saber Dance Option",
+            "Includes Saber Dance in the AoE rotation when at or over the Esprit threshold.", DNC.JobID, 0)]
+            DNC_AdvAoE_SaberDance = 4027,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Flourish Option",
-            "Includes Flourish in the AoE rotation.", DNC.JobID, 6, "", "")]
-            DNC_AdvAoE_Flourish = 4030,
+            "Includes Flourish in the AoE rotation.", DNC.JobID, 0)]
+            DNC_AdvAoE_Flourish = 4028,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Feathers Option",
             "Expends a feather in the next available weave window when capped." +
             "\nWeaves feathers where possible during Technical Finish." +
-            "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 7, "", "")]
-            DNC_AdvAoE_Feathers = 4031,
+            "\nWeaves feathers whenever available when under Lv.70.", DNC.JobID, 0)]
+            DNC_AdvAoE_Feathers = 4029,
 
                 /*
                 [ParentCombo(DNC_AdvAoE_Feathers)]
                 [CustomComboInfo("AoE Feather Pooling Option",
-                "Expends a feather in the next available weave window when capped.", DNC.JobID, 8, "", "")]
-                DNC_AoE_Simple_FeatherPooling = 4032,
+                "Expends a feather in the next available weave window when capped.", DNC.JobID, 0)]
+                DNC_AoE_Simple_FeatherPooling = 4030,
                 */
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Panic Heals Option",
-            "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages.", DNC.JobID, 9, "", "")]
-            DNC_AdvAoE_PanicHeals = 4033,
+            "Includes Curing Waltz and Second Wind in the AoE rotation when available and your HP is below the set percentages." +
+            "\nSet to 0 to disable.", DNC.JobID, 0)]
+            DNC_AdvAoE_PanicHeals = 4030,
+
+            [ParentCombo(DNC_AdvAoE)]
+            [CustomComboInfo("AoE Interrupt Option",
+            "Includes Head Graze in the AoE rotation during the second weave window (if applicable to your current target).", DNC.JobID, 0)]
+            DNC_AdvAoE_Interrupt = 4031,
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Improvisation Option",
-            "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 10, "", "")]
-            DNC_AdvAoE_Improvisation = 4034,
+            "Includes Improvisation in the AoE rotation when available.", DNC.JobID, 0)]
+            DNC_AdvAoE_Improvisation = 4032,
         #endregion
 
         [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
@@ -910,13 +902,13 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Dance Step Solver Feature",
         "Change Standard Step and Technical Step into each dance step while dancing." +
         "\nWorks with Simple/Advanced Dancer Single Target and AoE." +
-        "\nWorks with Legacy Features.", DNC.JobID, 0, "", "")]
+        "\nWorks with Legacy Features.", DNC.JobID, 0)]
         DNC_DanceStepSolver = 4040,
 
         #region Legacy Features (L)
         [ConflictingCombos(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
         [CustomComboInfo("Legacy Features",
-        "Deprecated features more closely resembling traditional XIVCombo implementation.", DNC.JobID, 0, "", "")]
+        "Deprecated features more closely resembling traditional XIVCombo implementation.", DNC.JobID, 0)]
         DNC_LegacyFeatures = 4100,
 
             #region Single Target Multibutton (L)
@@ -924,22 +916,22 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos()]
             [CustomComboInfo("Single Target Multibutton Feature (Legacy)",
-            "Single target combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
+            "Single target combo with Fan Dances and Esprit use.", DNC.JobID, 0)]
             DNC_ST_MultiButton = 4110,
 
                 [ParentCombo(DNC_ST_MultiButton)]
                 [CustomComboInfo("ST Esprit Overcap Option",
-                "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0, "", "")]
+                "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0)]
                 DNC_ST_EspritOvercap = 4111,
 
                 [ParentCombo(DNC_ST_MultiButton)]
                 [CustomComboInfo("Fan Dance Overcap Protection Option",
-                "Adds Fan Dance 1 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
+                "Adds Fan Dance 1 when Fourfold Feathers are full.", DNC.JobID, 0)]
                 DNC_ST_FanDanceOvercap = 4112,
 
                 [ParentCombo(DNC_ST_MultiButton)]
                 [CustomComboInfo("Fan Dance Option",
-                "Adds Fan Dance 3/4 when available.", DNC.JobID, 0, "", "")]
+                "Adds Fan Dance 3/4 when available.", DNC.JobID, 0)]
                 DNC_ST_FanDance34 = 4113,
             #endregion
 
@@ -948,22 +940,22 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos()]
             [CustomComboInfo("AoE Multibutton Feature (Legacy)",
-            "AoE combo with Fan Dances and Esprit use.", DNC.JobID, 0, "", "")]
+            "AoE combo with Fan Dances and Esprit use.", DNC.JobID, 0)]
             DNC_AoE_MultiButton = 4120,
 
                 [ParentCombo(DNC_AoE_MultiButton)]
                 [CustomComboInfo("AoE Esprit Overcap Option",
-                "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0, "", "")]
+                "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0)]
                 DNC_AoE_EspritOvercap = 4121,
 
                 [ParentCombo(DNC_AoE_MultiButton)]
                 [CustomComboInfo("AoE Fan Dance Overcap Protection Option",
-                "Adds Fan Dance 2 when Fourfold Feathers are full.", DNC.JobID, 0, "", "")]
+                "Adds Fan Dance 2 when Fourfold Feathers are full.", DNC.JobID, 0)]
                 DNC_AoE_FanDanceOvercap = 4122,
 
                 [ParentCombo(DNC_AoE_MultiButton)]
                 [CustomComboInfo("AoE Fan Dance Option",
-                "Adds Fan Dance 3/4 when available.", DNC.JobID, 0, "", "")]
+                "Adds Fan Dance 3/4 when available.", DNC.JobID, 0)]
                 DNC_AoE_FanDance34 = 4123,
             #endregion
 
@@ -971,29 +963,27 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos(DNC_DanceStepSolver)]
             [CustomComboInfo("Dance Features (Legacy)",
-            "Features and options for Standard Step and Technical Step.", DNC.JobID, 0, "", "")]
+            "Features and options for Standard Step and Technical Step.", DNC.JobID, 0)]
             DNC_Dance_Menu = 4130,
 
-                #region Combined Dance Feature
                 [ReplaceSkill(DNC.StandardStep)]
                 [ParentCombo(DNC_Dance_Menu)]
                 [ConflictingCombos(DNC_DanceComboReplacer)]
                 [CustomComboInfo("Combined Dance Feature",
                 "Standard And Technical Dance on one button." +
                 "\nStandard > Technical." +
-                "\nThis combos out into Tillana and Starfall Dance.", DNC.JobID, 0, "", "")]
+                "\nThis combos out into Tillana and Starfall Dance.", DNC.JobID, 0)]
                 DNC_CombinedDances = 4131,
 
                     [ParentCombo(DNC_CombinedDances)]
                     [CustomComboInfo("Devilment Plus Option",
-                    "Adds Devilment right after Technical finish.", DNC.JobID, 0, "", "")]
+                    "Adds Devilment right after Technical finish.", DNC.JobID, 0)]
                     DNC_CombinedDances_Devilment = 4132,
 
                     [ParentCombo(DNC_CombinedDances)]
                     [CustomComboInfo("Flourish Plus Option",
-                    "Adds Flourish to the Combined Dance Feature.", DNC.JobID, 0, "", "")]
+                    "Adds Flourish to the Combined Dance Feature.", DNC.JobID, 0)]
                     DNC_CombinedDances_Flourish = 4133,
-                #endregion
 
                 [ParentCombo(DNC_Dance_Menu)]
                 [ConflictingCombos(DNC_CombinedDances)]
@@ -1002,53 +992,53 @@ namespace XIVSlothCombo.Combos
                 "\nThis helps ensure you can still dance with combos on, without using auto dance." +
                 "\nYou can change the respective actions by inputting action IDs below for each dance step." +
                 "\nThe defaults are Cascade, Flourish, Fan Dance and Fan Dance II. If set to 0, they will reset to these actions." +
-                "\nYou can get Action IDs with Garland Tools by searching for the action and clicking the cog.", DNC.JobID, 0, "", "")]
+                "\nYou can get Action IDs with Garland Tools by searching for the action and clicking the cog.", DNC.JobID, 0)]
                 DNC_DanceComboReplacer = 4134,
-        #endregion
+            #endregion
 
             #region Flourishing Features (L)
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos()]
             [CustomComboInfo("Flourishing Features (Legacy)",
-            "Features and options for Fourfold Feathers and Flourish.", DNC.JobID, 0, "", "")]
+            "Features and options for Fourfold Feathers and Flourish.", DNC.JobID, 0)]
             DNC_FlourishingFeatures_Menu = 4140,
 
                 [ReplaceSkill(DNC.Flourish)]
                 [ParentCombo(DNC_FlourishingFeatures_Menu)]
                 [ConflictingCombos()]
                 [CustomComboInfo("Flourishing Fan Dance Feature",
-                "Replace Flourish with Fan Dance 3 & 4 during weave-windows, when Flourish is on cooldown.", DNC.JobID, 0, "", "")]
+                "Replace Flourish with Fan Dance 3 & 4 during weave-windows, when Flourish is on cooldown.", DNC.JobID, 0)]
                 DNC_FlourishingFanDances = 4141,
 
                 [ParentCombo(DNC_FlourishingFeatures_Menu)]
                 [ConflictingCombos()]
                 [CustomComboInfo("Fan Dance Combo Feature (Legacy)",
                 "Options for Fan Dance combos." +
-                "\nFan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0, "", "")]
+                "\nFan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0)]
                 DNC_FanDanceCombos = 4142,
 
                     [ReplaceSkill(DNC.FanDance1)]
                     [ParentCombo(DNC_FanDanceCombos)]
                     [CustomComboInfo("Fan Dance 1 -> 3 Option",
-                    "Changes Fan Dance 1 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
+                    "Changes Fan Dance 1 to Fan Dance 3 when available.", DNC.JobID, 0)]
                     DNC_FanDance_1to3_Combo = 4143,
 
                     [ReplaceSkill(DNC.FanDance1)]
                     [ParentCombo(DNC_FanDanceCombos)]
                     [CustomComboInfo("Fan Dance 1 -> 4 Option",
-                    "Changes Fan Dance 1 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
+                    "Changes Fan Dance 1 to Fan Dance 4 when available.", DNC.JobID, 0)]
                     DNC_FanDance_1to4_Combo = 4144,
 
                     [ReplaceSkill(DNC.FanDance2)]
                     [ParentCombo(DNC_FanDanceCombos)]
                     [CustomComboInfo("Fan Dance 2 -> 3 Option",
-                    "Changes Fan Dance 2 to Fan Dance 3 when available.", DNC.JobID, 0, "", "")]
+                    "Changes Fan Dance 2 to Fan Dance 3 when available.", DNC.JobID, 0)]
                     DNC_FanDance_2to3_Combo = 4145,
 
                     [ReplaceSkill(DNC.FanDance2)]
                     [ParentCombo(DNC_FanDanceCombos)]
                     [CustomComboInfo("Fan Dance 2 -> 4 Option",
-                    "Changes Fan Dance 2 to Fan Dance 4 when available.", DNC.JobID, 0, "", "")]
+                    "Changes Fan Dance 2 to Fan Dance 4 when available.", DNC.JobID, 0)]
                     DNC_FanDance_2to4_Combo = 4146,
             #endregion
 
@@ -1057,7 +1047,7 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos()]
             [CustomComboInfo("Devilment to Starfall Feature (Legacy)",
-            "Change Devilment into Starfall Dance after use.", DNC.JobID, 0, "", "")]
+            "Change Devilment into Starfall Dance after use.", DNC.JobID, 0)]
             DNC_Starfall_Devilment = 4150,
             #endregion
 
@@ -1067,13 +1057,13 @@ namespace XIVSlothCombo.Combos
         [Variant]
         [VariantParent(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
         [CustomComboInfo("Rampart Option",
-        "Use Variant Rampart on cooldown.", DNC.JobID)]
+        "Use Variant Rampart on cooldown.", DNC.JobID, 0)]
         DNC_Variant_Rampart = 4200,
 
         [Variant]
         [VariantParent(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
         [CustomComboInfo("Cure Option",
-        "Use Variant Cure when HP is below set threshold.", DNC.JobID)]
+        "Use Variant Cure when HP is below set threshold.", DNC.JobID, 0)]
         DNC_VariantCure = 4201,
 
         #endregion

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -866,157 +866,94 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
-        [ConflictingCombos(DNC_Dance_Menu)]
+        [ConflictingCombos(DNC_Legacy_Dance)]
         [CustomComboInfo("Dance Step Solver Feature",
         "Change Standard Step and Technical Step into each dance step while dancing." +
         "\nWorks with Simple/Advanced Dancer Single Target and AoE." +
         "\nWorks with Legacy Features.", DNC.JobID, 0)]
         DNC_DanceStepSolver = 4040,
 
-        #region Legacy Features (L)
+        #region Legacy Features [L]
         [ConflictingCombos(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
         [CustomComboInfo("Legacy Features",
-        "Deprecated features more closely resembling traditional XIVCombo implementation.", DNC.JobID, 0)]
+        "Deprecated features more closely resembling traditional XIVCombo implementation.\nThese features are marked with a '[L]'.", DNC.JobID, 0)]
         DNC_LegacyFeatures = 4100,
 
-            #region Single Target Multibutton (L)
             [ReplaceSkill(DNC.Cascade)]
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos()]
-            [CustomComboInfo("Single Target Multibutton Feature (Legacy)",
+            [CustomComboInfo("[L] - Single Target Multibutton Feature",
             "Single target combo with Fan Dances and Esprit use.", DNC.JobID, 0)]
-            DNC_ST_MultiButton = 4110,
+            DNC_LegacyST_MultiButton = 4110,
 
-                [ParentCombo(DNC_ST_MultiButton)]
-                [CustomComboInfo("ST Esprit Overcap Option",
-                "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0)]
-                DNC_ST_EspritOvercap = 4111,
-
-                [ParentCombo(DNC_ST_MultiButton)]
-                [CustomComboInfo("Fan Dance Overcap Protection Option",
-                "Adds Fan Dance 1 when Fourfold Feathers are full.", DNC.JobID, 0)]
-                DNC_ST_FanDanceOvercap = 4112,
-
-                [ParentCombo(DNC_ST_MultiButton)]
-                [CustomComboInfo("Fan Dance Option",
-                "Adds Fan Dance 3/4 when available.", DNC.JobID, 0)]
-                DNC_ST_FanDance34 = 4113,
-            #endregion
-
-            #region AoE Multibutton (L)
             [ReplaceSkill(DNC.Windmill)]
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos()]
-            [CustomComboInfo("AoE Multibutton Feature (Legacy)",
+            [CustomComboInfo("[L] - AoE Multibutton Feature",
             "AoE combo with Fan Dances and Esprit use.", DNC.JobID, 0)]
-            DNC_AoE_MultiButton = 4120,
+            DNC_LegacyAoE_MultiButton = 4120,
 
-                [ParentCombo(DNC_AoE_MultiButton)]
-                [CustomComboInfo("AoE Esprit Overcap Option",
-                "Adds Saber Dance above the set Esprit threshold.", DNC.JobID, 0)]
-                DNC_AoE_EspritOvercap = 4121,
-
-                [ParentCombo(DNC_AoE_MultiButton)]
-                [CustomComboInfo("AoE Fan Dance Overcap Protection Option",
-                "Adds Fan Dance 2 when Fourfold Feathers are full.", DNC.JobID, 0)]
-                DNC_AoE_FanDanceOvercap = 4122,
-
-                [ParentCombo(DNC_AoE_MultiButton)]
-                [CustomComboInfo("AoE Fan Dance Option",
-                "Adds Fan Dance 3/4 when available.", DNC.JobID, 0)]
-                DNC_AoE_FanDance34 = 4123,
-            #endregion
-
-            #region Dance Features (L)
+            #region Dance Features [L]
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos(DNC_DanceStepSolver)]
-            [CustomComboInfo("Dance Features (Legacy)",
+            [CustomComboInfo("[L] - Dance Features",
             "Features and options for Standard Step and Technical Step.", DNC.JobID, 0)]
-            DNC_Dance_Menu = 4130,
+            DNC_Legacy_Dance = 4130,
 
                 [ReplaceSkill(DNC.StandardStep)]
-                [ParentCombo(DNC_Dance_Menu)]
-                [ConflictingCombos(DNC_DanceComboReplacer)]
+                [ParentCombo(DNC_Legacy_Dance)]
+                [ConflictingCombos(DNC_Legacy_Dance_DanceActionReplacer)]
                 [CustomComboInfo("Combined Dance Feature",
                 "Standard And Technical Dance on one button." +
                 "\nStandard > Technical." +
                 "\nThis combos out into Tillana and Starfall Dance.", DNC.JobID, 0)]
-                DNC_CombinedDances = 4131,
+                DNC_Legacy_Dance_ComboDances = 4131,
 
-                    [ParentCombo(DNC_CombinedDances)]
+                    [ParentCombo(DNC_Legacy_Dance_ComboDances)]
                     [CustomComboInfo("Devilment Plus Option",
                     "Adds Devilment right after Technical finish.", DNC.JobID, 0)]
-                    DNC_CombinedDances_Devilment = 4132,
+                    DNC_Legacy_Dance_ComboDances_Devilment = 4132,
 
-                    [ParentCombo(DNC_CombinedDances)]
+                    [ParentCombo(DNC_Legacy_Dance_ComboDances)]
                     [CustomComboInfo("Flourish Plus Option",
                     "Adds Flourish to the Combined Dance Feature.", DNC.JobID, 0)]
-                    DNC_CombinedDances_Flourish = 4133,
+                    DNC_Legacy_Dance_ComboDances_Flourish = 4133,
 
-                [ParentCombo(DNC_Dance_Menu)]
-                [ConflictingCombos(DNC_CombinedDances)]
+                [ParentCombo(DNC_Legacy_Dance)]
+                [ConflictingCombos(DNC_Legacy_Dance_ComboDances)]
                 [CustomComboInfo("Custom Dance Step Feature",
                 "Change custom actions into dance steps while dancing." +
                 "\nThis helps ensure you can still dance with combos on, without using auto dance." +
                 "\nYou can change the respective actions by inputting action IDs below for each dance step." +
                 "\nThe defaults are Cascade, Flourish, Fan Dance and Fan Dance II. If set to 0, they will reset to these actions." +
                 "\nYou can get Action IDs with Garland Tools by searching for the action and clicking the cog.", DNC.JobID, 0)]
-                DNC_DanceComboReplacer = 4134,
+                DNC_Legacy_Dance_DanceActionReplacer = 4134,
             #endregion
 
-            #region Flourishing Features (L)
+            #region Flourishing Features [L]
+            [ReplaceSkill(DNC.Flourish)]
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos()]
-            [CustomComboInfo("Flourishing Features (Legacy)",
-            "Features and options for Fourfold Feathers and Flourish.", DNC.JobID, 0)]
-            DNC_FlourishingFeatures_Menu = 4140,
+            [CustomComboInfo("[L] - Flourishing Fan Dance Feature",
+            "Replace Flourish with Fan Dance III & IV during weave-windows when Flourish is on cooldown.", DNC.JobID, 0)]
+            DNC_Legacy_FlourishingFanDances = 4140,
 
-                [ReplaceSkill(DNC.Flourish)]
-                [ParentCombo(DNC_FlourishingFeatures_Menu)]
-                [ConflictingCombos()]
-                [CustomComboInfo("Flourishing Fan Dance Feature",
-                "Replace Flourish with Fan Dance 3 & 4 during weave-windows, when Flourish is on cooldown.", DNC.JobID, 0)]
-                DNC_FlourishingFanDances = 4141,
+            [ParentCombo(DNC_LegacyFeatures)]
+            [ConflictingCombos()]
+            [CustomComboInfo("[L] - Fan Dance Combo Feature",
+            "Options for Fan Dance combos." +
+            "\nFan Dance III takes priority over Fan Dance IV.", DNC.JobID, 0)]
+            DNC_Legacy_FanDanceCombos = 4150,
 
-                [ParentCombo(DNC_FlourishingFeatures_Menu)]
-                [ConflictingCombos()]
-                [CustomComboInfo("Fan Dance Combo Feature (Legacy)",
-                "Options for Fan Dance combos." +
-                "\nFan Dance 3 takes priority over Fan Dance 4.", DNC.JobID, 0)]
-                DNC_FanDanceCombos = 4142,
-
-                    [ReplaceSkill(DNC.FanDance1)]
-                    [ParentCombo(DNC_FanDanceCombos)]
-                    [CustomComboInfo("Fan Dance 1 -> 3 Option",
-                    "Changes Fan Dance 1 to Fan Dance 3 when available.", DNC.JobID, 0)]
-                    DNC_FanDance_1to3_Combo = 4143,
-
-                    [ReplaceSkill(DNC.FanDance1)]
-                    [ParentCombo(DNC_FanDanceCombos)]
-                    [CustomComboInfo("Fan Dance 1 -> 4 Option",
-                    "Changes Fan Dance 1 to Fan Dance 4 when available.", DNC.JobID, 0)]
-                    DNC_FanDance_1to4_Combo = 4144,
-
-                    [ReplaceSkill(DNC.FanDance2)]
-                    [ParentCombo(DNC_FanDanceCombos)]
-                    [CustomComboInfo("Fan Dance 2 -> 3 Option",
-                    "Changes Fan Dance 2 to Fan Dance 3 when available.", DNC.JobID, 0)]
-                    DNC_FanDance_2to3_Combo = 4145,
-
-                    [ReplaceSkill(DNC.FanDance2)]
-                    [ParentCombo(DNC_FanDanceCombos)]
-                    [CustomComboInfo("Fan Dance 2 -> 4 Option",
-                    "Changes Fan Dance 2 to Fan Dance 4 when available.", DNC.JobID, 0)]
-                    DNC_FanDance_2to4_Combo = 4146,
             #endregion
 
-            #region Devilment --> Starfall (L)
+            #region Devilment --> Starfall [L]
             [ReplaceSkill(DNC.Devilment)]
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos()]
-            [CustomComboInfo("Devilment to Starfall Feature (Legacy)",
+            [CustomComboInfo("[L] - Devilment to Starfall Feature",
             "Change Devilment into Starfall Dance after use.", DNC.JobID, 0)]
-            DNC_Starfall_Devilment = 4150,
+            DNC_Starfall_Devilment = 4160,
             #endregion
 
         #endregion

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -771,7 +771,7 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_AdvST)]
             [CustomComboInfo("Interrupt Option",
-            "Includes Head Graze in the rotation during the second weave window (if applicable to your current target).", DNC.JobID, 0)]
+            "Includes Head Graze in the rotation (if applicable to your current target).", DNC.JobID, 0)]
             DNC_AdvST_Interrupt = 4011,
 
             [ParentCombo(DNC_AdvST)]
@@ -845,7 +845,7 @@ namespace XIVSlothCombo.Combos
 
             [ParentCombo(DNC_AdvAoE)]
             [CustomComboInfo("AoE Interrupt Option",
-            "Includes Head Graze in the AoE rotation during the second weave window (if applicable to your current target).", DNC.JobID, 0)]
+            "Includes Head Graze in the AoE rotation (if applicable to your current target).", DNC.JobID, 0)]
             DNC_AdvAoE_Interrupt = 4030,
 
             [ParentCombo(DNC_AdvAoE)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -708,8 +708,7 @@ namespace XIVSlothCombo.Combos
         [ConflictingCombos(DNC_AdvST, DNC_LegacyFeatures)]
         [CustomComboInfo("Simple Dancer (Single Target) Feature",
         "Single button, single target." +
-        "\nIncludes songs, flourishes and overprotections." +
-        "\nConflicts with all other non-simple features except 'Dance Step Solver Feature'.", DNC.JobID, 0)]
+        "\nIncludes dances, flourishes, burst and overcap protections.", DNC.JobID, 0)]
         DNC_ST_SimpleMode = 4000,
 
         #region Advanced Dancer (Single Target)
@@ -717,9 +716,8 @@ namespace XIVSlothCombo.Combos
         [ConflictingCombos(DNC_ST_SimpleMode, DNC_LegacyFeatures)]
         [CustomComboInfo("Advanced Dancer (Single Target) Feature",
         "Single button, single target." +
-        "\nIncludes songs, flourishes and overprotections." +
-        "\nComplete with options for Advanced use." +
-        "\nConflicts with all other non-advanced features except 'Dance Step Solver Feature'.", DNC.JobID, 0)]
+        "\nIncludes dances, flourishes, burst and overcap protections." +
+        "\nComplete with options for advanced use.", DNC.JobID, 0)]
         DNC_AdvST = 4001,
 
             [ParentCombo(DNC_AdvST)]
@@ -793,8 +791,7 @@ namespace XIVSlothCombo.Combos
         [ConflictingCombos(DNC_AdvAoE, DNC_LegacyFeatures)]
         [CustomComboInfo("Simple Dancer (AoE) Feature",
         "Single button, AoE." +
-        "\nIncludes songs, flourishes and overprotections." +
-        "\nConflicts with all other non-simple features except 'Dance Step Solver Feature'.", DNC.JobID, 0)]
+        "\nIncludes dances, flourishes, burst and overcap protections.", DNC.JobID, 0)]
         DNC_AoE_SimpleMode = 4020,
 
         #region Advanced Dancer (AoE)
@@ -802,9 +799,8 @@ namespace XIVSlothCombo.Combos
         [ConflictingCombos(DNC_AoE_SimpleMode, DNC_LegacyFeatures)]
         [CustomComboInfo("Advanced Dancer (AoE) Feature",
         "Single button, AoE." +
-        "\nIncludes songs, flourishes and overprotections." +
-        "\nComplete with options for Advanced use." +
-        "\nConflicts with all other non-advanced features except 'Dance Step Solver Feature'.", DNC.JobID, 0)]
+        "\nIncludes dances, flourishes, burst and overcap protections." +
+        "\nComplete with options for advanced use.", DNC.JobID, 0)]
         DNC_AdvAoE = 4021,
 
             [ParentCombo(DNC_AdvAoE)]
@@ -868,10 +864,24 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(DNC.StandardStep, DNC.TechnicalStep)]
         [ConflictingCombos(DNC_Legacy_Dance)]
         [CustomComboInfo("Dance Step Solver Feature",
-        "Change Standard Step and Technical Step into each dance step while dancing." +
-        "\nWorks with Simple/Advanced Dancer Single Target and AoE." +
-        "\nWorks with Legacy Features.", DNC.JobID, 0)]
+        "Change Standard Step and Technical Step into each dance step while dancing, and their respective Finish.", DNC.JobID, 0)]
         DNC_DanceStepSolver = 4040,
+
+        [ReplaceSkill(DNC.Flourish)]
+        [CustomComboInfo("Flourishing Fan Dance Feature",
+        "Replace Flourish with Fan Dance III & IV during weave windows when Flourish is on cooldown.", DNC.JobID, 0)]
+        DNC_FlourishingFanDances = 4050,
+
+        [ReplaceSkill(DNC.FanDance1, DNC.FanDance2)]
+        [CustomComboInfo("Fan Dance Combo Feature",
+        "Options for Fan Dance combos." +
+        "\nFan Dance III takes priority over Fan Dance IV.", DNC.JobID, 0)]
+        DNC_FanDanceCombos = 4060,
+
+        [ReplaceSkill(DNC.Devilment)]
+        [CustomComboInfo("Devilment to Starfall Dance Feature",
+        "Change Devilment into Starfall Dance after use.", DNC.JobID, 0)]
+        DNC_Starfall_Devilment = 4070,
 
         #region Legacy Features [L]
         [ConflictingCombos(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
@@ -926,30 +936,6 @@ namespace XIVSlothCombo.Combos
                 "\nThe defaults are Cascade, Flourish, Fan Dance and Fan Dance II. If set to 0, they will reset to these actions." +
                 "\nYou can get Action IDs with Garland Tools by searching for the action and clicking the cog.", DNC.JobID, 0)]
                 DNC_Legacy_Dance_DanceActionReplacer = 4134,
-            #endregion
-
-            #region Flourishing Features [L]
-            [ReplaceSkill(DNC.Flourish)]
-            [ParentCombo(DNC_LegacyFeatures)]
-            [CustomComboInfo("[L] - Flourishing Fan Dance Feature",
-            "Replace Flourish with Fan Dance III & IV during weave-windows when Flourish is on cooldown.", DNC.JobID, 0)]
-            DNC_Legacy_FlourishingFanDances = 4140,
-
-            [ReplaceSkill(DNC.FanDance1, DNC.FanDance2)]
-            [ParentCombo(DNC_LegacyFeatures)]
-            [CustomComboInfo("[L] - Fan Dance Combo Feature",
-            "Options for Fan Dance combos." +
-            "\nFan Dance III takes priority over Fan Dance IV.", DNC.JobID, 0)]
-            DNC_Legacy_FanDanceCombos = 4150,
-
-            #endregion
-
-            #region Devilment --> Starfall [L]
-            [ReplaceSkill(DNC.Devilment)]
-            [ParentCombo(DNC_LegacyFeatures)]
-            [CustomComboInfo("[L] - Devilment to Starfall Dance Feature",
-            "Change Devilment into Starfall Dance after use.", DNC.JobID, 0)]
-            DNC_Starfall_Devilment = 4160,
             #endregion
 
         #endregion

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -881,14 +881,12 @@ namespace XIVSlothCombo.Combos
 
             [ReplaceSkill(DNC.Cascade)]
             [ParentCombo(DNC_LegacyFeatures)]
-            [ConflictingCombos()]
             [CustomComboInfo("[L] - Single Target Multibutton Feature",
             "Single target combo with Fan Dances and Esprit use.", DNC.JobID, 0)]
             DNC_LegacyST_MultiButton = 4110,
 
             [ReplaceSkill(DNC.Windmill)]
             [ParentCombo(DNC_LegacyFeatures)]
-            [ConflictingCombos()]
             [CustomComboInfo("[L] - AoE Multibutton Feature",
             "AoE combo with Fan Dances and Esprit use.", DNC.JobID, 0)]
             DNC_LegacyAoE_MultiButton = 4120,
@@ -897,7 +895,7 @@ namespace XIVSlothCombo.Combos
             [ParentCombo(DNC_LegacyFeatures)]
             [ConflictingCombos(DNC_DanceStepSolver)]
             [CustomComboInfo("[L] - Dance Features",
-            "Features and options for Standard Step and Technical Step.", DNC.JobID, 0)]
+            "Features and options for Dances.", DNC.JobID, 0)]
             DNC_Legacy_Dance = 4130,
 
                 [ReplaceSkill(DNC.StandardStep)]
@@ -933,13 +931,12 @@ namespace XIVSlothCombo.Combos
             #region Flourishing Features [L]
             [ReplaceSkill(DNC.Flourish)]
             [ParentCombo(DNC_LegacyFeatures)]
-            [ConflictingCombos()]
             [CustomComboInfo("[L] - Flourishing Fan Dance Feature",
             "Replace Flourish with Fan Dance III & IV during weave-windows when Flourish is on cooldown.", DNC.JobID, 0)]
             DNC_Legacy_FlourishingFanDances = 4140,
 
+            [ReplaceSkill(DNC.FanDance1, DNC.FanDance2)]
             [ParentCombo(DNC_LegacyFeatures)]
-            [ConflictingCombos()]
             [CustomComboInfo("[L] - Fan Dance Combo Feature",
             "Options for Fan Dance combos." +
             "\nFan Dance III takes priority over Fan Dance IV.", DNC.JobID, 0)]
@@ -950,8 +947,7 @@ namespace XIVSlothCombo.Combos
             #region Devilment --> Starfall [L]
             [ReplaceSkill(DNC.Devilment)]
             [ParentCombo(DNC_LegacyFeatures)]
-            [ConflictingCombos()]
-            [CustomComboInfo("[L] - Devilment to Starfall Feature",
+            [CustomComboInfo("[L] - Devilment to Starfall Dance Feature",
             "Change Devilment into Starfall Dance after use.", DNC.JobID, 0)]
             DNC_Starfall_Devilment = 4160,
             #endregion

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -709,11 +709,11 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Dancer (Single Target) Feature",
         "Single button, single target." +
         "\nIncludes dances, flourishes, burst and overcap protections.", DNC.JobID, 0)]
-        DNC_ST_SimpleMode = 4000,
+        DNC_SimpleST = 4000,
 
         #region Advanced Dancer (Single Target)
         [ReplaceSkill(DNC.Cascade)]
-        [ConflictingCombos(DNC_ST_SimpleMode, DNC_LegacyFeatures)]
+        [ConflictingCombos(DNC_SimpleST, DNC_LegacyFeatures)]
         [CustomComboInfo("Advanced Dancer (Single Target) Feature",
         "Single button, single target." +
         "\nIncludes dances, flourishes, burst and overcap protections." +
@@ -792,11 +792,11 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Dancer (AoE) Feature",
         "Single button, AoE." +
         "\nIncludes dances, flourishes, burst and overcap protections.", DNC.JobID, 0)]
-        DNC_AoE_SimpleMode = 4020,
+        DNC_SimpleAoE = 4020,
 
         #region Advanced Dancer (AoE)
         [ReplaceSkill(DNC.Windmill)]
-        [ConflictingCombos(DNC_AoE_SimpleMode, DNC_LegacyFeatures)]
+        [ConflictingCombos(DNC_SimpleAoE, DNC_LegacyFeatures)]
         [CustomComboInfo("Advanced Dancer (AoE) Feature",
         "Single button, AoE." +
         "\nIncludes dances, flourishes, burst and overcap protections." +
@@ -884,7 +884,7 @@ namespace XIVSlothCombo.Combos
         DNC_Starfall_Devilment = 4070,
 
         #region Legacy Features [L]
-        [ConflictingCombos(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
+        [ConflictingCombos(DNC_SimpleST, DNC_AdvST, DNC_SimpleAoE, DNC_AdvAoE)]
         [CustomComboInfo("Legacy Features",
         "Deprecated features more closely resembling traditional XIVCombo implementation.\nThese features are marked with a '[L]'.", DNC.JobID, 0)]
         DNC_LegacyFeatures = 4100,
@@ -942,13 +942,13 @@ namespace XIVSlothCombo.Combos
 
         #region Variant
         [Variant]
-        [VariantParent(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
+        [VariantParent(DNC_SimpleST, DNC_AdvST, DNC_SimpleAoE, DNC_AdvAoE)]
         [CustomComboInfo("Rampart Option",
         "Use Variant Rampart on cooldown.", DNC.JobID, 0)]
         DNC_Variant_Rampart = 4200,
 
         [Variant]
-        [VariantParent(DNC_ST_SimpleMode, DNC_AdvST, DNC_AoE_SimpleMode, DNC_AdvAoE)]
+        [VariantParent(DNC_SimpleST, DNC_AdvST, DNC_SimpleAoE, DNC_AdvAoE)]
         [CustomComboInfo("Cure Option",
         "Use Variant Cure when HP is below set threshold.", DNC.JobID, 0)]
         DNC_VariantCure = 4201,

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -26,14 +26,8 @@ namespace XIVSlothCombo.Combos.PvE
             // Dancing
             StandardStep = 15997,
             TechnicalStep = 15998,
-            StandardFinish0 = 16003,
-            StandardFinish1 = 16191,
-            StandardFinish2 = 16192,
-            TechnicalFinish0 = 16004,
-            TechnicalFinish1 = 16193,
-            TechnicalFinish2 = 16194,
-            TechnicalFinish3 = 16195,
-            TechnicalFinish4 = 16196,
+            StandardFinish = 16192,
+            TechnicalFinish = 16196,
             // Fan Dances
             FanDance1 = 16007,
             FanDance2 = 16008,
@@ -42,12 +36,28 @@ namespace XIVSlothCombo.Combos.PvE
             // Other
             Peloton = 7557,
             SaberDance = 16005,
-            EnAvant = 16010,
             Devilment = 16011,
             ShieldSamba = 16012,
             Flourish = 16013,
             Improvisation = 16014,
             CuringWaltz = 16015;
+
+        /* Unused
+        EnAvant = 16010,
+        ClosedPosition = 16006,
+        Ending = 18073,
+        Emboite = 15999,
+        Entrechat = 16000,
+        Jete = 16001,
+        Pirouette = 16002,
+        StandardFinish0 = 16003,
+        StandardFinish1 = 16191,
+        TechnicalFinish0 = 16004,
+        TechnicalFinish1 = 16193,
+        TechnicalFinish2 = 16194,
+        TechnicalFinish3 = 16195,
+        ImprovisedFinish = 25789,
+        */
 
         public static class Buffs
         {
@@ -76,6 +86,23 @@ namespace XIVSlothCombo.Combos.PvE
                 Peloton = 1199,
                 ShieldSamba = 1826;
         }
+
+        /* Traits
+        public static class Traits
+        {
+            public const ushort
+                FourfoldFantasy = 252,
+                ActionDamage1 = 251,
+                ActionDamage2 = 253,
+                EnhancedEnAvant = 254,
+                EnhancedEnAvant2 = 256,
+                EnhancedTechnicalFinish = 453,
+                EnhancedEsprit = 454,
+                EnhancedFlourish = 455,
+                EnhancedShieldSamba = 456,
+                EnhancedDevilment = 457;
+        }
+        */
 
         public static class Config
         {
@@ -184,13 +211,13 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is StandardStep && gauge.IsDancing && HasEffect(Buffs.StandardStep))
                     return gauge.CompletedSteps < 2
                         ? gauge.NextStep
-                        : StandardFinish2;
+                        : StandardFinish;
 
                 // Technical Step
                 if ((actionID is TechnicalStep) && gauge.IsDancing && HasEffect(Buffs.TechnicalStep))
                     return gauge.CompletedSteps < 4
                         ? gauge.NextStep
-                        : TechnicalFinish4;
+                        : TechnicalFinish;
 
                 return actionID;
             }
@@ -366,14 +393,14 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             return gauge.CompletedSteps < 2
                                 ? gauge.NextStep
-                                : StandardFinish2;
+                                : StandardFinish;
                         }
 
                         if (HasEffect(Buffs.TechnicalStep))
                         {
                             return gauge.CompletedSteps < 4
                                 ? gauge.NextStep
-                                : TechnicalFinish4;
+                                : TechnicalFinish;
                         }
                     }
                 }
@@ -409,14 +436,14 @@ namespace XIVSlothCombo.Combos.PvE
                         HasEffect(Buffs.StandardStep))
                         return gauge.CompletedSteps < 2
                             ? gauge.NextStep
-                            : StandardFinish2;
+                            : StandardFinish;
 
                     // ST Technical (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_TechFill)) &&
                         HasEffect(Buffs.TechnicalStep))
                         return gauge.CompletedSteps < 4
                             ? gauge.NextStep
-                            : TechnicalFinish4;
+                            : TechnicalFinish;
                     #endregion
 
                     #region Weaves
@@ -577,14 +604,14 @@ namespace XIVSlothCombo.Combos.PvE
                         HasEffect(Buffs.StandardStep))
                         return gauge.CompletedSteps < 2
                             ? gauge.NextStep
-                            : StandardFinish2;
+                            : StandardFinish;
 
                     // AoE Technical (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_TechFill)) &&
                         HasEffect(Buffs.TechnicalStep))
                         return gauge.CompletedSteps < 4
                             ? gauge.NextStep
-                            : TechnicalFinish4;
+                            : TechnicalFinish;
                     #endregion
 
                     #region Weaves

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -158,6 +158,7 @@ namespace XIVSlothCombo.Combos.PvE
                 DNC_VariantCurePct                  = new("DNC_VariantCurePct");                    // Variant Cure     player HP% threshold
         }
 
+        // Dance Step Solver
         internal class DNC_DanceStepSolver : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_DanceStepSolver;
@@ -180,7 +181,7 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        #region Legacy Features
+        // Legacy Features
         internal class DNC_LegacyFeatures : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_LegacyFeatures;
@@ -378,252 +379,7 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        /* Old code
-        internal class DNC_Legacy_Dance_DanceActionReplacer : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Legacy_Dance_DanceActionReplacer;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (Gauge.IsDancing)
-                {
-                    uint[]? actionIDs = Service.Configuration.DancerDanceCompatActionIDs;
-
-                    if (actionID == actionIDs[0] || (actionIDs[0] == 0 && actionID == Cascade))     // Cascade replacement
-                        return OriginalHook(Cascade);
-                    if (actionID == actionIDs[1] || (actionIDs[1] == 0 && actionID == Flourish))    // Fountain replacement
-                        return OriginalHook(Fountain);
-                    if (actionID == actionIDs[2] || (actionIDs[2] == 0 && actionID == FanDance1))   // Reverse Cascade replacement
-                        return OriginalHook(ReverseCascade);
-                    if (actionID == actionIDs[3] || (actionIDs[3] == 0 && actionID == FanDance2))   // Fountainfall replacement
-                        return OriginalHook(Fountainfall);
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class DNC_Legacy_FanDanceCombos : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Legacy_FanDanceCombos;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                // FD 1 --> 3, FD 1 --> 4
-                if (actionID is FanDance1)
-                {
-                    if (IsEnabled(CustomComboPreset.DNC_FanDance_1to3_Combo) &&
-                        HasEffect(Buffs.ThreeFoldFanDance))
-                        return FanDance3;
-                    if (IsEnabled(CustomComboPreset.DNC_FanDance_1to4_Combo) &&
-                        HasEffect(Buffs.FourFoldFanDance))
-                        return FanDance4;
-                }
-
-                // FD 2 --> 3, FD 2 --> 4
-                if (actionID is FanDance2)
-                {
-                    if (IsEnabled(CustomComboPreset.DNC_FanDance_2to3_Combo) &&
-                        HasEffect(Buffs.ThreeFoldFanDance))
-                        return FanDance3;
-                    if (IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo) &&
-                        HasEffect(Buffs.FourFoldFanDance))
-                        return FanDance4;
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class DNC_Legacy_FlourishingFanDances : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Legacy_FlourishingFanDances;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                // Fan Dance 3 & 4 on Flourish
-                if (actionID is Flourish && CanWeave(actionID))
-                {
-                    if (HasEffect(Buffs.ThreeFoldFanDance))
-                        return FanDance3;
-                    if (HasEffect(Buffs.FourFoldFanDance))
-                        return FanDance4;
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class DNC_LegacyST_MultiButton : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_LegacyST_MultiButton;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is Cascade)
-                {
-                    #region Types
-                    bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
-                    bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
-                    #endregion
-
-                    // ST Esprit overcap protection
-                    if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyST_Multi_EspritThreshold))
-                        return SaberDance;
-
-                    if (CanWeave(actionID))
-                    {
-                        // ST Fan Dance overcap protection
-                        if (IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap) &&
-                            LevelChecked(FanDance1) && Gauge.Feathers is 4)
-                            return FanDance1;
-
-                        // ST Fan Dance 3/4 on combo
-                        if (IsEnabled(CustomComboPreset.DNC_ST_FanDance34))
-                        {
-                            if (HasEffect(Buffs.ThreeFoldFanDance))
-                                return FanDance3;
-                            if (HasEffect(Buffs.FourFoldFanDance))
-                                return FanDance4;
-                        }
-                    }
-
-                    // ST base combos
-                    if (LevelChecked(Fountainfall) && flow)
-                        return Fountainfall;
-                    if (LevelChecked(ReverseCascade) && symmetry)
-                        return ReverseCascade;
-                    if (LevelChecked(Fountain) && lastComboMove is Cascade)
-                        return Fountain;
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class DNC_LegacyAoE_MultiButton : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_LegacyAoE_MultiButton;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is Windmill)
-                {
-                    #region Types
-                    bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
-                    bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
-                    #endregion
-
-                    // AoE Esprit overcap protection
-                    if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyAoE_Multi_EspritThreshold))
-                        return SaberDance;
-
-                    if (CanWeave(actionID))
-                    {
-                        // AoE Fan Dance overcap protection
-                        if (IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap) &&
-                            LevelChecked(FanDance2) && Gauge.Feathers is 4)
-                            return FanDance2;
-
-                        // AoE Fan Dance 3/4 on combo
-                        if (IsEnabled(CustomComboPreset.DNC_AoE_FanDance34))
-                        {
-                            if (HasEffect(Buffs.ThreeFoldFanDance))
-                                return FanDance3;
-                            if (HasEffect(Buffs.FourFoldFanDance))
-                                return FanDance4;
-                        }
-                    }
-
-                    // AoE base combos
-                    if (LevelChecked(Bloodshower) && flow)
-                        return Bloodshower;
-                    if (LevelChecked(RisingWindmill) && symmetry)
-                        return RisingWindmill;
-                    if (LevelChecked(Bladeshower) && lastComboMove is Windmill)
-                        return Bladeshower;
-                }
-
-                return actionID;
-            }
-        }
-
-        internal class DNC_Starfall_Devilment : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Starfall_Devilment;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is Devilment && HasEffect(Buffs.FlourishingStarfall))
-                    return StarfallDance;
-                else
-                    return actionID;
-            }
-        }
-
-        internal class DNC_Legacy_Dance_ComboDances : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Legacy_Dance_ComboDances;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                // One-button mode for both dances (SS/TS). SS takes priority.
-                if (actionID is StandardStep)
-                {
-                    // Devilment
-                    if (IsEnabled(CustomComboPreset.DNC_Legacy_Dance_ComboDances_Devilment) && IsOnCooldown(StandardStep) && IsOffCooldown(Devilment) && !Gauge.IsDancing)
-                    {
-                        if ((LevelChecked(Devilment) && !LevelChecked(TechnicalStep)) ||    // Lv. 62 - 69
-                            (LevelChecked(TechnicalStep) && IsOnCooldown(TechnicalStep)))   // Lv. 70+ during Tech
-                            return Devilment;
-                    }
-
-                    // Flourish
-                    if (IsEnabled(CustomComboPreset.DNC_Legacy_Dance_ComboDances_Flourish) &&
-                        InCombat() && !Gauge.IsDancing &&
-                        ActionReady(Flourish) &&
-                        IsOnCooldown(StandardStep))
-                        return Flourish;
-
-                    if (HasEffect(Buffs.FlourishingStarfall))
-                        return StarfallDance;
-                    if (HasEffect(Buffs.FlourishingFinish))
-                        return Tillana;
-
-                    // Tech Step
-                    if (IsOnCooldown(StandardStep) && IsOffCooldown(TechnicalStep) &&
-                        !Gauge.IsDancing && !HasEffect(Buffs.StandardStep))
-                        return TechnicalStep;
-
-                    // Dance steps
-                    if (Gauge.IsDancing)
-                    {
-                        if (HasEffect(Buffs.StandardStep))
-                        {
-                            return Gauge.CompletedSteps < 2
-                                ? Gauge.NextStep
-                                : StandardFinish;
-                        }
-
-                        if (HasEffect(Buffs.TechnicalStep))
-                        {
-                            return Gauge.CompletedSteps < 4
-                                ? Gauge.NextStep
-                                : TechnicalFinish;
-                        }
-                    }
-                }
-
-                return actionID;
-            }
-        }
-        #endregion
-        */
-        #endregion
-
-        #region Siple/Advanced Single Target Modes
+        // Simple Single Target
         internal class DNC_ST_SimpleMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_ST_SimpleMode;
@@ -794,6 +550,7 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
+        // Advanced Single Target
         internal class DNC_AdvST : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_AdvST;
@@ -974,9 +731,8 @@ namespace XIVSlothCombo.Combos.PvE
                 return actionID;
             }
         }
-        #endregion
 
-        #region Simple/Advanced AoE Modes
+        // Simple AoE
         internal class DNC_AoE_SimpleMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_AoE_SimpleMode;
@@ -1157,6 +913,7 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
+        // Advanced AoE
         internal class DNC_AdvAoE : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_AdvAoE;
@@ -1347,6 +1104,5 @@ namespace XIVSlothCombo.Combos.PvE
                 return actionID;
             }
         }
-        #endregion
     }
 }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -423,7 +423,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Pre-pull
                     // Simple ST Standard Step (pre-pull)
-                    if (Config.DNC_SimpleST_Dances[0] && ActionReady(StandardStep) && IsOffCooldown(TechnicalStep) && !InCombat())
+                    if (Config.DNC_SimpleST_Dances[0] && !InCombat() && ActionReady(StandardStep) && IsOffCooldown(TechnicalStep))
                         return StandardStep;
                     #endregion
 
@@ -519,15 +519,14 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Simple ST Technical Step
-                    if (ActionReady(TechnicalStep) &&
-                        Config.DNC_SimpleST_Dances[1] &&
-                        (!HasTarget() || GetTargetHPPercent() > 5) &&
-                        !HasEffect(Buffs.StandardStep))
+                    if (Config.DNC_SimpleST_Dances[1] &&
+                        ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep) &&
+                        (!HasTarget() || GetTargetHPPercent() > 5))
                         return TechnicalStep;
 
                     // Simple ST Standard Step (outside of burst)
-                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
-                        Config.DNC_SimpleST_Dances[0])
+                    if (Config.DNC_SimpleST_Dances[0] &&
+                        ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if ((!HasTarget() || GetTargetHPPercent() > 5) &&
                             (GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -536,11 +535,10 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Simple ST Saber Dance
-                    if (LevelChecked(SaberDance) && (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
-                    {
-                        if (Gauge.Esprit >= 85 || (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
-                            return SaberDance;
-                    }
+                    if (LevelChecked(SaberDance) &&
+                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
+                        (Gauge.Esprit >= 85 || (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50)))
+                        return SaberDance;
 
                     // Simple ST Starfall Dance / Tillana
                     if (HasEffect(Buffs.FlourishingStarfall))
@@ -553,10 +551,9 @@ namespace XIVSlothCombo.Combos.PvE
                         return Fountain;
 
                     // Simple ST Standard Step (inside of burst)
-                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
-                        Config.DNC_SimpleST_Dances[0] &&
-                        (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5) &&
-                        Gauge.Esprit < 25 &&
+                    if (Config.DNC_SimpleST_Dances[0] &&
+                        IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                        (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5) && Gauge.Esprit <= 20 &&
                         GetTargetHPPercent() > 5)
                         return StandardStep;
 
@@ -596,8 +593,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced ST Standard Step (pre-pull)
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && Config.DNC_AdvST_SS_Options == 2 &&
-                        ActionReady(StandardStep) &&
-                        IsOffCooldown(TechnicalStep) && !InCombat())
+                        !InCombat() && ActionReady(StandardStep) && IsOffCooldown(TechnicalStep))
                         return StandardStep;
                     #endregion
 
@@ -723,12 +719,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SaberDance) && LevelChecked(SaberDance) &&
-                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
-                    {
-                        if (Gauge.Esprit >= Config.DNC_AdvST_SaberThreshold ||
-                            (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
-                            return SaberDance;
-                    }
+                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
+                        (Gauge.Esprit >= Config.DNC_AdvST_SaberThreshold ||
+                        (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50)))
+                        return SaberDance;
 
                     // Advanced ST Starfall Dance / Tillana
                     if (HasEffect(Buffs.FlourishingStarfall))
@@ -743,9 +737,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // Advanced ST Standard Step (inside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && Config.DNC_AdvST_SS_Options == 2 && Config.DNC_AdvST_SS_Options_Burst &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
-                        Gauge.Esprit < 25 &&
-                        GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct &&
-                        (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 5))
+                        (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 5) && Gauge.Esprit <= 20 &&
+                        GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct)
                         return StandardStep;
 
                     // Advanced ST base GCDs
@@ -894,14 +887,14 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Simple AoE Technical Step
-                    if (ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep) &&
-                        Config.DNC_SimpleAoE_Dances[1] &&
+                    if (Config.DNC_SimpleST_Dances[1] &&
+                        ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep) &&
                         (!HasTarget() || GetTargetHPPercent() > 5))
                         return TechnicalStep;
 
                     // Simple AoE Standard Step (outside of burst)
-                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
-                        Config.DNC_SimpleAoE_Dances[0])
+                    if (Config.DNC_SimpleAoE_Dances[0] &&
+                        ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if ((!HasTarget() || GetTargetHPPercent() > 5) &&
                             (GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -912,8 +905,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // Simple AoE Saber Dance
                     if (LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
-                        ((HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50) ||
-                        Gauge.Esprit >= 80))
+                        (Gauge.Esprit >= 80 || (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50)))
                         return SaberDance;
 
                     // Simple AoE Starfall Dance / Tillana
@@ -927,9 +919,10 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // Simple AoE Standard Step (inside of burst)
-                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
-                        Config.DNC_SimpleAoE_Dances[0] &&
-                        GetTargetHPPercent() > 5 && (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))
+                    if (Config.DNC_SimpleAoE_Dances[0] &&
+                        IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                        (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 5) && Gauge.Esprit <= 20 &&
+                        GetTargetHPPercent() > 5)
                         return StandardStep;
 
                     // Simple AoE base GCDs
@@ -1110,8 +1103,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // Advanced AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
-                        ((HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50) ||
-                        Gauge.Esprit >= Config.DNC_AdvAoE_SaberThreshold))
+                        (Gauge.Esprit >= Config.DNC_AdvAoE_SaberThreshold ||
+                        (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50)))
                         return SaberDance;
 
                     // Advanced AoE Starfall Dance / Tillana
@@ -1128,7 +1121,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && Config.DNC_AdvAoE_SS_Options == 2 && Config.DNC_AdvAoE_SS_Options_Burst &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct &&
-                        (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))
+                        (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 5) && Gauge.Esprit <= 20)
                         return StandardStep;
 
                     // Advanced AoE base GCDs

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -167,7 +167,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                #region Dance Combo Replacer
+                #region Dance Combo Replacer (L)
                 if (IsEnabled(CustomComboPreset.DNC_Dance_Menu) && IsEnabled(CustomComboPreset.DNC_DanceComboReplacer) && Gauge.IsDancing)
                 {
                     uint[]? actionIDs = Service.Configuration.DancerDanceCompatActionIDs;
@@ -183,7 +183,7 @@ namespace XIVSlothCombo.Combos.PvE
                 }
                 #endregion
 
-                #region Fan Dance Combos
+                #region Fan Dance Combos (L)
                 if (IsEnabled(CustomComboPreset.DNC_FanDanceCombos))
                 {
                     // FD 1 --> 3, FD 1 --> 4
@@ -210,7 +210,7 @@ namespace XIVSlothCombo.Combos.PvE
                 }
                 #endregion
 
-                #region Fan Dance 3 & 4 on Flourish
+                #region Fan Dance 3 & 4 on Flourish (L)
                 if (IsEnabled(CustomComboPreset.DNC_FlourishingFanDances) && actionID is Flourish && CanWeave(actionID))
                 {
                     if (HasEffect(Buffs.ThreeFoldFanDance))
@@ -220,7 +220,7 @@ namespace XIVSlothCombo.Combos.PvE
                 }
                 #endregion
 
-                #region ST Multibutton
+                #region ST Multibutton (L)
                 if (IsEnabled(CustomComboPreset.DNC_ST_MultiButton) && actionID is Cascade)
                 {
                     #region Types
@@ -260,7 +260,7 @@ namespace XIVSlothCombo.Combos.PvE
                 }
                 #endregion
 
-                #region AoE Multibutton
+                #region AoE Multibutton (L)
                 if (IsEnabled(CustomComboPreset.DNC_AoE_MultiButton) && actionID is Windmill)
                 {
                     #region Types
@@ -300,12 +300,12 @@ namespace XIVSlothCombo.Combos.PvE
                 }
                 #endregion
 
-                #region Devilment --> Starfall Dance
+                #region Devilment --> Starfall Dance (L)
                 if (IsEnabled(CustomComboPreset.DNC_Starfall_Devilment) && actionID is Devilment && HasEffect(Buffs.FlourishingStarfall))
                     return StarfallDance;
                 #endregion
 
-                #region Combined Dances
+                #region Combined Dances (L)
                 // One-button mode for both dances (SS/TS). SS takes priority.
                 if (IsEnabled(CustomComboPreset.DNC_Dance_Menu) && IsEnabled(CustomComboPreset.DNC_CombinedDances) && actionID is StandardStep)
                 {
@@ -619,20 +619,20 @@ namespace XIVSlothCombo.Combos.PvE
 
                     /*
                     #region Pre-pull
-                    // ST Peloton
+                    // Simple ST Peloton
                     if (!InCombat() && !HasEffectAny(Buffs.Peloton) && GetBuffRemainingTime(Buffs.StandardStep) > 5)
                         return Peloton;
                     #endregion
                     */
 
                     #region Dance Fills
-                    // ST Standard (Dance) Steps & Fill
+                    // Simple ST Standard (Dance) Steps & Fill
                     if (HasEffect(Buffs.StandardStep))
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
-                    // ST Technical (Dance) Steps & Fill
+                    // Simple ST Technical (Dance) Steps & Fill
                     if (HasEffect(Buffs.TechnicalStep))
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
@@ -640,25 +640,27 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region Weaves
-                    // ST Devilment
+                    // Simple ST Devilment
                     if (CanWeave(actionID) && ActionReady(Devilment) &&
                         (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
-                    // ST Flourish
+                    // Simple ST Flourish
                     if (CanDelayedWeave(actionID, 1.25, 0.5) && ActionReady(Flourish) &&
                         !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
                         !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
                         return Flourish;
 
-                    // ST Interrupt
+                    // Simple ST Interrupt
                     if (CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
+                    // Simple ST Variant Cure
                     if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
+                    // Simple ST Variant Rampart
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
                         IsEnabled(Variant.VariantRampart) &&
                         IsOffCooldown(Variant.VariantRampart) &&
@@ -667,7 +669,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (CanWeave(actionID))
                     {
-                        // ST Feathers & Fans
+                        // Simple ST Feathers & Fans
                         if (LevelChecked(FanDance1))
                         {
                             // FD3
@@ -699,7 +701,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (HasEffect(Buffs.FourFoldFanDance))
                             return FanDance4;
 
-                        // ST Panic Heals
+                        // Simple ST Panic Heals
                         if (ActionReady(CuringWaltz) &&
                             PlayerHealthPercentageHp() < 50)
                             return CuringWaltz;
@@ -709,7 +711,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return All.SecondWind;
 
                         /*
-                        // ST Improvisation
+                        // Simple ST Improvisation
                         if (ActionReady(Improvisation))
                             return Improvisation;
                         */
@@ -717,7 +719,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region GCD
-                    // ST Standard Step (outside of burst)
+                    // Simple ST Standard Step (outside of burst)
                     if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > 5) &&
@@ -727,35 +729,37 @@ namespace XIVSlothCombo.Combos.PvE
                             return StandardStep;
                     }
 
-                    // ST Technical Step
+                    // Simple ST Technical Step
                     if (ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > 5) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
-                    // ST Saber Dance
+                    // Simple ST Saber Dance
                     if (LevelChecked(SaberDance) && (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
                         if (Gauge.Esprit >= 85 || (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
                             return SaberDance;
                     }
 
+                    // Simple ST Starfall Dance / Tillana
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
 
-                    // ST combos and burst attacks
+                    // Simple ST combos and burst attacks
                     if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime is < 2 and > 0)
                         return Fountain;
 
-                    // ST Standard Step (inside of burst)
+                    // Simple ST Standard Step (inside of burst)
                     if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         Gauge.Esprit < 25 &&
                         GetTargetHPPercent() > 5 &&
                         (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
                         return StandardStep;
 
+                    // Simple ST base GCDs
                     if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
                     if (LevelChecked(ReverseCascade) && symmetry)
@@ -783,21 +787,21 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region Pre-pull
-                    // ST Peloton
+                    // Advanced ST Peloton
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Peloton) &&
                         !InCombat() && !HasEffectAny(Buffs.Peloton) && GetBuffRemainingTime(Buffs.StandardStep) > 5)
                         return Peloton;
                     #endregion
 
                     #region Dance Fills
-                    // ST Standard (Dance) Steps & Fill
+                    // Advanced ST Standard (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_AdvST_SS) || IsEnabled(CustomComboPreset.DNC_AdvST_StandardFill)) &&
                         HasEffect(Buffs.StandardStep))
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
-                    // ST Technical (Dance) Steps & Fill
+                    // Advanced ST Technical (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_AdvST_TS) || IsEnabled(CustomComboPreset.DNC_AdvST_TechFill)) &&
                         HasEffect(Buffs.TechnicalStep))
                         return Gauge.CompletedSteps < 4
@@ -806,28 +810,30 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region Weaves
-                    // ST Devilment
+                    // Advanced ST Devilment
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Devilment) &&
                         CanWeave(actionID) && ActionReady(Devilment) &&
                         (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
-                    // ST Flourish
+                    // Advanced ST Flourish
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Flourish) &&
                         CanDelayedWeave(actionID, 1.25, 0.5) && ActionReady(Flourish) &&
                         !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
                         !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
                         return Flourish;
 
-                    // ST Interrupt
+                    // Advanced ST Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Interrupt) &&
                         CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
+                    // Advanced ST Variant Cure
                     if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
+                    // Advanced ST Variant Rampart
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
                         IsEnabled(Variant.VariantRampart) &&
                         IsOffCooldown(Variant.VariantRampart) &&
@@ -836,7 +842,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (CanWeave(actionID))
                     {
-                        // ST Feathers & Fans
+                        // Advanced ST Feathers & Fans
                         if (IsEnabled(CustomComboPreset.DNC_AdvST_Feathers) && LevelChecked(FanDance1))
                         {
                             // FD3
@@ -868,7 +874,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (HasEffect(Buffs.FourFoldFanDance))
                             return FanDance4;
 
-                        // ST Panic Heals
+                        // Advanced ST Panic Heals
                         if (IsEnabled(CustomComboPreset.DNC_AdvST_PanicHeals))
                         {
                             if (ActionReady(CuringWaltz) &&
@@ -880,7 +886,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return All.SecondWind;
                         }
 
-                        // ST Improvisation
+                        // Advanced ST Improvisation
                         if (IsEnabled(CustomComboPreset.DNC_AdvST_Improvisation) &&
                             ActionReady(Improvisation))
                             return Improvisation;
@@ -888,7 +894,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region GCD
-                    // ST Standard Step (outside of burst)
+                    // Advanced ST Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct) &&
@@ -898,13 +904,13 @@ namespace XIVSlothCombo.Combos.PvE
                             return StandardStep;
                     }
 
-                    // ST Technical Step
+                    // Advanced ST Technical Step
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_TS) && ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_TSBurstPct) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
-                    // ST Saber Dance
+                    // Advanced ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
@@ -913,16 +919,17 @@ namespace XIVSlothCombo.Combos.PvE
                             return SaberDance;
                     }
 
+                    // Advanced ST Starfall Dance / Tillana
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
 
-                    // ST combos and burst attacks
+                    // Advanced ST combos and burst attacks
                     if (LevelChecked(Fountain) && lastComboMove is Cascade && comboTime is < 2 and > 0)
                         return Fountain;
 
-                    // ST Standard Step (inside of burst)
+                    // Advanced ST Standard Step (inside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SS_Burst) &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         Gauge.Esprit < 25 &&
@@ -930,6 +937,7 @@ namespace XIVSlothCombo.Combos.PvE
                         (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 5))
                         return StandardStep;
 
+                    // Advanced ST base GCDs
                     if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
                     if (LevelChecked(ReverseCascade) && symmetry)
@@ -959,13 +967,13 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region Dance Fills
-                    // AoE Standard (Dance) Steps & Fill
+                    // Simple AoE Standard (Dance) Steps & Fill
                     if (HasEffect(Buffs.StandardStep))
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
-                    // AoE Technical (Dance) Steps & Fill
+                    // Simple AoE Technical (Dance) Steps & Fill
                     if (HasEffect(Buffs.TechnicalStep))
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
@@ -973,25 +981,27 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region Weaves
-                    // AoE Devilment
+                    // Simple AoE Devilment
                     if (CanWeave(actionID) && ActionReady(Devilment) &&
                         (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
-                    // AoE Flourish
+                    // Simple AoE Flourish
                     if (CanDelayedWeave(actionID, 1.25, 0.5) && ActionReady(Flourish) &&
                         !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
                         !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
                         return Flourish;
 
-                    // AoE Interrupt
+                    // Simple AoE Interrupt
                     if (CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
+                    // Simple AoE Variant Cure
                     if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
+                    // Simple AoE Variant Rampart
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
                         IsEnabled(Variant.VariantRampart) &&
                         IsOffCooldown(Variant.VariantRampart) &&
@@ -1001,7 +1011,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (CanWeave(actionID))
                     {
                         /*
-                        // AoE Feathers & Fans
+                        // Simple AoE Feathers & Fans
                         if (LevelChecked(FanDance1))
                         {
                             int minFeathers = LevelChecked(TechnicalStep)
@@ -1018,7 +1028,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         */
 
-                        // AoE Feathers & Fans
+                        // Simple AoE Feathers & Fans
                         if (LevelChecked(FanDance1))
                         {
                             // FD3
@@ -1052,20 +1062,17 @@ namespace XIVSlothCombo.Combos.PvE
                         if (HasEffect(Buffs.FourFoldFanDance))
                             return FanDance4;
 
-                        // AoE Panic Heals
-                        if (IsEnabled(CustomComboPreset.DNC_AdvAoE_PanicHeals))
-                        {
-                            if (ActionReady(CuringWaltz) &&
-                                PlayerHealthPercentageHp() < 50)
-                                return CuringWaltz;
+                        // Simple AoE Panic Heals
+                        if (ActionReady(CuringWaltz) &&
+                            PlayerHealthPercentageHp() < 50)
+                            return CuringWaltz;
 
-                            if (ActionReady(All.SecondWind) &&
-                                PlayerHealthPercentageHp() < 30)
-                                return All.SecondWind;
-                        }
+                        if (ActionReady(All.SecondWind) &&
+                            PlayerHealthPercentageHp() < 30)
+                            return All.SecondWind;
 
                         /*
-                        // AoE Improvisation
+                        // Simple AoE Improvisation
                         if (ActionReady(Improvisation))
                             return Improvisation;
                         */
@@ -1073,7 +1080,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region GCD
-                    // AoE Standard Step (outside of burst)
+                    // Simple AoE Standard Step (outside of burst)
                     if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > 5) &&
@@ -1083,33 +1090,35 @@ namespace XIVSlothCombo.Combos.PvE
                             return StandardStep;
                     }
 
-                    // AoE Technical Step
+                    // Simple AoE Technical Step
                     if (ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > 5) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
-                    // AoE Saber Dance
+                    // Simple AoE Saber Dance
                     if (LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
                         ((HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50) ||
                         Gauge.Esprit >= 80))
                         return SaberDance;
 
+                    // Simple AoE Starfall Dance / Tillana
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
 
-                    // AoE combos and burst attacks
+                    // Simple AoE combos and burst attacks
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime is < 2 and > 0)
                         return Bladeshower;
 
-                    // AoE Standard Step (inside of burst)
+                    // Simple AoE Standard Step (inside of burst)
                     if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         GetTargetHPPercent() > 5 && (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))
                         return StandardStep;
 
+                    // Simple AoE base GCDs
                     if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;
                     if (LevelChecked(RisingWindmill) && symmetry)
@@ -1137,14 +1146,14 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region Dance Fills
-                    // AoE Standard (Dance) Steps & Fill
+                    // Advanced AoE Standard (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) || IsEnabled(CustomComboPreset.DNC_AdvAoE_StandardFill)) &&
                         HasEffect(Buffs.StandardStep))
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
-                    // AoE Technical (Dance) Steps & Fill
+                    // Advanced AoE Technical (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_AdvAoE_TS) || IsEnabled(CustomComboPreset.DNC_AdvAoE_TechFill)) &&
                         HasEffect(Buffs.TechnicalStep))
                         return Gauge.CompletedSteps < 4
@@ -1153,28 +1162,30 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region Weaves
-                    // AoE Devilment
+                    // Advanced AoE Devilment
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Devilment) &&
                         CanWeave(actionID) && ActionReady(Devilment) &&
                         (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
-                    // AoE Flourish
+                    // Advanced AoE Flourish
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Flourish) &&
                         CanDelayedWeave(actionID, 1.25, 0.5) && ActionReady(Flourish)
                         && !HasEffect(Buffs.ThreeFoldFanDance) && !HasEffect(Buffs.FourFoldFanDance) &&
                         !HasEffect(Buffs.FlourishingSymmetry) && !HasEffect(Buffs.FlourishingFlow))
                         return Flourish;
 
-                    // AoE Interrupt
+                    // Advanced AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Interrupt) &&
                         CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
+                    // Advanced AoE Variant Cure
                     if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
+                    // Advanced AoE Variant Rampart
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
                         IsEnabled(Variant.VariantRampart) &&
                         IsOffCooldown(Variant.VariantRampart) &&
@@ -1184,7 +1195,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (CanWeave(actionID))
                     {
                         /*
-                        // AoE Feathers & Fans
+                        // Advanced AoE Feathers & Fans
                         if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Feathers) && LevelChecked(FanDance1))
                         {
                             int minFeathers = IsEnabled(CustomComboPreset.DNC_AdvAoE_FeatherPooling) && LevelChecked(TechnicalStep)
@@ -1201,7 +1212,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         */
 
-                        // AoE Feathers & Fans
+                        // Advanced AoE Feathers & Fans
                         if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Feathers) && LevelChecked(FanDance1))
                         {
                             // FD3
@@ -1235,7 +1246,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (HasEffect(Buffs.FourFoldFanDance))
                             return FanDance4;
 
-                        // AoE Panic Heals
+                        // Advanced AoE Panic Heals
                         if (IsEnabled(CustomComboPreset.DNC_AdvAoE_PanicHeals))
                         {
                             if (ActionReady(CuringWaltz) &&
@@ -1247,7 +1258,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return All.SecondWind;
                         }
 
-                        // AoE Improvisation
+                        // Advanced AoE Improvisation
                         if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Improvisation) &&
                             ActionReady(Improvisation))
                             return Improvisation;
@@ -1255,7 +1266,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region GCD
-                    // AoE Standard Step (outside of burst)
+                    // Advanced AoE Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct) &&
@@ -1265,35 +1276,37 @@ namespace XIVSlothCombo.Combos.PvE
                             return StandardStep;
                     }
 
-                    // AoE Technical Step
+                    // Advanced AoE Technical Step
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_TS) && ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_TSBurstPct) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
-                    // AoE Saber Dance
+                    // Advanced AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
                         ((HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50) ||
                         Gauge.Esprit >= Config.DNC_AdvAoE_SaberTh))
                         return SaberDance;
 
+                    // Advanced AoE Starfall Dance / Tillana
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
                     if (HasEffect(Buffs.FlourishingFinish))
                         return Tillana;
 
-                    // AoE combos and burst attacks
+                    // Advanced AoE combos and burst attacks
                     if (LevelChecked(Bladeshower) && lastComboMove is Windmill && comboTime is < 2 and > 0)
                         return Bladeshower;
 
-                    // AoE Standard Step (inside of burst)
+                    // Advanced AoE Standard Step (inside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct &&
                         (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))
                         return StandardStep;
 
+                    // Advanced AoE base GCDs
                     if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;
                     if (LevelChecked(RisingWindmill) && symmetry)

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -115,7 +115,7 @@ namespace XIVSlothCombo.Combos.PvE
                 DNC_LegacyAoE_EspritTh      = new("DNC_LegacyAoE_EspritTh");    // AoE Esprit threshold (L)
             #endregion
 
-            #region Advanced ST Sliders
+            #region Advanced ST config
             internal static UserInt
                 DNC_AdvST_SSBurstPct        = new("DNC_AdvST_SSBurstPct"),      // Standard Step    target HP% threshold
                 DNC_AdvST_TSBurstPct        = new("DNC_AdvST_TSBurstPct"),      // Technical Step   target HP% threshold
@@ -123,15 +123,21 @@ namespace XIVSlothCombo.Combos.PvE
                 DNC_AdvST_SaberTh           = new("DNC_AdvST_SaberTh"),         // Saber Dance      Esprit     threshold
                 DNC_AdvST_PanicWaltzPct     = new("DNC_AdvST_PanicWaltzPct"),   // Curing Waltz     player HP% threshold
                 DNC_AdvST_PanicWindPct      = new("DNC_AdvST_PanicWindPct");    // Second Wind      player HP% threshold
+
+            internal static UserBool
+                DNC_AdvST_InterruptAny      = new("DNC_AdvST_InterruptAny");   // Interrupt any time, outside of weave windows
             #endregion
 
-            #region Advanced AoE Sliders
+            #region Advanced AoE config
             internal static UserInt
                 DNC_AdvAoE_SSBurstPct       = new("DNC_AdvAoE_SSBurstPct"),     // Standard Step    target HP% threshold
                 DNC_AdvAoE_TSBurstPct       = new("DNC_AdvAoE_TSBurstPct"),     // Technical Step   target HP% threshold
                 DNC_AdvAoE_SaberTh          = new("DNC_AdvAoE_SaberTh"),        // Saber Dance      Esprit     threshold
                 DNC_AdvAoE_PanicWaltzPct    = new("DNC_AdvAoE_PanicWaltzPct"),  // Curing Waltz     player HP% threshold
                 DNC_AdvAoE_PanicWindPct     = new("DNC_AdvAoE_PanicWindPct");   // Second Wind      player HP% threshold
+
+            internal static UserBool
+                DNC_AdvAoE_InterruptAny      = new("DNC_AdvAoE_InterruptAny");  // Interrupt any time, outside of weave windows
             #endregion
 
             internal static UserInt
@@ -652,7 +658,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Flourish;
 
                     // Simple ST Interrupt
-                    if (CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
+                    if (CanInterruptEnemy() && CanDelayedWeave(actionID, 1.25, 0.6) &&
+                        ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
@@ -825,6 +832,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced ST Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Interrupt) &&
+                        (Config.DNC_AdvST_InterruptAny || CanDelayedWeave(actionID, 1.25, 0.6)) &&
                         CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
@@ -993,7 +1001,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Flourish;
 
                     // Simple AoE Interrupt
-                    if (CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
+                    if (CanInterruptEnemy() && CanDelayedWeave(actionID, 1.25, 0.6) &&
+                        ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
@@ -1177,6 +1186,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Interrupt) &&
+                        (Config.DNC_AdvAoE_InterruptAny || CanDelayedWeave(actionID, 1.25, 0.6)) &&
                         CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -1,6 +1,5 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using XIVSlothCombo.Combos.PvE.Content;
-using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.Services;
 using XIVSlothCombo.CustomComboNS.Functions;
@@ -111,39 +110,41 @@ namespace XIVSlothCombo.Combos.PvE
         {
             #region Legacy config
             internal static UserInt
-                DNC_LegacyST_EspritTh       = new("DNC_LegacyST_EspritTh"),     // Single target Esprit threshold (L)
-                DNC_LegacyAoE_EspritTh      = new("DNC_LegacyAoE_EspritTh");    // AoE Esprit threshold (L)
+                DNC_LegacyST_EspritThreshold    = new("DNC_LegacyST_EspritThreshold"),  // Single target Esprit threshold (L)
+                DNC_LegacyAoE_EspritThreshold   = new("DNC_LegacyAoE_EspritThreshold"); // AoE Esprit threshold (L)
             #endregion
 
             #region Advanced ST config
-            internal static UserInt
-                DNC_AdvST_SSBurstPct        = new("DNC_AdvST_SSBurstPct"),      // Standard Step    target HP% threshold
-                DNC_AdvST_TSBurstPct        = new("DNC_AdvST_TSBurstPct"),      // Technical Step   target HP% threshold
-                DNC_AdvST_FeatherBurstPct   = new("DNC_AdvST_FeatherBurstPct"), // Feather burst    target HP% threshold
-                DNC_AdvST_SaberTh           = new("DNC_AdvST_SaberTh"),         // Saber Dance      Esprit     threshold
-                DNC_AdvST_PanicWaltzPct     = new("DNC_AdvST_PanicWaltzPct"),   // Curing Waltz     player HP% threshold
-                DNC_AdvST_PanicWindPct      = new("DNC_AdvST_PanicWindPct");    // Second Wind      player HP% threshold
-
             internal static UserBool
-                DNC_AdvST_SS_Burst          = new("DNC_AdvST_SS_Burst"),        // Standard Step during TS burst phase
-                DNC_AdvST_InterruptAny      = new("DNC_AdvST_InterruptAny");    // Interrupt any time, outside of weave windows
+                DNC_AdvST_SS_Options_Burst      = new("DNC_AdvST_SS_Options_Burst");    // Standard Step during TS burst phase
+            internal static UserInt
+                DNC_AdvST_SS_Options            = new("DNC_AdvST_SS_Options"),          // Standard Step    usage choice
+                DNC_AdvST_SSBurstPct            = new("DNC_AdvST_SSBurstPct"),          // Standard Step    target HP% threshold
+                DNC_AdvST_TS_Options            = new("DNC_AdvST_TS_Options"),          // Technical Step   usage choice
+                DNC_AdvST_TSBurstPct            = new("DNC_AdvST_TSBurstPct"),          // Technical Step   target HP% threshold
+                DNC_AdvST_FeatherBurstPct       = new("DNC_AdvST_FeatherBurstPct"),     // Feather burst    target HP% threshold
+                DNC_AdvST_SaberThreshold        = new("DNC_AdvST_SaberThreshold"),      // Saber Dance      Esprit     threshold
+                DNC_AdvST_PanicWaltzPct         = new("DNC_AdvST_PanicWaltzPct"),       // Curing Waltz     player HP% threshold
+                DNC_AdvST_PanicWindPct          = new("DNC_AdvST_PanicWindPct"),        // Second Wind      player HP% threshold
+                DNC_AdvST_Interrupt             = new("DNC_AdvST_Interrupt");           // Interrupt        usage choice
             #endregion
 
             #region Advanced AoE config
-            internal static UserInt
-                DNC_AdvAoE_SSBurstPct       = new("DNC_AdvAoE_SSBurstPct"),     // Standard Step    target HP% threshold
-                DNC_AdvAoE_TSBurstPct       = new("DNC_AdvAoE_TSBurstPct"),     // Technical Step   target HP% threshold
-                DNC_AdvAoE_SaberTh          = new("DNC_AdvAoE_SaberTh"),        // Saber Dance      Esprit     threshold
-                DNC_AdvAoE_PanicWaltzPct    = new("DNC_AdvAoE_PanicWaltzPct"),  // Curing Waltz     player HP% threshold
-                DNC_AdvAoE_PanicWindPct     = new("DNC_AdvAoE_PanicWindPct");   // Second Wind      player HP% threshold
-
             internal static UserBool
-                DNC_AdvAoE_SS_Burst         = new("DNC_AdvAoE_SS_Burst"),       // Standard Step during TS burst phase
-                DNC_AdvAoE_InterruptAny     = new("DNC_AdvAoE_InterruptAny");   // Interrupt any time, outside of weave windows
+                DNC_AdvAoE_SS_Options_Burst     = new("DNC_AdvAoE_SS_Options_Burst");   // Standard Step during TS burst phase
+            internal static UserInt
+                DNC_AdvAoE_SS_Options           = new("DNC_AdvAoE_SS_Options"),         // Standard Step    usage choice
+                DNC_AdvAoE_SSBurstPct           = new("DNC_AdvAoE_SSBurstPct"),         // Standard Step    target HP% threshold
+                DNC_AdvAoE_TS_Options           = new("DNC_AdvAoE_TS_Options"),         // Technical Step   usage choice
+                DNC_AdvAoE_TSBurstPct           = new("DNC_AdvAoE_TSBurstPct"),         // Technical Step   target HP% threshold
+                DNC_AdvAoE_SaberThreshold       = new("DNC_AdvAoE_SaberThreshold"),     // Saber Dance      Esprit     threshold
+                DNC_AdvAoE_PanicWaltzPct        = new("DNC_AdvAoE_PanicWaltzPct"),      // Curing Waltz     player HP% threshold
+                DNC_AdvAoE_PanicWindPct         = new("DNC_AdvAoE_PanicWindPct"),       // Second Wind      player HP% threshold
+                DNC_AdvAoE_Interrupt            = new("DNC_AdvAoE_Interrupt");          // Interrupt        usage choice
             #endregion
 
             internal static UserInt
-                DNC_VariantCurePct          = new("DNC_VariantCurePct");        // Variant Cure     player HP% threshold
+                DNC_VariantCurePct              = new("DNC_VariantCurePct");            // Variant Cure     player HP% threshold
         }
 
         internal class DNC_DanceStepSolver : CustomCombo
@@ -238,7 +239,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= Config.DNC_LegacyST_EspritTh)
+                        Gauge.Esprit >= Config.DNC_LegacyST_EspritThreshold)
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -278,7 +279,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= Config.DNC_LegacyAoE_EspritTh)
+                        Gauge.Esprit >= Config.DNC_LegacyAoE_EspritThreshold)
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -457,7 +458,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyST_EspritTh))
+                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyST_EspritThreshold))
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -505,7 +506,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyAoE_EspritTh))
+                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyAoE_EspritThreshold))
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -804,14 +805,14 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Dance Fills
                     // Advanced ST Standard (Dance) Steps & Fill
-                    if ((IsEnabled(CustomComboPreset.DNC_AdvST_SS) || IsEnabled(CustomComboPreset.DNC_AdvST_StandardFill)) &&
+                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) &&
                         HasEffect(Buffs.StandardStep))
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
                     // Advanced ST Technical (Dance) Steps & Fill
-                    if ((IsEnabled(CustomComboPreset.DNC_AdvST_TS) || IsEnabled(CustomComboPreset.DNC_AdvST_TechFill)) &&
+                    if (IsEnabled(CustomComboPreset.DNC_AdvST_TS) &&
                         HasEffect(Buffs.TechnicalStep))
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
@@ -834,7 +835,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced ST Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Interrupt) &&
-                        (Config.DNC_AdvST_InterruptAny || CanDelayedWeave(actionID, 1.25, 0.6)) &&
+                        ((Config.DNC_AdvST_Interrupt == 1 && CanDelayedWeave(actionID, 1.25, 0.6)) ||
+                         (Config.DNC_AdvST_Interrupt == 2 && CanDelayedWeave(actionID, 2.25, 0.7)) ||
+                         (Config.DNC_AdvST_Interrupt == 3)) &&
                         CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
@@ -905,7 +908,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Advanced ST Standard Step (outside of burst)
-                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (Config.DNC_AdvST_SS_Options == 2 && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -915,7 +918,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Advanced ST Technical Step
-                    if (IsEnabled(CustomComboPreset.DNC_AdvST_TS) && ActionReady(TechnicalStep) &&
+                    if (Config.DNC_AdvST_TS_Options == 2 && ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_TSBurstPct) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
@@ -924,7 +927,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
-                        if (Gauge.Esprit >= Config.DNC_AdvST_SaberTh ||
+                        if (Gauge.Esprit >= Config.DNC_AdvST_SaberThreshold ||
                             (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
                             return SaberDance;
                     }
@@ -940,7 +943,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Fountain;
 
                     // Advanced ST Standard Step (inside of burst)
-                    if (Config.DNC_AdvST_SS_Burst &&
+                    if (Config.DNC_AdvST_SS_Options_Burst &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         Gauge.Esprit < 25 &&
                         GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct &&
@@ -1158,14 +1161,14 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Dance Fills
                     // Advanced AoE Standard (Dance) Steps & Fill
-                    if ((IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) || IsEnabled(CustomComboPreset.DNC_AdvAoE_StandardFill)) &&
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) &&
                         HasEffect(Buffs.StandardStep))
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
                     // Advanced AoE Technical (Dance) Steps & Fill
-                    if ((IsEnabled(CustomComboPreset.DNC_AdvAoE_TS) || IsEnabled(CustomComboPreset.DNC_AdvAoE_TechFill)) &&
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_TS) &&
                         HasEffect(Buffs.TechnicalStep))
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
@@ -1188,7 +1191,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Interrupt) &&
-                        (Config.DNC_AdvAoE_InterruptAny || CanDelayedWeave(actionID, 1.25, 0.6)) &&
+                        ((Config.DNC_AdvAoE_Interrupt == 1 && CanDelayedWeave(actionID, 1.25, 0.6)) ||
+                         (Config.DNC_AdvAoE_Interrupt == 2 && CanDelayedWeave(actionID, 2.25, 0.7)) ||
+                         (Config.DNC_AdvAoE_Interrupt == 3)) &&
                         CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
@@ -1279,7 +1284,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Advanced AoE Standard Step (outside of burst)
-                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (Config.DNC_AdvAoE_SS_Options == 2 && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -1289,7 +1294,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Advanced AoE Technical Step
-                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_TS) && ActionReady(TechnicalStep) &&
+                    if (Config.DNC_AdvAoE_TS_Options == 2 && ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_TSBurstPct) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
@@ -1298,7 +1303,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
                         ((HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50) ||
-                        Gauge.Esprit >= Config.DNC_AdvAoE_SaberTh))
+                        Gauge.Esprit >= Config.DNC_AdvAoE_SaberThreshold))
                         return SaberDance;
 
                     // Advanced AoE Starfall Dance / Tillana
@@ -1312,7 +1317,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // Advanced AoE Standard Step (inside of burst)
-                    if (Config.DNC_AdvAoE_SS_Burst &&
+                    if (Config.DNC_AdvAoE_SS_Options_Burst &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct &&
                         (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -3,6 +3,7 @@ using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.Services;
+using XIVSlothCombo.CustomComboNS.Functions;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -42,22 +43,22 @@ namespace XIVSlothCombo.Combos.PvE
             Improvisation = 16014,
             CuringWaltz = 16015;
 
-        /* Unused
-        EnAvant = 16010,
-        ClosedPosition = 16006,
-        Ending = 18073,
-        Emboite = 15999,
-        Entrechat = 16000,
-        Jete = 16001,
-        Pirouette = 16002,
-        StandardFinish0 = 16003,
-        StandardFinish1 = 16191,
-        TechnicalFinish0 = 16004,
-        TechnicalFinish1 = 16193,
-        TechnicalFinish2 = 16194,
-        TechnicalFinish3 = 16195,
-        ImprovisedFinish = 25789,
-        */
+            /* Unused
+            EnAvant = 16010,
+            ClosedPosition = 16006,
+            Ending = 18073,
+            Emboite = 15999,
+            Entrechat = 16000,
+            Jete = 16001,
+            Pirouette = 16002,
+            StandardFinish0 = 16003,
+            StandardFinish1 = 16191,
+            TechnicalFinish0 = 16004,
+            TechnicalFinish1 = 16193,
+            TechnicalFinish2 = 16194,
+            TechnicalFinish3 = 16195,
+            ImprovisedFinish = 25789,
+            */
 
         public static class Buffs
         {
@@ -106,41 +107,33 @@ namespace XIVSlothCombo.Combos.PvE
 
         public static class Config
         {
-            public const string
-                DNCEspritThreshold_ST = "DNCEspritThreshold_ST";                            // Single target Esprit threshold
-            public const string
-                DNCEspritThreshold_AoE = "DNCEspritThreshold_AoE";                          // AoE Esprit threshold
+            #region Legacy config
+            internal static UserInt
+                DNCEspritThreshold_ST = new("DNCEspritThreshold_ST"),                           // Single target Esprit threshold
+                DNCEspritThreshold_AoE = new("DNCEspritThreshold_AoE");                         // AoE Esprit threshold
+            #endregion
 
             #region Simple ST Sliders
-            public const string
-                DNCSimpleSSBurstPercent = "DNCSimpleSSBurstPercent";                        // Standard Step    target HP% threshold
-            public const string
-                DNCSimpleTSBurstPercent = "DNCSimpleTSBurstPercent";                        // Technical Step   target HP% threshold
-            public const string
-                DNCSimpleFeatherBurstPercent = "DNCSimpleFeatherBurstPercent";              // Feather burst    target HP% threshold
-            public const string
-                DNCSimpleSaberThreshold = "DNCSimpleSaberThreshold";                        // Saber Dance      Esprit threshold
-            public const string
-                DNCSimplePanicHealWaltzPercent = "DNCSimplePanicHealWaltzPercent";          // Curing Waltz     player HP% threshold
-            public const string
-                DNCSimplePanicHealWindPercent = "DNCSimplePanicHealWindPercent";            // Second Wind      player HP% threshold
+            internal static UserInt
+                DNCSimpleSSBurstPercent = new("DNCSimpleSSBurstPercent"),                       // Standard Step    target HP% threshold
+                DNCSimpleTSBurstPercent = new("DNCSimpleTSBurstPercent"),                       // Technical Step   target HP% threshold
+                DNCSimpleFeatherBurstPercent = new("DNCSimpleFeatherBurstPercent"),             // Feather burst    target HP% threshold
+                DNCSimpleSaberThreshold = new("DNCSimpleSaberThreshold"),                       // Saber Dance      Esprit threshold
+                DNCSimplePanicHealWaltzPercent = new("DNCSimplePanicHealWaltzPercent"),         // Curing Waltz     player HP% threshold
+                DNCSimplePanicHealWindPercent = new("DNCSimplePanicHealWindPercent");           // Second Wind      player HP% threshold
             #endregion
 
             #region Simple AoE Sliders
-            public const string
-                DNCSimpleSSAoEBurstPercent = "DNCSimpleSSAoEBurstPercent";                  // Standard Step    target HP% threshold
-            public const string
-                DNCSimpleTSAoEBurstPercent = "DNCSimpleTSAoEBurstPercent";                  // Technical Step   target HP% threshold
-            public const string
-                DNCSimpleAoESaberThreshold = "DNCSimpleAoESaberThreshold";                  // Saber Dance      Esprit threshold
-            public const string
-                DNCSimpleAoEPanicHealWaltzPercent = "DNCSimpleAoEPanicHealWaltzPercent";    // Curing Waltz     player HP% threshold 
-            public const string
-                DNCSimpleAoEPanicHealWindPercent = "DNCSimpleAoEPanicHealWindPercent";      // Second Wind      player HP% threshold
+            internal static UserInt
+                DNCSimpleSSAoEBurstPercent = new("DNCSimpleSSAoEBurstPercent"),                 // Standard Step    target HP% threshold
+                DNCSimpleTSAoEBurstPercent = new("DNCSimpleTSAoEBurstPercent"),                 // Technical Step   target HP% threshold
+                DNCSimpleAoESaberThreshold = new("DNCSimpleAoESaberThreshold"),                 // Saber Dance      Esprit threshold
+                DNCSimpleAoEPanicHealWaltzPercent = new("DNCSimpleAoEPanicHealWaltzPercent"),   // Curing Waltz     player HP% threshold
+                DNCSimpleAoEPanicHealWindPercent = new("DNCSimpleAoEPanicHealWindPercent");     // Second Wind      player HP% threshold
             #endregion
 
-            public const string
-                DNCVariantCurePercent = "DNCVariantCurePercent";                            // Variant Cure     player HP% threshold
+            internal static UserInt
+                DNCVariantCurePercent = new("DNCVariantCurePercent");                           // Variant Cure     player HP% threshold
         }
 
         internal class DNC_DanceComboReplacer : CustomCombo

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -516,10 +516,9 @@ namespace XIVSlothCombo.Combos.PvE
                     if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
                         Config.DNC_SimpleST_Dances[0])
                     {
-                        if (((!HasTarget() || GetTargetHPPercent() > 5) &&
+                        if ((!HasTarget() || GetTargetHPPercent() > 5) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
-                            IsOffCooldown(StandardStep))
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
                             return StandardStep;
                     }
 
@@ -698,10 +697,9 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && Config.DNC_AdvST_SS_Options == 2 &&
                         ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct) &&
+                        if ((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
-                            IsOffCooldown(StandardStep))
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))
                             return StandardStep;
                     }
 
@@ -881,10 +879,9 @@ namespace XIVSlothCombo.Combos.PvE
                     if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
                         Config.DNC_SimpleAoE_Dances[0])
                     {
-                        if (((!HasTarget() || GetTargetHPPercent() > 5) &&
+                        if ((!HasTarget() || GetTargetHPPercent() > 5) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
-                            IsOffCooldown(StandardStep))
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
                             return StandardStep;
                     }
 
@@ -1073,10 +1070,9 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && Config.DNC_AdvAoE_SS_Options == 2 &&
                         ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct) &&
+                        if ((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
-                            IsOffCooldown(StandardStep))
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
                             return StandardStep;
                     }
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -587,6 +587,12 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Peloton) &&
                         !InCombat() && !HasEffectAny(Buffs.Peloton) && GetBuffRemainingTime(Buffs.StandardStep) > 5)
                         return Peloton;
+
+                    // Advanced ST Standard Step (pre-pull)
+                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && Config.DNC_AdvST_SS_Options == 2 &&
+                        ActionReady(StandardStep) &&
+                        IsOffCooldown(TechnicalStep) && !InCombat())
+                        return StandardStep;
                     #endregion
 
                     #region Dance Fills
@@ -693,21 +699,21 @@ namespace XIVSlothCombo.Combos.PvE
                         PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
-                    // Advanced ST Standard Step (outside of burst)
-                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && Config.DNC_AdvST_SS_Options == 2 &&
-                        ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
-                    {
-                        if ((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct) &&
-                            ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
-                            return StandardStep;
-                    }
-
                     // Advanced ST Technical Step
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_TS) && Config.DNC_AdvST_TS_Options == 2 &&
                         ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep) &&
                         (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_TSBurstPct))
                         return TechnicalStep;
+
+                    // Advanced ST Standard Step (outside of burst)
+                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && Config.DNC_AdvST_SS_Options == 2 &&
+                        ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    {
+                        if ((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct) &&
+                            (GetCooldownRemainingTime(TechnicalStep) > 5) &&
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
+                            return StandardStep;
+                    }
 
                     // Advanced ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SaberDance) && LevelChecked(SaberDance) &&

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -710,7 +710,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
-                        if (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
+                        if (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) ||
                             (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50))
                             return SaberDance;
                     }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -1090,12 +1090,11 @@ namespace XIVSlothCombo.Combos.PvE
                         return TechnicalStep;
 
                     // AoE Saber Dance
-                    if (LevelChecked(SaberDance) && (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
-                    {
-                        if (Gauge.Esprit >= 80 ||
-                            (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
-                            return SaberDance;
-                    }
+                    if (LevelChecked(SaberDance) &&
+                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
+                        ((HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50) ||
+                        Gauge.Esprit >= 80))
+                        return SaberDance;
 
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
@@ -1107,12 +1106,9 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // AoE Standard Step (inside of burst)
-                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
-                    {
-                        if (GetTargetHPPercent() > 5 &&
-                            (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
-                            return StandardStep;
-                    }
+                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                        GetTargetHPPercent() > 5 && (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))
+                        return StandardStep;
 
                     if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;
@@ -1277,12 +1273,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SaberDance) && LevelChecked(SaberDance) &&
-                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
-                    {
-                        if (Gauge.Esprit >= Config.DNC_AdvAoE_SaberTh ||
-                            (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
-                            return SaberDance;
-                    }
+                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
+                        ((HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50) ||
+                        Gauge.Esprit >= Config.DNC_AdvAoE_SaberTh))
+                        return SaberDance;
 
                     if (HasEffect(Buffs.FlourishingStarfall))
                         return StarfallDance;
@@ -1294,12 +1288,11 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // AoE Standard Step (inside of burst)
-                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
-                    {
-                        if (GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct &&
-                            (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
-                            return StandardStep;
-                    }
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) &&
+                        IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                        GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct &&
+                        (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))
+                        return StandardStep;
 
                     if (LevelChecked(Bloodshower) && flow)
                         return Bloodshower;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -119,40 +119,38 @@ namespace XIVSlothCombo.Combos.PvE
             #endregion
 
             #region Simple ST/AoE
-            internal static UserBool
-                DNC_SimpleST_SS                     = new("DNC_SimpleST_SS"),                       // Simple ST Standard Step inclusion
-                DNC_SimpleST_TS                     = new("DNC_SimpleST_TS"),                       // Simple ST Technical Step inclusion
-                DNC_SimpleAoE_SS                    = new("DNC_SimpleAoE_SS"),                      // Simple AoE Standard Step inclusion
-                DNC_SimpleAoE_TS                    = new("DNC_SimpleAoE_TS");                      // Simple AoE Technical Step inclusion
+            internal static UserBoolArray
+                DNC_SimpleST_Dances                 = new("DNC_SimpleST_Dances"),                   // Simple ST        Dance choice
+                DNC_SimpleAoE_Dances                = new("DNC_SimpleAoE_Dances");                  // Simple AoE       Dance choice
             #endregion
 
             #region Advanced ST
             internal static UserBool
                 DNC_AdvST_SS_Options_Burst          = new("DNC_AdvST_SS_Options_Burst");            // Standard Step during TS burst phase
             internal static UserInt
-                DNC_AdvST_SS_Options                = new("DNC_AdvST_SS_Options"),                  // Standard Step    usage choice
-                DNC_AdvST_SSBurstPct                = new("DNC_AdvST_SSBurstPct"),                  // Standard Step    target HP% threshold
-                DNC_AdvST_TS_Options                = new("DNC_AdvST_TS_Options"),                  // Technical Step   usage choice
-                DNC_AdvST_TSBurstPct                = new("DNC_AdvST_TSBurstPct"),                  // Technical Step   target HP% threshold
-                DNC_AdvST_FeatherBurstPct           = new("DNC_AdvST_FeatherBurstPct"),             // Feather burst    target HP% threshold
+                DNC_AdvST_SS_Options                = new("DNC_AdvST_SS_Options"),                  // Standard Step    Usage choice
+                DNC_AdvST_SSBurstPct                = new("DNC_AdvST_SSBurstPct"),                  // Standard Step    Target HP% threshold
+                DNC_AdvST_TS_Options                = new("DNC_AdvST_TS_Options"),                  // Technical Step   Usage choice
+                DNC_AdvST_TSBurstPct                = new("DNC_AdvST_TSBurstPct"),                  // Technical Step   Target HP% threshold
+                DNC_AdvST_FeatherBurstPct           = new("DNC_AdvST_FeatherBurstPct"),             // Feather burst    Target HP% threshold
                 DNC_AdvST_SaberThreshold            = new("DNC_AdvST_SaberThreshold"),              // Saber Dance      Esprit     threshold
-                DNC_AdvST_PanicWaltzPct             = new("DNC_AdvST_PanicWaltzPct"),               // Curing Waltz     player HP% threshold
-                DNC_AdvST_PanicWindPct              = new("DNC_AdvST_PanicWindPct"),                // Second Wind      player HP% threshold
-                DNC_AdvST_Interrupt                 = new("DNC_AdvST_Interrupt");                   // Interrupt        usage choice
+                DNC_AdvST_PanicWaltzPct             = new("DNC_AdvST_PanicWaltzPct"),               // Curing Waltz     Player HP% threshold
+                DNC_AdvST_PanicWindPct              = new("DNC_AdvST_PanicWindPct"),                // Second Wind      Player HP% threshold
+                DNC_AdvST_Interrupt                 = new("DNC_AdvST_Interrupt");                   // Interrupt        Usage choice
             #endregion
 
             #region Advanced AoE
             internal static UserBool
                 DNC_AdvAoE_SS_Options_Burst         = new("DNC_AdvAoE_SS_Options_Burst");           // Standard Step during TS burst phase
             internal static UserInt
-                DNC_AdvAoE_SS_Options               = new("DNC_AdvAoE_SS_Options"),                 // Standard Step    usage choice
-                DNC_AdvAoE_SSBurstPct               = new("DNC_AdvAoE_SSBurstPct"),                 // Standard Step    target HP% threshold
-                DNC_AdvAoE_TS_Options               = new("DNC_AdvAoE_TS_Options"),                 // Technical Step   usage choice
-                DNC_AdvAoE_TSBurstPct               = new("DNC_AdvAoE_TSBurstPct"),                 // Technical Step   target HP% threshold
+                DNC_AdvAoE_SS_Options               = new("DNC_AdvAoE_SS_Options"),                 // Standard Step    Usage choice
+                DNC_AdvAoE_SSBurstPct               = new("DNC_AdvAoE_SSBurstPct"),                 // Standard Step    Target HP% threshold
+                DNC_AdvAoE_TS_Options               = new("DNC_AdvAoE_TS_Options"),                 // Technical Step   Usage choice
+                DNC_AdvAoE_TSBurstPct               = new("DNC_AdvAoE_TSBurstPct"),                 // Technical Step   Target HP% threshold
                 DNC_AdvAoE_SaberThreshold           = new("DNC_AdvAoE_SaberThreshold"),             // Saber Dance      Esprit     threshold
-                DNC_AdvAoE_PanicWaltzPct            = new("DNC_AdvAoE_PanicWaltzPct"),              // Curing Waltz     player HP% threshold
-                DNC_AdvAoE_PanicWindPct             = new("DNC_AdvAoE_PanicWindPct"),               // Second Wind      player HP% threshold
-                DNC_AdvAoE_Interrupt                = new("DNC_AdvAoE_Interrupt");                  // Interrupt        usage choice
+                DNC_AdvAoE_PanicWaltzPct            = new("DNC_AdvAoE_PanicWaltzPct"),              // Curing Waltz     Player HP% threshold
+                DNC_AdvAoE_PanicWindPct             = new("DNC_AdvAoE_PanicWindPct"),               // Second Wind      Player HP% threshold
+                DNC_AdvAoE_Interrupt                = new("DNC_AdvAoE_Interrupt");                  // Interrupt        Usage choice
             #endregion
 
             #region Legacy
@@ -425,13 +423,15 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Dance Fills
                     // Simple ST Standard (Dance) Steps & Fill
-                    if (HasEffect(Buffs.StandardStep) && Config.DNC_SimpleST_SS)
+                    if (HasEffect(Buffs.StandardStep) &&
+                        Config.DNC_SimpleST_Dances[0])
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
                     // Simple ST Technical (Dance) Steps & Fill
-                    if (HasEffect(Buffs.TechnicalStep) && Config.DNC_SimpleST_TS)
+                    if (HasEffect(Buffs.TechnicalStep) &&
+                        Config.DNC_SimpleST_Dances[1])
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
                             : TechnicalFinish;
@@ -513,7 +513,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Simple ST Standard Step (outside of burst)
-                    if (Config.DNC_SimpleST_SS && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
+                        Config.DNC_SimpleST_Dances[0])
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > 5) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -523,7 +524,8 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Simple ST Technical Step
-                    if (Config.DNC_SimpleST_TS && ActionReady(TechnicalStep) &&
+                    if (ActionReady(TechnicalStep) &&
+                        Config.DNC_SimpleST_Dances[1] &&
                         (!HasTarget() || GetTargetHPPercent() > 5) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
@@ -546,11 +548,11 @@ namespace XIVSlothCombo.Combos.PvE
                         return Fountain;
 
                     // Simple ST Standard Step (inside of burst)
-                    if (Config.DNC_SimpleST_SS &&
-                        IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                        Config.DNC_SimpleST_Dances[0] &&
+                        (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5) &&
                         Gauge.Esprit < 25 &&
-                        GetTargetHPPercent() > 5 &&
-                        (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
+                        GetTargetHPPercent() > 5)
                         return StandardStep;
 
                     // Simple ST base GCDs
@@ -620,9 +622,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced ST Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Interrupt) &&
-                        ((Config.DNC_AdvST_Interrupt == 1 && CanDelayedWeave(actionID, 1.25, 0.6)) ||
-                         (Config.DNC_AdvST_Interrupt == 2 && CanDelayedWeave(actionID, 2.25, 0.7)) ||
-                         (Config.DNC_AdvST_Interrupt == 3)) &&
+                        ((Config.DNC_AdvST_Interrupt == 0 && CanDelayedWeave(actionID, 1.25, 0.6)) ||
+                         (Config.DNC_AdvST_Interrupt == 1 && CanDelayedWeave(actionID, 2.25, 0.7)) ||
+                         (Config.DNC_AdvST_Interrupt == 2)) &&
                         CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
@@ -766,13 +768,15 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Dance Fills
                     // Simple AoE Standard (Dance) Steps & Fill
-                    if (HasEffect(Buffs.StandardStep) && Config.DNC_SimpleAoE_SS)
+                    if (HasEffect(Buffs.StandardStep) &&
+                        Config.DNC_SimpleAoE_Dances[0])
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
                     // Simple AoE Technical (Dance) Steps & Fill
-                    if (HasEffect(Buffs.TechnicalStep) && Config.DNC_SimpleAoE_TS)
+                    if (HasEffect(Buffs.TechnicalStep) &&
+                        Config.DNC_SimpleAoE_Dances[1])
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
                             : TechnicalFinish;
@@ -874,7 +878,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Simple AoE Standard Step (outside of burst)
-                    if (Config.DNC_SimpleAoE_SS && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
+                        Config.DNC_SimpleAoE_Dances[0])
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > 5) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -884,9 +889,9 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Simple AoE Technical Step
-                    if (Config.DNC_SimpleAoE_TS && ActionReady(TechnicalStep) &&
-                        (!HasTarget() || GetTargetHPPercent() > 5) &&
-                        !HasEffect(Buffs.StandardStep))
+                    if (ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep) &&
+                        Config.DNC_SimpleAoE_Dances[1] &&
+                        (!HasTarget() || GetTargetHPPercent() > 5))
                         return TechnicalStep;
 
                     // Simple AoE Saber Dance
@@ -907,8 +912,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // Simple AoE Standard Step (inside of burst)
-                    if (Config.DNC_SimpleAoE_SS &&
-                        IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                        Config.DNC_SimpleAoE_Dances[0] &&
                         GetTargetHPPercent() > 5 && (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))
                         return StandardStep;
 
@@ -972,9 +977,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced AoE Interrupt
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Interrupt) &&
-                        ((Config.DNC_AdvAoE_Interrupt == 1 && CanDelayedWeave(actionID, 1.25, 0.6)) ||
-                         (Config.DNC_AdvAoE_Interrupt == 2 && CanDelayedWeave(actionID, 2.25, 0.7)) ||
-                         (Config.DNC_AdvAoE_Interrupt == 3)) &&
+                        ((Config.DNC_AdvAoE_Interrupt == 0 && CanDelayedWeave(actionID, 1.25, 0.6)) ||
+                         (Config.DNC_AdvAoE_Interrupt == 1 && CanDelayedWeave(actionID, 2.25, 0.7)) ||
+                         (Config.DNC_AdvAoE_Interrupt == 2)) &&
                         CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -111,31 +111,31 @@ namespace XIVSlothCombo.Combos.PvE
         {
             #region Legacy config
             internal static UserInt
-                DNCEspritThreshold_ST = new("DNCEspritThreshold_ST"),                           // Single target Esprit threshold
-                DNCEspritThreshold_AoE = new("DNCEspritThreshold_AoE");                         // AoE Esprit threshold
+                DNC_LegacyST_EspritTh       = new("DNC_LegacyST_EspritTh"),       // Single target Esprit threshold
+                DNC_LegacyAoE_EspritTh      = new("DNC_LegacyAoE_EspritTh");      // AoE Esprit threshold
             #endregion
 
-            #region Simple ST Sliders
+            #region Advanced ST Sliders
             internal static UserInt
-                DNCSimpleSSBurstPercent = new("DNCSimpleSSBurstPercent"),                       // Standard Step    target HP% threshold
-                DNCSimpleTSBurstPercent = new("DNCSimpleTSBurstPercent"),                       // Technical Step   target HP% threshold
-                DNCSimpleFeatherBurstPercent = new("DNCSimpleFeatherBurstPercent"),             // Feather burst    target HP% threshold
-                DNCSimpleSaberThreshold = new("DNCSimpleSaberThreshold"),                       // Saber Dance      Esprit threshold
-                DNCSimplePanicHealWaltzPercent = new("DNCSimplePanicHealWaltzPercent"),         // Curing Waltz     player HP% threshold
-                DNCSimplePanicHealWindPercent = new("DNCSimplePanicHealWindPercent");           // Second Wind      player HP% threshold
+                DNC_AdvST_SSBurstPct        = new("DNC_AdvST_SSBurstPct"),        // Standard Step    target HP% threshold
+                DNC_AdvST_TSBurstPct        = new("DNC_AdvST_TSBurstPct"),        // Technical Step   target HP% threshold
+                DNC_AdvST_FeatherBurstPct   = new("DNC_AdvST_FeatherBurstPct"),   // Feather burst    target HP% threshold
+                DNC_AdvST_SaberTh           = new("DNC_AdvST_SaberTh"),           // Saber Dance      Esprit     threshold
+                DNC_AdvST_PanicWaltzPct     = new("DNC_AdvST_PanicWaltzPct"),     // Curing Waltz     player HP% threshold
+                DNC_AdvST_PanicWindPct      = new("DNC_AdvST_PanicWindPct");      // Second Wind      player HP% threshold
             #endregion
 
-            #region Simple AoE Sliders
+            #region Advanced AoE Sliders
             internal static UserInt
-                DNCSimpleSSAoEBurstPercent = new("DNCSimpleSSAoEBurstPercent"),                 // Standard Step    target HP% threshold
-                DNCSimpleTSAoEBurstPercent = new("DNCSimpleTSAoEBurstPercent"),                 // Technical Step   target HP% threshold
-                DNCSimpleAoESaberThreshold = new("DNCSimpleAoESaberThreshold"),                 // Saber Dance      Esprit threshold
-                DNCSimpleAoEPanicHealWaltzPercent = new("DNCSimpleAoEPanicHealWaltzPercent"),   // Curing Waltz     player HP% threshold
-                DNCSimpleAoEPanicHealWindPercent = new("DNCSimpleAoEPanicHealWindPercent");     // Second Wind      player HP% threshold
+                DNC_AdvAoE_SSBurstPct       = new("DNC_AdvAoE_SSBurstPct"),       // Standard Step    target HP% threshold
+                DNC_AdvAoE_TSBurstPct       = new("DNC_AdvAoE_TSBurstPct"),       // Technical Step   target HP% threshold
+                DNC_AdvAoE_SaberTh          = new("DNC_AdvAoE_SaberTh"),          // Saber Dance      Esprit     threshold
+                DNC_AdvAoE_PanicWaltzPct    = new("DNC_AdvAoE_PanicWaltzPct"),    // Curing Waltz     player HP% threshold
+                DNC_AdvAoE_PanicWindPct     = new("DNC_AdvAoE_PanicWindPct");     // Second Wind      player HP% threshold
             #endregion
 
             internal static UserInt
-                DNCVariantCurePercent = new("DNCVariantCurePercent");                           // Variant Cure     player HP% threshold
+                DNC_Variant_CurePct         = new("DNC_Variant_CurePct");         // Variant Cure     player HP% threshold
         }
 
         internal class DNC_DanceComboReplacer : CustomCombo
@@ -250,7 +250,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_ST))
+                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyST_EspritTh))
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -298,7 +298,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_AoE))
+                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyAoE_EspritTh))
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -454,7 +454,7 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    if (IsEnabled(CustomComboPreset.DNC_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.DNCVariantCurePercent))
+                    if (IsEnabled(CustomComboPreset.DNC_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.DNC_Variant_CurePct))
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
@@ -473,7 +473,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return FanDance3;
 
                             // FD1 HP% Dump
-                            if (GetTargetHPPercent() <= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent) && Gauge.Feathers > 0)
+                            if (GetTargetHPPercent() <= PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_FeatherBurstPct) && Gauge.Feathers > 0)
                                 return FanDance1;
 
                             if (LevelChecked(TechnicalStep))
@@ -501,11 +501,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.DNC_ST_Simple_PanicHeals))
                         {
                             if (ActionReady(CuringWaltz) &&
-                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWaltzPercent))
+                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_PanicWaltzPct))
                                 return CuringWaltz;
 
                             if (ActionReady(All.SecondWind) &&
-                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimplePanicHealWindPercent))
+                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_PanicWindPct))
                                 return All.SecondWind;
                         }
 
@@ -520,7 +520,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent)) &&
+                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_SSBurstPct)) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
                             (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
                             IsOffCooldown(StandardStep))
@@ -529,7 +529,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Technical Step
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) && ActionReady(TechnicalStep) &&
-                        (!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSBurstPercent)) &&
+                        (!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_TSBurstPct)) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
@@ -537,7 +537,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
-                        if (Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
+                        if (Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_SaberTh) ||
                             (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
                             return SaberDance;
                     }
@@ -554,7 +554,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Standard Step (inside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSBurstPercent) &&
+                        if (GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_SSBurstPct) &&
                             (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
                             return StandardStep;
                     }
@@ -621,7 +621,7 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    if (IsEnabled(CustomComboPreset.DNC_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.DNCVariantCurePercent))
+                    if (IsEnabled(CustomComboPreset.DNC_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.DNC_Variant_CurePct))
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
@@ -688,11 +688,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_PanicHeals))
                         {
                             if (ActionReady(CuringWaltz) &&
-                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWaltzPercent))
+                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_PanicWaltzPct))
                                 return CuringWaltz;
 
                             if (ActionReady(All.SecondWind) &&
-                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoEPanicHealWindPercent))
+                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_PanicWindPct))
                                 return All.SecondWind;
                         }
 
@@ -707,7 +707,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent)) &&
+                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_SSBurstPct)) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
                             (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
                             IsOffCooldown(StandardStep))
@@ -716,7 +716,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Technical Step
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) && ActionReady(TechnicalStep) &&
-                        (!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleTSAoEBurstPercent)) &&
+                        (!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_TSBurstPct)) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
@@ -724,7 +724,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
-                        if (Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) ||
+                        if (Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_SaberTh) ||
                             (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
                             return SaberDance;
                     }
@@ -741,7 +741,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Standard Step (inside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSSAoEBurstPercent) &&
+                        if (GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_SSBurstPct) &&
                             (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
                             return StandardStep;
                     }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -676,7 +676,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Advanced ST Standard Step (outside of burst)
-                    if (Config.DNC_AdvST_SS_Options == 2 && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && Config.DNC_AdvST_SS_Options == 2 &&
+                        ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -686,9 +687,9 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Advanced ST Technical Step
-                    if (Config.DNC_AdvST_TS_Options == 2 && ActionReady(TechnicalStep) &&
-                        (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_TSBurstPct) &&
-                        !HasEffect(Buffs.StandardStep))
+                    if (IsEnabled(CustomComboPreset.DNC_AdvST_TS) && Config.DNC_AdvST_TS_Options == 2 &&
+                        ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep) &&
+                        (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_TSBurstPct))
                         return TechnicalStep;
 
                     // Advanced ST Saber Dance
@@ -711,7 +712,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Fountain;
 
                     // Advanced ST Standard Step (inside of burst)
-                    if (Config.DNC_AdvST_SS_Options_Burst &&
+                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && Config.DNC_AdvST_SS_Options == 2 && Config.DNC_AdvST_SS_Options_Burst &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         Gauge.Esprit < 25 &&
                         GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct &&
@@ -1052,7 +1053,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Advanced AoE Standard Step (outside of burst)
-                    if (Config.DNC_AdvAoE_SS_Options == 2 && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && Config.DNC_AdvAoE_SS_Options == 2 &&
+                        ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -1062,9 +1064,9 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Advanced AoE Technical Step
-                    if (Config.DNC_AdvAoE_TS_Options == 2 && ActionReady(TechnicalStep) &&
-                        (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_TSBurstPct) &&
-                        !HasEffect(Buffs.StandardStep))
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_TS) && Config.DNC_AdvAoE_TS_Options == 2 &&
+                        ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep) &&
+                        (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_TSBurstPct))
                         return TechnicalStep;
 
                     // Advanced AoE Saber Dance
@@ -1085,7 +1087,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // Advanced AoE Standard Step (inside of burst)
-                    if (Config.DNC_AdvAoE_SS_Options_Burst &&
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && Config.DNC_AdvAoE_SS_Options == 2 && Config.DNC_AdvAoE_SS_Options_Burst &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct &&
                         (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -615,8 +615,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Weaves
                     // Advanced ST Devilment
-                    if (IsEnabled(CustomComboPreset.DNC_AdvST_Devilment) &&
-                        CanWeave(actionID) && ActionReady(Devilment) &&
+                    if (IsEnabled(CustomComboPreset.DNC_AdvST_Devilment) && ActionReady(Devilment) &&
                         (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
@@ -719,7 +718,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced ST Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SaberDance) && LevelChecked(SaberDance) &&
-                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
+                        (GetCooldownRemainingTime(TechnicalStep) > 4 || IsOffCooldown(TechnicalStep)) &&
                         (Gauge.Esprit >= Config.DNC_AdvST_SaberThreshold ||
                         (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50)))
                         return SaberDance;
@@ -978,8 +977,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Weaves
                     // Advanced AoE Devilment
-                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Devilment) &&
-                        CanWeave(actionID) && ActionReady(Devilment) &&
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Devilment) && ActionReady(Devilment) &&
                         (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
@@ -1102,7 +1100,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Advanced AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SaberDance) && LevelChecked(SaberDance) &&
-                        (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)) &&
+                        (GetCooldownRemainingTime(TechnicalStep) > 4 || IsOffCooldown(TechnicalStep)) &&
                         (Gauge.Esprit >= Config.DNC_AdvAoE_SaberThreshold ||
                         (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50)))
                         return SaberDance;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -125,7 +125,8 @@ namespace XIVSlothCombo.Combos.PvE
                 DNC_AdvST_PanicWindPct      = new("DNC_AdvST_PanicWindPct");    // Second Wind      player HP% threshold
 
             internal static UserBool
-                DNC_AdvST_InterruptAny      = new("DNC_AdvST_InterruptAny");   // Interrupt any time, outside of weave windows
+                DNC_AdvST_SS_Burst          = new("DNC_AdvST_SS_Burst"),        // Standard Step during TS burst phase
+                DNC_AdvST_InterruptAny      = new("DNC_AdvST_InterruptAny");    // Interrupt any time, outside of weave windows
             #endregion
 
             #region Advanced AoE config
@@ -137,7 +138,8 @@ namespace XIVSlothCombo.Combos.PvE
                 DNC_AdvAoE_PanicWindPct     = new("DNC_AdvAoE_PanicWindPct");   // Second Wind      player HP% threshold
 
             internal static UserBool
-                DNC_AdvAoE_InterruptAny      = new("DNC_AdvAoE_InterruptAny");  // Interrupt any time, outside of weave windows
+                DNC_AdvAoE_SS_Burst         = new("DNC_AdvAoE_SS_Burst"),       // Standard Step during TS burst phase
+                DNC_AdvAoE_InterruptAny     = new("DNC_AdvAoE_InterruptAny");   // Interrupt any time, outside of weave windows
             #endregion
 
             internal static UserInt
@@ -938,7 +940,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Fountain;
 
                     // Advanced ST Standard Step (inside of burst)
-                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS_Burst) &&
+                    if (Config.DNC_AdvST_SS_Burst &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         Gauge.Esprit < 25 &&
                         GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct &&
@@ -1310,7 +1312,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // Advanced AoE Standard Step (inside of burst)
-                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS_Burst) &&
+                    if (Config.DNC_AdvAoE_SS_Burst &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct &&
                         (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -656,19 +656,14 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    // Simple ST Variant Cure
-                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
-                        return Variant.VariantCure;
-
-                    // Simple ST Variant Rampart
-                    if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
-                        return Variant.VariantRampart;
-
                     if (CanWeave(actionID))
                     {
+                        // Simple ST Variant Rampart
+                        if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
+                            IsEnabled(Variant.VariantRampart) &&
+                            IsOffCooldown(Variant.VariantRampart))
+                            return Variant.VariantRampart;
+
                         // Simple ST Feathers & Fans
                         if (LevelChecked(FanDance1))
                         {
@@ -719,6 +714,11 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region GCD
+                    // Simple ST Variant Cure
+                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) &&
+                        PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
+                        return Variant.VariantCure;
+
                     // Simple ST Standard Step (outside of burst)
                     if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
@@ -829,19 +829,14 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    // Advanced ST Variant Cure
-                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
-                        return Variant.VariantCure;
-
-                    // Advanced ST Variant Rampart
-                    if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
-                        return Variant.VariantRampart;
-
                     if (CanWeave(actionID))
                     {
+                        // Advanced ST Variant Rampart
+                        if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
+                            IsEnabled(Variant.VariantRampart) &&
+                            IsOffCooldown(Variant.VariantRampart))
+                            return Variant.VariantRampart;
+
                         // Advanced ST Feathers & Fans
                         if (IsEnabled(CustomComboPreset.DNC_AdvST_Feathers) && LevelChecked(FanDance1))
                         {
@@ -894,6 +889,11 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region GCD
+                    // Advanced ST Variant Cure
+                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) &&
+                        PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
+                        return Variant.VariantCure;
+
                     // Advanced ST Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
@@ -997,19 +997,14 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    // Simple AoE Variant Cure
-                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
-                        return Variant.VariantCure;
-
-                    // Simple AoE Variant Rampart
-                    if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
-                        return Variant.VariantRampart;
-
                     if (CanWeave(actionID))
                     {
+                        // Simple AoE Variant Rampart
+                        if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
+                            IsEnabled(Variant.VariantRampart) &&
+                            IsOffCooldown(Variant.VariantRampart))
+                            return Variant.VariantRampart;
+
                         /*
                         // Simple AoE Feathers & Fans
                         if (LevelChecked(FanDance1))
@@ -1080,6 +1075,11 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region GCD
+                    // Simple AoE Variant Cure
+                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) &&
+                        PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
+                        return Variant.VariantCure;
+
                     // Simple AoE Standard Step (outside of burst)
                     if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
@@ -1181,19 +1181,14 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    // Advanced AoE Variant Cure
-                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
-                        return Variant.VariantCure;
-
-                    // Advanced AoE Variant Rampart
-                    if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
-                        return Variant.VariantRampart;
-
                     if (CanWeave(actionID))
                     {
+                        // Advanced AoE Variant Rampart
+                        if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
+                            IsEnabled(Variant.VariantRampart) &&
+                            IsOffCooldown(Variant.VariantRampart))
+                            return Variant.VariantRampart;
+
                         /*
                         // Advanced AoE Feathers & Fans
                         if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Feathers) && LevelChecked(FanDance1))
@@ -1266,6 +1261,11 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     #region GCD
+                    // Advanced AoE Variant Cure
+                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) &&
+                        PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
+                        return Variant.VariantCure;
+
                     // Advanced AoE Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -3,6 +3,7 @@ using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.Services;
 using XIVSlothCombo.CustomComboNS.Functions;
+using System;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -445,8 +446,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Weaves
                     // Simple ST Devilment
-                    if (CanWeave(actionID) && ActionReady(Devilment) &&
-                        (WasLastAction(TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                    if (ActionReady(Devilment) && (WasLastWeaponskill(TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
                     // Simple ST Flourish
@@ -473,7 +473,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (LevelChecked(FanDance1))
                         {
                             // FD3
-                            if (HasEffect(Buffs.ThreeFoldFanDance))
+                            if (HasEffect(Buffs.ThreeFoldFanDance) &&
+                                (GetCooldownRemainingTime(TechnicalStep) > 26f ||
+                                HasEffect(Buffs.TechnicalFinish) ||
+                                Gauge.Feathers is 4 ||
+                                GetBuffRemainingTime(Buffs.ThreeFoldFanDance) < 3f))
                                 return FanDance3;
 
                             // FD1 HP% Dump
@@ -495,7 +499,6 @@ namespace XIVSlothCombo.Combos.PvE
                             // FD1 Non-pooling & under burst level
                             if (!LevelChecked(TechnicalStep) && Gauge.Feathers > 0)
                                 return FanDance1;
-
                         }
 
                         if (HasEffect(Buffs.FourFoldFanDance))
@@ -616,7 +619,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Weaves
                     // Advanced ST Devilment
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Devilment) && ActionReady(Devilment) &&
-                        (WasLastAction(TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                        (WasLastWeaponskill(TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
                     // Advanced ST Flourish
@@ -631,8 +634,8 @@ namespace XIVSlothCombo.Combos.PvE
                         ((Config.DNC_AdvST_Interrupt == 0 && CanDelayedWeave(actionID, 1.25, 0.6)) ||
                          (Config.DNC_AdvST_Interrupt == 1 && CanDelayedWeave(actionID, 2.25, 0.7)) ||
                          (Config.DNC_AdvST_Interrupt == 2)) &&
-                        CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
-                        !HasEffect(Buffs.TechnicalFinish))
+                         CanInterruptEnemy() && ActionReady(All.HeadGraze) &&
+                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
                     if (CanWeave(actionID))
@@ -647,7 +650,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.DNC_AdvST_Feathers) && LevelChecked(FanDance1))
                         {
                             // FD3
-                            if (HasEffect(Buffs.ThreeFoldFanDance))
+                            if (HasEffect(Buffs.ThreeFoldFanDance) &&
+                                (GetCooldownRemainingTime(TechnicalStep) > 26f ||
+                                HasEffect(Buffs.TechnicalFinish) ||
+                                Gauge.Feathers is 4 ||
+                                GetBuffRemainingTime(Buffs.ThreeFoldFanDance) < 3f))
                                 return FanDance3;
 
                             // FD1 HP% Dump
@@ -669,7 +676,6 @@ namespace XIVSlothCombo.Combos.PvE
                             // FD1 Non-pooling & under burst level
                             if (!LevelChecked(TechnicalStep) && Gauge.Feathers > 0)
                                 return FanDance1;
-
                         }
 
                         if (HasEffect(Buffs.FourFoldFanDance))
@@ -792,8 +798,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Weaves
                     // Simple AoE Devilment
-                    if (CanWeave(actionID) && ActionReady(Devilment) &&
-                        (WasLastAction(TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                    if (ActionReady(Devilment) && (WasLastWeaponskill(TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
                     // Simple AoE Flourish
@@ -838,7 +843,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (LevelChecked(FanDance1))
                         {
                             // FD3
-                            if (HasEffect(Buffs.ThreeFoldFanDance))
+                            if (HasEffect(Buffs.ThreeFoldFanDance) &&
+                                (GetCooldownRemainingTime(TechnicalStep) > 26f ||
+                                HasEffect(Buffs.TechnicalFinish) ||
+                                Gauge.Feathers is 4 ||
+                                GetBuffRemainingTime(Buffs.ThreeFoldFanDance) < 3f))
                                 return FanDance3;
 
                             if (LevelChecked(FanDance2))
@@ -978,7 +987,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Weaves
                     // Advanced AoE Devilment
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Devilment) && ActionReady(Devilment) &&
-                        (WasLastAction(TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                        (WasLastWeaponskill(TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
                     // Advanced AoE Flourish
@@ -1027,7 +1036,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Feathers) && LevelChecked(FanDance1))
                         {
                             // FD3
-                            if (HasEffect(Buffs.ThreeFoldFanDance))
+                            if (HasEffect(Buffs.ThreeFoldFanDance) &&
+                                (GetCooldownRemainingTime(TechnicalStep) > 26f ||
+                                HasEffect(Buffs.TechnicalFinish) ||
+                                Gauge.Feathers is 4 ||
+                                GetBuffRemainingTime(Buffs.ThreeFoldFanDance) < 3f))
                                 return FanDance3;
 
                             if (LevelChecked(FanDance2))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -120,10 +120,10 @@ namespace XIVSlothCombo.Combos.PvE
 
             #region Simple ST/AoE
             internal static UserBool
-                DNC_ST_SimpleMode_SS                = new("DNC_ST_SimpleMode_SS"),                  // Simple ST Standard Step inclusion
-                DNC_ST_SimpleMode_TS                = new("DNC_ST_SimpleMode_TS"),                  // Simple ST Technical Step inclusion
-                DNC_AoE_SimpleMode_SS               = new("DNC_AoE_SimpleMode_SS"),                 // Simple AoE Standard Step inclusion
-                DNC_AoE_SimpleMode_TS               = new("DNC_AoE_SimpleMode_TS");                 // Simple AoE Technical Step inclusion
+                DNC_SimpleST_SS                     = new("DNC_SimpleST_SS"),                       // Simple ST Standard Step inclusion
+                DNC_SimpleST_TS                     = new("DNC_SimpleST_TS"),                       // Simple ST Technical Step inclusion
+                DNC_SimpleAoE_SS                    = new("DNC_SimpleAoE_SS"),                      // Simple AoE Standard Step inclusion
+                DNC_SimpleAoE_TS                    = new("DNC_SimpleAoE_TS");                      // Simple AoE Technical Step inclusion
             #endregion
 
             #region Advanced ST
@@ -410,9 +410,9 @@ namespace XIVSlothCombo.Combos.PvE
         }
 
         // Simple Single Target
-        internal class DNC_ST_SimpleMode : CustomCombo
+        internal class DNC_SimpleST : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_ST_SimpleMode;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_SimpleST;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -425,13 +425,13 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Dance Fills
                     // Simple ST Standard (Dance) Steps & Fill
-                    if (HasEffect(Buffs.StandardStep) && Config.DNC_ST_SimpleMode_SS)
+                    if (HasEffect(Buffs.StandardStep) && Config.DNC_SimpleST_SS)
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
                     // Simple ST Technical (Dance) Steps & Fill
-                    if (HasEffect(Buffs.TechnicalStep) && Config.DNC_ST_SimpleMode_TS)
+                    if (HasEffect(Buffs.TechnicalStep) && Config.DNC_SimpleST_TS)
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
                             : TechnicalFinish;
@@ -513,7 +513,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Simple ST Standard Step (outside of burst)
-                    if (Config.DNC_ST_SimpleMode_SS && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (Config.DNC_SimpleST_SS && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > 5) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -523,7 +523,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Simple ST Technical Step
-                    if (Config.DNC_ST_SimpleMode_TS && ActionReady(TechnicalStep) &&
+                    if (Config.DNC_SimpleST_TS && ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > 5) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
@@ -546,7 +546,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Fountain;
 
                     // Simple ST Standard Step (inside of burst)
-                    if (Config.DNC_ST_SimpleMode_SS &&
+                    if (Config.DNC_SimpleST_SS &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         Gauge.Esprit < 25 &&
                         GetTargetHPPercent() > 5 &&
@@ -751,9 +751,9 @@ namespace XIVSlothCombo.Combos.PvE
         }
 
         // Simple AoE
-        internal class DNC_AoE_SimpleMode : CustomCombo
+        internal class DNC_SimpleAoE : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_AoE_SimpleMode;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_SimpleAoE;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -766,13 +766,13 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Dance Fills
                     // Simple AoE Standard (Dance) Steps & Fill
-                    if (HasEffect(Buffs.StandardStep) && Config.DNC_AoE_SimpleMode_SS)
+                    if (HasEffect(Buffs.StandardStep) && Config.DNC_SimpleAoE_SS)
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
                     // Simple AoE Technical (Dance) Steps & Fill
-                    if (HasEffect(Buffs.TechnicalStep) && Config.DNC_AoE_SimpleMode_TS)
+                    if (HasEffect(Buffs.TechnicalStep) && Config.DNC_SimpleAoE_TS)
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
                             : TechnicalFinish;
@@ -874,7 +874,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Simple AoE Standard Step (outside of burst)
-                    if (Config.DNC_AoE_SimpleMode_SS && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (Config.DNC_SimpleAoE_SS && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > 5) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -884,7 +884,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Simple AoE Technical Step
-                    if (Config.DNC_AoE_SimpleMode_TS && ActionReady(TechnicalStep) &&
+                    if (Config.DNC_SimpleAoE_TS && ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > 5) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
@@ -907,7 +907,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // Simple AoE Standard Step (inside of burst)
-                    if (Config.DNC_AoE_SimpleMode_SS &&
+                    if (Config.DNC_SimpleAoE_SS &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         GetTargetHPPercent() > 5 && (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))
                         return StandardStep;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -108,24 +108,25 @@ namespace XIVSlothCombo.Combos.PvE
 
         public static class Config
         {
-            #region Legacy config
+            #region Miscellaneous
             internal static UserBool
-                DNC_LegacyST_Multi_Esprit           = new("DNC_LegacyST_Multi_Esprit"),             // ST Esprit overcap protection (L)
-                DNC_LegacyST_Multi_FanOvercap       = new("DNC_LegacyST_Multi_FanOvercap"),         // ST Fan overcap protection (L)
-                DNC_LegacyST_Multi_FanDance34       = new("DNC_LegacyST_Multi_FanDance34"),         // ST Fan Dance III/IV (L)
-                DNC_LegacyAoE_Multi_Esprit          = new("DNC_LegacyAoE_Multi_Esprit"),            // AoE Esprit overcap protection (L)
-                DNC_LegacyAoE_Multi_FanOvercap      = new("DNC_LegacyAoE_Multi_FanOvercap"),        // AoE Fan overcap protection (L)
-                DNC_LegacyAoE_Multi_FanDance34      = new("DNC_LegacyAoE_Multi_FanDance34"),        // AoE Fan Dance III/IV (L)
-                DNC_Legacy_FanDanceCombos_13        = new("DNC_Legacy_FanDanceCombos_13"),          // Fan Dance 1 —> 3 Option
-                DNC_Legacy_FanDanceCombos_14        = new("DNC_Legacy_FanDanceCombos_14"),          // Fan Dance 1 —> 4 Option
-                DNC_Legacy_FanDanceCombos_23        = new("DNC_Legacy_FanDanceCombos_23"),          // Fan Dance 2 —> 3 Option
-                DNC_Legacy_FanDanceCombos_24        = new("DNC_Legacy_FanDanceCombos_24");          // Fan Dance 2 —> 4 Option
+                DNC_FanDanceCombos_13               = new("DNC_FanDanceCombos_13"),                 // Fan Dance 1 —> 3 Option
+                DNC_FanDanceCombos_14               = new("DNC_FanDanceCombos_14"),                 // Fan Dance 1 —> 4 Option
+                DNC_FanDanceCombos_23               = new("DNC_FanDanceCombos_23"),                 // Fan Dance 2 —> 3 Option
+                DNC_FanDanceCombos_24               = new("DNC_FanDanceCombos_24");                 // Fan Dance 2 —> 4 Option
             internal static UserInt
-                DNC_LegacyST_Multi_EspritThreshold  = new("DNC_LegacyST_Multi_EspritThreshold"),    // ST Esprit threshold (L)
-                DNC_LegacyAoE_Multi_EspritThreshold = new("DNC_LegacyAoE_Multi_EspritThreshold");   // AoE Esprit threshold (L)
+                DNC_VariantCurePct                  = new("DNC_VariantCurePct");                    // Variant Cure     player HP% threshold
             #endregion
 
-            #region Advanced ST config
+            #region Simple ST/AoE
+            internal static UserBool
+                DNC_ST_SimpleMode_SS                = new("DNC_ST_SimpleMode_SS"),                  // Simple ST Standard Step inclusion
+                DNC_ST_SimpleMode_TS                = new("DNC_ST_SimpleMode_TS"),                  // Simple ST Technical Step inclusion
+                DNC_AoE_SimpleMode_SS               = new("DNC_AoE_SimpleMode_SS"),                 // Simple AoE Standard Step inclusion
+                DNC_AoE_SimpleMode_TS               = new("DNC_AoE_SimpleMode_TS");                 // Simple AoE Technical Step inclusion
+            #endregion
+
+            #region Advanced ST
             internal static UserBool
                 DNC_AdvST_SS_Options_Burst          = new("DNC_AdvST_SS_Options_Burst");            // Standard Step during TS burst phase
             internal static UserInt
@@ -140,7 +141,7 @@ namespace XIVSlothCombo.Combos.PvE
                 DNC_AdvST_Interrupt                 = new("DNC_AdvST_Interrupt");                   // Interrupt        usage choice
             #endregion
 
-            #region Advanced AoE config
+            #region Advanced AoE
             internal static UserBool
                 DNC_AdvAoE_SS_Options_Burst         = new("DNC_AdvAoE_SS_Options_Burst");           // Standard Step during TS burst phase
             internal static UserInt
@@ -154,8 +155,18 @@ namespace XIVSlothCombo.Combos.PvE
                 DNC_AdvAoE_Interrupt                = new("DNC_AdvAoE_Interrupt");                  // Interrupt        usage choice
             #endregion
 
+            #region Legacy
+            internal static UserBool
+                DNC_LegacyST_Multi_Esprit           = new("DNC_LegacyST_Multi_Esprit"),             // ST Esprit overcap protection (L)
+                DNC_LegacyST_Multi_FanOvercap       = new("DNC_LegacyST_Multi_FanOvercap"),         // ST Fan overcap protection (L)
+                DNC_LegacyST_Multi_FanDance34       = new("DNC_LegacyST_Multi_FanDance34"),         // ST Fan Dance III/IV (L)
+                DNC_LegacyAoE_Multi_Esprit          = new("DNC_LegacyAoE_Multi_Esprit"),            // AoE Esprit overcap protection (L)
+                DNC_LegacyAoE_Multi_FanOvercap      = new("DNC_LegacyAoE_Multi_FanOvercap"),        // AoE Fan overcap protection (L)
+                DNC_LegacyAoE_Multi_FanDance34      = new("DNC_LegacyAoE_Multi_FanDance34");        // AoE Fan Dance III/IV (L)
             internal static UserInt
-                DNC_VariantCurePct                  = new("DNC_VariantCurePct");                    // Variant Cure     player HP% threshold
+                DNC_LegacyST_Multi_EspritThreshold  = new("DNC_LegacyST_Multi_EspritThreshold"),    // ST Esprit threshold (L)
+                DNC_LegacyAoE_Multi_EspritThreshold = new("DNC_LegacyAoE_Multi_EspritThreshold");   // AoE Esprit threshold (L)
+            #endregion
         }
 
         // Dance Step Solver
@@ -201,43 +212,6 @@ namespace XIVSlothCombo.Combos.PvE
                         return OriginalHook(ReverseCascade);
                     if (actionID == actionIDs[3] || (actionIDs[3] == 0 && actionID == FanDance2))   // Fountainfall replacement
                         return OriginalHook(Fountainfall);
-                }
-                #endregion
-
-                #region Fan Dance Combos (L)
-                if (IsEnabled(CustomComboPreset.DNC_Legacy_FanDanceCombos))
-                {
-                    // FD 1 —> 3, FD 1 —> 4
-                    if (actionID is FanDance1)
-                    {
-                        if (Config.DNC_Legacy_FanDanceCombos_13 &&
-                            HasEffect(Buffs.ThreeFoldFanDance))
-                            return FanDance3;
-                        if (Config.DNC_Legacy_FanDanceCombos_14 &&
-                            HasEffect(Buffs.FourFoldFanDance))
-                            return FanDance4;
-                    }
-
-                    // FD 2 —> 3, FD 2 —> 4
-                    if (actionID is FanDance2)
-                    {
-                        if (Config.DNC_Legacy_FanDanceCombos_23 &&
-                            HasEffect(Buffs.ThreeFoldFanDance))
-                            return FanDance3;
-                        if (Config.DNC_Legacy_FanDanceCombos_24 &&
-                            HasEffect(Buffs.FourFoldFanDance))
-                            return FanDance4;
-                    }
-                }
-                #endregion
-
-                #region Fan Dance 3 & 4 on Flourish (L)
-                if (IsEnabled(CustomComboPreset.DNC_Legacy_FlourishingFanDances) && actionID is Flourish && CanWeave(actionID))
-                {
-                    if (HasEffect(Buffs.ThreeFoldFanDance))
-                        return FanDance3;
-                    if (HasEffect(Buffs.FourFoldFanDance))
-                        return FanDance4;
                 }
                 #endregion
 
@@ -321,11 +295,6 @@ namespace XIVSlothCombo.Combos.PvE
                 }
                 #endregion
 
-                #region Devilment --> Starfall Dance (L)
-                if (IsEnabled(CustomComboPreset.DNC_Starfall_Devilment) && actionID is Devilment && HasEffect(Buffs.FlourishingStarfall))
-                    return StarfallDance;
-                #endregion
-
                 #region Combined Dances (L)
                 // One-button mode for both dances (SS/TS). SS takes priority.
                 if (IsEnabled(CustomComboPreset.DNC_Legacy_Dance) && IsEnabled(CustomComboPreset.DNC_Legacy_Dance_ComboDances) && actionID is StandardStep)
@@ -379,6 +348,67 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
+        // Fan Dance/2 —> 3/4
+        internal class DNC_FanDanceCombos : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_FanDanceCombos;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is FanDance1)
+                {
+                    if (Config.DNC_FanDanceCombos_13 &&         // 1 —> 3
+                        HasEffect(Buffs.ThreeFoldFanDance))
+                        return FanDance3;
+                    if (Config.DNC_FanDanceCombos_14 &&         // 1 —> 4
+                        HasEffect(Buffs.FourFoldFanDance))
+                        return FanDance4;
+                }
+
+                if (actionID is FanDance2)
+                {
+                    if (Config.DNC_FanDanceCombos_23 &&         // 2 —> 3
+                        HasEffect(Buffs.ThreeFoldFanDance))
+                        return FanDance3;
+                    if (Config.DNC_FanDanceCombos_24 &&         // 2 —> 4
+                        HasEffect(Buffs.FourFoldFanDance))
+                        return FanDance4;
+                }
+
+                return actionID;
+            }
+        }
+
+        // Starfall Dance on Devilment
+        internal class DNC_Starfall_Devilment : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Starfall_Devilment;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level) =>
+                actionID is Devilment && HasEffect(Buffs.FlourishingStarfall)
+                    ? StarfallDance
+                    : actionID;
+        }
+
+        // Fan Dance 3 & 4 on Flourish
+        internal class DNC_FlourishingFanDances : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_FlourishingFanDances;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                if (actionID is Flourish && CanWeave(actionID))
+                {
+                    if (HasEffect(Buffs.ThreeFoldFanDance))
+                        return FanDance3;
+                    if (HasEffect(Buffs.FourFoldFanDance))
+                        return FanDance4;
+                }
+
+                return actionID;
+            }
+        }
+
         // Simple Single Target
         internal class DNC_ST_SimpleMode : CustomCombo
         {
@@ -393,23 +423,15 @@ namespace XIVSlothCombo.Combos.PvE
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     #endregion
 
-                    /*
-                    #region Pre-pull
-                    // Simple ST Peloton
-                    if (!InCombat() && !HasEffectAny(Buffs.Peloton) && GetBuffRemainingTime(Buffs.StandardStep) > 5)
-                        return Peloton;
-                    #endregion
-                    */
-
                     #region Dance Fills
                     // Simple ST Standard (Dance) Steps & Fill
-                    if (HasEffect(Buffs.StandardStep))
+                    if (HasEffect(Buffs.StandardStep) && Config.DNC_ST_SimpleMode_SS)
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
                     // Simple ST Technical (Dance) Steps & Fill
-                    if (HasEffect(Buffs.TechnicalStep))
+                    if (HasEffect(Buffs.TechnicalStep) && Config.DNC_ST_SimpleMode_TS)
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
                             : TechnicalFinish;
@@ -481,12 +503,6 @@ namespace XIVSlothCombo.Combos.PvE
                         if (ActionReady(All.SecondWind) &&
                             PlayerHealthPercentageHp() < 30)
                             return All.SecondWind;
-
-                        /*
-                        // Simple ST Improvisation
-                        if (ActionReady(Improvisation))
-                            return Improvisation;
-                        */
                     }
                     #endregion
 
@@ -497,7 +513,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Simple ST Standard Step (outside of burst)
-                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (Config.DNC_ST_SimpleMode_SS && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > 5) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -507,7 +523,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Simple ST Technical Step
-                    if (ActionReady(TechnicalStep) &&
+                    if (Config.DNC_ST_SimpleMode_TS && ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > 5) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
@@ -530,7 +546,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Fountain;
 
                     // Simple ST Standard Step (inside of burst)
-                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                    if (Config.DNC_ST_SimpleMode_SS &&
+                        IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         Gauge.Esprit < 25 &&
                         GetTargetHPPercent() > 5 &&
                         (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
@@ -749,13 +766,13 @@ namespace XIVSlothCombo.Combos.PvE
 
                     #region Dance Fills
                     // Simple AoE Standard (Dance) Steps & Fill
-                    if (HasEffect(Buffs.StandardStep))
+                    if (HasEffect(Buffs.StandardStep) && Config.DNC_AoE_SimpleMode_SS)
                         return Gauge.CompletedSteps < 2
                             ? Gauge.NextStep
                             : StandardFinish;
 
                     // Simple AoE Technical (Dance) Steps & Fill
-                    if (HasEffect(Buffs.TechnicalStep))
+                    if (HasEffect(Buffs.TechnicalStep) && Config.DNC_AoE_SimpleMode_TS)
                         return Gauge.CompletedSteps < 4
                             ? Gauge.NextStep
                             : TechnicalFinish;
@@ -847,12 +864,6 @@ namespace XIVSlothCombo.Combos.PvE
                         if (ActionReady(All.SecondWind) &&
                             PlayerHealthPercentageHp() < 30)
                             return All.SecondWind;
-
-                        /*
-                        // Simple AoE Improvisation
-                        if (ActionReady(Improvisation))
-                            return Improvisation;
-                        */
                     }
                     #endregion
 
@@ -863,7 +874,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantCure;
 
                     // Simple AoE Standard Step (outside of burst)
-                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    if (Config.DNC_AoE_SimpleMode_SS && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
                         if (((!HasTarget() || GetTargetHPPercent() > 5) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
@@ -873,7 +884,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Simple AoE Technical Step
-                    if (ActionReady(TechnicalStep) &&
+                    if (Config.DNC_AoE_SimpleMode_TS && ActionReady(TechnicalStep) &&
                         (!HasTarget() || GetTargetHPPercent() > 5) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
@@ -896,7 +907,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // Simple AoE Standard Step (inside of burst)
-                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                    if (Config.DNC_AoE_SimpleMode_SS &&
+                        IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         GetTargetHPPercent() > 5 && (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))
                         return StandardStep;
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -750,11 +750,11 @@ namespace XIVSlothCombo.Combos.PvE
                         return Fountain;
 
                     // ST Standard Step (inside of burst)
-                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
-                    {
-                        if (GetTargetHPPercent() > 5 && (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
-                            return StandardStep;
-                    }
+                    if (IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                        Gauge.Esprit < 25 &&
+                        GetTargetHPPercent() > 5 &&
+                        (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
+                        return StandardStep;
 
                     if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;
@@ -923,12 +923,12 @@ namespace XIVSlothCombo.Combos.PvE
                         return Fountain;
 
                     // ST Standard Step (inside of burst)
-                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
-                    {
-                        if (GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct &&
-                            (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
-                            return StandardStep;
-                    }
+                    if (IsEnabled(CustomComboPreset.DNC_AdvST_SS_Burst) &&
+                        IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
+                        Gauge.Esprit < 25 &&
+                        GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct &&
+                        (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 5))
+                        return StandardStep;
 
                     if (LevelChecked(Fountainfall) && flow)
                         return Fountainfall;

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -699,7 +699,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if ((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
                             return StandardStep;
                     }
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -109,42 +109,53 @@ namespace XIVSlothCombo.Combos.PvE
         public static class Config
         {
             #region Legacy config
+            internal static UserBool
+                DNC_LegacyST_Multi_Esprit           = new("DNC_LegacyST_Multi_Esprit"),             // ST Esprit overcap protection (L)
+                DNC_LegacyST_Multi_FanOvercap       = new("DNC_LegacyST_Multi_FanOvercap"),         // ST Fan overcap protection (L)
+                DNC_LegacyST_Multi_FanDance34       = new("DNC_LegacyST_Multi_FanDance34"),         // ST Fan Dance III/IV (L)
+                DNC_LegacyAoE_Multi_Esprit          = new("DNC_LegacyAoE_Multi_Esprit"),            // AoE Esprit overcap protection (L)
+                DNC_LegacyAoE_Multi_FanOvercap      = new("DNC_LegacyAoE_Multi_FanOvercap"),        // AoE Fan overcap protection (L)
+                DNC_LegacyAoE_Multi_FanDance34      = new("DNC_LegacyAoE_Multi_FanDance34"),        // AoE Fan Dance III/IV (L)
+                DNC_Legacy_FanDanceCombos_13        = new("DNC_Legacy_FanDanceCombos_13"),          // Fan Dance 1 —> 3 Option
+                DNC_Legacy_FanDanceCombos_14        = new("DNC_Legacy_FanDanceCombos_14"),          // Fan Dance 1 —> 4 Option
+                DNC_Legacy_FanDanceCombos_23        = new("DNC_Legacy_FanDanceCombos_23"),          // Fan Dance 2 —> 3 Option
+                DNC_Legacy_FanDanceCombos_24        = new("DNC_Legacy_FanDanceCombos_24");          // Fan Dance 2 —> 4 Option
             internal static UserInt
-                DNC_LegacyST_EspritThreshold    = new("DNC_LegacyST_EspritThreshold"),  // Single target Esprit threshold (L)
-                DNC_LegacyAoE_EspritThreshold   = new("DNC_LegacyAoE_EspritThreshold"); // AoE Esprit threshold (L)
+                DNC_LegacyST_Multi_EspritThreshold  = new("DNC_LegacyST_Multi_EspritThreshold"),    // ST Esprit threshold (L)
+                DNC_LegacyAoE_Multi_EspritThreshold = new("DNC_LegacyAoE_Multi_EspritThreshold");   // AoE Esprit threshold (L)
             #endregion
 
             #region Advanced ST config
             internal static UserBool
-                DNC_AdvST_SS_Options_Burst      = new("DNC_AdvST_SS_Options_Burst");    // Standard Step during TS burst phase
+                DNC_AdvST_SS_Options_Burst          = new("DNC_AdvST_SS_Options_Burst");            // Standard Step during TS burst phase
             internal static UserInt
-                DNC_AdvST_SS_Options            = new("DNC_AdvST_SS_Options"),          // Standard Step    usage choice
-                DNC_AdvST_SSBurstPct            = new("DNC_AdvST_SSBurstPct"),          // Standard Step    target HP% threshold
-                DNC_AdvST_TS_Options            = new("DNC_AdvST_TS_Options"),          // Technical Step   usage choice
-                DNC_AdvST_TSBurstPct            = new("DNC_AdvST_TSBurstPct"),          // Technical Step   target HP% threshold
-                DNC_AdvST_FeatherBurstPct       = new("DNC_AdvST_FeatherBurstPct"),     // Feather burst    target HP% threshold
-                DNC_AdvST_SaberThreshold        = new("DNC_AdvST_SaberThreshold"),      // Saber Dance      Esprit     threshold
-                DNC_AdvST_PanicWaltzPct         = new("DNC_AdvST_PanicWaltzPct"),       // Curing Waltz     player HP% threshold
-                DNC_AdvST_PanicWindPct          = new("DNC_AdvST_PanicWindPct"),        // Second Wind      player HP% threshold
-                DNC_AdvST_Interrupt             = new("DNC_AdvST_Interrupt");           // Interrupt        usage choice
+                DNC_AdvST_SS_Options                = new("DNC_AdvST_SS_Options"),                  // Standard Step    usage choice
+                DNC_AdvST_SSBurstPct                = new("DNC_AdvST_SSBurstPct"),                  // Standard Step    target HP% threshold
+                DNC_AdvST_TS_Options                = new("DNC_AdvST_TS_Options"),                  // Technical Step   usage choice
+                DNC_AdvST_TSBurstPct                = new("DNC_AdvST_TSBurstPct"),                  // Technical Step   target HP% threshold
+                DNC_AdvST_FeatherBurstPct           = new("DNC_AdvST_FeatherBurstPct"),             // Feather burst    target HP% threshold
+                DNC_AdvST_SaberThreshold            = new("DNC_AdvST_SaberThreshold"),              // Saber Dance      Esprit     threshold
+                DNC_AdvST_PanicWaltzPct             = new("DNC_AdvST_PanicWaltzPct"),               // Curing Waltz     player HP% threshold
+                DNC_AdvST_PanicWindPct              = new("DNC_AdvST_PanicWindPct"),                // Second Wind      player HP% threshold
+                DNC_AdvST_Interrupt                 = new("DNC_AdvST_Interrupt");                   // Interrupt        usage choice
             #endregion
 
             #region Advanced AoE config
             internal static UserBool
-                DNC_AdvAoE_SS_Options_Burst     = new("DNC_AdvAoE_SS_Options_Burst");   // Standard Step during TS burst phase
+                DNC_AdvAoE_SS_Options_Burst         = new("DNC_AdvAoE_SS_Options_Burst");           // Standard Step during TS burst phase
             internal static UserInt
-                DNC_AdvAoE_SS_Options           = new("DNC_AdvAoE_SS_Options"),         // Standard Step    usage choice
-                DNC_AdvAoE_SSBurstPct           = new("DNC_AdvAoE_SSBurstPct"),         // Standard Step    target HP% threshold
-                DNC_AdvAoE_TS_Options           = new("DNC_AdvAoE_TS_Options"),         // Technical Step   usage choice
-                DNC_AdvAoE_TSBurstPct           = new("DNC_AdvAoE_TSBurstPct"),         // Technical Step   target HP% threshold
-                DNC_AdvAoE_SaberThreshold       = new("DNC_AdvAoE_SaberThreshold"),     // Saber Dance      Esprit     threshold
-                DNC_AdvAoE_PanicWaltzPct        = new("DNC_AdvAoE_PanicWaltzPct"),      // Curing Waltz     player HP% threshold
-                DNC_AdvAoE_PanicWindPct         = new("DNC_AdvAoE_PanicWindPct"),       // Second Wind      player HP% threshold
-                DNC_AdvAoE_Interrupt            = new("DNC_AdvAoE_Interrupt");          // Interrupt        usage choice
+                DNC_AdvAoE_SS_Options               = new("DNC_AdvAoE_SS_Options"),                 // Standard Step    usage choice
+                DNC_AdvAoE_SSBurstPct               = new("DNC_AdvAoE_SSBurstPct"),                 // Standard Step    target HP% threshold
+                DNC_AdvAoE_TS_Options               = new("DNC_AdvAoE_TS_Options"),                 // Technical Step   usage choice
+                DNC_AdvAoE_TSBurstPct               = new("DNC_AdvAoE_TSBurstPct"),                 // Technical Step   target HP% threshold
+                DNC_AdvAoE_SaberThreshold           = new("DNC_AdvAoE_SaberThreshold"),             // Saber Dance      Esprit     threshold
+                DNC_AdvAoE_PanicWaltzPct            = new("DNC_AdvAoE_PanicWaltzPct"),              // Curing Waltz     player HP% threshold
+                DNC_AdvAoE_PanicWindPct             = new("DNC_AdvAoE_PanicWindPct"),               // Second Wind      player HP% threshold
+                DNC_AdvAoE_Interrupt                = new("DNC_AdvAoE_Interrupt");                  // Interrupt        usage choice
             #endregion
 
             internal static UserInt
-                DNC_VariantCurePct              = new("DNC_VariantCurePct");            // Variant Cure     player HP% threshold
+                DNC_VariantCurePct                  = new("DNC_VariantCurePct");                    // Variant Cure     player HP% threshold
         }
 
         internal class DNC_DanceStepSolver : CustomCombo
@@ -177,7 +188,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 #region Dance Combo Replacer (L)
-                if (IsEnabled(CustomComboPreset.DNC_Dance_Menu) && IsEnabled(CustomComboPreset.DNC_DanceComboReplacer) && Gauge.IsDancing)
+                if (IsEnabled(CustomComboPreset.DNC_Legacy_Dance) && IsEnabled(CustomComboPreset.DNC_Legacy_Dance_DanceActionReplacer) && Gauge.IsDancing)
                 {
                     uint[]? actionIDs = Service.Configuration.DancerDanceCompatActionIDs;
 
@@ -193,26 +204,26 @@ namespace XIVSlothCombo.Combos.PvE
                 #endregion
 
                 #region Fan Dance Combos (L)
-                if (IsEnabled(CustomComboPreset.DNC_FanDanceCombos))
+                if (IsEnabled(CustomComboPreset.DNC_Legacy_FanDanceCombos))
                 {
-                    // FD 1 --> 3, FD 1 --> 4
+                    // FD 1 —> 3, FD 1 —> 4
                     if (actionID is FanDance1)
                     {
-                        if (IsEnabled(CustomComboPreset.DNC_FanDance_1to3_Combo) &&
+                        if (Config.DNC_Legacy_FanDanceCombos_13 &&
                             HasEffect(Buffs.ThreeFoldFanDance))
                             return FanDance3;
-                        if (IsEnabled(CustomComboPreset.DNC_FanDance_1to4_Combo) &&
+                        if (Config.DNC_Legacy_FanDanceCombos_14 &&
                             HasEffect(Buffs.FourFoldFanDance))
                             return FanDance4;
                     }
 
-                    // FD 2 --> 3, FD 2 --> 4
+                    // FD 2 —> 3, FD 2 —> 4
                     if (actionID is FanDance2)
                     {
-                        if (IsEnabled(CustomComboPreset.DNC_FanDance_2to3_Combo) &&
+                        if (Config.DNC_Legacy_FanDanceCombos_23 &&
                             HasEffect(Buffs.ThreeFoldFanDance))
                             return FanDance3;
-                        if (IsEnabled(CustomComboPreset.DNC_FanDance_2to4_Combo) &&
+                        if (Config.DNC_Legacy_FanDanceCombos_24 &&
                             HasEffect(Buffs.FourFoldFanDance))
                             return FanDance4;
                     }
@@ -220,7 +231,7 @@ namespace XIVSlothCombo.Combos.PvE
                 #endregion
 
                 #region Fan Dance 3 & 4 on Flourish (L)
-                if (IsEnabled(CustomComboPreset.DNC_FlourishingFanDances) && actionID is Flourish && CanWeave(actionID))
+                if (IsEnabled(CustomComboPreset.DNC_Legacy_FlourishingFanDances) && actionID is Flourish && CanWeave(actionID))
                 {
                     if (HasEffect(Buffs.ThreeFoldFanDance))
                         return FanDance3;
@@ -230,7 +241,7 @@ namespace XIVSlothCombo.Combos.PvE
                 #endregion
 
                 #region ST Multibutton (L)
-                if (IsEnabled(CustomComboPreset.DNC_ST_MultiButton) && actionID is Cascade)
+                if (IsEnabled(CustomComboPreset.DNC_LegacyST_MultiButton) && actionID is Cascade)
                 {
                     #region Types
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
@@ -238,19 +249,19 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     // ST Esprit overcap protection
-                    if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= Config.DNC_LegacyST_EspritThreshold)
+                    if (Config.DNC_LegacyST_Multi_Esprit && LevelChecked(SaberDance) &&
+                        Gauge.Esprit >= Config.DNC_LegacyST_Multi_EspritThreshold)
                         return SaberDance;
 
                     if (CanWeave(actionID))
                     {
                         // ST Fan Dance overcap protection
-                        if (IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap) &&
+                        if (Config.DNC_LegacyST_Multi_FanOvercap &&
                             LevelChecked(FanDance1) && Gauge.Feathers is 4)
                             return FanDance1;
 
                         // ST Fan Dance 3/4 on combo
-                        if (IsEnabled(CustomComboPreset.DNC_ST_FanDance34))
+                        if (Config.DNC_LegacyST_Multi_FanDance34)
                         {
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
@@ -270,7 +281,7 @@ namespace XIVSlothCombo.Combos.PvE
                 #endregion
 
                 #region AoE Multibutton (L)
-                if (IsEnabled(CustomComboPreset.DNC_AoE_MultiButton) && actionID is Windmill)
+                if (IsEnabled(CustomComboPreset.DNC_LegacyAoE_MultiButton) && actionID is Windmill)
                 {
                     #region Types
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
@@ -278,19 +289,19 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     // AoE Esprit overcap protection
-                    if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= Config.DNC_LegacyAoE_EspritThreshold)
+                    if (Config.DNC_LegacyAoE_Multi_Esprit && LevelChecked(SaberDance) &&
+                        Gauge.Esprit >= Config.DNC_LegacyAoE_Multi_EspritThreshold)
                         return SaberDance;
 
                     if (CanWeave(actionID))
                     {
                         // AoE Fan Dance overcap protection
-                        if (IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap) &&
+                        if (Config.DNC_LegacyAoE_Multi_FanOvercap &&
                             LevelChecked(FanDance2) && Gauge.Feathers is 4)
                             return FanDance2;
 
                         // AoE Fan Dance 3/4 on combo
-                        if (IsEnabled(CustomComboPreset.DNC_AoE_FanDance34))
+                        if (Config.DNC_LegacyAoE_Multi_FanDance34)
                         {
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
@@ -316,10 +327,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 #region Combined Dances (L)
                 // One-button mode for both dances (SS/TS). SS takes priority.
-                if (IsEnabled(CustomComboPreset.DNC_Dance_Menu) && IsEnabled(CustomComboPreset.DNC_CombinedDances) && actionID is StandardStep)
+                if (IsEnabled(CustomComboPreset.DNC_Legacy_Dance) && IsEnabled(CustomComboPreset.DNC_Legacy_Dance_ComboDances) && actionID is StandardStep)
                 {
                     // Devilment
-                    if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Devilment) && IsOnCooldown(StandardStep) && IsOffCooldown(Devilment) && !Gauge.IsDancing)
+                    if (IsEnabled(CustomComboPreset.DNC_Legacy_Dance_ComboDances_Devilment) && IsOnCooldown(StandardStep) && IsOffCooldown(Devilment) && !Gauge.IsDancing)
                     {
                         if ((LevelChecked(Devilment) && !LevelChecked(TechnicalStep)) ||    // Lv. 62 - 69
                             (LevelChecked(TechnicalStep) && IsOnCooldown(TechnicalStep)))   // Lv. 70+ during Tech
@@ -327,7 +338,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Flourish
-                    if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Flourish) &&
+                    if (IsEnabled(CustomComboPreset.DNC_Legacy_Dance_ComboDances_Flourish) &&
                         InCombat() && !Gauge.IsDancing &&
                         ActionReady(Flourish) &&
                         IsOnCooldown(StandardStep))
@@ -368,9 +379,9 @@ namespace XIVSlothCombo.Combos.PvE
         }
 
         /* Old code
-        internal class DNC_DanceComboReplacer : CustomCombo
+        internal class DNC_Legacy_Dance_DanceActionReplacer : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_DanceComboReplacer;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Legacy_Dance_DanceActionReplacer;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -392,9 +403,9 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class DNC_FanDanceCombos : CustomCombo
+        internal class DNC_Legacy_FanDanceCombos : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_FanDanceCombos;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Legacy_FanDanceCombos;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -424,9 +435,9 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class DNC_FlourishingFanDances : CustomCombo
+        internal class DNC_Legacy_FlourishingFanDances : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_FlourishingFanDances;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Legacy_FlourishingFanDances;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -443,9 +454,9 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class DNC_ST_MultiButton : CustomCombo
+        internal class DNC_LegacyST_MultiButton : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_ST_MultiButton;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_LegacyST_MultiButton;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -458,7 +469,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyST_EspritThreshold))
+                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyST_Multi_EspritThreshold))
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -491,9 +502,9 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class DNC_AoE_MultiButton : CustomCombo
+        internal class DNC_LegacyAoE_MultiButton : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_AoE_MultiButton;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_LegacyAoE_MultiButton;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -506,7 +517,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyAoE_EspritThreshold))
+                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyAoE_Multi_EspritThreshold))
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -552,9 +563,9 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class DNC_CombinedDances : CustomCombo
+        internal class DNC_Legacy_Dance_ComboDances : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_CombinedDances;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_Legacy_Dance_ComboDances;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -562,7 +573,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is StandardStep)
                 {
                     // Devilment
-                    if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Devilment) && IsOnCooldown(StandardStep) && IsOffCooldown(Devilment) && !Gauge.IsDancing)
+                    if (IsEnabled(CustomComboPreset.DNC_Legacy_Dance_ComboDances_Devilment) && IsOnCooldown(StandardStep) && IsOffCooldown(Devilment) && !Gauge.IsDancing)
                     {
                         if ((LevelChecked(Devilment) && !LevelChecked(TechnicalStep)) ||    // Lv. 62 - 69
                             (LevelChecked(TechnicalStep) && IsOnCooldown(TechnicalStep)))   // Lv. 70+ during Tech
@@ -570,7 +581,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Flourish
-                    if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Flourish) &&
+                    if (IsEnabled(CustomComboPreset.DNC_Legacy_Dance_ComboDances_Flourish) &&
                         InCombat() && !Gauge.IsDancing &&
                         ActionReady(Flourish) &&
                         IsOnCooldown(StandardStep))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -1300,7 +1300,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Bladeshower;
 
                     // Advanced AoE Standard Step (inside of burst)
-                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) &&
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS_Burst) &&
                         IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish) &&
                         GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct &&
                         (GetBuffRemainingTime(Buffs.TechnicalFinish) >= 7))

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -105,6 +105,8 @@ namespace XIVSlothCombo.Combos.PvE
         }
         */
 
+        private static DNCGauge Gauge => CustomComboFunctions.GetJobGauge<DNCGauge>();
+
         public static class Config
         {
             #region Legacy config
@@ -142,7 +144,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (GetJobGauge<DNCGauge>().IsDancing)
+                if (Gauge.IsDancing)
                 {
                     uint[]? actionIDs = Service.Configuration.DancerDanceCompatActionIDs;
 
@@ -198,18 +200,16 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                DNCGauge? gauge = GetJobGauge<DNCGauge>();
-
                 // Standard Step
-                if (actionID is StandardStep && gauge.IsDancing && HasEffect(Buffs.StandardStep))
-                    return gauge.CompletedSteps < 2
-                        ? gauge.NextStep
+                if (actionID is StandardStep && Gauge.IsDancing && HasEffect(Buffs.StandardStep))
+                    return Gauge.CompletedSteps < 2
+                        ? Gauge.NextStep
                         : StandardFinish;
 
                 // Technical Step
-                if ((actionID is TechnicalStep) && gauge.IsDancing && HasEffect(Buffs.TechnicalStep))
-                    return gauge.CompletedSteps < 4
-                        ? gauge.NextStep
+                if ((actionID is TechnicalStep) && Gauge.IsDancing && HasEffect(Buffs.TechnicalStep))
+                    return Gauge.CompletedSteps < 4
+                        ? Gauge.NextStep
                         : TechnicalFinish;
 
                 return actionID;
@@ -244,21 +244,20 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Cascade)
                 {
                     #region Types
-                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     #endregion
 
                     // ST Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) && LevelChecked(SaberDance) &&
-                        gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_ST))
+                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_ST))
                         return SaberDance;
 
                     if (CanWeave(actionID))
                     {
                         // ST Fan Dance overcap protection
                         if (IsEnabled(CustomComboPreset.DNC_ST_FanDanceOvercap) &&
-                            LevelChecked(FanDance1) && gauge.Feathers is 4)
+                            LevelChecked(FanDance1) && Gauge.Feathers is 4)
                             return FanDance1;
 
                         // ST Fan Dance 3/4 on combo
@@ -293,21 +292,20 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Windmill)
                 {
                     #region Types
-                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     #endregion
 
                     // AoE Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) && LevelChecked(SaberDance) &&
-                        gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_AoE))
+                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCEspritThreshold_AoE))
                         return SaberDance;
 
                     if (CanWeave(actionID))
                     {
                         // AoE Fan Dance overcap protection
                         if (IsEnabled(CustomComboPreset.DNC_AoE_FanDanceOvercap) &&
-                            LevelChecked(FanDance2) && gauge.Feathers is 4)
+                            LevelChecked(FanDance2) && Gauge.Feathers is 4)
                             return FanDance2;
 
                         // AoE Fan Dance 3/4 on combo
@@ -352,10 +350,8 @@ namespace XIVSlothCombo.Combos.PvE
                 // One-button mode for both dances (SS/TS). SS takes priority.
                 if (actionID is StandardStep)
                 {
-                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
-
                     // Devilment
-                    if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Devilment) && IsOnCooldown(StandardStep) && IsOffCooldown(Devilment) && !gauge.IsDancing)
+                    if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Devilment) && IsOnCooldown(StandardStep) && IsOffCooldown(Devilment) && !Gauge.IsDancing)
                     {
                         if ((LevelChecked(Devilment) && !LevelChecked(TechnicalStep)) ||    // Lv. 62 - 69
                             (LevelChecked(TechnicalStep) && IsOnCooldown(TechnicalStep)))   // Lv. 70+ during Tech
@@ -364,7 +360,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Flourish
                     if (IsEnabled(CustomComboPreset.DNC_CombinedDances_Flourish) &&
-                        InCombat() && !gauge.IsDancing &&
+                        InCombat() && !Gauge.IsDancing &&
                         ActionReady(Flourish) &&
                         IsOnCooldown(StandardStep))
                         return Flourish;
@@ -376,23 +372,23 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Tech Step
                     if (IsOnCooldown(StandardStep) && IsOffCooldown(TechnicalStep) &&
-                        !gauge.IsDancing && !HasEffect(Buffs.StandardStep))
+                        !Gauge.IsDancing && !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
                     // Dance steps
-                    if (gauge.IsDancing)
+                    if (Gauge.IsDancing)
                     {
                         if (HasEffect(Buffs.StandardStep))
                         {
-                            return gauge.CompletedSteps < 2
-                                ? gauge.NextStep
+                            return Gauge.CompletedSteps < 2
+                                ? Gauge.NextStep
                                 : StandardFinish;
                         }
 
                         if (HasEffect(Buffs.TechnicalStep))
                         {
-                            return gauge.CompletedSteps < 4
-                                ? gauge.NextStep
+                            return Gauge.CompletedSteps < 4
+                                ? Gauge.NextStep
                                 : TechnicalFinish;
                         }
                     }
@@ -411,7 +407,6 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Cascade)
                 {
                     #region Types
-                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     #endregion
@@ -427,15 +422,15 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Standard (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_ST_Simple_SS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_StandardFill)) &&
                         HasEffect(Buffs.StandardStep))
-                        return gauge.CompletedSteps < 2
-                            ? gauge.NextStep
+                        return Gauge.CompletedSteps < 2
+                            ? Gauge.NextStep
                             : StandardFinish;
 
                     // ST Technical (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_ST_Simple_TS) || IsEnabled(CustomComboPreset.DNC_ST_Simple_TechFill)) &&
                         HasEffect(Buffs.TechnicalStep))
-                        return gauge.CompletedSteps < 4
-                            ? gauge.NextStep
+                        return Gauge.CompletedSteps < 4
+                            ? Gauge.NextStep
                             : TechnicalFinish;
                     #endregion
 
@@ -478,23 +473,23 @@ namespace XIVSlothCombo.Combos.PvE
                                 return FanDance3;
 
                             // FD1 HP% Dump
-                            if (GetTargetHPPercent() <= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent) && gauge.Feathers > 0)
+                            if (GetTargetHPPercent() <= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleFeatherBurstPercent) && Gauge.Feathers > 0)
                                 return FanDance1;
 
                             if (LevelChecked(TechnicalStep))
                             {
                                 // Burst FD1
-                                if (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)
+                                if (HasEffect(Buffs.TechnicalFinish) && Gauge.Feathers > 0)
                                     return FanDance1;
 
                                 // FD1 Pooling
-                                if (gauge.Feathers > 3 &&
+                                if (Gauge.Feathers > 3 &&
                                     (GetCooldownRemainingTime(TechnicalStep) > 2.5f || IsOffCooldown(TechnicalStep)))
                                     return FanDance1;
                             }
 
                             // FD1 Non-pooling & under burst level
-                            if (!LevelChecked(TechnicalStep) && gauge.Feathers > 0)
+                            if (!LevelChecked(TechnicalStep) && Gauge.Feathers > 0)
                                 return FanDance1;
 
                         }
@@ -542,8 +537,8 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_ST_Simple_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
-                        if (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
-                            (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50))
+                        if (Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleSaberThreshold) ||
+                            (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
                             return SaberDance;
                     }
 
@@ -586,7 +581,6 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Windmill)
                 {
                     #region Types
-                    DNCGauge? gauge = GetJobGauge<DNCGauge>();
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     #endregion
@@ -595,15 +589,15 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Standard (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_AoE_Simple_SS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_StandardFill)) &&
                         HasEffect(Buffs.StandardStep))
-                        return gauge.CompletedSteps < 2
-                            ? gauge.NextStep
+                        return Gauge.CompletedSteps < 2
+                            ? Gauge.NextStep
                             : StandardFinish;
 
                     // AoE Technical (Dance) Steps & Fill
                     if ((IsEnabled(CustomComboPreset.DNC_AoE_Simple_TS) || IsEnabled(CustomComboPreset.DNC_AoE_Simple_TechFill)) &&
                         HasEffect(Buffs.TechnicalStep))
-                        return gauge.CompletedSteps < 4
-                            ? gauge.NextStep
+                        return Gauge.CompletedSteps < 4
+                            ? Gauge.NextStep
                             : TechnicalFinish;
                     #endregion
 
@@ -649,8 +643,8 @@ namespace XIVSlothCombo.Combos.PvE
                             if (HasEffect(Buffs.ThreeFoldFanDance))
                                 return FanDance3;
 
-                            if ((gauge.Feathers > minFeathers ||
-                                (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)) &&
+                            if ((Gauge.Feathers > minFeathers ||
+                                (HasEffect(Buffs.TechnicalFinish) && Gauge.Feathers > 0)) &&
                                 LevelChecked(FanDance2))
                                 return FanDance2;
                         }
@@ -668,22 +662,22 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (LevelChecked(TechnicalStep))
                                 {
                                     // Burst FD2
-                                    if (HasEffect(Buffs.TechnicalFinish) && gauge.Feathers > 0)
+                                    if (HasEffect(Buffs.TechnicalFinish) && Gauge.Feathers > 0)
                                         return FanDance2;
 
                                     // FD2 Pooling
-                                    if (gauge.Feathers > 3 &&
+                                    if (Gauge.Feathers > 3 &&
                                         (GetCooldownRemainingTime(TechnicalStep) > 2.5f || IsOffCooldown(TechnicalStep)))
                                         return FanDance2;
                                 }
 
                                 // FD2 Non-pooling & under burst level
-                                if (!LevelChecked(TechnicalStep) && gauge.Feathers > 0)
+                                if (!LevelChecked(TechnicalStep) && Gauge.Feathers > 0)
                                     return FanDance2;
                             }
 
                             // FD1 Replacement for Lv.30-49
-                            if (!LevelChecked(FanDance2) && gauge.Feathers > 0)
+                            if (!LevelChecked(FanDance2) && Gauge.Feathers > 0)
                                 return FanDance1;
                         }
 
@@ -730,8 +724,8 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Simple_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
-                        if (gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) ||
-                            (HasEffect(Buffs.TechnicalFinish) && gauge.Esprit >= 50))
+                        if (Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNCSimpleAoESaberThreshold) ||
+                            (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
                             return SaberDance;
                     }
 

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -446,7 +446,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Weaves
                     // Simple ST Devilment
                     if (CanWeave(actionID) && ActionReady(Devilment) &&
-                        (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                        (WasLastAction(TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
                     // Simple ST Flourish
@@ -616,7 +616,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Weaves
                     // Advanced ST Devilment
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_Devilment) && ActionReady(Devilment) &&
-                        (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                        (WasLastAction(TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
                     // Advanced ST Flourish
@@ -793,7 +793,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Weaves
                     // Simple AoE Devilment
                     if (CanWeave(actionID) && ActionReady(Devilment) &&
-                        (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                        (WasLastAction(TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
                     // Simple AoE Flourish
@@ -978,7 +978,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Weaves
                     // Advanced AoE Devilment
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_Devilment) && ActionReady(Devilment) &&
-                        (HasEffect(Buffs.TechnicalFinish) || !LevelChecked(TechnicalStep)))
+                        (WasLastAction(TechnicalFinish) || !LevelChecked(TechnicalStep)))
                         return Devilment;
 
                     // Advanced AoE Flourish

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -421,6 +421,12 @@ namespace XIVSlothCombo.Combos.PvE
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     #endregion
 
+                    #region Pre-pull
+                    // Simple ST Standard Step (pre-pull)
+                    if (Config.DNC_SimpleST_Dances[0] && ActionReady(StandardStep) && IsOffCooldown(TechnicalStep) && !InCombat())
+                        return StandardStep;
+                    #endregion
+
                     #region Dance Fills
                     // Simple ST Standard (Dance) Steps & Fill
                     if (HasEffect(Buffs.StandardStep) &&
@@ -512,22 +518,22 @@ namespace XIVSlothCombo.Combos.PvE
                         PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
-                    // Simple ST Standard Step (outside of burst)
-                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
-                        Config.DNC_SimpleST_Dances[0])
-                    {
-                        if ((!HasTarget() || GetTargetHPPercent() > 5) &&
-                            ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
-                            return StandardStep;
-                    }
-
                     // Simple ST Technical Step
                     if (ActionReady(TechnicalStep) &&
                         Config.DNC_SimpleST_Dances[1] &&
                         (!HasTarget() || GetTargetHPPercent() > 5) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
+
+                    // Simple ST Standard Step (outside of burst)
+                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
+                        Config.DNC_SimpleST_Dances[0])
+                    {
+                        if ((!HasTarget() || GetTargetHPPercent() > 5) &&
+                            (GetCooldownRemainingTime(TechnicalStep) > 5) &&
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
+                            return StandardStep;
+                    }
 
                     // Simple ST Saber Dance
                     if (LevelChecked(SaberDance) && (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
@@ -770,6 +776,12 @@ namespace XIVSlothCombo.Combos.PvE
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
                     #endregion
 
+                    #region Pre-pull
+                    // Simple AoE Standard Step (pre-pull)
+                    if (Config.DNC_SimpleAoE_Dances[0] && ActionReady(StandardStep) && IsOffCooldown(TechnicalStep) && !InCombat())
+                        return StandardStep;
+                    #endregion
+
                     #region Dance Fills
                     // Simple AoE Standard (Dance) Steps & Fill
                     if (HasEffect(Buffs.StandardStep) &&
@@ -881,21 +893,21 @@ namespace XIVSlothCombo.Combos.PvE
                         PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
-                    // Simple AoE Standard Step (outside of burst)
-                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
-                        Config.DNC_SimpleAoE_Dances[0])
-                    {
-                        if ((!HasTarget() || GetTargetHPPercent() > 5) &&
-                            ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
-                            return StandardStep;
-                    }
-
                     // Simple AoE Technical Step
                     if (ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep) &&
                         Config.DNC_SimpleAoE_Dances[1] &&
                         (!HasTarget() || GetTargetHPPercent() > 5))
                         return TechnicalStep;
+
+                    // Simple AoE Standard Step (outside of burst)
+                    if (ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish) &&
+                        Config.DNC_SimpleAoE_Dances[0])
+                    {
+                        if ((!HasTarget() || GetTargetHPPercent() > 5) &&
+                            (GetCooldownRemainingTime(TechnicalStep) > 5) &&
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
+                            return StandardStep;
+                    }
 
                     // Simple AoE Saber Dance
                     if (LevelChecked(SaberDance) &&
@@ -946,6 +958,13 @@ namespace XIVSlothCombo.Combos.PvE
                     #region Types
                     bool flow = HasEffect(Buffs.SilkenFlow) || HasEffect(Buffs.FlourishingFlow);
                     bool symmetry = HasEffect(Buffs.SilkenSymmetry) || HasEffect(Buffs.FlourishingSymmetry);
+                    #endregion
+
+                    #region Pre-pull
+                    // Advanced AoE Standard Step (pre-pull)
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && Config.DNC_AdvAoE_SS_Options == 2 &&
+                        ActionReady(StandardStep) && IsOffCooldown(TechnicalStep) && !InCombat())
+                        return StandardStep;
                     #endregion
 
                     #region Dance Fills
@@ -1072,21 +1091,21 @@ namespace XIVSlothCombo.Combos.PvE
                         PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
-                    // Advanced AoE Standard Step (outside of burst)
-                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && Config.DNC_AdvAoE_SS_Options == 2 &&
-                        ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
-                    {
-                        if ((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct) &&
-                            ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
-                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
-                            return StandardStep;
-                    }
-
                     // Advanced AoE Technical Step
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_TS) && Config.DNC_AdvAoE_TS_Options == 2 &&
                         ActionReady(TechnicalStep) && !HasEffect(Buffs.StandardStep) &&
                         (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_TSBurstPct))
                         return TechnicalStep;
+
+                    // Advanced AoE Standard Step (outside of burst)
+                    if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && Config.DNC_AdvAoE_SS_Options == 2 &&
+                        ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
+                    {
+                        if ((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct) &&
+                            (GetCooldownRemainingTime(TechnicalStep) > 5) &&
+                            (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5)))
+                            return StandardStep;
+                    }
 
                     // Advanced AoE Saber Dance
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SaberDance) && LevelChecked(SaberDance) &&

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -230,7 +230,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_ST_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyST_EspritTh))
+                        Gauge.Esprit >= Config.DNC_LegacyST_EspritTh)
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -270,7 +270,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Esprit overcap protection
                     if (IsEnabled(CustomComboPreset.DNC_AoE_EspritOvercap) && LevelChecked(SaberDance) &&
-                        Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_LegacyAoE_EspritTh))
+                        Gauge.Esprit >= Config.DNC_LegacyAoE_EspritTh)
                         return SaberDance;
 
                     if (CanWeave(actionID))
@@ -656,7 +656,7 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.DNC_VariantCurePct))
+                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
@@ -825,7 +825,7 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.DNC_VariantCurePct))
+                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
@@ -844,7 +844,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return FanDance3;
 
                             // FD1 HP% Dump
-                            if (GetTargetHPPercent() <= PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_FeatherBurstPct) && Gauge.Feathers > 0)
+                            if (GetTargetHPPercent() <= Config.DNC_AdvST_FeatherBurstPct && Gauge.Feathers > 0)
                                 return FanDance1;
 
                             if (LevelChecked(TechnicalStep))
@@ -872,11 +872,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.DNC_AdvST_PanicHeals))
                         {
                             if (ActionReady(CuringWaltz) &&
-                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_PanicWaltzPct))
+                                PlayerHealthPercentageHp() < Config.DNC_AdvST_PanicWaltzPct)
                                 return CuringWaltz;
 
                             if (ActionReady(All.SecondWind) &&
-                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_PanicWindPct))
+                                PlayerHealthPercentageHp() < Config.DNC_AdvST_PanicWindPct)
                                 return All.SecondWind;
                         }
 
@@ -891,7 +891,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_SSBurstPct)) &&
+                        if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
                             (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
                             IsOffCooldown(StandardStep))
@@ -900,7 +900,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // ST Technical Step
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_TS) && ActionReady(TechnicalStep) &&
-                        (!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_TSBurstPct)) &&
+                        (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvST_TSBurstPct) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
@@ -908,7 +908,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
-                        if (Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_SaberTh) ||
+                        if (Gauge.Esprit >= Config.DNC_AdvST_SaberTh ||
                             (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
                             return SaberDance;
                     }
@@ -925,7 +925,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Standard Step (inside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvST_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvST_SSBurstPct) &&
+                        if (GetTargetHPPercent() > Config.DNC_AdvST_SSBurstPct &&
                             (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
                             return StandardStep;
                     }
@@ -944,7 +944,7 @@ namespace XIVSlothCombo.Combos.PvE
         }
         #endregion
 
-        #region Siple/Advanced AoE Modes
+        #region Simple/Advanced AoE Modes
         internal class DNC_AoE_SimpleMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DNC_AoE_SimpleMode;
@@ -989,7 +989,7 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.DNC_VariantCurePct))
+                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
@@ -1176,7 +1176,7 @@ namespace XIVSlothCombo.Combos.PvE
                         !HasEffect(Buffs.TechnicalFinish))
                         return All.HeadGraze;
 
-                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.DNC_VariantCurePct))
+                    if (IsEnabled(CustomComboPreset.DNC_VariantCure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.DNC_VariantCurePct)
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
@@ -1243,11 +1243,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.DNC_AdvAoE_PanicHeals))
                         {
                             if (ActionReady(CuringWaltz) &&
-                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_PanicWaltzPct))
+                                PlayerHealthPercentageHp() < Config.DNC_AdvAoE_PanicWaltzPct)
                                 return CuringWaltz;
 
                             if (ActionReady(All.SecondWind) &&
-                                PlayerHealthPercentageHp() < PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_PanicWindPct))
+                                PlayerHealthPercentageHp() < Config.DNC_AdvAoE_PanicWindPct)
                                 return All.SecondWind;
                         }
 
@@ -1262,7 +1262,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Standard Step (outside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && ActionReady(StandardStep) && !HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (((!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_SSBurstPct)) &&
+                        if (((!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct) &&
                             ((IsOffCooldown(TechnicalStep) && !InCombat()) || GetCooldownRemainingTime(TechnicalStep) > 5) &&
                             (IsOffCooldown(Flourish) || (GetCooldownRemainingTime(Flourish) > 5))) ||
                             IsOffCooldown(StandardStep))
@@ -1271,7 +1271,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // AoE Technical Step
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_TS) && ActionReady(TechnicalStep) &&
-                        (!HasTarget() || GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_TSBurstPct)) &&
+                        (!HasTarget() || GetTargetHPPercent() > Config.DNC_AdvAoE_TSBurstPct) &&
                         !HasEffect(Buffs.StandardStep))
                         return TechnicalStep;
 
@@ -1279,7 +1279,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SaberDance) && LevelChecked(SaberDance) &&
                         (GetCooldownRemainingTime(TechnicalStep) > 5 || IsOffCooldown(TechnicalStep)))
                     {
-                        if (Gauge.Esprit >= PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_SaberTh) ||
+                        if (Gauge.Esprit >= Config.DNC_AdvAoE_SaberTh ||
                             (HasEffect(Buffs.TechnicalFinish) && Gauge.Esprit >= 50))
                             return SaberDance;
                     }
@@ -1296,7 +1296,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Standard Step (inside of burst)
                     if (IsEnabled(CustomComboPreset.DNC_AdvAoE_SS) && IsOffCooldown(StandardStep) && HasEffect(Buffs.TechnicalFinish))
                     {
-                        if (GetTargetHPPercent() > PluginConfiguration.GetCustomIntValue(Config.DNC_AdvAoE_SSBurstPct) &&
+                        if (GetTargetHPPercent() > Config.DNC_AdvAoE_SSBurstPct &&
                             (GetBuffRemainingTime(Buffs.TechnicalFinish) > 5))
                             return StandardStep;
                     }

--- a/XIVSlothCombo/Core/PluginConfiguration.cs
+++ b/XIVSlothCombo/Core/PluginConfiguration.cs
@@ -232,7 +232,7 @@ namespace XIVSlothCombo.Core
         /// <summary> Gets active Blue Mage (BLU) spells. </summary>
         public List<uint> ActiveBLUSpells { get; set; } = new List<uint>();
 
-        /// <summary> Gets or sets an array of 4 ability IDs to interact with the <see cref="CustomComboPreset.DNC_DanceComboReplacer"/> combo. </summary>
+        /// <summary> Gets or sets an array of 4 ability IDs to interact with the <see cref="CustomComboPreset.DNC_Legacy_Dance_DanceActionReplacer"/> combo. </summary>
         public uint[] DancerDanceCompatActionIDs { get; set; } = new uint[]
         {
             DNC.Cascade,

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1235,7 +1235,7 @@ namespace XIVSlothCombo.Window.Functions
             // SS Config
             if (preset is CustomComboPreset.DNC_AdvST_SS)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_SS_Options, "Resolve Only", "Adds ONLY Standard dance steps and Standard Finish to the rotation.\nStandard Step itself must be initiated manually when using this option.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_SS_Options, "Resolve", "Adds ONLY Standard dance steps and Standard Finish to the rotation.\nStandard Step itself must be initiated manually when using this option.", 1);
                 UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_SS_Options, "Initiate + Resolve", "Adds Standard Step, all dance steps and Standard Finish to the rotation.", 2);
 
                 if (DNC.Config.DNC_AdvST_SS_Options == 2)
@@ -1252,7 +1252,7 @@ namespace XIVSlothCombo.Window.Functions
             // TS Config
             if (preset is CustomComboPreset.DNC_AdvST_TS)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_TS_Options, "Resolve Only", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_TS_Options, "Resolve", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1);
                 UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_TS_Options, "Initiate + Resolve", "Adds Technical Step, all dance steps and Standard Finish to the rotation.", 2);
 
                 if (DNC.Config.DNC_AdvST_TS_Options == 2)
@@ -1306,7 +1306,7 @@ namespace XIVSlothCombo.Window.Functions
             // SS Config
             if (preset is CustomComboPreset.DNC_AdvAoE_SS)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_SS_Options, "Resolve Only", "Adds ONLY Standard dance steps and Standard Finish to the rotation.\nStandard Step itself must be initiated manually when using this option.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_SS_Options, "Resolve", "Adds ONLY Standard dance steps and Standard Finish to the rotation.\nStandard Step itself must be initiated manually when using this option.", 1);
                 UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_SS_Options, "Initiate + Resolve", "Adds Standard Step, all dance steps and Standard Finish to the rotation.", 2);
 
                 if (DNC.Config.DNC_AdvAoE_SS_Options == 2)
@@ -1323,7 +1323,7 @@ namespace XIVSlothCombo.Window.Functions
             // TS Config
             if (preset is CustomComboPreset.DNC_AdvAoE_TS)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_TS_Options, "Resolve Only", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_TS_Options, "Resolve", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1);
                 UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_TS_Options, "Initiate + Resolve", "Adds Technical Step, all dance steps and Standard Finish to the rotation.", 2);
 
                 if (DNC.Config.DNC_AdvAoE_TS_Options == 2)

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1165,72 +1165,32 @@ namespace XIVSlothCombo.Window.Functions
             // ====================================================================================
             #region DANCER
 
-            #region Legacy config
-
-            // Dance Combo Replacer
-            if (preset is CustomComboPreset.DNC_Legacy_Dance_DanceActionReplacer)
-            {
-                int[]? actions = Service.Configuration.DancerDanceCompatActionIDs.Cast<int>().ToArray();
-                bool inputChanged = false;
-
-                inputChanged |= ImGui.InputInt("Emboite (Red) ActionID", ref actions[0], 0);
-                inputChanged |= ImGui.InputInt("Entrechat (Blue) ActionID", ref actions[1], 0);
-                inputChanged |= ImGui.InputInt("Jete (Green) ActionID", ref actions[2], 0);
-                inputChanged |= ImGui.InputInt("Pirouette (Yellow) ActionID", ref actions[3], 0);
-
-                if (inputChanged)
-                {
-                    Service.Configuration.DancerDanceCompatActionIDs = actions.Cast<uint>().ToArray();
-                    Service.Configuration.Save();
-                }
-
-                ImGui.Spacing();
-            }
-
-            // ST Multibutton Feature
-            if (preset is CustomComboPreset.DNC_LegacyST_MultiButton)
-            {
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyST_Multi_Esprit, "Esprit Overcap Option", "Adds Saber Dance when Esprit is at or above the set threshold.");
-
-                if (DNC.Config.DNC_LegacyST_Multi_Esprit == true)
-                {
-                    ImGui.Indent();
-                    UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyST_Multi_EspritThreshold, " Esprit", 150, SliderIncrements.Fives);
-                    ImGui.Unindent();
-                }
-
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyST_Multi_FanOvercap, "Fan Dance Overcap Protection Option", "Adds Fan Dance I when Fourfold Feathers are full.");
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyST_Multi_FanDance34, "Fan Dance Option", "Adds Fan Dance III/IV when available.");
-            }
-
-            // AoE Multibutton Feature
-            if (preset is CustomComboPreset.DNC_LegacyAoE_MultiButton)
-            {
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyAoE_Multi_Esprit, "AoE Esprit Overcap Option", "Adds Saber Dance when Esprit is at or above the set threshold.");
-
-                if (DNC.Config.DNC_LegacyAoE_Multi_Esprit == true)
-                {
-                    ImGui.Indent();
-                    UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyAoE_Multi_EspritThreshold, " Esprit", 150, SliderIncrements.Fives);
-                    ImGui.Unindent();
-                }
-
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyAoE_Multi_FanOvercap, "AoE Fan Dance Overcap Protection Option", "Adds Fan Dance II when Fourfold Feathers are full.");
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyAoE_Multi_FanDance34, "AoE Fan Dance Option", "Adds Fan Dance III/IV when available.");
-            }
-
             // Fan Dance Combo Feature
-            if (preset is CustomComboPreset.DNC_Legacy_FanDanceCombos)
+            if (preset is CustomComboPreset.DNC_FanDanceCombos)
             {
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_Legacy_FanDanceCombos_13, "Fan Dance —> III Option", "Changes Fan Dance to Fan Dance III when available.");
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_Legacy_FanDanceCombos_14, "Fan Dance —> IV Option", "Changes Fan Dance to Fan Dance IV when available.");
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_Legacy_FanDanceCombos_23, "Fan Dance II —> III Option", "Changes Fan Dance II to Fan Dance III when available.");
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_Legacy_FanDanceCombos_24, "Fan Dance II —> IV Option", "Changes Fan Dance II to Fan Dance IV when available.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_FanDanceCombos_13, "Fan Dance —> III Option", "Changes Fan Dance to Fan Dance III when available.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_FanDanceCombos_14, "Fan Dance —> IV Option", "Changes Fan Dance to Fan Dance IV when available.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_FanDanceCombos_23, "Fan Dance II —> III Option", "Changes Fan Dance II to Fan Dance III when available.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_FanDanceCombos_24, "Fan Dance II —> IV Option", "Changes Fan Dance II to Fan Dance IV when available.");
+            }
+
+            #region Simple ST/AoE
+
+            if (preset is CustomComboPreset.DNC_ST_SimpleMode)
+            {
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_ST_SimpleMode_SS, "Include Standard Step", "Adds Standard Step to the rotation.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_ST_SimpleMode_TS, "Include Technical Step", "Adds Technical Step to the rotation.");
+            }
+
+            if (preset is CustomComboPreset.DNC_AoE_SimpleMode)
+            {
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AoE_SimpleMode_SS, "Include Standard Step", "Adds Standard Step to the AoE rotation.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AoE_SimpleMode_TS, "Include Technical Step", "Adds Technical Step to the AoE rotation.");
             }
 
             #endregion
 
-            #region Advanced ST config
+            #region Advanced ST
 
             // SS Config
             if (preset is CustomComboPreset.DNC_AdvST_SS)
@@ -1301,7 +1261,7 @@ namespace XIVSlothCombo.Window.Functions
 
             #endregion
 
-            #region Advanced AoE config
+            #region Advanced AoE
 
             // SS Config
             if (preset is CustomComboPreset.DNC_AdvAoE_SS)
@@ -1364,14 +1324,66 @@ namespace XIVSlothCombo.Window.Functions
 
             #endregion
 
-            #region Miscellaneous config
+            #region Legacy
+
+            // Dance Combo Replacer
+            if (preset is CustomComboPreset.DNC_Legacy_Dance_DanceActionReplacer)
+            {
+                int[]? actions = Service.Configuration.DancerDanceCompatActionIDs.Cast<int>().ToArray();
+                bool inputChanged = false;
+
+                inputChanged |= ImGui.InputInt("Emboite (Red) ActionID", ref actions[0], 0);
+                inputChanged |= ImGui.InputInt("Entrechat (Blue) ActionID", ref actions[1], 0);
+                inputChanged |= ImGui.InputInt("Jete (Green) ActionID", ref actions[2], 0);
+                inputChanged |= ImGui.InputInt("Pirouette (Yellow) ActionID", ref actions[3], 0);
+
+                if (inputChanged)
+                {
+                    Service.Configuration.DancerDanceCompatActionIDs = actions.Cast<uint>().ToArray();
+                    Service.Configuration.Save();
+                }
+
+                ImGui.Spacing();
+            }
+
+            // ST Multibutton Feature
+            if (preset is CustomComboPreset.DNC_LegacyST_MultiButton)
+            {
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyST_Multi_Esprit, "Esprit Overcap Option", "Adds Saber Dance when Esprit is at or above the set threshold.");
+
+                if (DNC.Config.DNC_LegacyST_Multi_Esprit == true)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyST_Multi_EspritThreshold, " Esprit", 150, SliderIncrements.Fives);
+                    ImGui.Unindent();
+                }
+
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyST_Multi_FanOvercap, "Fan Dance Overcap Protection Option", "Adds Fan Dance I when Fourfold Feathers are full.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyST_Multi_FanDance34, "Fan Dance Option", "Adds Fan Dance III/IV when available.");
+            }
+
+            // AoE Multibutton Feature
+            if (preset is CustomComboPreset.DNC_LegacyAoE_MultiButton)
+            {
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyAoE_Multi_Esprit, "AoE Esprit Overcap Option", "Adds Saber Dance when Esprit is at or above the set threshold.");
+
+                if (DNC.Config.DNC_LegacyAoE_Multi_Esprit == true)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyAoE_Multi_EspritThreshold, " Esprit", 150, SliderIncrements.Fives);
+                    ImGui.Unindent();
+                }
+
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyAoE_Multi_FanOvercap, "AoE Fan Dance Overcap Protection Option", "Adds Fan Dance II when Fourfold Feathers are full.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyAoE_Multi_FanDance34, "AoE Fan Dance Option", "Adds Fan Dance III/IV when available.");
+            }
+
+            #endregion
 
             if (preset is CustomComboPreset.DNC_VariantCure)
                 UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_VariantCurePct, " HP% to be at or under", 200);
 
-            #endregion
-
-            #region PvP config
+            #region PvP
 
             if (preset == CustomComboPreset.DNCPvP_BurstMode_CuringWaltz)
                 UserConfig.DrawSliderInt(0, 90, DNCPvP.Config.DNCPvP_WaltzThreshold, " Curing Waltz HP% - caps at 90 to prevent waste.", 150, SliderIncrements.Ones);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1168,7 +1168,7 @@ namespace XIVSlothCombo.Window.Functions
             #region Legacy config
 
             // Dance Combo Replacer
-            if (preset is CustomComboPreset.DNC_DanceComboReplacer)
+            if (preset is CustomComboPreset.DNC_Legacy_Dance_DanceActionReplacer)
             {
                 int[]? actions = Service.Configuration.DancerDanceCompatActionIDs.Cast<int>().ToArray();
                 bool inputChanged = false;
@@ -1187,13 +1187,46 @@ namespace XIVSlothCombo.Window.Functions
                 ImGui.Spacing();
             }
 
-            // ST Multibutton Esprit overcap
-            if (preset is CustomComboPreset.DNC_ST_EspritOvercap)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyST_EspritThreshold, "Esprit", 150, SliderIncrements.Fives);
+            // ST Multibutton Feature
+            if (preset is CustomComboPreset.DNC_LegacyST_MultiButton)
+            {
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyST_Multi_Esprit, "Esprit Overcap Option", "Adds Saber Dance when Esprit is at or above the set threshold.");
 
-            // AoE Multibutton Esprit overcap
-            if (preset is CustomComboPreset.DNC_AoE_EspritOvercap)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyAoE_EspritThreshold, "Esprit", 150, SliderIncrements.Fives);
+                if (DNC.Config.DNC_LegacyST_Multi_Esprit == true)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyST_Multi_EspritThreshold, " Esprit", 150, SliderIncrements.Fives);
+                    ImGui.Unindent();
+                }
+
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyST_Multi_FanOvercap, "Fan Dance Overcap Protection Option", "Adds Fan Dance I when Fourfold Feathers are full.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyST_Multi_FanDance34, "Fan Dance Option", "Adds Fan Dance III/IV when available.");
+            }
+
+            // AoE Multibutton Feature
+            if (preset is CustomComboPreset.DNC_LegacyAoE_MultiButton)
+            {
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyAoE_Multi_Esprit, "AoE Esprit Overcap Option", "Adds Saber Dance when Esprit is at or above the set threshold.");
+
+                if (DNC.Config.DNC_LegacyAoE_Multi_Esprit == true)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyAoE_Multi_EspritThreshold, " Esprit", 150, SliderIncrements.Fives);
+                    ImGui.Unindent();
+                }
+
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyAoE_Multi_FanOvercap, "AoE Fan Dance Overcap Protection Option", "Adds Fan Dance II when Fourfold Feathers are full.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_LegacyAoE_Multi_FanDance34, "AoE Fan Dance Option", "Adds Fan Dance III/IV when available.");
+            }
+
+            // Fan Dance Combo Feature
+            if (preset is CustomComboPreset.DNC_Legacy_FanDanceCombos)
+            {
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_Legacy_FanDanceCombos_13, "Fan Dance —> III Option", "Changes Fan Dance to Fan Dance III when available.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_Legacy_FanDanceCombos_14, "Fan Dance —> IV Option", "Changes Fan Dance to Fan Dance IV when available.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_Legacy_FanDanceCombos_23, "Fan Dance II —> III Option", "Changes Fan Dance II to Fan Dance III when available.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_Legacy_FanDanceCombos_24, "Fan Dance II —> IV Option", "Changes Fan Dance II to Fan Dance IV when available.");
+            }
 
             #endregion
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1189,93 +1189,159 @@ namespace XIVSlothCombo.Window.Functions
 
             // ST Multibutton Esprit overcap
             if (preset is CustomComboPreset.DNC_ST_EspritOvercap)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyST_EspritTh, "Esprit", 150, SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyST_EspritThreshold, "Esprit", 150, SliderIncrements.Fives);
 
             // AoE Multibutton Esprit overcap
             if (preset is CustomComboPreset.DNC_AoE_EspritOvercap)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyAoE_EspritTh, "Esprit", 150, SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyAoE_EspritThreshold, "Esprit", 150, SliderIncrements.Fives);
 
             #endregion
 
             #region Advanced ST config
 
-            // Standard Step HP% throttle
+            // SS Config
             if (preset is CustomComboPreset.DNC_AdvST_SS)
-                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
+            {
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_SS_Options, "Resolve Only", "Adds ONLY Standard dance steps and Standard Finish to the rotation.\nStandard Step itself must be initiated manually when using this option.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_SS_Options, "Initiate + Resolve", "Adds Standard Step, all dance steps and Standard Finish to the rotation.", 2);
 
-            // Standard Dance Burst Option
-            if (preset is CustomComboPreset.DNC_AdvST_SS)
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvST_SS_Burst, "Standard Dance Burst Option", "Includes Standard Step (and all steps) in the burst with low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.");
+                if (DNC.Config.DNC_AdvST_SS_Options == 2)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_SSBurstPct, " Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
+                    ImGui.Unindent();
+                    UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvST_SS_Options_Burst, "Standard Dance Burst Option", "Additionally triggers Standard Step in the burst with low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.");
+                }
 
-            // Technical Step HP% throttle
+                ImGui.Spacing();
+            }
+
+            // TS Config
             if (preset is CustomComboPreset.DNC_AdvST_TS)
-                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_TSBurstPct, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
+            {
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_TS_Options, "Resolve Only", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_TS_Options, "Initiate + Resolve", "Adds Technical Step, all dance steps and Standard Finish to the rotation.", 2);
+
+                if (DNC.Config.DNC_AdvST_TS_Options == 2)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_TSBurstPct, " Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
+                    ImGui.Unindent();
+                }
+
+                ImGui.Spacing();
+            }
 
             // Pooled Feathers HP% dump
             if (preset is CustomComboPreset.DNC_AdvST_Feathers)
-                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_FeatherBurstPct, "Target HP% to dump all pooled feathers below", 75, SliderIncrements.Ones);
+            {
+                ImGui.Indent(); ImGui.Indent();
+                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_FeatherBurstPct, " Target HP% to dump all pooled feathers below", 75, SliderIncrements.Ones);
+                ImGui.Unindent(); ImGui.Unindent();
+            }
 
             // Saber Dance Esprit threshold
             if (preset is CustomComboPreset.DNC_AdvST_SaberDance)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvST_SaberTh, "Esprit", 150, SliderIncrements.Fives);
+            {
+                ImGui.Indent(); ImGui.Indent();
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvST_SaberThreshold, " Esprit", 150, SliderIncrements.Fives);
+                ImGui.Unindent(); ImGui.Unindent();
+            }
 
-            // Curing Waltz HP%
+            // Curing Waltz & Second Wind HP%
             if (preset is CustomComboPreset.DNC_AdvST_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWaltzPct, "Curing Waltz HP%", 200, SliderIncrements.Ones);
-
-            // Second Wind HP%
-            if (preset is CustomComboPreset.DNC_AdvST_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWindPct, "Second Wind HP%", 200, SliderIncrements.Ones);
+            {
+                ImGui.Indent(); ImGui.Indent();
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWaltzPct, " Curing Waltz HP%", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWindPct, " Second Wind HP%", 200, SliderIncrements.Ones);
+                ImGui.Unindent(); ImGui.Unindent();
+            }
 
             // Interrupt
             if (preset is CustomComboPreset.DNC_AdvST_Interrupt)
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvST_InterruptAny, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.");
+            {
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 2);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.", 3);
+                ImGui.Spacing();
+            }
 
             #endregion
 
             #region Advanced AoE config
 
-            // Standard Step HP% throttle
+            // SS Config
             if (preset is CustomComboPreset.DNC_AdvAoE_SS)
-                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNC_AdvAoE_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
+            {
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_SS_Options, "Resolve Only", "Adds ONLY Standard dance steps and Standard Finish to the rotation.\nStandard Step itself must be initiated manually when using this option.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_SS_Options, "Initiate + Resolve", "Adds Standard Step, all dance steps and Standard Finish to the rotation.", 2);
 
-            // Standard Dance Burst Option
-            if (preset is CustomComboPreset.DNC_AdvAoE_SS)
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvAoE_SS_Burst, "Standard Dance Burst Option", "Includes Standard Step (and all steps) in the burst with low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.");
+                if (DNC.Config.DNC_AdvAoE_SS_Options == 2)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvAoE_SSBurstPct, " Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
+                    ImGui.Unindent();
+                    UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvAoE_SS_Options_Burst, "AoE Standard Dance Burst Option", "Additionally triggers Standard Step in the burst with low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.");
+                }
 
-            // Technical Step HP% throttle
+                ImGui.Spacing();
+            }
+
+            // TS Config
             if (preset is CustomComboPreset.DNC_AdvAoE_TS)
-                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNC_AdvAoE_TSBurstPct, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
+            {
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_TS_Options, "Resolve Only", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_TS_Options, "Initiate + Resolve", "Adds Technical Step, all dance steps and Standard Finish to the rotation.", 2);
+
+                if (DNC.Config.DNC_AdvAoE_TS_Options == 2)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvAoE_TSBurstPct, " Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
+                    ImGui.Unindent();
+                }
+
+                ImGui.Spacing();
+            }
 
             // Saber Dance Esprit threshold
             if (preset is CustomComboPreset.DNC_AdvAoE_SaberDance)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvAoE_SaberTh, "Esprit", 150, SliderIncrements.Fives);
+            {
+                ImGui.Indent(); ImGui.Indent();
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvAoE_SaberThreshold, " Esprit", 150, SliderIncrements.Fives);
+                ImGui.Unindent(); ImGui.Unindent();
+            }
 
-            // Curing Waltz HP%
+            // Curing Waltz & Second Wind HP%
             if (preset is CustomComboPreset.DNC_AdvAoE_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWaltzPct, "Curing Waltz HP%", 200, SliderIncrements.Ones);
-
-            // Second Wind HP%
-            if (preset is CustomComboPreset.DNC_AdvAoE_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWindPct, "Second Wind HP%", 200, SliderIncrements.Ones);
+            {
+                ImGui.Indent(); ImGui.Indent();
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWaltzPct, " Curing Waltz HP%", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWindPct, " Second Wind HP%", 200, SliderIncrements.Ones);
+                ImGui.Unindent(); ImGui.Unindent();
+            }
 
             // Interrupt
             if (preset is CustomComboPreset.DNC_AdvAoE_Interrupt)
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvAoE_InterruptAny, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.");
+            {
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 2);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.", 3);
+                ImGui.Spacing();
+            }
 
             #endregion
 
             #region Miscellaneous config
 
             if (preset is CustomComboPreset.DNC_VariantCure)
-                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_VariantCurePct, "HP% to be at or under", 200);
+                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_VariantCurePct, " HP% to be at or under", 200);
 
             #endregion
 
             #region PvP config
 
             if (preset == CustomComboPreset.DNCPvP_BurstMode_CuringWaltz)
-                UserConfig.DrawSliderInt(0, 90, DNCPvP.Config.DNCPvP_WaltzThreshold, "Curing Waltz HP% - caps at 90 to prevent waste.", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 90, DNCPvP.Config.DNCPvP_WaltzThreshold, " Curing Waltz HP% - caps at 90 to prevent waste.", 150, SliderIncrements.Ones);
 
             #endregion
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1165,7 +1165,10 @@ namespace XIVSlothCombo.Window.Functions
             // ====================================================================================
             #region DANCER
 
-            if (preset == CustomComboPreset.DNC_DanceComboReplacer)
+            #region Legacy config
+
+            // Dance Combo Replacer
+            if (preset is CustomComboPreset.DNC_DanceComboReplacer)
             {
                 int[]? actions = Service.Configuration.DancerDanceCompatActionIDs.Cast<int>().ToArray();
                 bool inputChanged = false;
@@ -1184,57 +1187,84 @@ namespace XIVSlothCombo.Window.Functions
                 ImGui.Spacing();
             }
 
-            if (preset == CustomComboPreset.DNC_ST_EspritOvercap)
+            // ST Multibutton Esprit overcap
+            if (preset is CustomComboPreset.DNC_ST_EspritOvercap)
                 UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyST_EspritTh, "Esprit", 150, SliderIncrements.Fives);
 
-            if (preset == CustomComboPreset.DNC_AoE_EspritOvercap)
+            // AoE Multibutton Esprit overcap
+            if (preset is CustomComboPreset.DNC_AoE_EspritOvercap)
                 UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyAoE_EspritTh, "Esprit", 150, SliderIncrements.Fives);
 
-            if (preset == CustomComboPreset.DNC_VariantCure)
-                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_VariantCurePct, "HP% to be at or under", 200);
+            #endregion
 
-            #region Simple ST Sliders
+            #region Advanced ST config
 
-            if (preset == CustomComboPreset.DNC_AdvST_SS)
+            // Standard Step HP% throttle
+            if (preset is CustomComboPreset.DNC_AdvST_SS)
                 UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AdvST_TS)
+            // Technical Step HP% throttle
+            if (preset is CustomComboPreset.DNC_AdvST_TS)
                 UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_TSBurstPct, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AdvST_Feathers)
+            // Pooled Feathers HP% dump
+            if (preset is CustomComboPreset.DNC_AdvST_Feathers)
                 UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_FeatherBurstPct, "Target HP% to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AdvST_SaberDance)
+            // Saber Dance Esprit threshold
+            if (preset is CustomComboPreset.DNC_AdvST_SaberDance)
                 UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvST_SaberTh, "Esprit", 150, SliderIncrements.Fives);
 
-            if (preset == CustomComboPreset.DNC_AdvST_PanicHeals)
+            // Curing Waltz HP%
+            if (preset is CustomComboPreset.DNC_AdvST_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWaltzPct, "Curing Waltz HP%", 200, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AdvST_PanicHeals)
+            // Second Wind HP%
+            if (preset is CustomComboPreset.DNC_AdvST_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWindPct, "Second Wind HP%", 200, SliderIncrements.Ones);
 
+            // Interrupt
+            if (preset is CustomComboPreset.DNC_AdvST_Interrupt)
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvST_InterruptAny, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.");
+
             #endregion
 
-            #region Simple AoE Sliders
+            #region Advanced AoE config
 
-            if (preset == CustomComboPreset.DNC_AdvAoE_SS)
+            // Standard Step HP% throttle
+            if (preset is CustomComboPreset.DNC_AdvAoE_SS)
                 UserConfig.DrawSliderInt(0, 10, DNC.Config.DNC_AdvAoE_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AdvAoE_TS)
+            // Technical Step HP% throttle
+            if (preset is CustomComboPreset.DNC_AdvAoE_TS)
                 UserConfig.DrawSliderInt(0, 10, DNC.Config.DNC_AdvAoE_TSBurstPct, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AdvAoE_SaberDance)
+            // Saber Dance Esprit threshold
+            if (preset is CustomComboPreset.DNC_AdvAoE_SaberDance)
                 UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvAoE_SaberTh, "Esprit", 150, SliderIncrements.Fives);
 
-            if (preset == CustomComboPreset.DNC_AdvAoE_PanicHeals)
+            // Curing Waltz HP%
+            if (preset is CustomComboPreset.DNC_AdvAoE_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWaltzPct, "Curing Waltz HP%", 200, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AdvAoE_PanicHeals)
+            // Second Wind HP%
+            if (preset is CustomComboPreset.DNC_AdvAoE_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWindPct, "Second Wind HP%", 200, SliderIncrements.Ones);
+
+            // Interrupt
+            if (preset is CustomComboPreset.DNC_AdvAoE_Interrupt)
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvAoE_InterruptAny, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.");
 
             #endregion
 
-            #region PvP Sliders
+            #region Miscellaneous config
+
+            if (preset is CustomComboPreset.DNC_VariantCure)
+                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_VariantCurePct, "HP% to be at or under", 200);
+
+            #endregion
+
+            #region PvP config
 
             if (preset == CustomComboPreset.DNCPvP_BurstMode_CuringWaltz)
                 UserConfig.DrawSliderInt(0, 90, DNCPvP.Config.DNCPvP_WaltzThreshold, "Curing Waltz HP% - caps at 90 to prevent waste.", 150, SliderIncrements.Ones);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1176,16 +1176,16 @@ namespace XIVSlothCombo.Window.Functions
 
             #region Simple ST/AoE
 
-            if (preset is CustomComboPreset.DNC_ST_SimpleMode)
+            if (preset is CustomComboPreset.DNC_SimpleST)
             {
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_ST_SimpleMode_SS, "Include Standard Step", "Adds Standard Step to the rotation.");
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_ST_SimpleMode_TS, "Include Technical Step", "Adds Technical Step to the rotation.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_SimpleST_SS, "Include Standard Step", "Adds Standard Step to the rotation.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_SimpleST_TS, "Include Technical Step", "Adds Technical Step to the rotation.");
             }
 
-            if (preset is CustomComboPreset.DNC_AoE_SimpleMode)
+            if (preset is CustomComboPreset.DNC_SimpleAoE)
             {
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AoE_SimpleMode_SS, "Include Standard Step", "Adds Standard Step to the AoE rotation.");
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AoE_SimpleMode_TS, "Include Technical Step", "Adds Technical Step to the AoE rotation.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_SimpleAoE_SS, "Include Standard Step", "Adds Standard Step to the AoE rotation.");
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_SimpleAoE_TS, "Include Technical Step", "Adds Technical Step to the AoE rotation.");
             }
 
             #endregion

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1190,46 +1190,46 @@ namespace XIVSlothCombo.Window.Functions
             if (preset == CustomComboPreset.DNC_AoE_EspritOvercap)
                 UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyAoE_EspritTh, "Esprit", 150, SliderIncrements.Fives);
 
-            if (preset == CustomComboPreset.DNC_Variant_Cure)
-                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_Variant_CurePct, "HP% to be at or under", 200);
+            if (preset == CustomComboPreset.DNC_VariantCure)
+                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_VariantCurePct, "HP% to be at or under", 200);
 
             #region Simple ST Sliders
 
-            if (preset == CustomComboPreset.DNC_ST_Simple_SS)
+            if (preset == CustomComboPreset.DNC_AdvST_SS)
                 UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_ST_Simple_TS)
+            if (preset == CustomComboPreset.DNC_AdvST_TS)
                 UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_TSBurstPct, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_ST_Simple_Feathers)
+            if (preset == CustomComboPreset.DNC_AdvST_Feathers)
                 UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_FeatherBurstPct, "Target HP% to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_ST_Simple_SaberDance)
+            if (preset == CustomComboPreset.DNC_AdvST_SaberDance)
                 UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvST_SaberTh, "Esprit", 150, SliderIncrements.Fives);
 
-            if (preset == CustomComboPreset.DNC_ST_Simple_PanicHeals)
+            if (preset == CustomComboPreset.DNC_AdvST_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWaltzPct, "Curing Waltz HP%", 200, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_ST_Simple_PanicHeals)
+            if (preset == CustomComboPreset.DNC_AdvST_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWindPct, "Second Wind HP%", 200, SliderIncrements.Ones);
 
             #endregion
 
             #region Simple AoE Sliders
 
-            if (preset == CustomComboPreset.DNC_AoE_Simple_SS)
+            if (preset == CustomComboPreset.DNC_AdvAoE_SS)
                 UserConfig.DrawSliderInt(0, 10, DNC.Config.DNC_AdvAoE_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AoE_Simple_TS)
+            if (preset == CustomComboPreset.DNC_AdvAoE_TS)
                 UserConfig.DrawSliderInt(0, 10, DNC.Config.DNC_AdvAoE_TSBurstPct, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AoE_Simple_SaberDance)
+            if (preset == CustomComboPreset.DNC_AdvAoE_SaberDance)
                 UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvAoE_SaberTh, "Esprit", 150, SliderIncrements.Fives);
 
-            if (preset == CustomComboPreset.DNC_AoE_Simple_PanicHeals)
+            if (preset == CustomComboPreset.DNC_AdvAoE_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWaltzPct, "Curing Waltz HP%", 200, SliderIncrements.Ones);
 
-            if (preset == CustomComboPreset.DNC_AoE_Simple_PanicHeals)
+            if (preset == CustomComboPreset.DNC_AdvAoE_PanicHeals)
                 UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWindPct, "Second Wind HP%", 200, SliderIncrements.Ones);
 
             #endregion

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1203,6 +1203,10 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.DNC_AdvST_SS)
                 UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
 
+            // Standard Dance Burst Option
+            if (preset is CustomComboPreset.DNC_AdvST_SS)
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvST_SS_Burst, "Standard Dance Burst Option", "Includes Standard Step (and all steps) in the burst with low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.");
+
             // Technical Step HP% throttle
             if (preset is CustomComboPreset.DNC_AdvST_TS)
                 UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_TSBurstPct, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
@@ -1234,6 +1238,10 @@ namespace XIVSlothCombo.Window.Functions
             // Standard Step HP% throttle
             if (preset is CustomComboPreset.DNC_AdvAoE_SS)
                 UserConfig.DrawSliderInt(0, 10, DNC.Config.DNC_AdvAoE_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
+
+            // Standard Dance Burst Option
+            if (preset is CustomComboPreset.DNC_AdvAoE_SS)
+                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_AdvAoE_SS_Burst, "Standard Dance Burst Option", "Includes Standard Step (and all steps) in the burst with low priority, provided there is enough time to fully execute Standard Finish and you are unlikely to generate enough Esprit for another Saber Dance during burst.");
 
             // Technical Step HP% throttle
             if (preset is CustomComboPreset.DNC_AdvAoE_TS)

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1185,52 +1185,52 @@ namespace XIVSlothCombo.Window.Functions
             }
 
             if (preset == CustomComboPreset.DNC_ST_EspritOvercap)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_ST, "Esprit", 150, SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyST_EspritTh, "Esprit", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DNC_AoE_EspritOvercap)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_AoE, "Esprit", 150, SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_LegacyAoE_EspritTh, "Esprit", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DNC_Variant_Cure)
-                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNCVariantCurePercent, "HP% to be at or under", 200);
+                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_Variant_CurePct, "HP% to be at or under", 200);
 
             #region Simple ST Sliders
 
             if (preset == CustomComboPreset.DNC_ST_Simple_SS)
-                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleSSBurstPercent, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_ST_Simple_TS)
-                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleTSBurstPercent, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_TSBurstPct, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_ST_Simple_Feathers)
-                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNCSimpleFeatherBurstPercent, "Target HP% to dump all pooled feathers below", 75, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 5, DNC.Config.DNC_AdvST_FeatherBurstPct, "Target HP% to dump all pooled feathers below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_ST_Simple_SaberDance)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCSimpleSaberThreshold, "Esprit", 150, SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvST_SaberTh, "Esprit", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DNC_ST_Simple_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWaltzPercent, "Curing Waltz HP%", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWaltzPct, "Curing Waltz HP%", 200, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_ST_Simple_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimplePanicHealWindPercent, "Second Wind HP%", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWindPct, "Second Wind HP%", 200, SliderIncrements.Ones);
 
             #endregion
 
             #region Simple AoE Sliders
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_SS)
-                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNCSimpleSSAoEBurstPercent, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNC_AdvAoE_SSBurstPct, "Target HP% to stop using Standard Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_TS)
-                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNCSimpleTSAoEBurstPercent, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 10, DNC.Config.DNC_AdvAoE_TSBurstPct, "Target HP% to stop using Technical Step below", 75, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_SaberDance)
-                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCSimpleAoESaberThreshold, "Esprit", 150, SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(50, 100, DNC.Config.DNC_AdvAoE_SaberTh, "Esprit", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWaltzPercent, "Curing Waltz HP%", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWaltzPct, "Curing Waltz HP%", 200, SliderIncrements.Ones);
 
             if (preset == CustomComboPreset.DNC_AoE_Simple_PanicHeals)
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNCSimpleAoEPanicHealWindPercent, "Second Wind HP%", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWindPct, "Second Wind HP%", 200, SliderIncrements.Ones);
 
             #endregion
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1178,14 +1178,20 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset is CustomComboPreset.DNC_SimpleST)
             {
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_SimpleST_SS, "Include Standard Step", "Adds Standard Step to the rotation.");
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_SimpleST_TS, "Include Technical Step", "Adds Technical Step to the rotation.");
+                ImGui.Indent();
+                ImGui.Spacing();
+                UserConfig.DrawHorizontalMultiChoice(DNC.Config.DNC_SimpleST_Dances, "Standard Step", "Adds Standard Step, all dance steps and Standard Finish to the rotation.", 2, 0, 150, ImGuiColors.ParsedGold);
+                UserConfig.DrawHorizontalMultiChoice(DNC.Config.DNC_SimpleST_Dances, "Technical Step", "Adds Technical Step, all dance steps and Technical Finish to the rotation.", 2, 1, 150, Colors.Blue);
+                ImGui.Unindent();
             }
 
             if (preset is CustomComboPreset.DNC_SimpleAoE)
             {
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_SimpleAoE_SS, "Include Standard Step", "Adds Standard Step to the AoE rotation.");
-                UserConfig.DrawAdditionalBoolChoice(DNC.Config.DNC_SimpleAoE_TS, "Include Technical Step", "Adds Technical Step to the AoE rotation.");
+                ImGui.Indent();
+                ImGui.Spacing();
+                UserConfig.DrawHorizontalMultiChoice(DNC.Config.DNC_SimpleAoE_Dances, "Standard Step", "Adds Standard Step, all dance steps and Standard Finish to the rotation.", 2, 0, 150, ImGuiColors.ParsedGold);
+                UserConfig.DrawHorizontalMultiChoice(DNC.Config.DNC_SimpleAoE_Dances, "Technical Step", "Adds Technical Step, all dance steps and Technical Finish to the rotation.", 2, 1, 150, Colors.Blue);
+                ImGui.Unindent();
             }
 
             #endregion
@@ -1245,17 +1251,17 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.DNC_AdvST_PanicHeals)
             {
                 ImGui.Indent(); ImGui.Indent();
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWaltzPct, " Curing Waltz HP%", 200, SliderIncrements.Ones);
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWindPct, " Second Wind HP%", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWaltzPct, " Curing Waltz HP%", 200, SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvST_PanicWindPct, " Second Wind HP%", 200, SliderIncrements.Fives);
                 ImGui.Unindent(); ImGui.Unindent();
             }
 
             // Interrupt
             if (preset is CustomComboPreset.DNC_AdvST_Interrupt)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 1);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 2);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.", 3);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 0);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.", 2);
                 ImGui.Spacing();
             }
 
@@ -1308,17 +1314,17 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.DNC_AdvAoE_PanicHeals)
             {
                 ImGui.Indent(); ImGui.Indent();
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWaltzPct, " Curing Waltz HP%", 200, SliderIncrements.Ones);
-                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWindPct, " Second Wind HP%", 200, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWaltzPct, " Curing Waltz HP%", 200, SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(0, 100, DNC.Config.DNC_AdvAoE_PanicWindPct, " Second Wind HP%", 200, SliderIncrements.Fives);
                 ImGui.Unindent(); ImGui.Unindent();
             }
 
             // Interrupt
             if (preset is CustomComboPreset.DNC_AdvAoE_Interrupt)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 1);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 2);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.", 3);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 0);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 1);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.", 2);
                 ImGui.Spacing();
             }
 
@@ -1381,7 +1387,7 @@ namespace XIVSlothCombo.Window.Functions
             #endregion
 
             if (preset is CustomComboPreset.DNC_VariantCure)
-                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_VariantCurePct, " HP% to be at or under", 200);
+                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNC_VariantCurePct, " HP% to be at or under", 200, 5);
 
             #region PvP
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1240,8 +1240,8 @@ namespace XIVSlothCombo.Window.Functions
             // TS Config
             if (preset is CustomComboPreset.DNC_AdvST_TS)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_TS_Options, "Resolve", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_TS_Options, "Initiate + Resolve", "Adds Technical Step, all dance steps and Standard Finish to the rotation.", 2);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_TS_Options, "Resolve", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1, 150, Colors.Blue);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_TS_Options, "Initiate + Resolve", "Adds Technical Step, all dance steps and Standard Finish to the rotation.", 2, 150, Colors.Blue);
 
                 if (DNC.Config.DNC_AdvST_TS_Options == 2)
                 {
@@ -1281,9 +1281,9 @@ namespace XIVSlothCombo.Window.Functions
             // Interrupt
             if (preset is CustomComboPreset.DNC_AdvST_Interrupt)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 0);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 1);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.", 2);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 0, 150, ImGuiColors.ParsedGreen);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 1, 150, ImGuiColors.DalamudYellow);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvST_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window.\nUSE WITH CAUTION.", 2, 150, ImGuiColors.DalamudRed);
                 ImGui.Spacing();
             }
 
@@ -1311,8 +1311,8 @@ namespace XIVSlothCombo.Window.Functions
             // TS Config
             if (preset is CustomComboPreset.DNC_AdvAoE_TS)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_TS_Options, "Resolve", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_TS_Options, "Initiate + Resolve", "Adds Technical Step, all dance steps and Standard Finish to the rotation.", 2);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_TS_Options, "Resolve", "Adds ONLY Technical dance steps and Standard Finish to the rotation.\nTechnical Step itself must be initiated manually when using this option.", 1, 150, Colors.Blue);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_TS_Options, "Initiate + Resolve", "Adds Technical Step, all dance steps and Standard Finish to the rotation.", 2, 150, Colors.Blue);
 
                 if (DNC.Config.DNC_AdvAoE_TS_Options == 2)
                 {
@@ -1344,9 +1344,9 @@ namespace XIVSlothCombo.Window.Functions
             // Interrupt
             if (preset is CustomComboPreset.DNC_AdvAoE_Interrupt)
             {
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 0);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 1);
-                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window - use with caution.", 2);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Late Weave", "Includes Head Graze during the second weave window.\nSuitable for most interrupt cases.", 0, 150, ImGuiColors.ParsedGreen);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Early Weave", "Includes Head Graze during the first weave window.\nWill take priority over most other weaves, pushing them to the late window.", 1, 150, ImGuiColors.DalamudYellow);
+                UserConfig.DrawHorizontalRadioButton(DNC.Config.DNC_AdvAoE_Interrupt, "Interrupt at any time", "Allows Head Graze to trigger at any time, regardless of GCD.\nThis will cause the interrupt to be used in a way which is both extremely fast and may delay your GCD window.\nUSE WITH CAUTION.", 2, 150, ImGuiColors.DalamudRed);
                 ImGui.Spacing();
             }
 

--- a/XIVSlothCombo/XIVSlothCombo.cs
+++ b/XIVSlothCombo/XIVSlothCombo.cs
@@ -83,6 +83,7 @@ namespace XIVSlothCombo
             Service.Configuration.ResetFeatures("v3.0.18.0_GNBCleanup", Enumerable.Range(7000, 700).ToArray());
             Service.Configuration.ResetFeatures("v3.0.18.0_PvPCleanup", Enumerable.Range(80000, 11000).ToArray());
             Service.Configuration.ResetFeatures("v3.0.18.1_PLDRework", Enumerable.Range(11000, 100).ToArray());
+            Service.Configuration.ResetFeatures("v3.0.18.5_DNCRework", Enumerable.Range(4000, 300).ToArray());
         }
 
         private void DrawUI() => configWindow.Draw();


### PR DESCRIPTION
Wipes all DNC configs

Added `Advanced Single Target`/`Advanced AoE` modes
Added `Legacy Features`
Added traitIDs and tidied actionIDs
Update config to current method
Simplified gauge checks
Renamed & renumbered internal features/options/configs
Simplified `Standard Finish` and `Technical Finish` checks
Reworked Dance/Fill options for `Standard Step` & `Technical Step`
Fixed `Standard Step` checks outside of burst window
Fixed automatic `Standard Step` when `Technical Step` is manually controlled
Added `Esprit` checks to `Standard Step` to optimise burst uses
Added `AoE Standard Dance Burst Option` to `Advanced AoE`
Increased remaining `Technical Finish` buff time to execute `Standard Step`
Moved `Standard Dance Burst Option` to a config toggle
Re-numbered `Dance Step Solver Feature` ID to separate from other IDs
Added dance options to `Simple` modes
Fixed AoE `Saber Dance` slider not being independent of ST
Tidied AoE statements for `Standard Step` and `Saber Dance`
Removed options from `Simple` modes and defaulted to common optimal values
Reworked interrupt features and added options for early, late and "any" weave
Made default interrupt features apply during the late weave window only
Fixed interrupts breaking when no config selected
Config-ified `Legacy Features`
Fixed `Simple AoE Panic Heals` dependency on Advanced config
Moved `Variant Cure` to GCD code
Tidied `Variant Rampart` statements