### PR TITLE
Force LifeSurge to only be used on 5th Combo GCD

### DIFF
--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -315,7 +315,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.DRG_ST_LifeSurge) && ActionReady(LifeSurge) && AnimationLock.CanDRGWeave(LifeSurge) && !HasEffect(Buffs.LifeSurge) &&
                                 ((HasEffect(Buffs.RightEye) && HasEffect(Buffs.LanceCharge) && lastComboMove is VorpalThrust) ||
                                 (HasEffect(Buffs.LanceCharge) && lastComboMove is VorpalThrust) ||
-                                (HasEffect(Buffs.RightEye) && HasEffect(Buffs.LanceCharge) && (HasEffect(Buffs.EnhancedWheelingThrust) || HasEffect(Buffs.SharperFangAndClaw))) ||
+                                (HasEffect(Buffs.RightEye) && HasEffect(Buffs.LanceCharge) && HasEffect(Buffs.EnhancedWheelingThrust) && lastComboMove is FangAndClaw || HasEffect(Buffs.SharperFangAndClaw) && lastComboMove is WheelingThrust)) ||
                                 (IsOnCooldown(DragonSight) && IsOnCooldown(LanceCharge) && lastComboMove is VorpalThrust)))
                                 return LifeSurge;
 

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -315,7 +315,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.DRG_ST_LifeSurge) && ActionReady(LifeSurge) && AnimationLock.CanDRGWeave(LifeSurge) && !HasEffect(Buffs.LifeSurge) &&
                                 ((HasEffect(Buffs.RightEye) && HasEffect(Buffs.LanceCharge) && lastComboMove is VorpalThrust) ||
                                 (HasEffect(Buffs.LanceCharge) && lastComboMove is VorpalThrust) ||
-                                (HasEffect(Buffs.RightEye) && HasEffect(Buffs.LanceCharge) && HasEffect(Buffs.EnhancedWheelingThrust) && lastComboMove is FangAndClaw || HasEffect(Buffs.SharperFangAndClaw) && lastComboMove is WheelingThrust)) ||
+                                (HasEffect(Buffs.RightEye) && HasEffect(Buffs.LanceCharge) && HasEffect(Buffs.EnhancedWheelingThrust) && lastComboMove is FangAndClaw || (HasEffect(Buffs.SharperFangAndClaw) && lastComboMove is WheelingThrust))) ||
                                 (IsOnCooldown(DragonSight) && IsOnCooldown(LanceCharge) && lastComboMove is VorpalThrust)))
                                 return LifeSurge;
 

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -152,7 +152,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (!HasEffect(Buffs.LifeSurge) && HasCharges(LifeSurge) && AnimationLock.CanDRGWeave(LifeSurge) &&
                             ((HasEffect(Buffs.RightEye) && HasEffect(Buffs.LanceCharge) && lastComboMove is VorpalThrust) ||
                             (HasEffect(Buffs.LanceCharge) && lastComboMove is VorpalThrust) ||
-                            (HasEffect(Buffs.RightEye) && HasEffect(Buffs.LanceCharge) && (HasEffect(Buffs.EnhancedWheelingThrust) || HasEffect(Buffs.SharperFangAndClaw))) ||
+                            (HasEffect(Buffs.RightEye) && HasEffect(Buffs.LanceCharge) && (HasEffect(Buffs.EnhancedWheelingThrust) && lastComboMove is FangAndClaw || HasEffect(Buffs.SharperFangAndClaw) and lastComboMove is WheelingThrust)) ||
                             (IsOnCooldown(DragonSight) && IsOnCooldown(LanceCharge) && lastComboMove is VorpalThrust)))
                             return LifeSurge;
 


### PR DESCRIPTION
The 5th combo GCD in a Dragoon's rotation has 100 more Potency due to the Trait "Lance Mastery I".

While using Sloth I've noticed that outside of the Opener, it will use Life Surge on the 4th GCD instead of the 5th. Resulting in a huge Potency Loss overtime.

I added an extra check to DRG.cs that only uses LifeSurge on a positional if a positional has been done beforehand. 
  
Please review, I'm tired and I'm not sure if I placed all the ( ) correctly. :P 

