### PR TITLE
MCH Optimization/bugfixes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1564,7 +1564,7 @@ namespace XIVSlothCombo.Combos
 
         #region Advanced ST
 
-        [ReplaceSkill(MCH.SplitShot)]
+        [ReplaceSkill(MCH.SplitShot, MCH.HeatedSplitShot)]
         [ConflictingCombos(MCH_ST_SimpleMode)]
         [CustomComboInfo("Advanced Mode - Single Target", "Replaces Split Shot with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", MCH.JobID)]
         MCH_ST_AdvancedMode = 8100,
@@ -1579,7 +1579,7 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(MCH_ST_AdvancedMode)]
         [CustomComboInfo("Reassemble Option", "Adds Reassemble to the rotation.", MCH.JobID)]
-        MCH_ST_Adv_Reassembled = 8103,
+        MCH_ST_Adv_Reassemble = 8103,
 
         [ParentCombo(MCH_ST_AdvancedMode)]
         [CustomComboInfo("Gauss Round / Ricochet Option", "Adds Gauss Round and Ricochet to the rotation.\nWill prevent overcapping.", MCH.JobID)]
@@ -1639,7 +1639,7 @@ namespace XIVSlothCombo.Combos
 
         #region Advanced AoE
 
-        [ReplaceSkill(MCH.SpreadShot)]
+        [ReplaceSkill(MCH.SpreadShot, MCH.Scattergun)]
         [ConflictingCombos(MCH_AoE_SimpleMode)]
         [CustomComboInfo("Advanced Mode - AoE", "Replaces Spread Shot with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", MCH.JobID)]
         MCH_AoE_AdvancedMode = 8300,
@@ -1700,29 +1700,37 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Gauss Round/Ricochet Feature", "Replace Gauss Round and Ricochet with one or the other depending on which has more charges.", MCH.JobID)]
         MCH_GaussRoundRicochet = 8003,
 
-        [ReplaceSkill(MCH.Drill, MCH.AirAnchor, MCH.HotShot)]
+        [ReplaceSkill(MCH.Drill, MCH.AirAnchor, MCH.HotShot, MCH.ChainSaw)]
         [CustomComboInfo("Drill/Air Anchor (Hot Shot) Feature", "Replace Drill and Air Anchor (Hot Shot) with one or the other (or Chain Saw) depending on which is on cooldown.", MCH.JobID)]
         MCH_HotShotDrillChainSaw = 8004,
 
         [ReplaceSkill(MCH.HeatBlast)]
-        [CustomComboInfo("Single Button Heat Blast Feature", "Switches Heat Blast to Hypercharge.", MCH.JobID)]
-        MCH_HeatblastGaussRicochet = 8006,
+        [CustomComboInfo("Single Button Heat Blast Feature", "Turns Heat Blast into Hypercharge when at or above 50 heat.", MCH.JobID)]
+        MCH_Heatblast = 8006,
 
-        [ParentCombo(MCH_HeatblastGaussRicochet)]
-        [CustomComboInfo("Barrel Feature", "Adds Barrel Stabilizer to Single Button Heat Blast Feature when below 50 Heat Gauge and it is off cooldown", MCH.JobID)]
-        MCH_HeatblastGaussRicochet_AutoBarrel = 8052,
+        [ParentCombo(MCH_Heatblast)]
+        [CustomComboInfo("Barrel Option", "Adds Barrel Stabilizer to the feature when below 50 Heat Gauge.", MCH.JobID)]
+        MCH_Heatblast_AutoBarrel = 8052,
 
-        [ParentCombo(MCH_HeatblastGaussRicochet)]
-        [CustomComboInfo("Wildfire Option", "Adds Wildfire to the Single Button Heat Blast Feature if Wildfire is off cooldown and you have enough Heat Gauge for Hypercharge then Hypercharge will be replaced with Wildfire.\nAlso weaves Ricochet/Gauss Round on Heat Blast when necessary.", MCH.JobID)]
-        MCH_ST_Wildfire = 8015,
+        [ParentCombo(MCH_Heatblast)]
+        [CustomComboInfo("Wildfire Option", "Adds Wildfire to the feature when at or above 50 heat.", MCH.JobID)]
+        MCH_Heatblast_Wildfire = 8015,
+
+        [ParentCombo(MCH_Heatblast)]
+        [CustomComboInfo("Gauss Round / Ricochet Option", "Switches between Heat Blast and either Gauss Round or Ricochet, depending on cooldown timers.", MCH.JobID)]
+        MCH_Heatblast_GaussRound = 8016,
 
         [ReplaceSkill(MCH.AutoCrossbow)]
-        [CustomComboInfo("Single Button Auto Crossbow Feature", "Switches Auto Crossbow to Hypercharge and weaves Gauss Round/Ricochet.", MCH.JobID)]
-        MCH_AutoCrossbowGaussRicochet = 8018,
+        [CustomComboInfo("Single Button Auto Crossbow Feature", "Turns Auto Crossbow into Hypercharge when at or above 50 heat.", MCH.JobID)]
+        MCH_AutoCrossbow = 8018,
 
-        [ParentCombo(MCH_AutoCrossbowGaussRicochet)]
-        [CustomComboInfo("Barrel Feature", "Adds Barrel Stabilizer to Single Button Auto Crossbow Feature when below 50 Heat Gauge and it is off cooldown", MCH.JobID)]
-        MCH_AutoCrossbowGaussRicochet_AutoBarrel = 8019,
+        [ParentCombo(MCH_AutoCrossbow)]
+        [CustomComboInfo("Barrel Option", "Adds Barrel Stabilizer to the feature when below 50 Heat Gauge.", MCH.JobID)]
+        MCH_AutoCrossbow_AutoBarrel = 8019,
+
+        [ParentCombo(MCH_AutoCrossbow)]
+        [CustomComboInfo("Gauss Round / Ricochet Option", "Switches between Auto Crossbow and either Gauss Round or Ricochet, depending on cooldown timers.", MCH.JobID)]
+        MCH_AutoCrossbow_GaussRound = 8020,
 
         [ReplaceSkill(MCH.Dismantle)]
         [CustomComboInfo("Physical Ranged DPS: Double Dismantle Protection", "Prevents the use of Dismantle when target already has the effect by replacing it with Fire.", MCH.JobID)]

--- a/XIVSlothCombo/Combos/JobHelpers/MCH.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/MCH.cs
@@ -1,5 +1,6 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using ECommons.DalamudServices;
+using System.Windows.Forms;
 using XIVSlothCombo.Combos.JobHelpers.Enums;
 using XIVSlothCombo.Combos.PvE;
 using XIVSlothCombo.CustomComboNS.Functions;
@@ -141,8 +142,8 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     if (CustomComboFunctions.WasLastAction(HeatedSlugshot) && OpenerStep == 5) OpenerStep++;
                     else if (OpenerStep == 5) actionID = HeatedSlugshot;
 
-                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 6) OpenerStep++;
-                    else if (OpenerStep == 6) actionID = Ricochet;
+                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 6) OpenerStep++;
+                    else if (OpenerStep == 6) actionID = GaussRound;
 
                     if (CustomComboFunctions.WasLastAction(HeatedCleanShot) && OpenerStep == 7) OpenerStep++;
                     else if (OpenerStep == 7) actionID = HeatedCleanShot;
@@ -150,8 +151,8 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     if (CustomComboFunctions.WasLastAction(Reassemble) && OpenerStep == 8) OpenerStep++;
                     else if (OpenerStep == 8) actionID = Reassemble;
 
