### PR TITLE
[PLD] 6.4 Changes + Optimisation

### DIFF
--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -313,7 +313,7 @@ namespace XIVSlothCombo.Combos.PvE
                             // (arguably better to delay by less than a whole GCD and just stop moving to cast)
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_ShieldLob) &&
                                 ShieldLob.LevelChecked() &&
-                                GetResourceCost(HolySpirit) > LocalPlayer.CurrentMp)
+                                ((HolySpirit.LevelChecked() && GetResourceCost(HolySpirit) > LocalPlayer.CurrentMp) || (!HolySpirit.LevelChecked())))
                                 return ShieldLob;
                         }
 

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -377,13 +377,15 @@ namespace XIVSlothCombo.Combos.PvE
                             return FightOrFlight;
 
                         // Base combo
-                        if (comboTime > 1f)
+                        if (comboTime > 0)
                         {
-                            if (lastComboActionID == FastBlade && RiotBlade.LevelChecked())
+                            if (lastComboActionID is FastBlade && RiotBlade.LevelChecked())
                                 return RiotBlade;
 
-                            if (lastComboActionID == RiotBlade && OriginalHook(RoyalAuthority).LevelChecked())
-                                return OriginalHook(RoyalAuthority);
+                            if (lastComboActionID is RiotBlade && RageOfHalone.LevelChecked())
+                                return (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                                    ? HolySpirit
+                                    : OriginalHook(RageOfHalone);
                         }
 
                         if (CanWeave(actionID) && !ActionWatching.WasLast2ActionsAbilities())

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -148,9 +148,14 @@ namespace XIVSlothCombo.Combos.PvE
                                 return RiotBlade;
 
                             if (lastComboActionID is RiotBlade && RageOfHalone.LevelChecked())
+                            {
+                                if (HasEffect(Buffs.SwordOath))
+                                    return Atonement;
+
                                 return (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                     ? HolySpirit
                                     : OriginalHook(RageOfHalone);
+                            }
                         }
 
                         if (CanWeave(actionID))
@@ -343,10 +348,10 @@ namespace XIVSlothCombo.Combos.PvE
                                 GoringBlade.LevelChecked() &&
                                 IsOffCooldown(GoringBlade))
                                 return GoringBlade;
-
-                            // HS when Confiteor not unlocked
+                            
                             if (HasEffect(Buffs.Requiescat) && !Confiteor.LevelChecked())
                             {
+                                // HS when Confiteor not unlocked
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                                     GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                     return HolySpirit;
@@ -368,14 +373,29 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                                 HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                 return HolySpirit;
+
+                            if (HasEffect(Buffs.SwordOath))
+                                return Atonement;
                         }
 
                         // FoF (Starts burst)
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
                             FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID) &&
-                            !ActionWatching.WasLast2ActionsAbilities() &&
                             ActionWatching.CombatActions.Where(x => x == OriginalHook(RoyalAuthority)).Any())
                             return FightOrFlight;
+
+                        // CoS/SW outside of burst
+                        if (CanWeave(actionID, 0.6) && (!WasLastAction(FightOrFlight) &&
+                            GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF)))
+                        {
+                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
+                                CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                                return CircleOfScorn;
+
+                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
+                                OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                return OriginalHook(SpiritsWithin);
+                        }
 
                         // Base combo
                         if (comboTime > 0)
@@ -384,36 +404,18 @@ namespace XIVSlothCombo.Combos.PvE
                                 return RiotBlade;
 
                             if (lastComboActionID is RiotBlade && RageOfHalone.LevelChecked())
-                                return (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                            {
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) && HasEffect(Buffs.SwordOath))
+                                    return Atonement;
+
+                                return (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
+                                    HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                     ? HolySpirit
                                     : OriginalHook(RageOfHalone);
-                        }
-
-                        if (CanWeave(actionID) && !ActionWatching.WasLast2ActionsAbilities())
-                        {
-                            // Usage outside of burst (desync for Req, 30s windows for CoS/SW)
-                            if (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
-                            {
-                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
-                                    Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
-                                    return Requiescat;
-
-                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
-                                    CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                    return CircleOfScorn;
-
-                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
-                                    OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
-                                    return OriginalHook(SpiritsWithin);
                             }
                         }
 
-                        // HS under DM (outside of burst)
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                            (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) &&
-                            GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                            return HolySpirit;
-
+                        // Goring on cooldown (burst features disabled)
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
                             GoringBlade.LevelChecked() && IsOffCooldown(GoringBlade) &&
                             IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
@@ -428,11 +430,6 @@ namespace XIVSlothCombo.Combos.PvE
                             OriginalHook(Confiteor) != Confiteor &&
                             GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)))
                             return OriginalHook(Confiteor);
-
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
-                            HasEffectAny(Buffs.SwordOath) && Atonement.LevelChecked() &&
-                            GetCooldownRemainingTime(FightOrFlight) >= 7)
-                            return Atonement;
                     }
                 }
 

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -91,10 +91,10 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasBattleTarget())
                     {
                         if (!InMeleeRange() && HolySpirit.LevelChecked() && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp && !IsMoving)
-                            return OriginalHook(HolySpirit);
+                            return HolySpirit;
 
                         if (!InMeleeRange() && ShieldLob.LevelChecked())
-                            return OriginalHook(ShieldLob);
+                            return ShieldLob;
 
                         if (CanWeave(actionID))
                         {
@@ -114,40 +114,40 @@ namespace XIVSlothCombo.Combos.PvE
                             if (CanWeave(actionID))
                             {
                                 if (Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
-                                    return OriginalHook(Requiescat);
+                                    return Requiescat;
 
                                 if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                    return OriginalHook(CircleOfScorn);
+                                    return CircleOfScorn;
 
                                 if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
                                     return OriginalHook(SpiritsWithin);
                             }
 
                             if (GoringBlade.LevelChecked() && IsOffCooldown(GoringBlade))
-                                return OriginalHook(GoringBlade);
+                                return GoringBlade;
 
                             if (HasEffect(Buffs.Requiescat))
                             {
                                 // Confiteor & Blades
-                                if ((HasEffect(Buffs.ConfiteorReady) || BladeOfFaith.LevelChecked()) && GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp)
+                                if ((HasEffect(Buffs.ConfiteorReady) || BladeOfFaith.LevelChecked()) && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)
                                     return OriginalHook(Confiteor);
 
                                 if (GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                    return OriginalHook(HolySpirit);
+                                    return HolySpirit;
                             }
 
                             // HS under DM
                             if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                return OriginalHook(HolySpirit);
+                                return HolySpirit;
                         }
 
                         // Base combo
                         if (comboTime > 1f)
                         {
-                            if (lastComboActionID == OriginalHook(FastBlade) && RiotBlade.LevelChecked())
-                                return OriginalHook(RiotBlade);
+                            if (lastComboActionID == FastBlade && RiotBlade.LevelChecked())
+                                return RiotBlade;
 
-                            if (lastComboActionID == OriginalHook(RiotBlade) && OriginalHook(RoyalAuthority).LevelChecked())
+                            if (lastComboActionID == RiotBlade && OriginalHook(RoyalAuthority).LevelChecked())
                                 return OriginalHook(RoyalAuthority);
                         }
 
@@ -156,13 +156,13 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             // FoF (Starts burst)
                             if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
-                                return OriginalHook(FightOrFlight);
+                                return FightOrFlight;
 
                             // Usage outside of burst
                             if (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15)
                             {
                                 if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                    return OriginalHook(CircleOfScorn);
+                                    return CircleOfScorn;
 
                                 if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
                                     return OriginalHook(SpiritsWithin);
@@ -171,10 +171,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                         // HS under DM
                         if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                            return OriginalHook(HolySpirit);
+                            return HolySpirit;
 
                         if (HasEffectAny(Buffs.SwordOath) && Atonement.LevelChecked())
-                            return OriginalHook(Atonement);
+                            return Atonement;
                     }
                 }
 
@@ -211,10 +211,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (CanWeave(actionID))
                         {
                             if (Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
-                                return OriginalHook(Requiescat);
+                                return Requiescat;
 
                             if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                return OriginalHook(CircleOfScorn);
+                                return CircleOfScorn;
 
                             if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
@@ -222,32 +222,32 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (HasEffect(Buffs.Requiescat))
                         {
-                            if ((HasEffect(Buffs.ConfiteorReady) || BladeOfFaith.LevelChecked()) && GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp)
+                            if ((HasEffect(Buffs.ConfiteorReady) || BladeOfFaith.LevelChecked()) && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)
                                 return OriginalHook(Confiteor);
 
                             if (GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && HolyCircle.LevelChecked())
-                                return OriginalHook(HolyCircle);
+                                return HolyCircle;
 
                             if (GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp && HolySpirit.LevelChecked())
-                                return OriginalHook(HolySpirit);
+                                return HolySpirit;
                         }
 
                         if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && HolyCircle.LevelChecked())
-                            return OriginalHook(HolyCircle);
+                            return HolyCircle;
                     }
 
                     if (comboTime > 1f && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
-                        return OriginalHook(Prominence);
+                        return Prominence;
 
                     if (CanWeave(actionID))
                     {
                         if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
-                            return OriginalHook(FightOrFlight);
+                            return FightOrFlight;
 
                         if (!WasLastAction(FightOrFlight) && IsOnCooldown(FightOrFlight))
                         {
                             if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                return OriginalHook(CircleOfScorn);
+                                return CircleOfScorn;
 
                             if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
@@ -255,7 +255,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     if ((HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
-                        return OriginalHook(HolyCircle);
+                        return HolyCircle;
 
                     return actionID;
                 }
@@ -284,12 +284,12 @@ namespace XIVSlothCombo.Combos.PvE
                             HolySpirit.LevelChecked() &&
                             GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp &&
                             !IsMoving)
-                            return OriginalHook(HolySpirit);
+                            return HolySpirit;
 
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_ShieldLob) &&
                             !InMeleeRange() &&
                             ShieldLob.LevelChecked())
-                            return OriginalHook(ShieldLob);
+                            return ShieldLob;
 
                         if (CanWeave(actionID))
                         {
@@ -318,11 +318,11 @@ namespace XIVSlothCombo.Combos.PvE
                             {
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
                                     Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
-                                    return OriginalHook(Requiescat);
+                                    return Requiescat;
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
                                     CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                    return OriginalHook(CircleOfScorn);
+                                    return CircleOfScorn;
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
                                     OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
@@ -339,14 +339,14 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
                                 GoringBlade.LevelChecked() &&
                                 IsOffCooldown(GoringBlade))
-                                return OriginalHook(GoringBlade);
+                                return GoringBlade;
 
                             // HS when Confiteor not unlocked
                             if (HasEffect(Buffs.Requiescat) && !Confiteor.LevelChecked())
                             {
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                                     GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                    return OriginalHook(HolySpirit);
+                                    return HolySpirit;
                             }
                             else
                             {
@@ -357,30 +357,30 @@ namespace XIVSlothCombo.Combos.PvE
                                     (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
                                     BladeOfFaith.LevelChecked() && HasEffect(Buffs.Requiescat) &&
                                     OriginalHook(Confiteor) != Confiteor &&
-                                    GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp))
+                                    GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp))
                                     return OriginalHook(Confiteor);
                             }
 
                             // HS under DM
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                                 HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                return OriginalHook(HolySpirit);
+                                return HolySpirit;
                         }
 
                         // FoF (Starts burst)
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
                             FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID) &&
                             !ActionWatching.WasLast2ActionsAbilities() &&
