### PR TITLE
PLD: more dawntrail adjustments

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2211,7 +2211,7 @@ namespace XIVSlothCombo.Combos
 
         #region PALADIN
 
-        //// Last value = 11032
+        //// Last value = 11034
 
         [ConflictingCombos(PLD_ST_AdvancedMode)]
         [ReplaceSkill(PLD.FastBlade)]
@@ -2276,6 +2276,10 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Blades of Faith/Truth/Valor Option", "Adds Blades of Faith/Truth/Valor to Advanced Mode", PLD.JobID)]
         PLD_ST_AdvancedMode_Blades = 11014,
 
+        [ParentCombo(PLD_ST_AdvancedMode)]
+        [CustomComboInfo("Blades of Honor Option", "Adds Blades of Honor to Advanced Mode after Valor", PLD.JobID)]
+        PLD_ST_AdvancedMode_BladesOfHonor = 11033,
+
         [ConflictingCombos(PLD_AoE_SimpleMode)]
         [ReplaceSkill(PLD.TotalEclipse)]
         [CustomComboInfo("Advanced Mode - AoE", $"Replaces Total Eclipse with a one-button full AoE rotation.\nThese features are ideal if you want to customize the rotation.", PLD.JobID)]
@@ -2310,6 +2314,10 @@ namespace XIVSlothCombo.Combos
         PLD_AoE_AdvancedMode_Blades = 11022,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
+        [CustomComboInfo("Blades of Honor Option", "Adds Blades of Honor to Advanced Mode after Valor", PLD.JobID)]
+        PLD_AoE_AdvancedMode_BladesOfHonor = 11034,
+
+        [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Sheltron / Holy Sheltron Option", "Adds Sheltron / Holy Sheltron to Advanced Mode", PLD.JobID)]
         PLD_AoE_AdvancedMode_Sheltron = 11023,
 
@@ -2337,7 +2345,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Ultimatum Option", "Use Variant Ultimatum on cooldown.", PLD.JobID)]
         PLD_Variant_Ultimatum = 11032,
 
-        //// Last value = 11032
+        //// Last value = 11034
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2322,6 +2322,7 @@ namespace XIVSlothCombo.Combos
         PLD_AoE_AdvancedMode_Sheltron = 11023,
 
 
+        [ConflictingCombos(PLD_FoFRequiescat)]
         [ReplaceSkill(PLD.Requiescat)]
         [CustomComboInfo("Requiescat Spender Option", "Replaces Requiescat with the selected option while having stacks of \"Requiescat\"", PLD.JobID)]
         PLD_Requiescat_Options = 11024,
@@ -2329,6 +2330,11 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(PLD.SpiritsWithin, PLD.Expiacion)]
         [CustomComboInfo("Spirits Within / Expiacion / Circle of Scorn Feature", "Replaces Spirits Within / Expiacion with Circle of Scorn when off cooldown.", PLD.JobID)]
         PLD_SpiritsWithin = 11025,
+
+        [ConflictingCombos(PLD_Requiescat_Options)]
+        [ReplaceSkill(PLD.FightOrFlight)]
+        [CustomComboInfo("FoF Into Requiescat Option", "Replaces Fight or Flight with Requiescat/Imperator/Blade of Honor during FoF. Keeps your minute-burst oGCDs on one button.", PLD.JobID)]
+        PLD_FoFRequiescat = 11026,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2325,8 +2325,8 @@ namespace XIVSlothCombo.Combos
         PLD_ST_AdvancedMode_Blades = 11014,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Blades of Honor Option", "Adds Blades of Honor to Advanced Mode after Valor", PLD.JobID)]
-        PLD_ST_AdvancedMode_BladesOfHonor = 11033,
+        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode after Valor", PLD.JobID)]
+        PLD_ST_AdvancedMode_BladeOfHonor = 11033,
 
         [ConflictingCombos(PLD_AoE_SimpleMode)]
         [ReplaceSkill(PLD.TotalEclipse)]