-                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 9) OpenerStep++;
-                    else if (OpenerStep == 9) actionID = GaussRound;
+                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 9) OpenerStep++;
+                    else if (OpenerStep == 9) actionID = Ricochet;
 
                     if (CustomComboFunctions.WasLastAction(AirAnchor) && OpenerStep == 10) OpenerStep++;
                     else if (OpenerStep == 10) actionID = AirAnchor;
@@ -174,26 +175,26 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     if (CustomComboFunctions.WasLastAction(HeatBlast) && CustomComboFunctions.GetBuffStacks(Buffs.Overheated) == 4 && OpenerStep == 16) OpenerStep++;
                     else if (OpenerStep == 16) actionID = HeatBlast;
 
-                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 17) OpenerStep++;
-                    else if (OpenerStep == 17) actionID = Ricochet;
+                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 17) OpenerStep++;
+                    else if (OpenerStep == 17) actionID = GaussRound;
 
                     if (CustomComboFunctions.WasLastAction(HeatBlast) && CustomComboFunctions.GetBuffStacks(Buffs.Overheated) == 3 && OpenerStep == 18) OpenerStep++;
                     else if (OpenerStep == 18) actionID = HeatBlast;
 
-                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 19) OpenerStep++;
-                    else if (OpenerStep == 19) actionID = GaussRound;
+                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 19) OpenerStep++;
+                    else if (OpenerStep == 19) actionID = Ricochet;
 
                     if (CustomComboFunctions.WasLastAction(HeatBlast) && CustomComboFunctions.GetBuffStacks(Buffs.Overheated) == 2 && OpenerStep == 20) OpenerStep++;
                     else if (OpenerStep == 20) actionID = HeatBlast;
 
-                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 21) OpenerStep++;
-                    else if (OpenerStep == 21) actionID = Ricochet;
+                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 21) OpenerStep++;
+                    else if (OpenerStep == 21) actionID = GaussRound;
 
                     if (CustomComboFunctions.WasLastAction(HeatBlast) && CustomComboFunctions.GetBuffStacks(Buffs.Overheated) == 1 && OpenerStep == 22) OpenerStep++;
                     else if (OpenerStep == 22) actionID = HeatBlast;
 
-                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 23) OpenerStep++;
-                    else if (OpenerStep == 23) actionID = GaussRound;
+                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 23) OpenerStep++;
+                    else if (OpenerStep == 23) actionID = Ricochet;
 
                     if (CustomComboFunctions.WasLastAction(HeatBlast) && CustomComboFunctions.GetBuffStacks(Buffs.Overheated) == 0 && OpenerStep == 24) OpenerStep++;
                     else if (OpenerStep == 24) actionID = HeatBlast;
@@ -314,11 +315,11 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     if (CustomComboFunctions.WasLastAction(AirAnchor) && OpenerStep == 1) OpenerStep++;
                     else if (OpenerStep == 1) actionID = AirAnchor;
 
-                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 2) OpenerStep++;
-                    else if (OpenerStep == 2) actionID = Ricochet;
+                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 2) OpenerStep++;
+                    else if (OpenerStep == 2) actionID = GaussRound;
 
-                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 3) OpenerStep++;
-                    else if (OpenerStep == 3) actionID = GaussRound;
+                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 3) OpenerStep++;
+                    else if (OpenerStep == 3) actionID = Ricochet;
 
                     if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 4) OpenerStep++;
                     else if (OpenerStep == 4) actionID = Drill;
@@ -332,23 +333,23 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     if (CustomComboFunctions.WasLastAction(ChainSaw) && OpenerStep == 7) OpenerStep++;
                     else if (OpenerStep == 7) actionID = ChainSaw;
 
-                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 8) OpenerStep++;
-                    else if (OpenerStep == 8) actionID = Ricochet;
+                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 8) OpenerStep++;
+                    else if (OpenerStep == 8) actionID = GaussRound;
 
-                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 9) OpenerStep++;
-                    else if (OpenerStep == 9) actionID = GaussRound;
+                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 9) OpenerStep++;
+                    else if (OpenerStep == 9) actionID = Ricochet;
 
                     if (CustomComboFunctions.WasLastAction(HeatedSplitShot) && OpenerStep == 10) OpenerStep++;
                     else if (OpenerStep == 10) actionID = HeatedSplitShot;
 
-                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 11) OpenerStep++;
-                    else if (OpenerStep == 11) actionID = Ricochet;
+                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 11) OpenerStep++;
+                    else if (OpenerStep == 11) actionID = GaussRound;
 
                     if (CustomComboFunctions.WasLastAction(HeatedSlugshot) && OpenerStep == 12) OpenerStep++;
                     else if (OpenerStep == 12) actionID = HeatedSlugshot;
 
-                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 13) OpenerStep++;
-                    else if (OpenerStep == 13) actionID = GaussRound;
+                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 13) OpenerStep++;
+                    else if (OpenerStep == 13) actionID = Ricochet;
 
                     if (CustomComboFunctions.WasLastAction(Wildfire) && OpenerStep == 14) OpenerStep++;
                     else if (OpenerStep == 14) actionID = Wildfire;
@@ -365,14 +366,14 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     if (CustomComboFunctions.WasLastAction(HeatBlast) && CustomComboFunctions.GetBuffStacks(Buffs.Overheated) == 4 && OpenerStep == 18) OpenerStep++;
                     else if (OpenerStep == 18) actionID = HeatBlast;
 
-                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 19) OpenerStep++;
-                    else if (OpenerStep == 19) actionID = Ricochet;
+                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 19) OpenerStep++;
+                    else if (OpenerStep == 19) actionID = GaussRound;
 
                     if (CustomComboFunctions.WasLastAction(HeatBlast) && CustomComboFunctions.GetBuffStacks(Buffs.Overheated) == 3 && OpenerStep == 20) OpenerStep++;
                     else if (OpenerStep == 20) actionID = HeatBlast;
 
-                    if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 21) OpenerStep++;
-                    else if (OpenerStep == 21) actionID = GaussRound;
+                    if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 21) OpenerStep++;
+                    else if (OpenerStep == 21) actionID = Ricochet;
 
                     if (CustomComboFunctions.WasLastAction(HeatBlast) && CustomComboFunctions.GetBuffStacks(Buffs.Overheated) == 2 && OpenerStep == 22) OpenerStep++;
                     else if (OpenerStep == 22) actionID = HeatBlast;
@@ -517,22 +518,23 @@ namespace XIVSlothCombo.Combos.JobHelpers
             OpenerStep = 0;
         }
 