-                            ActionWatching.CombatActions.Where(x => x == RoyalAuthority).Any())
-                            return OriginalHook(FightOrFlight);
+                            ActionWatching.CombatActions.Where(x => x == OriginalHook(RoyalAuthority)).Any())
+                            return FightOrFlight;
 
                         // Base combo
                         if (comboTime > 1f)
                         {
-                            if (lastComboActionID == OriginalHook(FastBlade) && RiotBlade.LevelChecked())
-                                return OriginalHook(RiotBlade);
+                            if (lastComboActionID == FastBlade && RiotBlade.LevelChecked())
+                                return RiotBlade;
 
-                            if (lastComboActionID == OriginalHook(RiotBlade) && OriginalHook(RoyalAuthority).LevelChecked())
+                            if (lastComboActionID == RiotBlade && OriginalHook(RoyalAuthority).LevelChecked())
                                 return OriginalHook(RoyalAuthority);
                         }
 
@@ -391,11 +391,11 @@ namespace XIVSlothCombo.Combos.PvE
                             {
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
                                     Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
-                                    return OriginalHook(Requiescat);
+                                    return Requiescat;
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
                                     CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                    return OriginalHook(CircleOfScorn);
+                                    return CircleOfScorn;
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
                                     OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
@@ -407,12 +407,12 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                             (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) &&
                             GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                            return OriginalHook(HolySpirit);
+                            return HolySpirit;
 
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
                             GoringBlade.LevelChecked() && IsOffCooldown(GoringBlade) &&
                             IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
-                            return OriginalHook(GoringBlade);
+                            return GoringBlade;
 
                         // Confiteor & Blades
                         if (((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
@@ -421,13 +421,13 @@ namespace XIVSlothCombo.Combos.PvE
                             (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
                             BladeOfFaith.LevelChecked() && HasEffect(Buffs.Requiescat) &&
                             OriginalHook(Confiteor) != Confiteor &&
-                            GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp)))
+                            GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)))
                             return OriginalHook(Confiteor);
 
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
                             HasEffectAny(Buffs.SwordOath) && Atonement.LevelChecked() &&
                             GetCooldownRemainingTime(FightOrFlight) >= 7)
-                            return OriginalHook(Atonement);
+                            return Atonement;
                     }
                 }
 
@@ -471,11 +471,11 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) &&
                                 Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
-                                return OriginalHook(Requiescat);
+                                return Requiescat;
 
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) &&
                                 CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                return OriginalHook(CircleOfScorn);
+                                return CircleOfScorn;
 
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) &&
                                 OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
@@ -487,7 +487,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
                                 GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
-                                return OriginalHook(HolyCircle);
+                                return HolyCircle;
                         }
                         else
                         {
@@ -507,17 +507,17 @@ namespace XIVSlothCombo.Combos.PvE
                             (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) && 
                             GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp &&
                             HolyCircle.LevelChecked())
-                            return OriginalHook(HolyCircle);
+                            return HolyCircle;
                     }
 
                     if (comboTime > 1f && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
-                        return OriginalHook(Prominence);
+                        return Prominence;
 
                     if (CanWeave(actionID))
                     {
                         // FoF (Starts burst)
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
-                            return OriginalHook(FightOrFlight);
+                            return FightOrFlight;
 
                         // Usage outside of burst (desync for Req, 30s windows for CoS/SW)
                         if ((!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF)) &&
@@ -525,11 +525,11 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) &&
                                 Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
-                                return OriginalHook(Requiescat);
+                                return Requiescat;
 
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) &&
                                 CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                return OriginalHook(CircleOfScorn);
+                                return CircleOfScorn;
 
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) &&
                                 OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
@@ -551,7 +551,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // HS under DM (outside of burst)
                     if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && HasEffect(Buffs.DivineMight) &&
                         GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
-                        return OriginalHook(HolyCircle);
+                        return HolyCircle;
 
                     return actionID;
                 }
@@ -579,10 +579,10 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(Confiteor);
 
                         if (choice == 4 && HolySpirit.LevelChecked() && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                            return OriginalHook(HolySpirit);
+                            return HolySpirit;
 
                         if (choice == 5 && HolyCircle.LevelChecked() && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp)
-                            return OriginalHook(HolyCircle);
+                            return HolyCircle;
                     }
                 }
 
@@ -605,13 +605,13 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsOffCooldown(OriginalHook(SpiritsWithin)))
                         {
                             if (choice == 1)
-                                return OriginalHook(CircleOfScorn);
+                                return CircleOfScorn;
 
                             if (choice == 2)
                                 return OriginalHook(SpiritsWithin);
                         }
                         