@@ -2362,8 +2362,8 @@ namespace XIVSlothCombo.Combos
         PLD_AoE_AdvancedMode_Blades = 11022,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Blades of Honor Option", "Adds Blades of Honor to Advanced Mode after Valor", PLD.JobID)]
-        PLD_AoE_AdvancedMode_BladesOfHonor = 11034,
+        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode after Valor", PLD.JobID)]
+        PLD_AoE_AdvancedMode_BladeOfHonor = 11034,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Sheltron / Holy Sheltron Option", "Adds Sheltron / Holy Sheltron to Advanced Mode", PLD.JobID)]

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -152,14 +152,6 @@ namespace XIVSlothCombo.Combos.PvE
                                     return OriginalHook(Requiescat);
                             }
 
-<<<<<<< HEAD
-                            // New Goring Blade
-                            if (HasEffect(Buffs.GoringBladeReady) && InMeleeRange() && 
-                                (!BladeOfHonor.LevelChecked() || (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
-                                return GoringBlade;
-
-=======
->>>>>>> main
                             if (HasEffect(Buffs.Requiescat))
                             {
                                 // Confiteor & Blades
@@ -170,22 +162,6 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                     return HolySpirit;
                             }
-<<<<<<< HEAD
-                            
-                            // New Spell after Confi Combo (Weave)
-                            if (CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor))
-                                return OriginalHook(Requiescat);
-
-                            // Atonement combo before Holy Spirit
-                            if (HasEffect(Buffs.AtonementReady) || HasEffect(Buffs.SepulchreReady) || HasEffect(Buffs.SupplicationReady))
-                                return OriginalHook(Atonement);
-
-                            // HS under DM
-                            if (HasEffect(Buffs.DivineMight) &&
-                                GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                return HolySpirit;
-=======
->>>>>>> main
                         }
 
                         if (CanWeave(actionID) && InMeleeRange())
@@ -202,10 +178,11 @@ namespace XIVSlothCombo.Combos.PvE
                                             return FightOrFlight;
                                     }
 
-                                    // Levels 26-67
-                                    else if (lastComboActionID is RiotBlade)
-                                        return FightOrFlight;
-                                }
+                            // HS under DM
+                            if (HasEffect(Buffs.DivineMight) &&
+                                GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                                return HolySpirit;
+                        }
 
                                 // Levels 68+
                                 else if (IsOffCooldown(Requiescat) && lastComboActionID is RoyalAuthority)

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -161,7 +161,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(Requiescat);
 
                             // Atonement combo before Holy Spirit
-                            if (HasEffect(Buffs.SwordOath) || HasEffect(Buffs.SepulchreReady) || HasEffect(Buffs.SupplicationReady))
+                            if (HasEffect(Buffs.AtonementReady) || HasEffect(Buffs.SepulchreReady) || HasEffect(Buffs.SupplicationReady))
                                 return OriginalHook(Atonement);
 
                             // HS under DM

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -178,10 +178,9 @@ namespace XIVSlothCombo.Combos.PvE
                                             return FightOrFlight;
                                     }
 
-                            // HS under DM
-                            if (HasEffect(Buffs.DivineMight) &&
-                                GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                return HolySpirit;
+                                    // Levels 26-67
+                                    else if (lastComboActionID is RiotBlade)
+                                        return FightOrFlight;
                         }
 
                                 // Levels 68+
