### PR TITLE
Fix Egi summons always being blocked by Demi.

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -641,7 +641,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Egi Order
-                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder))
+                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder) && gauge.SummonTimerRemaining == 0)
                     {
                         if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
                             return OriginalHook(SummonRuby);

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -641,7 +641,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Egi Order
-                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder) && gauge.SummonTimerRemaining == 0 && IsOnCooldown(SummonPhoenix) && IsOnCooldown(SummonBahamut))
+                    if (IsEnabled(CustomComboPreset.SMN_DemiEgiMenu_EgiOrder))
                     {
                         if (gauge.IsIfritReady && !gauge.IsTitanReady && !gauge.IsGarudaReady && LevelChecked(SummonRuby))
                             return OriginalHook(SummonRuby);


### PR DESCRIPTION
Since the Egi summon is so low in the tree, the check for Demi summons being off cooldown isn't necessary and prevents players who choose not to add demi summons to the combo from summoning an egi when a demi is off cooldown.

This fixes https://github.com/Nik-Potokar/XIVSlothCombo/issues/1385