### PR TITLE
Sage Single Target Heal Action Priority

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -136,6 +136,8 @@ namespace XIVSlothCombo.Combos.PvE
 
             public static UserInt
                 SGE_Eukrasia_Mode = new("SGE_Eukrasia_Mode");
+            public static UserUIntArray
+                SGE_Heal_Priority = new("SGE_Heal_Priority");
         }
 
         internal static class Traits
@@ -423,57 +425,73 @@ namespace XIVSlothCombo.Combos.PvE
 
                     GameObject? healTarget = GetHealTarget(Config.SGE_ST_Heal_Adv && Config.SGE_ST_Heal_UIMouseOver);
 
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
-                        GetTargetHPPercent(healTarget) >= Config.SGE_ST_Heal_Esuna &&
-                        HasCleansableDebuff(healTarget))
-                        return All.Esuna;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && ActionReady(Druochole) &&
-                        Gauge.HasAddersgall() &&
-                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Druochole)
-                        return Druochole;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && ActionReady(Taurochole) &&
-                        Gauge.HasAddersgall() &&
-                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Taurochole)
-                        return Taurochole;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && ActionReady(Rhizomata) &&
-                        !Gauge.HasAddersgall())
-                        return Rhizomata;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Kardia) && LevelChecked(Kardia) &&
-                        FindEffect(Buffs.Kardia) is null &&
-                        FindEffect(Buffs.Kardion, healTarget, LocalPlayer?.ObjectId) is null)
-                        return Kardia;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) && ActionReady(Soteria) &&
-                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Soteria)
-                        return Soteria;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) && ActionReady(Zoe) &&
-                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Zoe)
-                        return Zoe;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) && ActionReady(Krasis) &&
-                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Krasis)
-                        return Krasis;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) && ActionReady(Pepsis) &&
-                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Pepsis &&
-                        FindEffect(Buffs.EukrasianDiagnosis, healTarget, LocalPlayer?.ObjectId) is not null)
-                        return Pepsis;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && ActionReady(Haima) &&
-                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Haima)
-                        return Haima;
-
-                    if (IsEnabled(CustomComboPreset.SGE_ST_Heal_EDiagnosis) && LevelChecked(Eukrasia) &&
-                        GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_EDiagnosisHP &&
-                        (Config.SGE_ST_Heal_EDiagnosisOpts[0] || FindEffectOnMember(Buffs.EukrasianDiagnosis, healTarget) is null) && //Ignore existing shield check
-                        (!Config.SGE_ST_Heal_EDiagnosisOpts[1] || FindEffectOnMember(SCH.Buffs.Galvanize, healTarget) is null)) //Galvenize Check
-                        return Eukrasia;
-
+                    for (int i = 0; i < Config.SGE_Heal_Priority.Count; i++)
+                    {
+                        switch (Config.SGE_Heal_Priority[i])
+                        {
+                            case All.Esuna:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Esuna) && ActionReady(All.Esuna) &&
+                                    HasCleansableDebuff(healTarget)) 
+                                    return All.Esuna;
+                                break;
+                            case Druochole:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Druochole) && ActionReady(Druochole) &&
+                                    Gauge.HasAddersgall() &&
+                                    GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Druochole)
+                                    return Druochole;
+                                break;
+                            case Taurochole:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Taurochole) && ActionReady(Taurochole) &&
+                                    Gauge.HasAddersgall() &&
+                                    GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Taurochole)
+                                    return Taurochole;
+                                break;
+                            case Rhizomata:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Rhizomata) && ActionReady(Rhizomata) &&
+                                    !Gauge.HasAddersgall())
+                                    return Rhizomata;
+                                break;
+                            case Kardia:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Kardia) && LevelChecked(Kardia) &&
+                                    FindEffect(Buffs.Kardia) is null &&
+                                    FindEffect(Buffs.Kardion, healTarget, LocalPlayer?.ObjectId) is null)
+                                    return Kardia;
+                                break;
+                            case Soteria:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Soteria) && ActionReady(Soteria) &&
+                                    GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Soteria)
+                                    return Soteria;
+                                break;
+                            case Zoe:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Zoe) && ActionReady(Zoe) &&
+                                    GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Zoe)
+                                    return Zoe;
+                                break;
+                            case Krasis:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Krasis) && ActionReady(Krasis) &&
+                                    GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Krasis)
+                                    return Krasis;
+                                break;
+                            case Pepsis:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Pepsis) && ActionReady(Pepsis) &&
+                                    GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Pepsis &&
+                                    FindEffect(Buffs.EukrasianDiagnosis, healTarget, LocalPlayer?.ObjectId) is not null)
+                                    return Pepsis;
+                                break;
+                            case Haima:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_Haima) && ActionReady(Haima) &&
+                                    GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_Haima)
+                                    return Haima;
+                                break;
+                            case Eukrasia:
+                                if (IsEnabled(CustomComboPreset.SGE_ST_Heal_EDiagnosis) && LevelChecked(Eukrasia) &&
+                                    GetTargetHPPercent(healTarget) <= Config.SGE_ST_Heal_EDiagnosisHP &&
+                                    (Config.SGE_ST_Heal_EDiagnosisOpts[0] || FindEffectOnMember(Buffs.EukrasianDiagnosis, healTarget) is null) && //Ignore existing shield check
+                                    (!Config.SGE_ST_Heal_EDiagnosisOpts[1] || FindEffectOnMember(SCH.Buffs.Galvanize, healTarget) is null)) //Galvenize Check
+                                    return Eukrasia;
+                                break;
+                        }
+                    }
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Core/PluginConfiguration.cs
+++ b/XIVSlothCombo/Core/PluginConfiguration.cs
@@ -230,6 +230,28 @@ namespace XIVSlothCombo.Core
 
         #endregion
 