@@ -411,8 +410,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                             // New Goring Blade
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
-                                InMeleeRange() && HasEffect(Buffs.GoringBladeReady) && 
-                                (!BladeOfHonor.LevelChecked() || (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
+                                InMeleeRange() && HasEffect(Buffs.GoringBladeReady) && (!BladeOfHonor.LevelChecked() ||
+                                (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
+                                // To accomodate native action change settings, do not use "OriginalHook" here
                                 return GoringBlade;
 
                             if (HasEffect(Buffs.Requiescat))

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -28,6 +28,7 @@ namespace XIVSlothCombo.Combos.PvE
             RoyalAuthority = 3539,
             TotalEclipse = 7381,
             Requiescat = 7383,
+            Imperator = 36921,
             HolySpirit = 7384,
             Prominence = 16457,
             HolyCircle = 16458,
@@ -709,6 +710,32 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     return CircleOfScorn;
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class PLD_FoF_Requiescat : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PLD_FoFRequiescat;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+            {
+                if (actionID is FightOrFlight)
+                {
+                    if (IsOffCooldown(FightOrFlight))
+                    {
+                        return FightOrFlight;
+                    }
+
+                    if (IsOffCooldown(Requiescat) || 
+                        (LevelChecked(BladeOfHonor) && (HasEffect(Buffs.Requiescat) || HasEffect(Buffs.BladeOfHonor))))
+                    {
+                        return OriginalHook(Requiescat);
+                    }
+
+                    return FightOrFlight;
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -618,7 +618,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // Blade of Honor after Confi Combo (Weave).
-                        if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladesOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
+                        if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladeOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
                             // To accomodate native action change settings, do not use "OriginalHook" here
                             return BladeOfHonor;
 

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -433,9 +433,10 @@ namespace XIVSlothCombo.Combos.PvE
                                     return HolySpirit;
                             }
                             
-                            // Blades of Honor after Confi Combo (Weave).
-                            if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_BladesOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
-                                return OriginalHook(Requiescat);
+                            // Blade of Honor after Confi Combo (Weave).
+                            if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_BladeOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
+                                // To accomodate native action change settings, do not use "OriginalHook" here
+                                return BladeOfHonor;
 
                             // HS under DM
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
@@ -472,9 +473,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) && CanWeave(actionID)) && ActionReady(Requiescat))
                             return OriginalHook(Requiescat);
 
-                        // Blades of Honor after Confi Combo (Weave).
-                        if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_BladesOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)) && IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
-                            return OriginalHook(Requiescat);
+                        // Blade of Honor after Confi Combo (Weave).
+                        if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_BladeOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)) && IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
+                            // To accomodate native action change settings, do not use "OriginalHook" here
+                            return BladeOfHonor;
                         
                         
                         // Confiteor & Blades
@@ -493,6 +495,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
                             HasEffect(Buffs.GoringBladeReady) &&
                             IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
+                            // To accomodate native action change settings, do not use "OriginalHook" here
                             return GoringBlade;
 
                         //Req HS
@@ -614,9 +617,10 @@ namespace XIVSlothCombo.Combos.PvE
                                 return HolyCircle;
                         }
 
-                        // Blades of Honor after Confi Combo (Weave).
+                        // Blade of Honor after Confi Combo (Weave).
                         if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladesOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
-                            return OriginalHook(Requiescat);
+                            // To accomodate native action change settings, do not use "OriginalHook" here
+                            return BladeOfHonor;
 
                         // HC under DM/Req
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
@@ -659,9 +663,10 @@ namespace XIVSlothCombo.Combos.PvE
                         IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF))
                         return OriginalHook(Confiteor);
 
-                    // Blades of Honor after Confi Combo (Weave).
-                    if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladesOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
-                        return OriginalHook(Requiescat);
+                    // Blade of Honor after Confi Combo (Weave).
+                    if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladeOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
+                        // To accomodate native action change settings, do not use "OriginalHook" here
+                        return BladeOfHonor;
 
                     // HS under DM (outside of burst)
                     if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && HasEffect(Buffs.DivineMight) &&

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -410,8 +410,8 @@ namespace XIVSlothCombo.Combos.PvE
                                     return HolySpirit;
                             }
                             
-                            // New Spell after Confi Combo (Weave) -- Maybe need an option for advanced mode - currently only available after blade combo.
-                            if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
+                            // Blades of Honor after Confi Combo (Weave).
+                            if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_BladesOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
                                 return OriginalHook(Requiescat);
 
                             // HS under DM
@@ -454,9 +454,9 @@ namespace XIVSlothCombo.Combos.PvE
                         //Req without FoF
                         if (IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) && CanWeave(actionID)) && ActionReady(Requiescat))
                             return OriginalHook(Requiescat);