-                        return OriginalHook(CircleOfScorn);
+                        return CircleOfScorn;
                     }
                 }
 

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -278,18 +278,20 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (HasBattleTarget())
                     {
-                        // HS when out of range
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                            !InMeleeRange() &&
-                            HolySpirit.LevelChecked() &&
-                            GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp &&
-                            !IsMoving)
-                            return HolySpirit;
+                        if (!InMeleeRange() && OriginalHook(Confiteor) is Confiteor &&
+                            !HasEffect(Buffs.ConfiteorReady) && !HasEffect(Buffs.DivineMight) && !HasEffect(Buffs.Requiescat))
+                        {
+                            // HS when out of range
+                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) && !IsMoving &&
+                                HolySpirit.LevelChecked() && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                                return HolySpirit;
 
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_ShieldLob) &&
-                            !InMeleeRange() &&
-                            ShieldLob.LevelChecked())
-                            return ShieldLob;
+                            // Shield lob uptime only if unable to stop and HS
+                            // (arguably better to delay by less than a whole GCD and just stop moving to cast)
+                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_ShieldLob) &&
+                                ShieldLob.LevelChecked() && GetResourceCost(HolySpirit) > LocalPlayer.CurrentMp)
+                                return ShieldLob;
+                        }
 
                         if (CanWeave(actionID))
                         {

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -58,7 +58,6 @@ namespace XIVSlothCombo.Combos.PvE
                 GoringBlade = 725;
         }
 
-
         public static class Config
         {
             public const string
@@ -93,6 +92,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (CanWeave(actionID))
                         {
                             Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+
                             if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) &&
                                 IsEnabled(Variant.VariantSpiritDart) &&
                                 (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
@@ -100,7 +100,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                             if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
                                 return Variant.VariantUltimatum;
-
                         }
 
                         if (HasEffect(Buffs.FightOrFlight))
@@ -115,7 +114,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
                                     return OriginalHook(SpiritsWithin);
-
                             }
 
                             if (GoringBlade.LevelChecked() && IsOffCooldown(GoringBlade))
@@ -130,25 +128,17 @@ namespace XIVSlothCombo.Combos.PvE
                                     return OriginalHook(HolySpirit);
                             }
 
-
                             if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                 return OriginalHook(HolySpirit);
-
                         }
-
 
                         if (comboTime > 1f)
                         {
                             if (lastComboActionID == OriginalHook(FastBlade) && RiotBlade.LevelChecked())
-                            {
                                 return OriginalHook(RiotBlade);
-                            }
 
                             if (lastComboActionID == OriginalHook(RiotBlade) && OriginalHook(RoyalAuthority).LevelChecked())
-                            {
                                 return OriginalHook(RoyalAuthority);
-                            }
-
                         }
 
                         if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID))
@@ -165,7 +155,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (HasEffectAny(Buffs.SwordOath) && Atonement.LevelChecked())
                             return OriginalHook(Atonement);
-
                     }
                 }
 
@@ -187,6 +176,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (CanWeave(actionID))
                     {
                         Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+
                         if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) &&
                             IsEnabled(Variant.VariantSpiritDart) &&
                             (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
@@ -194,9 +184,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
                             return Variant.VariantUltimatum;
-
                     }
-
 
                     if (HasEffect(Buffs.FightOrFlight))
                     {
@@ -210,9 +198,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                             if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
-
                         }
-
 
                         if (HasEffect(Buffs.Requiescat))
                         {
@@ -236,7 +222,6 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(Prominence);
                     }
 
-
                     if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID))
                         return OriginalHook(FightOrFlight);
 
@@ -248,7 +233,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if ((HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
                         return OriginalHook(HolyCircle);
-
 
                     return actionID;
                 }
@@ -265,7 +249,6 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is FastBlade)
                 {
-
                     if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) &&
                         IsEnabled(Variant.VariantCure) &&
                         PlayerHealthPercentageHp() <= GetOptionValue(Config.PLD_VariantCure))
@@ -288,6 +271,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (CanWeave(actionID))
                         {
                             Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+
                             if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) &&
                                 IsEnabled(Variant.VariantSpiritDart) &&
                                 (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
@@ -302,10 +286,8 @@ namespace XIVSlothCombo.Combos.PvE
                                 Sheltron.LevelChecked() &&
                                 !HasEffect(Buffs.Sheltron) &&
                                 !HasEffect(Buffs.HolySheltron) &&
-                                GetJobGauge<PLDGauge>().OathGauge >= GetOptionValue(Config.PLD_SheltronOption)
-                                )
+                                GetJobGauge<PLDGauge>().OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
                                 return OriginalHook(Sheltron);
-
                         }
 
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && HasEffect(Buffs.FightOrFlight))
@@ -332,14 +314,12 @@ namespace XIVSlothCombo.Combos.PvE
                                     GetRemainingCharges(Intervene) > GetOptionValue(Config.PLD_Intervene_HoldCharges) &&
                                     ((GetOptionBool(Config.PLD_Intervene_MeleeOnly) && InMeleeRange()) || (!GetOptionBool(Config.PLD_Intervene_MeleeOnly))))
                                     return OriginalHook(Intervene);
-
                             }
 
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
                                 GoringBlade.LevelChecked() &&
                                 IsOffCooldown(GoringBlade))
                                 return OriginalHook(GoringBlade);
-
 
                             if (HasEffect(Buffs.Requiescat) && !Confiteor.LevelChecked())
                             {
@@ -365,23 +345,15 @@ namespace XIVSlothCombo.Combos.PvE
                                 HasEffect(Buffs.DivineMight) &&
                                 GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                 return OriginalHook(HolySpirit);
-
                         }
 
                         if (comboTime > 1f)
                         {
-                            if (lastComboActionID == OriginalHook(FastBlade) &&
-                                RiotBlade.LevelChecked())
-                            {
+                            if (lastComboActionID == OriginalHook(FastBlade) && RiotBlade.LevelChecked())
                                 return OriginalHook(RiotBlade);
-                            }
 
-                            if (lastComboActionID == OriginalHook(RiotBlade) &&
-                                OriginalHook(RoyalAuthority).LevelChecked())
-                            {
+                            if (lastComboActionID == OriginalHook(RiotBlade) && OriginalHook(RoyalAuthority).LevelChecked())
                                 return OriginalHook(RoyalAuthority);
-                            }
-
                         }
 
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
@@ -440,7 +412,6 @@ namespace XIVSlothCombo.Combos.PvE
                             HasEffectAny(Buffs.SwordOath) &&
                             Atonement.LevelChecked())
                             return OriginalHook(Atonement);
-
                     }
                 }
 
@@ -462,6 +433,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (CanWeave(actionID))
                     {
                         Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+
                         if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) &&
                             IsEnabled(Variant.VariantSpiritDart) &&
                             (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
@@ -474,12 +446,9 @@ namespace XIVSlothCombo.Combos.PvE
                             Sheltron.LevelChecked() &&
                             !HasEffect(Buffs.Sheltron) &&
                             !HasEffect(Buffs.HolySheltron) &&
-                            GetJobGauge<PLDGauge>().OathGauge >= GetOptionValue(Config.PLD_SheltronOption)
-                            )
+                            GetJobGauge<PLDGauge>().OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
                             return OriginalHook(Sheltron);
-
                     }
-
 
                     if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && HasEffect(Buffs.FightOrFlight))
                     {
@@ -493,7 +462,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) && OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
-
                         }
 
                         if (HasEffect(Buffs.Requiescat) && !Confiteor.LevelChecked())
@@ -523,12 +491,8 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(HolyCircle);
                     }
 
-                    if (comboTime > 1f)
-                    {
-                        if (lastComboActionID is TotalEclipse && Prominence.LevelChecked())
-                            return OriginalHook(Prominence);
-                    }
-
+                    if (comboTime > 1f && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
+                        return OriginalHook(Prominence);
 
                     if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID))
                         return OriginalHook(FightOrFlight);
@@ -571,7 +535,6 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && HasEffect(Buffs.DivineMight) && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
                         return OriginalHook(HolyCircle);
 
-
                     return actionID;
                 }
 
@@ -600,7 +563,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (choice == 5 && HasEffect(Buffs.Requiescat) && HolyCircle.LevelChecked() && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp)
                         return OriginalHook(HolyCircle);
-
                 }
 
                 return actionID;
@@ -625,8 +587,8 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (IsOffCooldown(CircleOfScorn) && CircleOfScorn.LevelChecked())
                         return OriginalHook(CircleOfScorn);
-
                 }
+
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -78,7 +78,8 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is FastBlade)
                 {
 
-                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.PLD_VariantCure))
+                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
+                        PlayerHealthPercentageHp() <= GetOptionValue(Config.PLD_VariantCure))
                         return Variant.VariantCure;
 
                     if (HasBattleTarget())
