### PR TITLE
SAM Optimizations

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3049,6 +3049,11 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("True North Feature", "Adds True North on all single target combos if Meikyo Shisui's buff is on you.", SAM.JobID, 0, "", "")]
         SAM_TrueNorth = 15038,
 
+        [ParentCombo(SAM_TrueNorth)]
+        [ReplaceSkill(SAM.Gekko, SAM.Yukikaze, SAM.Kasha)]
+        [CustomComboInfo("Opener True North Feature", "Adds True North to all Meikyo Shisui buff windows in opener (Will use up all True North stacks by the end of opener).", SAM.JobID, 0, "", "")]
+        SAM_TrueNorth_Opener = 15049,
+
         [ParentCombo(SAM_ST_GekkoCombo)]
         [CustomComboInfo("Combo Heals Option", "Adds Bloodbath and Second Wind to the combo, using them when below the HP Percentage threshold.", SAM.JobID, 0, "", "")]
         SAM_ST_ComboHeals = 15043,
@@ -3068,7 +3073,7 @@ namespace XIVSlothCombo.Combos
         SAM_Variant_Rampart = 15048,
         #endregion
 
-        // Last value = 15048
+        // Last value = 15049
 
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -193,13 +193,29 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (CanSpellWeave(actionID) && IsEnabled(CustomComboPreset.SAM_TrueNorth) && TargetNeedsPositionals() && GetBuffStacks(Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked())
                     {
-                        if ((!OnTargetsFlank() && (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))))
+                        if (IsEnabled(CustomComboPreset.SAM_TrueNorth_Opener))
                         {
-                            return All.TrueNorth;
+                            if (!inOpener)
+                            {
+                                if ((!OnTargetsFlank() && (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))))
+                                {
+                                    return All.TrueNorth;
+                                }
+                                else if ((!OnTargetsRear() && (!HasEffect(Buffs.Fugetsu) || (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)))))
+                                {
+                                    return All.TrueNorth;
+                                }
+                            }
                         }
-                        else if ((!OnTargetsRear() && (!HasEffect(Buffs.Fugetsu) || (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)))))
-                        {
-                            return All.TrueNorth;
+                        else {
+                            if ((!OnTargetsFlank() && (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))))
+                            {
+                                return All.TrueNorth;
+                            }
+                            else if ((!OnTargetsRear() && (!HasEffect(Buffs.Fugetsu) || (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)))))
+                            {
+                                return All.TrueNorth;
+                            }
                         }
                     }
 

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -582,7 +582,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (HasEffect(Buffs.MeikyoShisui))
                         {
-                            if (OnTargetsFlank())
+                            if (OnTargetsFlank() && TargetNeedsPositionals())
                             {
                                 if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))
                                     return Kasha;
@@ -612,7 +612,7 @@ namespace XIVSlothCombo.Combos.PvE
                             {
                                 if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU) && Yukikaze.LevelChecked() && HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
                                     return Yukikaze;
-                                if (OnTargetsFlank())
+                                if (OnTargetsFlank() && TargetNeedsPositionals())
                                 {
                                     if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && LevelChecked(Shifu) &&
                                         ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka))) ||
@@ -895,7 +895,7 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     if (HasEffect(Buffs.MeikyoShisui))
                     {
-                        if (OnTargetsFlank())
+                        if (OnTargetsFlank() && TargetNeedsPositionals())
                         {
                             if (!HasEffect(Buffs.Fuka) || gauge.Sen.HasFlag(Sen.KA) == false)
                                 return Kasha;

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -188,11 +188,21 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_RangedUptime) && Enpi.LevelChecked() && !inEvenFiller && !inOddFiller && !InMeleeRange() && HasBattleTarget())
+                    if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_RangedUptime) && Enpi.LevelChecked() && !inEvenFiller && !inOddFiller && !InMeleeRange() && HasBattleTarget() && !inOpener)
                         return Enpi;
 
                     if (CanSpellWeave(actionID) && IsEnabled(CustomComboPreset.SAM_TrueNorth) && TargetNeedsPositionals() && GetBuffStacks(Buffs.MeikyoShisui) > 0 && !HasEffect(All.Buffs.TrueNorth) && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked())