-        public bool DoFullOpener(ref uint actionID, bool simpleMode)
+        public bool DoFullOpener(bool simpleMode, out uint openerId)
         {
+            openerId = 0;
             if (!LevelChecked) return false;
 
             if (CurrentState == OpenerState.PrePull)
-                if (DoPrePullSteps(ref actionID)) return true;
+                if (DoPrePullSteps(ref openerId)) return true;
 
             if (CurrentState == OpenerState.InOpener)
             {
                 if (simpleMode)
                 {
-                    if (DoOpenerSimple(ref actionID)) return true;
+                    if (DoOpenerSimple(ref openerId)) return true;
                 }
                 else
                 {
-                    if (DoOpener(ref actionID)) return true;
+                    if (DoOpener(ref openerId)) return true;
                 }
             }
 

--- a/XIVSlothCombo/Combos/PvE/MCH.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH.cs
@@ -41,7 +41,8 @@ namespace XIVSlothCombo.Combos.PvE
             BarrelStabilizer = 7414,
             Wildfire = 2878,
             Dismantle = 2887,
-            Flamethrower = 7418;
+            Flamethrower = 7418,
+            CrownCollider = 25787;
 
         internal static class Buffs
         {
@@ -56,7 +57,8 @@ namespace XIVSlothCombo.Combos.PvE
         internal static class Debuffs
         {
             internal const ushort
-            Dismantled = 2887;
+                Wildfire = 861,
+                Dismantled = 2887;
         }
 
         internal static class Config
@@ -67,7 +69,9 @@ namespace XIVSlothCombo.Combos.PvE
                 MCH_ST_RotationSelection = new("MCH_ST_RotationSelection"),
                 MCH_VariantCure = new("MCH_VariantCure"),
                 MCH_ST_TurretUsage = new("MCH_ST_Adv_TurretGauge"),
-                MCH_AoE_TurretUsage = new("MCH_AoE_TurretUsage");
+                MCH_AoE_TurretUsage = new("MCH_AoE_TurretUsage"),
+                MCH_ST_ReassemblePool = new("MCH_ST_ReassemblePool"),
+                MCH_AoE_ReassemblePool = new("MCH_AoE_ReassemblePool");
             public static UserBoolArray
                 MCH_ST_Reassembled = new("MCH_ST_Reassembled"),
                 MCH_AoE_Reassembled = new("MCH_AoE_Reassembled");
@@ -102,7 +106,6 @@ namespace XIVSlothCombo.Combos.PvE
                 ChainSaw = 90,
                 Dismantle = 62;
         }
-
         internal class MCH_ST_SimpleMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_ST_SimpleMode;
@@ -110,11 +113,11 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                MCHGauge? gauge = GetJobGauge<MCHGauge>();
                 float wildfireCDTime = GetCooldownRemainingTime(Wildfire);
+                MCHGauge? gauge = GetJobGauge<MCHGauge>();
                 bool interruptReady = ActionReady(All.HeadGraze) && CanInterruptEnemy();
 
-                if (actionID is SplitShot)
+                if (actionID is SplitShot or HeatedSplitShot)
                 {
                     if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
                     IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
@@ -127,148 +130,109 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantRampart;
 
                     // Opener for MCH
-                    if (MCHOpener.DoFullOpener(ref actionID, false))
-                        return actionID;
+                    if (MCHOpener.DoFullOpener(false, out var openerId))
+                        return openerId;
 
                     // Interrupt
                     if (interruptReady)
                         return All.HeadGraze;
 
                     // Wildfire
-                    if ((gauge.Heat >= 50 || WasLastAbility(Hypercharge)) && ActionReady(Wildfire)) //these try to ensure the correct loops
-                    {
-                        if (CanDelayedWeave(actionID))
-                        {
-                            if (!gauge.IsOverheated && WasLastWeaponskill(AirAnchor)) //WF EVEN BURST
-                                return Wildfire;
+                    if (gauge.Heat >= 50 && CanDelayedWeave(actionID) && ActionReady(Wildfire) && ActionReady(ChainSaw) &&
+                        !gauge.IsOverheated && WasLastWeaponskill(AirAnchor) && WasLastAction(Reassemble)) //these try to ensure the correct loops
+                        return Wildfire;
 
-                            else if (gauge.IsOverheated && WasLastWeaponskill(HeatBlast))
-                                return Wildfire;
-                        }
-                    }
+                    else if (gauge.Heat >= 50 && ActionReady(Wildfire))
+                        return Wildfire;
+
 
                     // BarrelStabilizer use
-                    if (CanWeave(actionID) && gauge.Heat <= 55 && ActionReady(BarrelStabilizer))
+                    if (CanWeave(actionID) && gauge.Heat <= 50 && ActionReady(BarrelStabilizer) && !gauge.IsOverheated)
                         return BarrelStabilizer;
 
                     //queen
-                    if (CanWeave(actionID) && !gauge.IsOverheated && LevelChecked(OriginalHook(RookAutoturret)) && !gauge.IsRobotActive)
+                    if (CanWeave(actionID) && !gauge.IsOverheated &&
+                        LevelChecked(OriginalHook(RookAutoturret)) && gauge.Battery > 0 && !TargetHasEffect(Debuffs.Wildfire))
                     {
-                        if (level >= 90)
-                        {
-                            // First condition
-                            if (gauge.Battery is 50 && CombatEngageDuration().TotalSeconds > 61 && CombatEngageDuration().TotalSeconds < 68)
-                                return OriginalHook(RookAutoturret);
+                        if (LevelChecked(ChainSaw) &&
+                            ((gauge.Battery is 50 && CombatEngageDuration().TotalSeconds > 59 && CombatEngageDuration().TotalSeconds < 68) || // First Minute Queen 
+                            (gauge.Battery is 100 && wildfireCDTime <= 7 && GetCooldownRemainingTime(AirAnchor) <= 3 && CombatEngageDuration().Minutes % 2 == 0) || // Even Minute Queen
+                            (gauge.Battery >= 80 && CombatEngageDuration().Minutes % 2 == 1 && wildfireCDTime > 45 && wildfireCDTime < 70))) // Odd minute Queen
+                            return OriginalHook(RookAutoturret);
 
-                            // Second condition
-                            if (gauge.Battery is 100 && gauge.LastSummonBatteryPower == 50 &&
-                                (GetCooldownRemainingTime(AirAnchor) <= 3 || ActionReady(AirAnchor)))
-                                return OriginalHook(RookAutoturret);
-
-                            // Third condition
-                            if (gauge.LastSummonBatteryPower == 100 && gauge.Battery >= 90)
-                                return OriginalHook(RookAutoturret);
-
-                            // Fourth condition
-                            else if (gauge.LastSummonBatteryPower == 90 && wildfireCDTime < 70 && wildfireCDTime > 45 && gauge.Battery >= 90)
-                                return OriginalHook(RookAutoturret);
-
-                            // Fifth condition
-                            else if (gauge.LastSummonBatteryPower != 50 && (wildfireCDTime <= 4 || (ActionReady(AirAnchor) && ActionReady(Wildfire))))
-                                return OriginalHook(RookAutoturret);
-                        }
-                        else if (LevelChecked(RookOverdrive) && gauge.Battery >= 50)
+                        else if (gauge.Battery is 100)
                             return OriginalHook(RookAutoturret);
                     }
 
                     if (CanWeave(actionID) && gauge.Heat >= 50 && LevelChecked(Hypercharge) && !gauge.IsOverheated)
                     {
                         //Protection & ensures Hyper charged is double weaved with WF during reopener
-                        if (HasEffect(Buffs.Wildfire) || !LevelChecked(Wildfire))
+                        if ((WasLastAction(ChainSaw) && HasEffect(Buffs.Wildfire)) ||
+                            (!LevelChecked(ChainSaw) && HasEffect(Buffs.Wildfire)) ||
+                            !LevelChecked(Wildfire))
                             return Hypercharge;
 
-                        if (LevelChecked(Drill) && GetCooldownRemainingTime(Drill) >= 8)
+                        if (LevelChecked(OriginalHook(AirAnchor)) && GetCooldownRemainingTime(OriginalHook(AirAnchor)) >= 8)
                         {
-                            if (LevelChecked(AirAnchor) && GetCooldownRemainingTime(AirAnchor) >= 8)
+                            if (LevelChecked(Drill) && GetCooldownRemainingTime(Drill) >= 8)
                             {
                                 if (LevelChecked(ChainSaw) && GetCooldownRemainingTime(ChainSaw) >= 8)
                                 {
-                                    if (UseHyperchargeStandard(gauge, wildfireCDTime))
+                                    if (UseSimpleTools(gauge, wildfireCDTime))
                                         return Hypercharge;
                                 }
 
                                 else if (!LevelChecked(ChainSaw))
                                 {
-                                    if (UseHyperchargeStandard(gauge, wildfireCDTime))
+                                    if (UseSimpleTools(gauge, wildfireCDTime))
                                         return Hypercharge;
                                 }
                             }
 
-                            else if (!LevelChecked(AirAnchor))
+                            else if (!LevelChecked(Drill))
                             {
-                                if (UseHyperchargeStandard(gauge, wildfireCDTime))
+                                if (UseSimpleTools(gauge, wildfireCDTime))
                                     return Hypercharge;
                             }
                         }
 
-                        else if (!LevelChecked(Drill))
+                        else if (!LevelChecked(OriginalHook(AirAnchor)))
                         {
-                            if (UseHyperchargeStandard(gauge, wildfireCDTime))
+                            if (UseSimpleTools(gauge, wildfireCDTime))
                                 return Hypercharge;
                         }
+
                     }
 
                     //Heatblast, Gauss, Rico
-                    if (gauge.IsOverheated && LevelChecked(HeatBlast))
+                    if (CanWeave(actionID) && WasLastAction(HeatBlast) && ActionWatching.GetAttackType(ActionWatching.LastAction) != ActionWatching.ActionAttackType.Ability)
                     {
-                        if (WasLastAction(HeatBlast) && CanWeave(actionID))
-                        {
-                            if (ActionReady(GaussRound) && GetRemainingCharges(GaussRound) >= GetRemainingCharges(Ricochet))
-                                return GaussRound;
-
-                            if (ActionReady(Ricochet) && GetRemainingCharges(Ricochet) >= GetRemainingCharges(GaussRound))
-                                return Ricochet;
-                        }
-                        return HeatBlast;
-                    }
-
-                    // OGCD's
-                    if (CanWeave(actionID) && !HasEffect(Buffs.Wildfire) &&
-                        !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) &&
-                        ((LevelChecked(ChainSaw) && GetCooldownRemainingTime(ChainSaw) < 1) || ActionReady(ChainSaw) ||
-                        (LevelChecked(AirAnchor) && GetCooldownRemainingTime(AirAnchor) < 1) || ActionReady(AirAnchor) ||
-                        (!LevelChecked(AirAnchor) && LevelChecked(Drill) && (GetCooldownRemainingTime(Drill) < 1)) || ActionReady(Drill)))
-                        return Reassemble;
-
-                    if (!HasEffect(Buffs.Wildfire) &&
-                        ((LevelChecked(ChainSaw) && GetCooldownRemainingTime(ChainSaw) < 1.2) || ActionReady(ChainSaw)) &&
-                        !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble))
-                        return Reassemble;
-
-                    if ((LevelChecked(ChainSaw) && GetCooldownRemainingTime(ChainSaw) < 1) || ActionReady(ChainSaw))
-                        return ChainSaw;
-
-                    if ((LevelChecked(AirAnchor) && GetCooldownRemainingTime(AirAnchor) < 1) ||
-                        (!LevelChecked(AirAnchor) && ActionReady(HotShot)) ||
-                        ActionReady(AirAnchor))
-                        return OriginalHook(AirAnchor);
-
-                    if ((LevelChecked(Drill) && GetCooldownRemainingTime(Drill) < 1) || ActionReady(Drill))
-                        return Drill;
-
-                    //gauss and ricochet overcap protection
-                    if (CanWeave(actionID) && !gauge.IsOverheated && !HasEffect(Buffs.Wildfire))
-                    {
-                        if (ActionReady(GaussRound) && GetRemainingCharges(GaussRound) >= GetMaxCharges(GaussRound))
+                        if (ActionReady(GaussRound) && GetRemainingCharges(GaussRound) >= GetRemainingCharges(Ricochet))
                             return GaussRound;
 
-                        if (ActionReady(Ricochet) && GetRemainingCharges(Ricochet) >= GetMaxCharges(Ricochet))
+                        if (ActionReady(Ricochet) && GetRemainingCharges(Ricochet) > GetRemainingCharges(GaussRound))
                             return Ricochet;
                     }
 