@@ -93,8 +94,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
 
-                            if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) &&
-                                IsEnabled(Variant.VariantSpiritDart) &&
+                            if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
                                 (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                                 return Variant.VariantSpiritDart;
 
@@ -141,14 +141,21 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(RoyalAuthority);
                         }
 
-                        if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID))
-                            return OriginalHook(FightOrFlight);
 
-                        if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn) && CanWeave(actionID) && !WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15)
-                            return OriginalHook(CircleOfScorn);
+                        if (CanWeave(actionID))
+                        {
+                            if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
+                                return OriginalHook(FightOrFlight);
 
-                        if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)) && CanWeave(actionID) && !WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15)
-                            return OriginalHook(SpiritsWithin);
+                            if (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15)
+                            {
+                                if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                                    return OriginalHook(CircleOfScorn);
+
+                                if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                    return OriginalHook(SpiritsWithin);
+                            }
+                        }
 
                         if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                             return OriginalHook(HolySpirit);
@@ -177,8 +184,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
 
-                        if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) &&
-                            IsEnabled(Variant.VariantSpiritDart) &&
+                        if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
                             (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                             return Variant.VariantSpiritDart;
 
@@ -216,20 +222,23 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(HolyCircle);
                     }
 
-                    if (comboTime > 1f)
+                    if (comboTime > 1f && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
+                        return OriginalHook(Prominence);
+
+                    if (CanWeave(actionID))
                     {
-                        if (lastComboActionID is TotalEclipse && Prominence.LevelChecked())
-                            return OriginalHook(Prominence);
+                        if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
+                            return OriginalHook(FightOrFlight);
+
+                        if (!WasLastAction(FightOrFlight) && IsOnCooldown(FightOrFlight))
+                        {
+                            if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                                return OriginalHook(CircleOfScorn);
+
+                            if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                return OriginalHook(SpiritsWithin);
+                        }
                     }
-
-                    if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID))
-                        return OriginalHook(FightOrFlight);
-
-                    if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn) && CanWeave(actionID) && !WasLastAction(FightOrFlight) && IsOnCooldown(FightOrFlight))
-                        return OriginalHook(CircleOfScorn);
-
-                    if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)) && CanWeave(actionID) && !WasLastAction(FightOrFlight) && IsOnCooldown(FightOrFlight))
-                        return OriginalHook(SpiritsWithin);
 
                     if ((HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
                         return OriginalHook(HolyCircle);
@@ -249,8 +258,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is FastBlade)
                 {
-                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
+                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
                         PlayerHealthPercentageHp() <= GetOptionValue(Config.PLD_VariantCure))
                         return Variant.VariantCure;
 
@@ -278,14 +286,11 @@ namespace XIVSlothCombo.Combos.PvE
                                 return Variant.VariantSpiritDart;
 
                             if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) &&
-                                IsEnabled(Variant.VariantUltimatum) &&
-                                IsOffCooldown(Variant.VariantUltimatum))
+                                IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
                                 return Variant.VariantUltimatum;
 
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) &&
-                                Sheltron.LevelChecked() &&
-                                !HasEffect(Buffs.Sheltron) &&
-                                !HasEffect(Buffs.HolySheltron) &&
+                                Sheltron.LevelChecked() && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
                                 GetJobGauge<PLDGauge>().OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
                                 return OriginalHook(Sheltron);
                         }
@@ -295,18 +300,15 @@ namespace XIVSlothCombo.Combos.PvE
                             if (CanWeave(actionID))
                             {
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
-                                    Requiescat.LevelChecked() &&
-                                    IsOffCooldown(Requiescat))
+                                    Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
                                     return OriginalHook(Requiescat);
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
-                                    CircleOfScorn.LevelChecked() &&
-                                    IsOffCooldown(CircleOfScorn))
+                                    CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
                                     return OriginalHook(CircleOfScorn);
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
-                                    OriginalHook(SpiritsWithin).LevelChecked() &&
-                                    IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                    OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
                                     return OriginalHook(SpiritsWithin);
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Intervene) &&
@@ -330,20 +332,17 @@ namespace XIVSlothCombo.Combos.PvE
                             else
                             {
                                 if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
-                                    Confiteor.LevelChecked() &&
-                                    HasEffect(Buffs.ConfiteorReady))
+                                    Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
                                     ||
                                     (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
-                                    BladeOfFaith.LevelChecked() &&
-                                    HasEffect(Buffs.Requiescat) &&
+                                    BladeOfFaith.LevelChecked() && HasEffect(Buffs.Requiescat) &&
                                     OriginalHook(Confiteor) != Confiteor &&
                                     GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp))
                                     return OriginalHook(Confiteor);
                             }
 
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                                HasEffect(Buffs.DivineMight) &&
-                                GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                                HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                 return OriginalHook(HolySpirit);
                         }
 
@@ -356,35 +355,27 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(RoyalAuthority);
                         }
 
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
-                            FightOrFlight.LevelChecked() &&
-                            IsOffCooldown(FightOrFlight) &&
-                            CanWeave(actionID) &&
-                            !ActionWatching.WasLast2ActionsAbilities())
-                            return OriginalHook(FightOrFlight);
+                        if (CanWeave(actionID) && !ActionWatching.WasLast2ActionsAbilities())
+                        {
+                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
+                                FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
+                                return OriginalHook(FightOrFlight);
 
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
-                            Requiescat.LevelChecked() && IsOffCooldown(Requiescat) &&
-                            CanWeave(actionID) &&
-                            (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF)) &&
-                            !ActionWatching.WasLast2ActionsAbilities())
-                            return OriginalHook(Requiescat);
+                            if (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
+                            {
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
+                                    Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
+                                    return OriginalHook(Requiescat);
 
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
-                            CircleOfScorn.LevelChecked() &&
-                            IsOffCooldown(CircleOfScorn) &&
-                            CanWeave(actionID) &&
-                            (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF)) &&
-                            !ActionWatching.WasLast2ActionsAbilities())
-                            return OriginalHook(CircleOfScorn);
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
+                                    CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                                    return OriginalHook(CircleOfScorn);
 
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
-                            OriginalHook(SpiritsWithin).LevelChecked() &&
-                            IsOffCooldown(OriginalHook(SpiritsWithin)) &&
-                            CanWeave(actionID) &&
-                            (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF)) &&
-                            !ActionWatching.WasLast2ActionsAbilities())
-                            return OriginalHook(SpiritsWithin);
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
+                                    OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                    return OriginalHook(SpiritsWithin);
+                            }
+                        }
 
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                             (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) &&
@@ -392,25 +383,21 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(HolySpirit);
 
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
-                            GoringBlade.LevelChecked() &&
-                            IsOffCooldown(GoringBlade) &&
+                            GoringBlade.LevelChecked() && IsOffCooldown(GoringBlade) &&
                             IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
                             return OriginalHook(GoringBlade);
 
                         if (((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
-                            Confiteor.LevelChecked() &&
-                            HasEffect(Buffs.ConfiteorReady))
+                            Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
                             ||
                             (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
-                            BladeOfFaith.LevelChecked() &&
-                            HasEffect(Buffs.Requiescat) &&
+                            BladeOfFaith.LevelChecked() && HasEffect(Buffs.Requiescat) &&
                             OriginalHook(Confiteor) != Confiteor &&
                             GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp)))
                             return OriginalHook(Confiteor);
 
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
-                            HasEffectAny(Buffs.SwordOath) &&
-                            Atonement.LevelChecked())
+                            HasEffectAny(Buffs.SwordOath) && Atonement.LevelChecked())
                             return OriginalHook(Atonement);
                     }
                 }
@@ -434,8 +421,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
 
-                        if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) &&
-                            IsEnabled(Variant.VariantSpiritDart) &&
+                        if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
                             (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                             return Variant.VariantSpiritDart;
 
@@ -443,9 +429,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return Variant.VariantUltimatum;
 
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron) &&
-                            Sheltron.LevelChecked() &&
-                            !HasEffect(Buffs.Sheltron) &&
-                            !HasEffect(Buffs.HolySheltron) &&
+                            Sheltron.LevelChecked() && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
                             GetJobGauge<PLDGauge>().OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
                             return OriginalHook(Sheltron);
                     }