-                        return All.TrueNorth;
+                    {
+                        if ((!OnTargetsFlank() && (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))))
+                        {
+                            return All.TrueNorth;
+                        }
+                        else if ((!OnTargetsRear() && (!HasEffect(Buffs.Fugetsu) || (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)))))
+                        {
+                            return All.TrueNorth;
+                        }
+                    }
+
 
                     if (InCombat())
                     {
@@ -262,10 +272,14 @@ namespace XIVSlothCombo.Combos.PvE
                                 return Hakaze;
 
                             if (meikyostacks == 3)
+                            {
                                 return Gekko;
+                            }
 
                             if (meikyostacks == 2 && !HasEffect(Buffs.OgiNamikiriReady) && gauge.Kaeshi == Kaeshi.NONE)
+                            {
                                 return Kasha;
+                            }
 
                             if (meikyostacks == 1)
                             {
@@ -273,7 +287,16 @@ namespace XIVSlothCombo.Combos.PvE
                                     return Yukikaze;
 
                                 if (gauge.MeditationStacks == 0 || !HasEffect(Buffs.OgiNamikiriReady))
-                                    return Gekko;
+                                {
+                                    if (!gauge.Sen.HasFlag(Sen.GETSU))
+                                    {
+                                        return Gekko;
+                                    }
+                                    else
+                                    {
+                                        return Kasha;
+                                    }
+                                }
                             }
 
                             if (GetRemainingCharges(TsubameGaeshi) == 0)
@@ -559,14 +582,28 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (HasEffect(Buffs.MeikyoShisui))
                         {
-                            if (!HasEffect(Buffs.Fugetsu) || (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)))
-                                return Gekko;
+                            if (OnTargetsFlank())
+                            {
+                                if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))
+                                    return Kasha;
 
-                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))
-                                return Kasha;
+                                if (!HasEffect(Buffs.Fugetsu) || (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)))
+                                    return Gekko;
 
-                            if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU))
-                                return Yukikaze;
+                                if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU))
+                                    return Yukikaze;
+                            }
+                            else
+                            {
+                                if (!HasEffect(Buffs.Fugetsu) || (!gauge.Sen.HasFlag(Sen.GETSU) && HasEffect(Buffs.Fuka)))
+                                    return Gekko;
+
+                                if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && ((!gauge.Sen.HasFlag(Sen.KA) && HasEffect(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka)))
+                                    return Kasha;
+
+                                if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU))
+                                    return Yukikaze;
+                            }
                         }
 
                         if (comboTime > 0)
@@ -575,15 +612,28 @@ namespace XIVSlothCombo.Combos.PvE
                             {
                                 if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Yukikaze) && !gauge.Sen.HasFlag(Sen.SETSU) && Yukikaze.LevelChecked() && HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
                                     return Yukikaze;
+                                if (OnTargetsFlank())
+                                {
+                                    if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && LevelChecked(Shifu) &&
+                                        ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka))) ||
+                                        (Kasha.LevelChecked() && (!HasEffect(Buffs.Fuka) || (HasEffect(Buffs.Fugetsu) && !gauge.Sen.HasFlag(Sen.KA)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)))))))
+                                        return Shifu;
 
-                                if ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka)) || !HasEffect(Buffs.Fugetsu))) ||
+                                    if ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka)) || !HasEffect(Buffs.Fugetsu))) ||
                                    (Kasha.LevelChecked() && (!HasEffect(Buffs.Fugetsu) || (HasEffect(Buffs.Fuka) && !gauge.Sen.HasFlag(Sen.GETSU)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka))))))
-                                    return Jinpu;
+                                        return Jinpu;
+                                }
+                                else
+                                {
+                                    if ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka)) || !HasEffect(Buffs.Fugetsu))) ||
+                                   (Kasha.LevelChecked() && (!HasEffect(Buffs.Fugetsu) || (HasEffect(Buffs.Fuka) && !gauge.Sen.HasFlag(Sen.GETSU)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fugetsu) < GetBuffRemainingTime(Buffs.Fuka))))))
+                                        return Jinpu;
 
