### PR TITLE
VS Warnings Cleanup

### DIFF
--- a/XIVSlothCombo/Combos/PvE/BLU.cs
+++ b/XIVSlothCombo/Combos/PvE/BLU.cs
@@ -401,7 +401,7 @@ namespace XIVSlothCombo.Combos.PvE
         internal class BLU_NewMoonFluteOpener : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BLU_NewMoonFluteOpener;
-            private static bool surpanakhaReady = false;
+            //private static bool surpanakhaReady = false;
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {

--- a/XIVSlothCombo/CustomCombo/Functions/PlayerCharacter.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/PlayerCharacter.cs
@@ -21,11 +21,11 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 
         /// <summary> Find if the player has a pet present. </summary>
         /// <returns> A value indicating whether the player has a pet (fairy/carbuncle) present. </returns>
-        public static bool HasPetPresent() => Service.BuddyList.PetBuddyPresent;
+        public static bool HasPetPresent() => Service.BuddyList.PetBuddy != null;
 
         /// <summary> Find if the player has a companion (chocobo) present. </summary>
         /// <returns> A value indicating whether the player has a companion (chocobo). </returns>
-        public static bool HasCompanionPresent() => Service.BuddyList.CompanionBuddyPresent;
+        public static bool HasCompanionPresent() => Service.BuddyList.CompanionBuddy != null;
 
         /// <summary> Checks if the player is in a PVP enabled zone. </summary>
         /// <returns> A value indicating whether the player is in a PVP enabled zone. </returns>


### PR DESCRIPTION
Disabled unused var in BLU
Applied Obsolete recommendations to SCH/SMN Pets and Chocobo detection