@@ -454,13 +438,16 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (CanWeave(actionID))
                         {
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) && Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) &&
+                                Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
                                 return OriginalHook(Requiescat);
 
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) && CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) &&
+                                CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
                                 return OriginalHook(CircleOfScorn);
 
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) && OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) &&
+                                OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
                         }
 
@@ -473,12 +460,10 @@ namespace XIVSlothCombo.Combos.PvE
                         else
                         {
                             if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
-                                Confiteor.LevelChecked() &&
-                                HasEffect(Buffs.ConfiteorReady))
+                                Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
                                 ||
                                 (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) &&
-                                BladeOfFaith.LevelChecked() &&
-                                HasEffect(Buffs.Requiescat) &&
+                                BladeOfFaith.LevelChecked() && HasEffect(Buffs.Requiescat) &&
                                 OriginalHook(Confiteor) != Confiteor &&
                                 GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp))
                                 return OriginalHook(Confiteor);
@@ -494,45 +479,40 @@ namespace XIVSlothCombo.Combos.PvE
                     if (comboTime > 1f && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
                         return OriginalHook(Prominence);
 
-                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID))
-                        return OriginalHook(FightOrFlight);
+                    if (CanWeave(actionID))
+                    {
+                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
+                            return OriginalHook(FightOrFlight);
 
-                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) &&
-                        Requiescat.LevelChecked() && IsOffCooldown(Requiescat) &&
-                        CanWeave(actionID) &&
-                        (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF)) &&
-                        !ActionWatching.WasLast2ActionsAbilities())
-                        return OriginalHook(Requiescat);
+                        if ((!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF)) &&
+                            !ActionWatching.WasLast2ActionsAbilities())
+                        {
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) &&
+                                Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
+                                return OriginalHook(Requiescat);
 
-                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) &&
-                        CircleOfScorn.LevelChecked() &&
-                        IsOffCooldown(CircleOfScorn) &&
-                        CanWeave(actionID) &&
-                        (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF)) &&
-                        !ActionWatching.WasLast2ActionsAbilities())
-                        return OriginalHook(CircleOfScorn);
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) &&
+                                CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                                return OriginalHook(CircleOfScorn);
 
-                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) &&
-                        OriginalHook(SpiritsWithin).LevelChecked() &&
-                        IsOffCooldown(OriginalHook(SpiritsWithin)) &&
-                        CanWeave(actionID) &&
-                        (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF)) &&
-                        !ActionWatching.WasLast2ActionsAbilities())
-                        return OriginalHook(SpiritsWithin);
-
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) &&
+                                OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                return OriginalHook(SpiritsWithin);
+                        }
+                    }
+                    
                     if (((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
-                        Confiteor.LevelChecked() &&
-                        HasEffect(Buffs.ConfiteorReady))
+                        Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
                         ||
                         (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) &&
-                        BladeOfFaith.LevelChecked() &&
-                        HasEffect(Buffs.Requiescat) &&
+                        BladeOfFaith.LevelChecked() && HasEffect(Buffs.Requiescat) &&
                         OriginalHook(Confiteor) != Confiteor &&
                         GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp)) &&
                         IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF))
                         return OriginalHook(Confiteor);
 
-                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && HasEffect(Buffs.DivineMight) && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
+                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && HasEffect(Buffs.DivineMight) &&
+                        GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
                         return OriginalHook(HolyCircle);
 
                     return actionID;
@@ -555,14 +535,17 @@ namespace XIVSlothCombo.Combos.PvE
                     if ((choice == 1 || choice == 3) && HasEffect(Buffs.ConfiteorReady) && Confiteor.LevelChecked() && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)
                         return OriginalHook(Confiteor);
 
-                    if ((choice == 2 || choice == 3) && HasEffect(Buffs.Requiescat) && OriginalHook(Confiteor) != Confiteor && BladeOfFaith.LevelChecked() && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)
-                        return OriginalHook(Confiteor);
+                    if (HasEffect(Buffs.Requiescat))
+                    {
+                        if ((choice == 2 || choice == 3) && OriginalHook(Confiteor) != Confiteor && BladeOfFaith.LevelChecked() && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)
+                            return OriginalHook(Confiteor);
 
-                    if (choice == 4 && HasEffect(Buffs.Requiescat) && HolySpirit.LevelChecked() && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                        return OriginalHook(HolySpirit);
+                        if (choice == 4 && HolySpirit.LevelChecked() && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                            return OriginalHook(HolySpirit);
 
-                    if (choice == 5 && HasEffect(Buffs.Requiescat) && HolyCircle.LevelChecked() && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp)
-                        return OriginalHook(HolyCircle);
+                        if (choice == 5 && HolyCircle.LevelChecked() && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp)
+                            return OriginalHook(HolyCircle);
+                    }
                 }
 
                 return actionID;
@@ -579,14 +562,19 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     var choice = GetOptionValue(Config.PLD_SpiritsWithinOption);
 
-                    if (choice == 1 && IsOffCooldown(CircleOfScorn) && CircleOfScorn.LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
-                        return OriginalHook(CircleOfScorn);
-
-                    if (choice == 2 && IsOffCooldown(CircleOfScorn) && CircleOfScorn.LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
-                        return OriginalHook(SpiritsWithin);
-
                     if (IsOffCooldown(CircleOfScorn) && CircleOfScorn.LevelChecked())
+                    {
+                        if (IsOffCooldown(OriginalHook(SpiritsWithin)))
+                        {
+                            if (choice == 1)
+                                return OriginalHook(CircleOfScorn);
+
+                            if (choice == 2)
+                                return OriginalHook(SpiritsWithin);
+                        }
+                        
                         return OriginalHook(CircleOfScorn);
+                    }
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -364,7 +364,7 @@ namespace XIVSlothCombo.Combos.PvE
                                         ActionReady(OriginalHook(SpiritsWithin)))
                                         return OriginalHook(SpiritsWithin);
                                 }
-                                
+
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Intervene) &&
                                     OriginalHook(Intervene).LevelChecked() &&
                                     !WasLastAction(Intervene) &&
@@ -381,25 +381,20 @@ namespace XIVSlothCombo.Combos.PvE
 
                             if (HasEffect(Buffs.Requiescat))
                             {
-                                if (!Confiteor.LevelChecked())
-                                {
-                                    // HS when Confiteor not unlocked
-                                    if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                                        GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                        return HolySpirit;
-                                }
-                                else
-                                {
-                                    // Confiteor & Blades
-                                    if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
-                                        HasEffect(Buffs.ConfiteorReady))
-                                        ||
-                                        (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
-                                        BladeOfFaith.LevelChecked() &&
-                                        OriginalHook(Confiteor) != Confiteor &&
-                                        GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp))
-                                        return OriginalHook(Confiteor);
-                                }
+                                // Confiteor & Blades
+                                if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
+                                    HasEffect(Buffs.ConfiteorReady))
+                                    ||
+                                    (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
+                                    BladeOfFaith.LevelChecked() &&
+                                    OriginalHook(Confiteor) != Confiteor &&
+                                    GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp))
+                                    return OriginalHook(Confiteor);
+
+                                // HS when Confiteor not unlocked or Confiteor used
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
+                                    GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                                    return HolySpirit;
                             }
 
                             // HS under DM
@@ -536,32 +531,28 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(SpiritsWithin);
                         }
 
-                        // HC when Confiteor not unlocked
                         if (HasEffect(Buffs.Requiescat))
                         {
-                            if (!Confiteor.LevelChecked())
-                            {
-                                if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
-                                    GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
-                                    return HolyCircle;
-                            }
-                            else
-                            {
-                                // Confiteor & Blades
-                                if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
-                                    HasEffect(Buffs.ConfiteorReady))
-                                    ||
-                                    (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) &&
-                                    BladeOfFaith.LevelChecked() &&
-                                    OriginalHook(Confiteor) != Confiteor &&
-                                    GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp))
-                                    return OriginalHook(Confiteor);
-                            }
+                            // Confiteor & Blades
+                            if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
+                                HasEffect(Buffs.ConfiteorReady))
+                                ||
+                                (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) &&
+                                BladeOfFaith.LevelChecked() &&
+                                OriginalHook(Confiteor) != Confiteor &&
+                                GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp))
+                                return OriginalHook(Confiteor);
+
+                            // HC when Confiteor not unlocked
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
+                                GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
+                                return HolyCircle;
+
                         }
 
                         // HC under DM/Req