+                    if (gauge.IsOverheated && LevelChecked(HeatBlast))
+                        return HeatBlast;
+
+                    if (ReassembledTools(ref actionID))
+                        return actionID;
+
+
+                    //gauss and ricochet overcap protection
+                    if (CanWeave(actionID) && !gauge.IsOverheated && !HasEffect(Buffs.Wildfire) && ActionWatching.GetAttackType(ActionWatching.LastAction) != ActionWatching.ActionAttackType.Ability)
+                    {
+                        if (GetRemainingCharges(GaussRound) > 1 && LevelChecked(GaussRound))
+                            return GaussRound;
+
+                        if (GetRemainingCharges(Ricochet) > 1 && LevelChecked(Ricochet))
+                            return Ricochet;
+                    }
 
                     // healing
-                    if (CanWeave(actionID) && PlayerHealthPercentageHp() <= 20 && ActionReady(All.SecondWind))
+                    if (CanWeave(actionID, 0.6) && PlayerHealthPercentageHp() <= 20 && ActionReady(All.SecondWind))
                         return All.SecondWind;
 
                     //1-2-3 Combo
@@ -277,35 +241,75 @@ namespace XIVSlothCombo.Combos.PvE
                         if (lastComboMove is SplitShot && LevelChecked(OriginalHook(SlugShot)))
                             return OriginalHook(SlugShot);
 
-                        if (lastComboMove is SlugShot && LevelChecked(OriginalHook(CleanShot)))
-                            return (!LevelChecked(Drill) && !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble))
-                                ? Reassemble
-                                : OriginalHook(CleanShot);
-                    }
-                    return OriginalHook(SplitShot);
+                        if (!LevelChecked(Drill) && !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) && lastComboMove is SlugShot)
+                            return Reassemble;
 
+                        if (lastComboMove is SlugShot && LevelChecked(OriginalHook(CleanShot)))
+                            return OriginalHook(CleanShot);
+                    }
+
+                    return OriginalHook(SplitShot);
                 }
+
                 return actionID;
             }
 
-            private bool UseHyperchargeStandard(MCHGauge gauge, float wildfireCDTime)
+            private static bool ReassembledTools(ref uint actionId)
             {
-                // i really do not remember why i put > 70 here for heat, and im afraid if i remove it itll break it lol
-                if (CombatEngageDuration().Minutes == 0 &&
-                    (gauge.Heat > 70 || CombatEngageDuration().Seconds <= 30) && !WasLastWeaponskill(OriginalHook(CleanShot)))
+                // TOOLS!! ChainSaw Drill Air Anchor
+                if (!HasEffect(Buffs.Wildfire) && !WasLastWeaponskill(HeatBlast) &&
+                    !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) &&
+                    ((LevelChecked(ChainSaw) && GetCooldownRemainingTime(ChainSaw) < 1) || ActionReady(ChainSaw) ||
+                    (LevelChecked(AirAnchor) && GetCooldownRemainingTime(AirAnchor) < 1) || ActionReady(AirAnchor) ||
+                    (!LevelChecked(AirAnchor) && LevelChecked(Drill) && (GetCooldownRemainingTime(Drill) < 1)) || ActionReady(Drill)))
+                {
+                    actionId = Reassemble;
+                    return true;
+                }
+
+                if (ChainSaw.LevelChecked() &&
+                    (GetCooldownRemainingTime(ChainSaw) < 1 || ActionReady(ChainSaw)))
+                {
+                    actionId = ChainSaw;
+                    return true;
+                }
+
+                if (LevelChecked(OriginalHook(AirAnchor)) &&
+                    (GetCooldownRemainingTime(OriginalHook(AirAnchor)) < 1 || ActionReady(OriginalHook(AirAnchor))))
+                {
+                    actionId = OriginalHook(AirAnchor);
+                    return true;
+                }
+
+                if (Drill.LevelChecked() &&
+                    (GetCooldownRemainingTime(Drill) < 1 || ActionReady(Drill)))
+                {
+                    actionId = Drill;
+                    return true;
+                }
+
+                return false;
+            }
+
+            private bool UseSimpleTools(MCHGauge gauge, float wildfireCDTime)
+            {
+                if (CombatEngageDuration().Minutes == 0 && (gauge.Heat == 60 || CombatEngageDuration().Seconds <= 33))
                     return true;
 
                 if (CombatEngageDuration().Minutes > 0)
                 {
-                    if (CombatEngageDuration().Minutes % 2 == 1 && gauge.Heat >= 90)
+                    if (gauge.Heat >= 50 && wildfireCDTime > 25)
                         return true;
 
-                    if (CombatEngageDuration().Minutes % 2 == 0)
+                    if (gauge.Heat >= 50 && wildfireCDTime <= 25 && wildfireCDTime >= 1)
+                        return false;
+
+                    if (gauge.Heat >= 50)
                         return true;
                 }
+
                 return false;
             }
