### PR TITLE
[BLM] Never let Thunder I/III uptime option break AF/UI

### DIFF
--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -493,7 +493,8 @@ namespace XIVSlothCombo.Combos.PvE
                             (currentMP >= MP.ThunderST || (HasEffect(Buffs.Sharpcast) && HasEffect(Buffs.Thundercloud))))
                         {
                             if (LevelChecked(Thunder) &&
-                                (dotDebuff is null || dotDebuff.RemainingTime <= thunderRefreshTime) && GetTargetHPPercent() > ThunderHP)
+                                (dotDebuff is null || dotDebuff.RemainingTime <= thunderRefreshTime) && GetTargetHPPercent() > ThunderHP &&
+                                gauge.ElementTimeRemaining >= 6000) // Never let AF/UI gauge drop to 0 
                                 return OriginalHook(Thunder);
                         }
                     }


### PR DESCRIPTION
Small tweak/suggestion based on behavior I saw when testing the Advanced BLM settings. Ensures Thunder DoT refresh won't queue up instead of Despair when the AF timer is getting low.