-                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && 
-                            (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) && 
+                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
+                            (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) &&
                             GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp &&
                             HolyCircle.LevelChecked())
                             return HolyCircle;
@@ -591,7 +582,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(SpiritsWithin);
                         }
                     }
-                    
+
                     // Confiteor & Blades
                     if (((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
                         Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -1,5 +1,6 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Statuses;
+using System.Linq;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.CustomComboNS.Functions;
@@ -363,6 +364,13 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(HolySpirit);
                         }
 
+                        // FoF (Starts burst)
+                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
+                            FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID) &&
+                            !ActionWatching.WasLast2ActionsAbilities() &&
+                            ActionWatching.CombatActions.Where(x => x == PLD.RoyalAuthority).Count() >= 1)
+                            return OriginalHook(FightOrFlight);
+
                         // Base combo
                         if (comboTime > 1f)
                         {
@@ -375,11 +383,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (CanWeave(actionID) && !ActionWatching.WasLast2ActionsAbilities())
                         {
-                            // FoF (Starts burst)
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
-                                FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
-                                return OriginalHook(FightOrFlight);
-
                             // Usage outside of burst (desync for Req, 30s windows for CoS/SW)
                             if (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
                             {
@@ -419,7 +422,8 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(Confiteor);
 
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
-                            HasEffectAny(Buffs.SwordOath) && Atonement.LevelChecked())
+                            HasEffectAny(Buffs.SwordOath) && Atonement.LevelChecked() &&
+                            GetCooldownRemainingTime(FightOrFlight) >= 7)
                             return OriginalHook(Atonement);
                     }
                 }

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -105,6 +105,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return Variant.VariantUltimatum;
                         }
 
+                        // Actions under FoF burst
                         if (HasEffect(Buffs.FightOrFlight))
                         {
                             if (CanWeave(actionID))
@@ -124,6 +125,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                             if (HasEffect(Buffs.Requiescat))
                             {
+                                // Confiteor & Blades
                                 if ((HasEffect(Buffs.ConfiteorReady) || BladeOfFaith.LevelChecked()) && GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp)
                                     return OriginalHook(Confiteor);
 
@@ -131,10 +133,12 @@ namespace XIVSlothCombo.Combos.PvE
                                     return OriginalHook(HolySpirit);
                             }
 
+                            // HS under DM
                             if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                 return OriginalHook(HolySpirit);
                         }
 
+                        // Base combo
                         if (comboTime > 1f)
                         {
                             if (lastComboActionID == OriginalHook(FastBlade) && RiotBlade.LevelChecked())
@@ -147,9 +151,11 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (CanWeave(actionID))
                         {
+                            // FoF (Starts burst)
                             if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
                                 return OriginalHook(FightOrFlight);
 
+                            // Usage outside of burst
                             if (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15)
                             {
                                 if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
@@ -160,6 +166,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
+                        // HS under DM
                         if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                             return OriginalHook(HolySpirit);
 
@@ -195,6 +202,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return Variant.VariantUltimatum;
                     }
 
+                    // Actions under FoF burst
                     if (HasEffect(Buffs.FightOrFlight))
                     {
                         if (CanWeave(actionID))
@@ -267,6 +275,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (HasBattleTarget())
                     {
+                        // HS when out of range
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                             !InMeleeRange() &&
                             HolySpirit.LevelChecked() &&
@@ -292,12 +301,14 @@ namespace XIVSlothCombo.Combos.PvE
                                 IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
                                 return Variant.VariantUltimatum;
 
+                            // (Holy) Sheltron overcap protection
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) &&
                                 Sheltron.LevelChecked() && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
                                 Gauge.OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
                                 return OriginalHook(Sheltron);
                         }
 
+                        // Actions under FoF burst
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && HasEffect(Buffs.FightOrFlight))
                         {
                             if (CanWeave(actionID))
@@ -326,6 +337,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 IsOffCooldown(GoringBlade))
                                 return OriginalHook(GoringBlade);
 
+                            // HS when Confiteor not unlocked
                             if (HasEffect(Buffs.Requiescat) && !Confiteor.LevelChecked())
                             {
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
@@ -334,6 +346,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                             else
                             {
+                                // Confiteor & Blades
                                 if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
                                     Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
                                     ||
@@ -344,11 +357,13 @@ namespace XIVSlothCombo.Combos.PvE
                                     return OriginalHook(Confiteor);
                             }
 
+                            // HS under DM
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                                 HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                 return OriginalHook(HolySpirit);
                         }
 
+                        // Base combo
                         if (comboTime > 1f)
                         {
                             if (lastComboActionID == OriginalHook(FastBlade) && RiotBlade.LevelChecked())
@@ -360,10 +375,12 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (CanWeave(actionID) && !ActionWatching.WasLast2ActionsAbilities())
                         {
+                            // FoF (Starts burst)
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
                                 FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
                                 return OriginalHook(FightOrFlight);
 
+                            // Usage outside of burst (desync for Req, 30s windows for CoS/SW)
                             if (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
                             {
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
@@ -380,6 +397,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
+                        // HS under DM (outside of burst)
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                             (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) &&
                             GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
@@ -390,6 +408,7 @@ namespace XIVSlothCombo.Combos.PvE
                             IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
                             return OriginalHook(GoringBlade);
 
+                        // Confiteor & Blades
                         if (((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
                             Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
                             ||
@@ -431,12 +450,14 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
                             return Variant.VariantUltimatum;
 
+                        // (Holy) Sheltron overcap protection
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron) &&
                             Sheltron.LevelChecked() && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
                             Gauge.OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
                             return OriginalHook(Sheltron);
                     }
 
+                    // Actions under FoF burst
                     if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && HasEffect(Buffs.FightOrFlight))
                     {
                         if (CanWeave(actionID))
@@ -454,6 +475,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(SpiritsWithin);
                         }
 
+                        // HS when Confiteor not unlocked
                         if (HasEffect(Buffs.Requiescat) && !Confiteor.LevelChecked())
                         {
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
@@ -462,6 +484,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                         else
                         {
+                            // Confiteor & Blades
                             if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
                                 Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
                                 ||
@@ -472,6 +495,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(Confiteor);
                         }
 
+                        // HS under DM/Req
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && 
                             (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) && 
                             GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp &&
@@ -484,9 +508,11 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (CanWeave(actionID))
                     {
+                        // FoF (Starts burst)
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
                             return OriginalHook(FightOrFlight);
 
+                        // Usage outside of burst (desync for Req, 30s windows for CoS/SW)
                         if ((!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF)) &&
                             !ActionWatching.WasLast2ActionsAbilities())
                         {
@@ -504,6 +530,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
                     
+                    // Confiteor & Blades
                     if (((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
                         Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
                         ||
@@ -514,6 +541,7 @@ namespace XIVSlothCombo.Combos.PvE
                         IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF))
                         return OriginalHook(Confiteor);
 
+                    // HS under DM (outside of burst)
                     if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && HasEffect(Buffs.DivineMight) &&
                         GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
                         return OriginalHook(HolyCircle);

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -2,6 +2,7 @@
 using Dalamud.Game.ClientState.Statuses;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Data;
 using XIVSlothCombo.Extensions;
 
@@ -57,6 +58,8 @@ namespace XIVSlothCombo.Combos.PvE
                 BladeOfValor = 2721,
                 GoringBlade = 725;
         }
+
+        private static PLDGauge Gauge => CustomComboFunctions.GetJobGauge<PLDGauge>();
 
         public static class Config
         {
@@ -291,7 +294,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) &&
                                 Sheltron.LevelChecked() && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
-                                GetJobGauge<PLDGauge>().OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
+                                Gauge.OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
                                 return OriginalHook(Sheltron);
                         }
 
@@ -430,7 +433,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron) &&
                             Sheltron.LevelChecked() && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
-                            GetJobGauge<PLDGauge>().OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
+                            Gauge.OathGauge >= GetOptionValue(Config.PLD_SheltronOption))
                             return OriginalHook(Sheltron);
                     }
 

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -113,17 +113,17 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (CanWeave(actionID))
                             {
-                                if (Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
+                                if (ActionReady(Requiescat))
                                     return Requiescat;
 
-                                if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                                if (ActionReady(CircleOfScorn))
                                     return CircleOfScorn;
 
-                                if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                if (ActionReady(OriginalHook(SpiritsWithin)))
                                     return OriginalHook(SpiritsWithin);
                             }
 
-                            if (GoringBlade.LevelChecked() && IsOffCooldown(GoringBlade))
+                            if (ActionReady(GoringBlade))
                                 return GoringBlade;
 
                             if (HasEffect(Buffs.Requiescat))
@@ -139,6 +139,23 @@ namespace XIVSlothCombo.Combos.PvE
                             // HS under DM
                             if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                 return HolySpirit;
+                        }
+
+                        if (CanWeave(actionID))
+                        {
+                            // FoF (Starts burst)
+                            if (ActionReady(FightOrFlight))
+                                return FightOrFlight;
+
+                            // Usage outside of burst
+                            if (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15)
+                            {
+                                if (ActionReady(CircleOfScorn))
+                                    return CircleOfScorn;
+
+                                if (ActionReady(OriginalHook(SpiritsWithin)))
+                                    return OriginalHook(SpiritsWithin);
+                            }
                         }
 
                         // Base combo
@@ -157,30 +174,6 @@ namespace XIVSlothCombo.Combos.PvE
                                     : OriginalHook(RageOfHalone);
                             }
                         }
-
-                        if (CanWeave(actionID))
-                        {
-                            // FoF (Starts burst)
-                            if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
-                                return FightOrFlight;
-
-                            // Usage outside of burst
-                            if (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15)
-                            {
-                                if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
-                                    return CircleOfScorn;
-
-                                if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
-                                    return OriginalHook(SpiritsWithin);
-                            }
-                        }
-
-                        // HS under DM
-                        if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                            return HolySpirit;
-
-                        if (HasEffectAny(Buffs.SwordOath) && Atonement.LevelChecked())
-                            return Atonement;
                     }
                 }
 