-
         }
 
         internal class MCH_ST_AdvancedMode : CustomCombo
@@ -320,7 +324,7 @@ namespace XIVSlothCombo.Combos.PvE
                 int rotationSelection = Config.MCH_ST_RotationSelection;
                 bool interruptReady = ActionReady(All.HeadGraze) && CanInterruptEnemy();
 
-                if (actionID is SplitShot)
+                if (actionID is SplitShot or HeatedSplitShot)
                 {
                     if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
                     IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
@@ -335,8 +339,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // Opener for MCH
                     if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener))
                     {
-                        if (MCHOpener.DoFullOpener(ref actionID, false))
-                            return actionID;
+                        if (MCHOpener.DoFullOpener(false, out var openerId))
+                            return openerId;
                     }
 
                     //Standard Rotation
@@ -349,67 +353,52 @@ namespace XIVSlothCombo.Combos.PvE
                         // Wildfire
                         if (IsEnabled(CustomComboPreset.MCH_ST_Adv_WildFire))
                         {
-                            if ((gauge.Heat >= 50 || WasLastAbility(Hypercharge)) && ActionReady(Wildfire) && level >= 90) //these try to ensure the correct loops
-                            {
-                                if (CanDelayedWeave(actionID))
-                                {
-                                    if (!gauge.IsOverheated && WasLastWeaponskill(AirAnchor)) //WF EVEN BURST
-                                        return Wildfire;
+                            if (gauge.Heat >= 50 && CanDelayedWeave(actionID) && ActionReady(Wildfire) && ActionReady(ChainSaw) &&
+                                !gauge.IsOverheated && WasLastWeaponskill(AirAnchor) && WasLastAction(Reassemble)) //these try to ensure the correct loops
+                                return Wildfire;
 
-                                    else if (gauge.IsOverheated && WasLastWeaponskill(HeatBlast))
-                                        return Wildfire;
-                                }
-                            }
                             else if (gauge.Heat >= 50 && ActionReady(Wildfire))
                                 return Wildfire;
                         }
 
                         // BarrelStabilizer use
                         if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Stabilizer) && CanWeave(actionID) &&
-                            gauge.Heat <= 55 && ActionReady(BarrelStabilizer) &&
-                            ((((wildfireCDTime <= 25 && wildfireCDTime >= 100) || HasEffect(Buffs.Wildfire)) && IsEnabled(CustomComboPreset.MCH_ST_Adv_Stabilizer_Wildfire_Only)) ||
-                            (wildfireCDTime >= 110 && !IsEnabled(CustomComboPreset.MCH_ST_Adv_Stabilizer_Wildfire_Only))))
+                            gauge.Heat <= 50 && ActionReady(BarrelStabilizer) && !gauge.IsOverheated)
                             return BarrelStabilizer;
 
                         //queen
-                        if (IsEnabled(CustomComboPreset.MCH_Adv_TurretQueen) && Config.MCH_ST_TurretUsage == 1 && CanWeave(actionID) && !gauge.IsOverheated && LevelChecked(OriginalHook(RookAutoturret)) && !gauge.IsRobotActive)
+                        if (IsEnabled(CustomComboPreset.MCH_Adv_TurretQueen) &&
+                            CanWeave(actionID) && !gauge.IsOverheated &&
+                            LevelChecked(OriginalHook(RookAutoturret)) && gauge.Battery > 0 && !TargetHasEffect(Debuffs.Wildfire))
                         {
-                            // First condition
-                            if (gauge.Battery is 50 && CombatEngageDuration().TotalSeconds > 59 && CombatEngageDuration().TotalSeconds < 68)
+                            if (Config.MCH_ST_TurretUsage == 0 && gauge.Battery >= 50)
                                 return OriginalHook(RookAutoturret);
 
-                            // Second condition
-                            if (gauge.Battery is 100 && gauge.LastSummonBatteryPower == 50 &&
-                                (GetCooldownRemainingTime(AirAnchor) <= 3 || ActionReady(AirAnchor)))
-                                return OriginalHook(RookAutoturret);
+                            if (Config.MCH_ST_TurretUsage == 1)
+                            {
+                                if (LevelChecked(ChainSaw) &&
+                                    ((gauge.Battery is 50 && CombatEngageDuration().TotalSeconds > 59 && CombatEngageDuration().TotalSeconds < 68) || // First Minute Queen 
+                                    (gauge.Battery is 100 && wildfireCDTime <= 7 && GetCooldownRemainingTime(AirAnchor) <= 3 && CombatEngageDuration().Minutes % 2 == 0) || // Even Minute Queen
+                                    (gauge.Battery >= 80 && CombatEngageDuration().Minutes % 2 == 1 && wildfireCDTime > 45 && wildfireCDTime < 70))) // Odd minute Queen
+                                    return OriginalHook(RookAutoturret);
 
-                            // Third condition
-                            if (gauge.LastSummonBatteryPower == 100 && gauge.Battery >= 90)
-                                return OriginalHook(RookAutoturret);
-
-                            // Fourth condition
-                            else if (gauge.LastSummonBatteryPower == 90 && wildfireCDTime < 70 && wildfireCDTime > 45 && gauge.Battery >= 90)
-                                return OriginalHook(RookAutoturret);
-
-                            // Fifth condition
-                            else if (gauge.LastSummonBatteryPower != 50 && (wildfireCDTime <= 4 || (ActionReady(AirAnchor) && ActionReady(Wildfire))))
-                                return OriginalHook(RookAutoturret);
+                                else if (gauge.Battery is 100)
+                                    return OriginalHook(RookAutoturret);
+                            }
                         }
-
-                        if (IsEnabled(CustomComboPreset.MCH_Adv_TurretQueen) && Config.MCH_ST_TurretUsage == 0 && CanWeave(actionID) && LevelChecked(OriginalHook(RookAutoturret)) &&
-                            gauge.Battery >= 50)
-                            return OriginalHook(RookAutoturret);
 
                         if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Hypercharge) &&
                                 CanWeave(actionID) && gauge.Heat >= 50 && LevelChecked(Hypercharge) && !gauge.IsOverheated)
                         {
                             //Protection & ensures Hyper charged is double weaved with WF during reopener
-                            if (HasEffect(Buffs.Wildfire) || !LevelChecked(Wildfire))
+                            if ((WasLastAction(ChainSaw) && HasEffect(Buffs.Wildfire)) ||
+                                (!LevelChecked(ChainSaw) && HasEffect(Buffs.Wildfire)) ||
+                                !LevelChecked(Wildfire))
                                 return Hypercharge;
 
-                            if (LevelChecked(Drill) && GetCooldownRemainingTime(Drill) >= 8)
+                            if (LevelChecked(OriginalHook(AirAnchor)) && GetCooldownRemainingTime(OriginalHook(AirAnchor)) >= 8)
                             {
-                                if (LevelChecked(AirAnchor) && GetCooldownRemainingTime(AirAnchor) >= 8)
+                                if (LevelChecked(Drill) && GetCooldownRemainingTime(Drill) >= 8)
                                 {
                                     if (LevelChecked(ChainSaw) && GetCooldownRemainingTime(ChainSaw) >= 8)
                                     {
@@ -424,51 +413,38 @@ namespace XIVSlothCombo.Combos.PvE
                                     }
                                 }
 
-                                else if (!LevelChecked(AirAnchor))
+                                else if (!LevelChecked(Drill))
                                 {
                                     if (UseHyperchargeDelayedTools(gauge, wildfireCDTime))
                                         return Hypercharge;
                                 }
                             }
 
-                            else if (!LevelChecked(Drill))
+                            else if (!LevelChecked(OriginalHook(AirAnchor)))
                             {
                                 if (UseHyperchargeDelayedTools(gauge, wildfireCDTime))
                                     return Hypercharge;
                             }
+
                         }
 
                         //Heatblast, Gauss, Rico