+        #region Custom UInt Array Values
+
+        [JsonProperty]
+        internal static Dictionary<string, uint[]> CustomUIntArrayValues { get; set; } = new Dictionary<string, uint[]>();
+
+        /// <summary> Gets a custom uint array value. </summary>
+        public static uint[] GetCustomUIntArrayValue(string config)
+        {
+            if (!CustomUIntArrayValues.TryGetValue(config, out uint[]? configValue))
+            {
+                SetCustomUIntArrayValue(config, Array.Empty<uint>());
+                return [];
+            }
+
+            return configValue;
+        }
+
+        /// <summary> Sets a custom uint array value. </summary>
+        public static void SetCustomUIntArrayValue(string config, uint[] value) => CustomUIntArrayValues[config] = value;
+
+        #endregion
+
         #region Job-specific
 
         /// <summary> Gets active Blue Mage (BLU) spells. </summary>

--- a/XIVSlothCombo/CustomCombo/Functions/Config.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Config.cs
@@ -16,34 +16,30 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         public static float GetOptionFloat(string SliderID) => PluginConfiguration.GetCustomFloatValue(SliderID);
     }
 
-    internal class UserData
+    internal class UserData(string v)
     {
-        protected string pName;
-        public UserData(string v) => pName = v;
+        protected string pName = v;
+
         public static implicit operator string(UserData o) => (o.pName);
     }
 
-    internal class UserFloat : UserData
+    internal class UserFloat(string v) : UserData(v)
     {
-        public UserFloat(string v) : base(v) { }
         public static implicit operator float(UserFloat o) => PluginConfiguration.GetCustomFloatValue(o.pName);
     }
 
-    internal class UserInt : UserData
+    internal class UserInt(string v) : UserData(v)
     {
-        public UserInt(string v) : base(v) { }
         public static implicit operator int(UserInt o) => PluginConfiguration.GetCustomIntValue(o.pName);
     }
 
-    internal class UserBool : UserData
+    internal class UserBool(string v) : UserData(v)
     {
-        public UserBool(string v) : base(v) { }
         public static implicit operator bool(UserBool o) => PluginConfiguration.GetCustomBoolValue(o.pName);
     }
 
-    internal class UserBoolArray : UserData
+    internal class UserBoolArray(string v) : UserData(v)
     {
-        public UserBoolArray(string v) : base(v) { }
         public int Count => PluginConfiguration.GetCustomBoolArrayValue(this.pName).Length;
         public static implicit operator bool[](UserBoolArray o) => PluginConfiguration.GetCustomBoolArrayValue(o.pName);
         public bool this[int index]
@@ -66,8 +62,29 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         {
             var array = PluginConfiguration.GetCustomBoolArrayValue(this.pName);
             return array.All(predicate);
-
         }
     }
+
+    internal class UserUIntArray(string v) : UserData(v)
+    {
+        public int Count => PluginConfiguration.GetCustomUIntArrayValue(this.pName).Length;
+        public static implicit operator uint[](UserUIntArray o) => PluginConfiguration.GetCustomUIntArrayValue(o.pName);
+        public uint this[int index]
+        {
+            get
+            {
+                if (index >= this.Count)
+                {
+                    var array = PluginConfiguration.GetCustomUIntArrayValue(this.pName);
+                    Array.Resize(ref array, index + 1);
+                    array[index] = 0;
+                    PluginConfiguration.SetCustomUIntArrayValue(this.pName, array);
+                    Service.Configuration.Save();
+                }
+                return PluginConfiguration.GetCustomUIntArrayValue(this.pName)[index];
+            }
+        }
+    }
+
 
 }


### PR DESCRIPTION
PluginConfiguration.cs: Added an UInt array as savable useroption data type

Config.cs
 - VS recommended edits to existing User Option Types.
 - Added UserUIntArray to read/save an array of uints

UserConfig.cs
 - Added DrawListBox and up/down manipulation buttons.  Needs refining. Current work around to select is to use the action.
 - DrawListBox added to Sage's Single Target Healing (SGE_Heal_Priority)

SGE.cs
 - Migrated Single Target Healing code into a priority checking setup (array loop of checking action IDs and running code)