@@ -216,13 +209,13 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (CanWeave(actionID))
                         {
-                            if (Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
+                            if (ActionReady(Requiescat))
                                 return Requiescat;
 
-                            if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                            if (ActionReady(CircleOfScorn))
                                 return CircleOfScorn;
 
-                            if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                            if (ActionReady(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
                         }
 
@@ -242,20 +235,20 @@ namespace XIVSlothCombo.Combos.PvE
                             return HolyCircle;
                     }
 
-                    if (comboTime > 1f && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
+                    if (comboTime > 0 && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
                         return Prominence;
 
                     if (CanWeave(actionID))
                     {
-                        if (FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
+                        if (ActionReady(FightOrFlight))
                             return FightOrFlight;
 
                         if (!WasLastAction(FightOrFlight) && IsOnCooldown(FightOrFlight))
                         {
-                            if (CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                            if (ActionReady(CircleOfScorn))
                                 return CircleOfScorn;
 
-                            if (OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                            if (ActionReady(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
                         }
                     }
@@ -324,16 +317,13 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (CanWeave(actionID))
                             {
-                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
-                                    Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) && ActionReady(Requiescat))
                                     return Requiescat;
 
-                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
-                                    CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) && ActionReady(CircleOfScorn))
                                     return CircleOfScorn;
 
-                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
-                                    OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) && ActionReady(OriginalHook(SpiritsWithin)))
                                     return OriginalHook(SpiritsWithin);
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Intervene) &&
@@ -345,8 +335,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
 
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
-                                GoringBlade.LevelChecked() &&
-                                IsOffCooldown(GoringBlade))
+                                ActionReady(GoringBlade))
                                 return GoringBlade;
                             
                             if (HasEffect(Buffs.Requiescat) && !Confiteor.LevelChecked())
@@ -380,20 +369,19 @@ namespace XIVSlothCombo.Combos.PvE
 
                         // FoF (Starts burst)
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
-                            FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID) &&
-                            ActionWatching.CombatActions.Where(x => x == OriginalHook(RoyalAuthority)).Any())
+                            ActionReady(FightOrFlight) && CanWeave(actionID) &&
+                            ActionWatching.CombatActions.Where(x => x == OriginalHook(RoyalAuthority)).Any()) // Check RA has been used for opener exception
                             return FightOrFlight;
 
                         // CoS/SW outside of burst
                         if (CanWeave(actionID, 0.6) && (!WasLastAction(FightOrFlight) &&
                             GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF)))
                         {
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
-                                CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) && ActionReady(CircleOfScorn))
                                 return CircleOfScorn;
 
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
-                                OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                ActionReady(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
                         }
 
@@ -416,8 +404,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // Goring on cooldown (burst features disabled)
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
-                            GoringBlade.LevelChecked() && IsOffCooldown(GoringBlade) &&
+                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) && ActionReady(GoringBlade) &&
                             IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
                             return GoringBlade;
 
@@ -471,16 +458,15 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (CanWeave(actionID))
                         {
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) &&
-                                Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) && ActionReady(Requiescat))
                                 return Requiescat;
 
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) &&
-                                CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                                ActionReady(CircleOfScorn))
                                 return CircleOfScorn;
 
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) &&
-                                OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                ActionReady(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
                         }
 
@@ -512,29 +498,27 @@ namespace XIVSlothCombo.Combos.PvE
                             return HolyCircle;
                     }
 
-                    if (comboTime > 1f && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
+                    if (comboTime > 0 && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
                         return Prominence;
 
                     if (CanWeave(actionID))
                     {
                         // FoF (Starts burst)
-                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight))
+                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && ActionReady(FightOrFlight))
                             return FightOrFlight;
 
                         // Usage outside of burst (desync for Req, 30s windows for CoS/SW)
                         if ((!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF)) &&
                             !ActionWatching.WasLast2ActionsAbilities())
                         {
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) &&
-                                Requiescat.LevelChecked() && IsOffCooldown(Requiescat))
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) && ActionReady(Requiescat))
                                 return Requiescat;
 
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) &&
-                                CircleOfScorn.LevelChecked() && IsOffCooldown(CircleOfScorn))
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) && ActionReady(CircleOfScorn))
                                 return CircleOfScorn;
 
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) &&
-                                OriginalHook(SpiritsWithin).LevelChecked() && IsOffCooldown(OriginalHook(SpiritsWithin)))
+                                ActionReady(OriginalHook(SpiritsWithin)))
                                 return OriginalHook(SpiritsWithin);
                         }
                     }
@@ -572,18 +556,18 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     int choice = Config.PLD_RequiescatOption;
 
-                    if ((choice == 1 || choice == 3) && HasEffect(Buffs.ConfiteorReady) && Confiteor.LevelChecked() && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)
+                    if ((choice is 1 || choice is 3) && HasEffect(Buffs.ConfiteorReady) && Confiteor.LevelChecked() && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)
                         return OriginalHook(Confiteor);
 
                     if (HasEffect(Buffs.Requiescat))
                     {
-                        if ((choice == 2 || choice == 3) && OriginalHook(Confiteor) != Confiteor && BladeOfFaith.LevelChecked() && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)
+                        if ((choice is 2 || choice is 3) && OriginalHook(Confiteor) != Confiteor && BladeOfFaith.LevelChecked() && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)
                             return OriginalHook(Confiteor);
 
-                        if (choice == 4 && HolySpirit.LevelChecked() && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                        if (choice is 4 && HolySpirit.LevelChecked() && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                             return HolySpirit;
 
-                        if (choice == 5 && HolyCircle.LevelChecked() && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp)
+                        if (choice is 5 && HolyCircle.LevelChecked() && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp)
                             return HolyCircle;
                     }
                 }
@@ -602,14 +586,14 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     int choice = Config.PLD_SpiritsWithinOption;
 
-                    if (IsOffCooldown(CircleOfScorn) && CircleOfScorn.LevelChecked())
+                    if (ActionReady(CircleOfScorn))
                     {
                         if (IsOffCooldown(OriginalHook(SpiritsWithin)))
                         {
-                            if (choice == 1)
+                            if (choice is 1)
                                 return CircleOfScorn;
 
-                            if (choice == 2)
+                            if (choice is 2)
                                 return OriginalHook(SpiritsWithin);
                         }
                         

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -378,27 +378,28 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
                                 ActionReady(GoringBlade) && InMeleeRange())
                                 return GoringBlade;
-                            
-                            if (HasEffect(Buffs.Requiescat) && !Confiteor.LevelChecked())
+
+                            if (HasEffect(Buffs.Requiescat))
                             {
-                                // HS when Confiteor not unlocked
-                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                                    GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                    return HolySpirit;
-                            }
-                            else
-                            {
-                                // Confiteor & Blades
-                                if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
-                                    Confiteor.LevelChecked() &&
-                                    HasEffect(Buffs.ConfiteorReady))
-                                    ||
-                                    (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
-                                    BladeOfFaith.LevelChecked() &&
-                                    HasEffect(Buffs.Requiescat) &&
-                                    OriginalHook(Confiteor) != Confiteor &&
-                                    GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp))
-                                    return OriginalHook(Confiteor);
+                                if (!Confiteor.LevelChecked())
+                                {
+                                    // HS when Confiteor not unlocked
+                                    if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
+                                        GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                                        return HolySpirit;
+                                }
+                                else
+                                {
+                                    // Confiteor & Blades
+                                    if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
+                                        HasEffect(Buffs.ConfiteorReady))
+                                        ||
+                                        (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
+                                        BladeOfFaith.LevelChecked() &&
+                                        OriginalHook(Confiteor) != Confiteor &&
+                                        GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp))
+                                        return OriginalHook(Confiteor);
+                                }
                             }
 
                             // HS under DM