-                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
-                            gauge.IsOverheated && LevelChecked(HeatBlast))
+                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) && CanWeave(actionID) && WasLastAction(HeatBlast) &&
+                            ActionWatching.GetAttackType(ActionWatching.LastAction) != ActionWatching.ActionAttackType.Ability)
                         {
-                            if (CanWeave(actionID))
-                            {
-                                if (GetRemainingCharges(GaussRound) >= GetRemainingCharges(Ricochet) && WasLastAction(HeatBlast))
-                                    return GaussRound;
+                            if (ActionReady(GaussRound) && GetRemainingCharges(GaussRound) >= GetRemainingCharges(Ricochet))
+                                return GaussRound;
 
-                                if (GetRemainingCharges(Ricochet) >= GetRemainingCharges(GaussRound) && WasLastAction(HeatBlast))
-                                    return Ricochet;
-                            }
-
-                            if (IsEnabled(CustomComboPreset.MCH_ST_Adv_HeatBlast))
-                                return HeatBlast;
+                            if (ActionReady(Ricochet) && GetRemainingCharges(Ricochet) > GetRemainingCharges(GaussRound))
+                                return Ricochet;
                         }
+
+                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_HeatBlast) &&
+                            gauge.IsOverheated && LevelChecked(HeatBlast))
+                            return HeatBlast;
 
                         if (ReassembledTools(ref actionID))
                             return actionID;
-
-                        //gauss and ricochet overcap protection
-                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
-                            CanWeave(actionID) && !gauge.IsOverheated && !HasEffect(Buffs.Wildfire))
-                        {
-                            if (HasCharges(GaussRound) && (!LevelChecked(Ricochet) ||
-                                GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
-                                return GaussRound;
-
-                            else if (ActionReady(Ricochet))
-                                return Ricochet;
-                        }
                     }
 
                     //123Tools Rotation
@@ -577,21 +553,8 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-
                         if (ReassembledTools(ref actionID))
                             return actionID;
-
-                        //gauss and ricochet overcap protection
-                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
-                            CanWeave(actionID) && !gauge.IsOverheated && !HasEffect(Buffs.Wildfire))
-                        {
-                            if (HasCharges(GaussRound) && (!LevelChecked(Ricochet) ||
-                                GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
-                                return GaussRound;
-
-                            else if (ActionReady(Ricochet))
-                                return Ricochet;
-                        }
                     }
 
                     //Early Tools Rotation
@@ -706,15 +669,18 @@ namespace XIVSlothCombo.Combos.PvE
                         if (ReassembledTools(ref actionID))
                             return actionID;
 
-                        //gauss and ricochet overcap protection
-                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
-                            CanWeave(actionID) && !gauge.IsOverheated && !HasEffect(Buffs.Wildfire))
-                        {
-                            if (HasCharges(GaussRound) && (level < Levels.Ricochet || GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet)))
-                                return GaussRound;
-                            else if (HasCharges(Ricochet) && level >= Levels.Ricochet)
-                                return Ricochet;
-                        }
+                    }
+
+                    //gauss and ricochet overcap protection
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_GaussRicochet) &&
+                        CanWeave(actionID) && !gauge.IsOverheated && !HasEffect(Buffs.Wildfire) &&
+                        ActionWatching.GetAttackType(ActionWatching.LastAction) != ActionWatching.ActionAttackType.Ability)
+                    {
+                        if (GetRemainingCharges(GaussRound) > 1 && LevelChecked(GaussRound))
+                            return GaussRound;
+
+                        if (GetRemainingCharges(Ricochet) > 1 && LevelChecked(Ricochet))
+                            return Ricochet;
                     }
 
                     // healing
@@ -728,6 +694,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (lastComboMove is SplitShot && LevelChecked(OriginalHook(SlugShot)))
                             return OriginalHook(SlugShot);
 
+                        if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && Config.MCH_ST_Reassembled[3] &&
+                            !LevelChecked(Drill) && !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) && lastComboMove is SlugShot)
+                            return Reassemble;
+
                         if (lastComboMove is SlugShot && LevelChecked(OriginalHook(CleanShot)))
                             return OriginalHook(CleanShot);
                     }
@@ -738,18 +708,19 @@ namespace XIVSlothCombo.Combos.PvE
                 return actionID;
             }
 
-            private bool ReassembledTools(ref uint actionId)
+            private static bool ReassembledTools(ref uint actionId)
             {
-                bool reassembledAnchor = (Config.MCH_ST_Reassembled[0] && HasEffect(Buffs.Reassembled)) || (!Config.MCH_ST_Reassembled[0] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) == 0);
-                bool reassembledDrill = (Config.MCH_ST_Reassembled[1] && HasEffect(Buffs.Reassembled)) || (!Config.MCH_ST_Reassembled[1] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) == 0);
-                bool reassembledChainsaw = (Config.MCH_ST_Reassembled[2] && HasEffect(Buffs.Reassembled)) || (!Config.MCH_ST_Reassembled[2] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) == 0);
+                bool reassembledAnchor = (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && Config.MCH_ST_Reassembled[0] && (HasEffect(Buffs.Reassembled) || !HasEffect(Buffs.Reassembled))) || (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && !Config.MCH_ST_Reassembled[0] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_ST_ReassemblePool) || (!IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble));
+                bool reassembledDrill = (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && Config.MCH_ST_Reassembled[1] && (HasEffect(Buffs.Reassembled) || !HasEffect(Buffs.Reassembled))) || (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && !Config.MCH_ST_Reassembled[1] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_ST_ReassemblePool) || (!IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble));
+                bool reassembledChainsaw = (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && Config.MCH_ST_Reassembled[2] && (HasEffect(Buffs.Reassembled) || !HasEffect(Buffs.Reassembled))) || (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && !Config.MCH_ST_Reassembled[2] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_ST_ReassemblePool) || (!IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble));
 
                 // TOOLS!! ChainSaw Drill Air Anchor
-                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassembled) && !HasEffect(Buffs.Wildfire) &&
+                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Reassemble) && !HasEffect(Buffs.Wildfire) && !WasLastWeaponskill(HeatBlast) &&
                     !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) &&
