### PR TITLE
GUI Scaling Bug in PvE Features Fix

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -513,7 +513,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Demi Nuke
                         if (OriginalHook(Ruin) is AstralImpulse or UmbralImpulse or FountainOfFire)
                         {
-                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && IsBahamutReady && (!LevelChecked(SummonSolarBahamut) || DemiAttackCount >= burstDelay))
+                            if (IsEnabled(CustomComboPreset.SMN_Advanced_Combo_DemiSummons_Attacks) && IsBahamutReady && (LevelChecked(SummonSolarBahamut) || DemiAttackCount >= burstDelay))
                             {
                                 if (IsOffCooldown(OriginalHook(EnkindleBahamut)) && LevelChecked(SummonBahamut))
                                     return OriginalHook(EnkindleBahamut);

--- a/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
@@ -1,8 +1,9 @@
-﻿using Dalamud.Interface.Internal;
+using Dalamud.Interface.Internal;
 using Dalamud.Interface.Textures.TextureWraps;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Utility.Raii;
 using ECommons.ImGuiMethods;
+using FFXIVClientStructs.FFXIV.Client.System.Input;
 using ImGuiNET;
 using System.Linq;
 using System.Numerics;
@@ -70,7 +71,7 @@ namespace XIVSlothCombo.Window.Tabs
                     var id = groupedPresets[OpenJob].First().Info.JobID;
                     IDalamudTextureWrap? icon = Icons.GetJobIcon(id);
 
-                    using (var headingTab = ImRaii.Child("HeadingTab", new Vector2(ImGui.GetContentRegionAvail().X, icon is null ? 24f.Scale() : (icon.Size.Y / icon.Size.Y / 2f * 1f.Scale()) + 4f)))
+                    using (var headingTab = ImRaii.Child("HeadingTab", new Vector2(ImGui.GetContentRegionAvail().X, icon is null ? 24f.Scale() * 2 : (icon.Size.Y / 2f * 1f.Scale() + 4f))))
                     {
                         if (ImGui.Button("Back"))
                         {
@@ -82,13 +83,14 @@ namespace XIVSlothCombo.Window.Tabs
                         {
                             if (icon != null)
                             {
-                                ImGui.Image(icon.ImGuiHandle, (icon.Size / icon.Size.Y / 2f * 1f.Scale()));
+                                ImGui.Image(icon.ImGuiHandle, (icon.Size / 2f * 1f.Scale()));
                                 ImGui.SameLine();
                             }
                             ImGuiEx.Text($"{OpenJob}");
                         });
-
                     }
+
+
 
                     using (var contents = ImRaii.Child("Contents", new Vector2(0)))
                     {

--- a/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
@@ -83,7 +83,7 @@ namespace XIVSlothCombo.Window.Tabs
                         {
                             if (icon != null)
                             {
-                                ImGui.Image(icon.ImGuiHandle, (icon.Size / 2f * 1f.Scale()));
+                                ImGui.Image(icon.ImGuiHandle, (icon.Size / 1.4f * 1f.Scale()));
                                 ImGui.SameLine();
                             }
                             ImGuiEx.Text($"{OpenJob}");

--- a/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
@@ -70,7 +70,7 @@ namespace XIVSlothCombo.Window.Tabs
                     var id = groupedPresets[OpenJob].First().Info.JobID;
                     IDalamudTextureWrap? icon = Icons.GetJobIcon(id);
 
-                    using (var headingTab = ImRaii.Child("HeadingTab", new Vector2(ImGui.GetContentRegionAvail().X, icon is null ? 24f.Scale() : (icon.Size.Y / 2f.Scale()) + 4f)))
+                    using (var headingTab = ImRaii.Child("HeadingTab", new Vector2(ImGui.GetContentRegionAvail().X, icon is null ? 24f.Scale() : (icon.Size.Y / icon.Size.Y / 2f * 1f.Scale()) + 4f)))
                     {
                         if (ImGui.Button("Back"))
                         {
@@ -82,7 +82,7 @@ namespace XIVSlothCombo.Window.Tabs
                         {
                             if (icon != null)
                             {
-                                ImGui.Image(icon.ImGuiHandle, (icon.Size / 2f.Scale()));
+                                ImGui.Image(icon.ImGuiHandle, (icon.Size / icon.Size.Y / 2f * 1f.Scale()));
                                 ImGui.SameLine();
                             }
                             ImGuiEx.Text($"{OpenJob}");


### PR DESCRIPTION
![image](https://github.com/Nik-Potokar/XIVSlothCombo/assets/39478392/5ac30f87-f866-4c4d-8c7e-3dc3f471720c)

Solves the issue pictured above, where raising the font scaling in Dalamud causes the margins in between the tab list and the scrollable region below to change and start clipping 

![image](https://github.com/Nik-Potokar/XIVSlothCombo/assets/39478392/e1d82b9a-0c05-4d8c-a7d9-5ae44903b088)

Also fixes the Job Icon's scaling and keeps it proportional to the text in the tab list title