@@ -449,6 +450,12 @@ namespace XIVSlothCombo.Combos.PvE
                             OriginalHook(Confiteor) != Confiteor &&
                             GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)))
                             return OriginalHook(Confiteor);
+
+                        //Req HS
+                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
+                            HasEffect(Buffs.Requiescat) &&
+                            GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                            return HolySpirit;
 
                         // Base combo
                         if (comboTime > 0)
@@ -529,27 +536,30 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(SpiritsWithin);
                         }
 
-                        // HS when Confiteor not unlocked
-                        if (HasEffect(Buffs.Requiescat) && !Confiteor.LevelChecked())
+                        // HC when Confiteor not unlocked
+                        if (HasEffect(Buffs.Requiescat))
                         {
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
-                                GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
-                                return HolyCircle;
-                        }
-                        else
-                        {
-                            // Confiteor & Blades
-                            if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
-                                Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
-                                ||
-                                (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) &&
-                                BladeOfFaith.LevelChecked() && HasEffect(Buffs.Requiescat) &&
-                                OriginalHook(Confiteor) != Confiteor &&
-                                GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp))
-                                return OriginalHook(Confiteor);
+                            if (!Confiteor.LevelChecked())
+                            {
+                                if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
+                                    GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
+                                    return HolyCircle;
+                            }
+                            else
+                            {
+                                // Confiteor & Blades
+                                if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
+                                    HasEffect(Buffs.ConfiteorReady))
+                                    ||
+                                    (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) &&
+                                    BladeOfFaith.LevelChecked() &&
+                                    OriginalHook(Confiteor) != Confiteor &&
+                                    GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp))
+                                    return OriginalHook(Confiteor);
+                            }
                         }
 
-                        // HS under DM/Req
+                        // HC under DM/Req
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && 
                             (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) && 
                             GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp &&

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -332,9 +332,9 @@ namespace XIVSlothCombo.Combos.PvE
                                     return OriginalHook(SpiritsWithin);
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Intervene) &&
-                                    OriginalHook(Intervene).LevelChecked() &&
-                                    !WasLastAction(Intervene) &&
+                                    OriginalHook(Intervene).LevelChecked() && !WasLastAction(Intervene) &&
                                     GetRemainingCharges(Intervene) > Config.PLD_Intervene_HoldCharges &&
+                                    GetCooldownRemainingTime(CircleOfScorn) > 3 && GetCooldownRemainingTime(OriginalHook(CircleOfScorn)) > 3 &&
                                     ((Config.PLD_Intervene_MeleeOnly && InMeleeRange()) || (!Config.PLD_Intervene_MeleeOnly)))
                                     return OriginalHook(Intervene);
                             }

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -142,15 +142,16 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // Base combo
-                        if (comboTime > 1f)
+                        if (comboTime > 0)
                         {
-                            if (lastComboActionID == FastBlade && RiotBlade.LevelChecked())
+                            if (lastComboActionID is FastBlade && RiotBlade.LevelChecked())
                                 return RiotBlade;
 
-                            if (lastComboActionID == RiotBlade && OriginalHook(RoyalAuthority).LevelChecked())
-                                return OriginalHook(RoyalAuthority);
+                            if (lastComboActionID is RiotBlade && RageOfHalone.LevelChecked())
+                                return (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                                    ? HolySpirit
+                                    : OriginalHook(RageOfHalone);
                         }
-
 
                         if (CanWeave(actionID))
                         {

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -330,6 +330,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Intervene) &&
                                     OriginalHook(Intervene).LevelChecked() &&
+                                    !WasLastAction(Intervene) &&
                                     GetRemainingCharges(Intervene) > Config.PLD_Intervene_HoldCharges &&
                                     ((Config.PLD_Intervene_MeleeOnly && InMeleeRange()) || (!Config.PLD_Intervene_MeleeOnly)))
                                     return OriginalHook(Intervene);
@@ -370,7 +371,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
                             FightOrFlight.LevelChecked() && IsOffCooldown(FightOrFlight) && CanWeave(actionID) &&
                             !ActionWatching.WasLast2ActionsAbilities() &&
-                            ActionWatching.CombatActions.Where(x => x == PLD.RoyalAuthority).Count() >= 1)
+                            ActionWatching.CombatActions.Where(x => x == RoyalAuthority).Any())
                             return OriginalHook(FightOrFlight);
 
                         // Base combo

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1483,6 +1483,20 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawRadioButton(PLD.Config.PLD_RequiescatOption, "Holy Circle", "", 5);
             }
 
+            if (preset is CustomComboPreset.PLD_ST_AdvancedMode_Requiescat)
+            {
+                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_ST_RequiescatWeave, "Standard Weave", "Weaves Requiescat immediately after Fight or Flight for a standard burst window.", 0, 150, ImGuiColors.ParsedGreen);
+                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_ST_RequiescatWeave, "Late Weave", "Late-weaves Requiescat after Fight or Flight.\nEnsures Requiescat's damage falls under the Fight or Flight buff, but may lead to misalignment in longer fights.", 1, 150, ImGuiColors.DalamudYellow);
+                ImGui.Spacing();
+            }
+
+            if (preset is CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat)
+            {
+                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_AoE_RequiescatWeave, "Standard Weave", "Weaves Requiescat immediately after Fight or Flight for a standard burst window.", 0, 150, ImGuiColors.ParsedGreen);
+                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_AoE_RequiescatWeave, "Late Weave", "Late-weaves Requiescat after Fight or Flight.\nEnsures Requiescat's damage falls under the Fight or Flight buff, but may lead to misalignment in longer fights.", 1, 150, ImGuiColors.DalamudYellow);
+                ImGui.Spacing();
+            }
+
             if (preset == CustomComboPreset.PLD_SpiritsWithin)
             {
                 UserConfig.DrawRadioButton(PLD.Config.PLD_SpiritsWithinOption, "Prioritize Circle of Scorn", "", 1);

--- a/XIVSlothCombo/XIVSlothCombo.csproj
+++ b/XIVSlothCombo/XIVSlothCombo.csproj
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<Authors>Aki, k-kz, ele-starshade, damolitionn, Taurenkey, Augporto, grimgal, Genesis-Nova, Tartarga</Authors>
 		<Company>-</Company>
-		<Version>3.0.18.2</Version>
+		<Version>3.0.18.3</Version>
 		<!-- This is the version that will be used when pushing to the repo.-->
 		<Description>XIVCombo for lazy players</Description>
 		<Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>


### PR DESCRIPTION
Removed `OriginalHook()` checks on actions without game hooks
Fixed filler window `Atonement` management
Fixed filler window `Holy Spirit` management
Optimised opener `Fight or Flight` GCD timing check
Adjusted non-opener `Fight or Flight` windows to burst off cooldown
Added check to prevent double-weave of `Intervene`
Added oGCD checks to `Intervene` use to optimise action order
Improved `Royal Authority` checks for burst optimisation
`Shield Lob` no longer used unless out of range and MP for `Holy Spirit`
Adjusted gauge check method
Converted level & cooldown checks to `ActionReady`
Adjusted action priority across rotation
Adjusted user config checks
Refactored & cleaned up code