-                    ((GetCooldownRemainingTime(OriginalHook(HotShot)) < 1 && Config.MCH_ST_Reassembled[0] && AirAnchor.LevelChecked()) ||
-                    (GetCooldownRemainingTime(OriginalHook(Drill)) < 1 && Config.MCH_ST_Reassembled[1] && Drill.LevelChecked()) ||
-                    (GetCooldownRemainingTime(OriginalHook(ChainSaw)) < 1 && Config.MCH_ST_Reassembled[2]) && ChainSaw.LevelChecked()))
+                    GetRemainingCharges(Reassemble) > Config.MCH_ST_ReassemblePool &&
+                    ((GetCooldownRemainingTime(AirAnchor) < 1 && Config.MCH_ST_Reassembled[0] && AirAnchor.LevelChecked()) ||
+                    (GetCooldownRemainingTime(OriginalHook(Drill)) < 1 && Config.MCH_ST_Reassembled[1] && Drill.LevelChecked() && !LevelChecked(AirAnchor)) ||
+                    (GetCooldownRemainingTime(OriginalHook(ChainSaw)) < 1 && Config.MCH_ST_Reassembled[2] && ChainSaw.LevelChecked())))
                 {
                     actionId = Reassemble;
                     return true;
@@ -764,20 +735,21 @@ namespace XIVSlothCombo.Combos.PvE
                     return true;
                 }
 
+                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_AirAnchor) &&
+                    reassembledAnchor &&
+                    LevelChecked(OriginalHook(AirAnchor)) &&
+                    (GetCooldownRemainingTime(OriginalHook(AirAnchor)) < 1 || ActionReady(OriginalHook(AirAnchor))))
+                {
+                    actionId = OriginalHook(AirAnchor);
+                    return true;
+                }
+
                 if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Drill) &&
                     reassembledDrill &&
                     Drill.LevelChecked() &&
                     (GetCooldownRemainingTime(Drill) < 1 || ActionReady(Drill)))
                 {
                     actionId = Drill;
-                    return true;
-                }
-                if (IsEnabled(CustomComboPreset.MCH_ST_Adv_AirAnchor) &&
-                    reassembledAnchor && 
-                    OriginalHook(AirAnchor).LevelChecked() &&
-                    (GetCooldownRemainingTime(OriginalHook(AirAnchor)) < 1 || ActionReady(OriginalHook(AirAnchor))))
-                {
-                    actionId = OriginalHook(AirAnchor);
                     return true;
                 }
 
@@ -791,15 +763,16 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (CombatEngageDuration().Minutes > 0)
                 {
-                    if (gauge.Heat >= 50 && wildfireCDTime >= 104)
+                    if (gauge.Heat >= 50 && wildfireCDTime > 25)
                         return true;
 
-                    if (gauge.Heat >= 50 && wildfireCDTime <= 33 && wildfireCDTime >= 1)
+                    if (gauge.Heat >= 50 && wildfireCDTime <= 25 && wildfireCDTime >= 1)
                         return false;
 
-                    if (gauge.Heat >= 55)
+                    if (gauge.Heat >= 50)
                         return true;
                 }
+
                 return false;
             }
 
@@ -876,7 +849,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //gauss and ricochet overcap protection
                     if (CanWeave(actionID) && !gauge.IsOverheated)
                     {
-                        if (ActionReady(GaussRound)&& GetRemainingCharges(GaussRound) >= GetMaxCharges(GaussRound))
+                        if (ActionReady(GaussRound) && GetRemainingCharges(GaussRound) >= GetMaxCharges(GaussRound))
                             return GaussRound;
 
                         if (ActionReady(Ricochet) && GetRemainingCharges(Ricochet) >= GetMaxCharges(Ricochet))
@@ -918,12 +891,12 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is SpreadShot)
+                if (actionID is SpreadShot or Scattergun)
                 {
                     MCHGauge? gauge = GetJobGauge<MCHGauge>();
-                    bool reassembledScattergun = (Config.MCH_AoE_Reassembled[0] && HasEffect(Buffs.Reassembled));
-                    bool reassembledCrossbow = (Config.MCH_AoE_Reassembled[1] && HasEffect(Buffs.Reassembled)) || (!Config.MCH_AoE_Reassembled[1] && !HasEffect(Buffs.Reassembled));
-                    bool reassembledChainsaw = (Config.MCH_AoE_Reassembled[2] && HasEffect(Buffs.Reassembled)) || (!Config.MCH_AoE_Reassembled[2] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) == 0);
+                    bool reassembledScattergun = IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled[0] && HasEffect(Buffs.Reassembled);
+                    bool reassembledCrossbow = (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled[1] && HasEffect(Buffs.Reassembled)) || (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled[1] && !HasEffect(Buffs.Reassembled)) || (!IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble));
+                    bool reassembledChainsaw = (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled[2] && HasEffect(Buffs.Reassembled)) || (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled[2] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_AoE_ReassemblePool) || (!IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble));
 
 
                     if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
@@ -941,6 +914,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !HasEffect(Buffs.Wildfire) &&
                         !HasEffect(Buffs.Reassembled) && HasCharges(Reassemble) &&
+                        GetRemainingCharges(Reassemble) > Config.MCH_AoE_ReassemblePool &&
                         ((Config.MCH_AoE_Reassembled[0] && Scattergun.LevelChecked()) ||
                         (gauge.IsOverheated && Config.MCH_AoE_Reassembled[1] && AutoCrossbow.LevelChecked()) ||
                         (GetCooldownRemainingTime(OriginalHook(ChainSaw)) < 1 && Config.MCH_AoE_Reassembled[2] && ChainSaw.LevelChecked())))
@@ -984,12 +958,14 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if ((WasLastAction(SpreadShot) || WasLastAction(AutoCrossbow) || Config.MCH_AoE_Hypercharge) && ActionWatching.GetAttackType(ActionWatching.LastAction) != ActionWatching.ActionAttackType.Ability)
                         {
-                            if (GetRemainingCharges(Ricochet) > 0)
+                            if (ActionReady(Ricochet) && GetRemainingCharges(Ricochet) > 0)
                                 return Ricochet;
 
-                            if (GetRemainingCharges(GaussRound) > 0)
+                            if (ActionReady(Ricochet) && GetRemainingCharges(GaussRound) > 0)
                                 return GaussRound;
 
+                            if (LevelChecked(Ricochet) && GetRemainingCharges(Ricochet) > GetRemainingCharges(GaussRound))
+                                return Ricochet;
                         }
                     }
 
@@ -1009,37 +985,41 @@ namespace XIVSlothCombo.Combos.PvE
 
         internal class MCH_HeatblastGaussRicochet : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_HeatblastGaussRicochet;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_Heatblast;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 MCHGauge? gauge = GetJobGauge<MCHGauge>();
+
                 if (actionID is HeatBlast)
                 {
-                    if (IsEnabled(CustomComboPreset.MCH_AutoCrossbowGaussRicochet_AutoBarrel)
-                        && ActionReady(BarrelStabilizer)
-                        && gauge.Heat < 50
-                        && !HasEffect(Buffs.Overheated))
+                    if (IsEnabled(CustomComboPreset.MCH_Heatblast_AutoBarrel) &&
+                        ActionReady(BarrelStabilizer) &&
+                        gauge.Heat < 50 &&
+                        !gauge.IsOverheated)
                         return BarrelStabilizer;
 
-                    if (IsEnabled(CustomComboPreset.MCH_ST_Wildfire)
-                        && ActionReady(Hypercharge)
-                        && ActionReady(Wildfire)
-                        && gauge.Heat >= 50)
+                    if (IsEnabled(CustomComboPreset.MCH_Heatblast_Wildfire) &&
+                        ActionReady(Hypercharge) &&
+                        ActionReady(Wildfire) &&
+                        gauge.Heat >= 50)
                         return Wildfire;
 
-                    if (!HasEffect(Buffs.Overheated) && LevelChecked(Hypercharge))
+                    if (!gauge.IsOverheated && LevelChecked(Hypercharge) && gauge.Heat >= 50)
                         return Hypercharge;
 
                     if (GetCooldownRemainingTime(HeatBlast) < 0.7 && LevelChecked(HeatBlast)) // Prioritize Heat Blast
                         return HeatBlast;
 
-                    if (!LevelChecked(Ricochet))
-                        return GaussRound;
+                    if (IsEnabled(CustomComboPreset.MCH_Heatblast_GaussRound) && gauge.IsOverheated)
+                    {
+                        if (!LevelChecked(Ricochet))
+                            return GaussRound;
 
-                    if (GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet))
-                        return GaussRound;
-                    return Ricochet;
+                        if (GetCooldownRemainingTime(GaussRound) < GetCooldownRemainingTime(Ricochet))
+                            return GaussRound;
+                        return Ricochet;
+                    }
                 }
                 return actionID;
             }