-                        
-                        // New Spell after Confi Combo (Weave) -- Maybe need an option for advanced mode - currently only available after blade combo.
-                        if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)) && IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
+
+                        // Blades of Honor after Confi Combo (Weave).
+                        if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_BladesOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)) && IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
                             return OriginalHook(Requiescat);
                         
                         
@@ -592,9 +592,9 @@ namespace XIVSlothCombo.Combos.PvE
                                 return HolyCircle;
 
                         }
-                        
-                        // New Spell after Confi Combo (Weave) -- Maybe need an option for advanced mode - currently only available after blade combo.
-                        if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
+
+                        // Blades of Honor after Confi Combo (Weave).
+                        if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladesOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
                             return OriginalHook(Requiescat);
 
                         // HC under DM/Req
@@ -640,9 +640,9 @@ namespace XIVSlothCombo.Combos.PvE
                         GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp)) &&
                         IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF))
                         return OriginalHook(Confiteor);
-                    
-                    // New Spell after Confi Combo (Weave) -- Maybe need an option for advanced mode - currently only available after blade combo.
-                    if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
+
+                    // Blades of Honor after Confi Combo (Weave).
+                    if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladesOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
                         return OriginalHook(Requiescat);
 
                     // HS under DM (outside of burst)

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -143,7 +143,7 @@ namespace XIVSlothCombo.Combos.PvE
                             // New Goring Blade
                             if (HasEffect(Buffs.GoringBladeReady) && InMeleeRange() && (!BladeOfHonor.LevelChecked() ||
                                 (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
-                                return OriginalHook(FightOrFlight);
+                                return GoringBlade;
 
                             if (HasEffect(Buffs.Requiescat))
                             {
@@ -400,7 +400,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
                                 InMeleeRange() && HasEffect(Buffs.GoringBladeReady) && (!BladeOfHonor.LevelChecked() ||
                                 (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
-                                return OriginalHook(FightOrFlight);
+                                return GoringBlade;
 
                             if (HasEffect(Buffs.Requiescat))
                             {
@@ -459,7 +459,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
                             HasEffect(Buffs.GoringBladeReady) &&
                             IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
-                            return OriginalHook(FightOrFlight);
+                            return GoringBlade;
 
                         //Req without FoF
                         if (IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) && CanWeave(actionID)) && ActionReady(Requiescat))
@@ -731,7 +731,7 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     if (IsOffCooldown(FightOrFlight))
                     {
-                        return FightOrFlight;
+                        return OriginalHook(FightOrFlight);
                     }
 
                     if (IsOffCooldown(Requiescat) || 
@@ -740,7 +740,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return OriginalHook(Requiescat);
                     }
 
-                    return FightOrFlight;
+                    return OriginalHook(FightOrFlight);
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -157,6 +157,10 @@ namespace XIVSlothCombo.Combos.PvE
                             if (CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor))
                                 return OriginalHook(Requiescat);
 
+                            // Atonement combo before Holy Spirit
+                            if (HasEffect(Buffs.SwordOath) || HasEffect(Buffs.SepulchreReady) || HasEffect(Buffs.SupplicationReady))
+                                return OriginalHook(Atonement);
+
                             // HS under DM
                             if (HasEffect(Buffs.DivineMight) &&
                                 GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
@@ -478,10 +482,6 @@ namespace XIVSlothCombo.Combos.PvE
                             GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                             return HolySpirit;
 
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
-                            (HasEffect(Buffs.SwordOath) || HasEffect(Buffs.SepulchreReady) || HasEffect(Buffs.SupplicationReady)) && InMeleeRange())
-                            return OriginalHook(Atonement);
-
                         // Base combo
                         if (comboTime > 0)
                         {
@@ -489,6 +489,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 RiotBlade.LevelChecked())
                                 return RiotBlade;
 
+                            // Insert Atonement/Holy Spirit before end of basic combo for "Late Spend" option
                             if (lastComboActionID is RiotBlade && RageOfHalone.LevelChecked())
                             {
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
@@ -505,11 +506,13 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
+                        // Atonement between basic combos for "Early Spend" option
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
                             (HasEffect(Buffs.SwordOath) || HasEffect(Buffs.SepulchreReady) || HasEffect(Buffs.SupplicationReady)) && InMeleeRange() &&
                             (Config.PLD_ST_AtonementTiming == 1 || (Config.PLD_ST_AtonementTiming == 3 && ActionWatching.CombatActions.Count(x => x == FightOrFlight) % 2 == 1)))
                             return OriginalHook(Atonement);
 
+                        // Holy Spirit between basic combos for "Early Spend" option
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
                             HasEffect(Buffs.DivineMight) &&
                             GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp &&
@@ -590,7 +593,6 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
                                 GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
                                 return HolyCircle;
-
                         }
 
                         // Blades of Honor after Confi Combo (Weave).

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -141,8 +141,8 @@ namespace XIVSlothCombo.Combos.PvE
                             }
 
                             // New Goring Blade
-                            if (HasEffect(Buffs.GoringBladeReady) && InMeleeRange() && (!BladeOfHonor.LevelChecked() ||
-                                (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
+                            if (HasEffect(Buffs.GoringBladeReady) && InMeleeRange() && 
+                                (!BladeOfHonor.LevelChecked() || (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
                                 return GoringBlade;
 
                             if (HasEffect(Buffs.Requiescat))
@@ -398,8 +398,8 @@ namespace XIVSlothCombo.Combos.PvE
 
                             // New Goring Blade
                             if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
-                                InMeleeRange() && HasEffect(Buffs.GoringBladeReady) && (!BladeOfHonor.LevelChecked() ||
-                                (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
+                                InMeleeRange() && HasEffect(Buffs.GoringBladeReady) && 
+                                (!BladeOfHonor.LevelChecked() || (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
                                 return GoringBlade;
 
                             if (HasEffect(Buffs.Requiescat))
@@ -455,12 +455,6 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(SpiritsWithin);
                         }
 
-                        // Goring on cooldown (burst features disabled) -- Goring Blade is only available with FoF
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
-                            HasEffect(Buffs.GoringBladeReady) &&
-                            IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
-                            return GoringBlade;
-
                         //Req without FoF
                         if (IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) && CanWeave(actionID)) && ActionReady(Requiescat))
                             return OriginalHook(Requiescat);
@@ -481,6 +475,12 @@ namespace XIVSlothCombo.Combos.PvE
                             OriginalHook(Confiteor) != Confiteor &&
                             GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)))
                             return OriginalHook(Confiteor);
+
+                        // Goring on cooldown (burst features disabled) -- Goring Blade is only available with FoF
+                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
+                            HasEffect(Buffs.GoringBladeReady) &&
+                            IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
+                            return GoringBlade;
 
                         //Req HS
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&

--- a/XIVSlothCombo/XIVSlothCombo.csproj
+++ b/XIVSlothCombo/XIVSlothCombo.csproj
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<Authors>Team Sloth</Authors>
 		<Company>-</Company>
-		<Version>3.2.0.0</Version>
+		<Version>3.2.0.1</Version>
 		<!-- This is the version that will be used when pushing to the repo.-->
 		<Description>XIVCombo for lazy players</Description>
 		<Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>


### PR DESCRIPTION
Updated for new July 11 Main changes

=========================

* Adds option to keep Blades of Honor (oGCD) separate from the standard blades combo (all GCD).
<img width="176" alt="image" src="https://github.com/Nik-Potokar/XIVSlothCombo/assets/15126089/bb502ca9-44a3-4b91-b6be-e7a812426bbb">

* Fix broken Atonement/Holy Spirit "Early Spend"/"Late Spend" configurations

* Add option to change Fight or Flight into Requiescat upon use (keep burst oGCDs on one button)
![image](https://github.com/Nik-Potokar/XIVSlothCombo/assets/15126089/b222c56c-8d5f-430c-a823-9d567c1d6a75)

* Move goring blade after Confiteor combo per Balance recommended rotation

* Adjust other PLD changes from main to avoid bugs when native FoF->Goring Blade "action change" is disabled