-                                if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && LevelChecked(Shifu) &&
-                                    ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka))) ||
-                                    (Kasha.LevelChecked() && (!HasEffect(Buffs.Fuka) || (HasEffect(Buffs.Fugetsu) && !gauge.Sen.HasFlag(Sen.KA)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)))))))
-                                    return Shifu;
+                                    if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_Kasha) && LevelChecked(Shifu) &&
+                                        ((!Kasha.LevelChecked() && ((GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)) || !HasEffect(Buffs.Fuka))) ||
+                                        (Kasha.LevelChecked() && (!HasEffect(Buffs.Fuka) || (HasEffect(Buffs.Fugetsu) && !gauge.Sen.HasFlag(Sen.KA)) || (threeSeal && (GetBuffRemainingTime(Buffs.Fuka) < GetBuffRemainingTime(Buffs.Fugetsu)))))))
+                                        return Shifu;
+                                }
                             }
 
                             if (lastComboMove == Jinpu && Gekko.LevelChecked())
@@ -665,7 +715,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (IsEnabled(CustomComboPreset.SAM_AoE_MangetsuCombo_Hagakure) && OriginalHook(Iaijutsu) == Setsugekka && LevelChecked(Hagakure))
                             return Hagakure;
-                      
+
                         if (IsEnabled(CustomComboPreset.SAM_AoE_MangetsuCombo_Guren) && ActionReady(Guren) && gauge.Kenki >= 25)
                             return Guren;
 
@@ -845,14 +895,29 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     if (HasEffect(Buffs.MeikyoShisui))
                     {
-                        if (!HasEffect(Buffs.Fugetsu) || gauge.Sen.HasFlag(Sen.GETSU) == false)
-                            return Gekko;
+                        if (OnTargetsFlank())
+                        {
+                            if (!HasEffect(Buffs.Fuka) || gauge.Sen.HasFlag(Sen.KA) == false)
+                                return Kasha;
 
-                        if (!HasEffect(Buffs.Fuka) || gauge.Sen.HasFlag(Sen.KA) == false)
-                            return Kasha;
+                            if (!HasEffect(Buffs.Fugetsu) || gauge.Sen.HasFlag(Sen.GETSU) == false)
+                                return Gekko;
 
-                        if (gauge.Sen.HasFlag(Sen.SETSU) == false)
-                            return Yukikaze;
+                            if (gauge.Sen.HasFlag(Sen.SETSU) == false)
+                                return Yukikaze;
+                        }
+                        else
+                        {
+                            if (!HasEffect(Buffs.Fugetsu) || gauge.Sen.HasFlag(Sen.GETSU) == false)
+                                return Gekko;
+
+                            if (!HasEffect(Buffs.Fuka) || gauge.Sen.HasFlag(Sen.KA) == false)
+                                return Kasha;
+
+                            if (gauge.Sen.HasFlag(Sen.SETSU) == false)
+                                return Yukikaze;
+                        }
+
                     }
 
                     return MeikyoShisui;

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -33,6 +33,7 @@ namespace XIVSlothCombo.Combos.PvE
             Higanbana = 7489,
             TenkaGoken = 7488,
             Setsugekka = 7487,
+            KaeshiSetsugekka = 16486,
             Shinten = 7490,
             Kyuten = 7491,
             Hagakure = 7495,
@@ -507,7 +508,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                                         if (IsEnabled(CustomComboPreset.SAM_ST_GekkoCombo_CDs_MeikyoShisui_Burst))
                                         {
-                                            if (hasDied || nonOpener || GetRemainingCharges(MeikyoShisui) == 2 || (gauge.Kaeshi == Kaeshi.NONE && gauge.Sen == Sen.NONE && GetDebuffRemainingTime(Debuffs.Higanbana) <= 15))
+                                            if (nonOpener || GetRemainingCharges(MeikyoShisui) == 2 || (gauge.Kaeshi == Kaeshi.NONE && gauge.Sen == Sen.NONE && WasLastAction(KaeshiSetsugekka)))
                                                 return MeikyoShisui;
                                         }
                                     }


### PR DESCRIPTION
- makes it so that combos are directional dependent rather than set order
- makes it so that skills during meikyo change based on position 
- adds an option to disable using all true north buffs while in opener
- disables ranged skill while opener has been activated to prevent accidental skill usage