@@ -1053,7 +1033,6 @@ namespace XIVSlothCombo.Combos.PvE
             {
 
                 if (actionID is GaussRound or Ricochet)
-
                 {
                     var gaussCharges = GetRemainingCharges(GaussRound);
                     var ricochetCharges = GetRemainingCharges(Ricochet);
@@ -1063,13 +1042,9 @@ namespace XIVSlothCombo.Combos.PvE
                     if (!LevelChecked(Ricochet))
                         return GaussRound;
 
-                    if (IsOffCooldown(GaussRound) && IsOffCooldown(Ricochet))
-                        return actionID;
-
-                    if ((gaussCharges >= ricochetCharges || level < Levels.Ricochet) &&
-                        level >= Levels.GaussRound)
+                    if (gaussCharges >= ricochetCharges)
                         return GaussRound;
-                    else if (ricochetCharges > 0 && level >= Levels.Ricochet)
+                    else if (ricochetCharges > 0)
                         return Ricochet;
                 }
 
@@ -1100,7 +1075,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID == Drill || actionID == HotShot || actionID == AirAnchor)
+                if (actionID is Drill || actionID is HotShot || actionID is AirAnchor || actionID is ChainSaw)
                 {
                     if (LevelChecked(ChainSaw))
                         return CalcBestAction(actionID, ChainSaw, AirAnchor, Drill);
@@ -1135,7 +1110,7 @@ namespace XIVSlothCombo.Combos.PvE
 
         internal class MCH_AutoCrossbowGaussRicochet : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_AutoCrossbowGaussRicochet;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_AutoCrossbow;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -1146,22 +1121,27 @@ namespace XIVSlothCombo.Combos.PvE
                     var ricochetCD = GetCooldown(Ricochet);
                     MCHGauge? gauge = GetJobGauge<MCHGauge>();
 
-                    if (IsEnabled(CustomComboPreset.MCH_AutoCrossbowGaussRicochet_AutoBarrel)
-                        && ActionReady(BarrelStabilizer)
-                        && gauge.Heat < 50
-                        && !HasEffect(Buffs.Overheated)
-                       ) return BarrelStabilizer;
+                    if (IsEnabled(CustomComboPreset.MCH_AutoCrossbow_AutoBarrel) &&
+                        ActionReady(BarrelStabilizer) &&
+                        gauge.Heat < 50 &&
+                        !gauge.IsOverheated)
+                        return BarrelStabilizer;
 
-                    if (!HasEffect(Buffs.Overheated) && ActionReady(Hypercharge))
+                    if (!gauge.IsOverheated && ActionReady(Hypercharge) && gauge.Heat >= 50)
                         return Hypercharge;
+
                     if (heatBlastCD.CooldownRemaining < 0.7 && LevelChecked(AutoCrossbow)) // prioritize autocrossbow
                         return AutoCrossbow;
-                    if (!LevelChecked(Ricochet))
-                        return GaussRound;
-                    if (gaussCD.CooldownRemaining < ricochetCD.CooldownRemaining)
-                        return GaussRound;
-                    else
-                        return Ricochet;
+
+                    if (IsEnabled(CustomComboPreset.MCH_AutoCrossbow_GaussRound) && gauge.IsOverheated)
+                    {
+                        if (!LevelChecked(Ricochet))
+                            return GaussRound;
+                        if (gaussCD.CooldownRemaining < ricochetCD.CooldownRemaining)
+                            return GaussRound;
+                        else
+                            return Ricochet;
+                    }
                 }
 
                 return actionID;
@@ -1178,7 +1158,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Dismantle)
                     if (TargetHasEffectAny(Debuffs.Dismantled) && IsOffCooldown(Dismantle))
-                        return BLM.Fire;
+                        return OriginalHook(11);
 
                 return actionID;
             }

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1541,11 +1541,18 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawHorizontalRadioButton(MCH.Config.MCH_ST_TurretUsage, "Dynamic Use", "Used at different values depending on current state, as per the Balance guidance.", 1);
             }
 
-            if (preset is CustomComboPreset.MCH_ST_Adv_Reassembled)
+            if (preset == CustomComboPreset.MCH_ST_Adv_Reassemble)
+                UserConfig.DrawSliderInt(0, 1, MCH.Config.MCH_ST_ReassemblePool, "Number of Charges to Save for Manual Use");
+
+            if (preset == CustomComboPreset.MCH_AoE_Adv_Reassemble)
+                UserConfig.DrawSliderInt(0, 1, MCH.Config.MCH_AoE_ReassemblePool, "Number of Charges to Save for Manual Use");
+
+            if (preset is CustomComboPreset.MCH_ST_Adv_Reassemble)
             {
-                UserConfig.DrawHorizontalMultiChoice(MCH.Config.MCH_ST_Reassembled, $"Use on {ActionWatching.GetActionName(MCH.HotShot)}/{ActionWatching.GetActionName(MCH.AirAnchor)}", "", 3, 0);
-                UserConfig.DrawHorizontalMultiChoice(MCH.Config.MCH_ST_Reassembled, $"Use on {ActionWatching.GetActionName(MCH.Drill)}", "", 3, 1);
-                UserConfig.DrawHorizontalMultiChoice(MCH.Config.MCH_ST_Reassembled, $"Use on {ActionWatching.GetActionName(MCH.ChainSaw)}", "", 3, 2);
+                UserConfig.DrawHorizontalMultiChoice(MCH.Config.MCH_ST_Reassembled, $"Use on {ActionWatching.GetActionName(MCH.HotShot)}/{ActionWatching.GetActionName(MCH.AirAnchor)}", "", 4, 0);
+                UserConfig.DrawHorizontalMultiChoice(MCH.Config.MCH_ST_Reassembled, $"Use on {ActionWatching.GetActionName(MCH.Drill)}", "", 4, 1);
+                UserConfig.DrawHorizontalMultiChoice(MCH.Config.MCH_ST_Reassembled, $"Use on {ActionWatching.GetActionName(MCH.ChainSaw)}", "", 4, 2);
+                UserConfig.DrawHorizontalMultiChoice(MCH.Config.MCH_ST_Reassembled, $"Use on {ActionWatching.GetActionName(MCH.CleanShot)}", "", 4, 3);
             }
 
             if (preset is CustomComboPreset.MCH_AoE_Adv_Reassemble)
@@ -1566,6 +1573,9 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.MCH_AoE_Adv_GaussRicochet)
                 UserConfig.DrawAdditionalBoolChoice(MCH.Config.MCH_AoE_Hypercharge, $"Use Outwith {ActionWatching.GetActionName(MCH.Hypercharge)}", "");
+
+            if (preset == CustomComboPreset.MCH_Variant_Cure)
+                UserConfig.DrawSliderInt(1, 100, MCH.Config.MCH_VariantCure, "HP% to be at or under", 200);
 
             #endregion
             // ====================================================================================


### PR DESCRIPTION
- update SimpleMode to be same as Advanced Standard rotation
- optimize :
-- queen timings to work for low lvl and high lvl
-- gauss/ricochet usage
-- wildfire usage
-- hypercharge usage
-- reassemble usage ( added clean shot as option + updated the use of when it would go off automatically) 