### PR TITLE
DRK Support disabling of Action Change, and lower level buffs

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1014,7 +1014,7 @@ namespace XIVSlothCombo.Combos
         #region Buff Options
 
         [ParentCombo(DRK_ST_Combo)]
-        [CustomComboInfo("Delirium on Cooldown", "Adds Delirium to main combo on cooldown and when Darkside is up. Will also spend 50 blood gauge if Delirium is nearly ready to protect from overcap.", DRK.JobID)]
+        [CustomComboInfo("Delirium on Cooldown", "Adds Delirium (or Blood Weapon at lower levels) to main combo on cooldown and when Darkside is up. Will also spend 50 blood gauge if Delirium is nearly ready to protect from overcap.", DRK.JobID)]
         DRK_ST_Delirium = 5002,
 
         [ParentCombo(DRK_ST_Delirium)]
@@ -1105,7 +1105,7 @@ namespace XIVSlothCombo.Combos
         #region Buff Options
 
         [ParentCombo(DRK_AoE_Combo)]
-        [CustomComboInfo("Delirium Option", "Adds Delirium to AoE combo on cooldown and when Darkside is up.", DRK.JobID)]
+        [CustomComboInfo("Delirium Option", "Adds Delirium (or Blood Weapon at lower levels) to AoE combo on cooldown and when Darkside is up.", DRK.JobID)]
         DRK_AoE_Delirium = 5017,
 
         [ParentCombo(DRK_AoE_Delirium)]

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -191,15 +191,17 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.DRK_ST_CDs))
                         {
                             // Salted Earth
-                            if (IsEnabled(CustomComboPreset.DRK_ST_CDs_SaltedEarth)
-                                && (ActionReady(SaltedEarth) || ActionReady(SaltAndDarkness)))
+                            if (IsEnabled(CustomComboPreset.DRK_ST_CDs_SaltedEarth))
                             {
+                                // Cast Salted Earth
                                 if (!HasEffect(Buffs.SaltedEarth)
-                                    && ActionReady(SaltedEarth) // Cast Salted Earth
-                                    || (HasEffect(Buffs.SaltedEarth)
-                                     && GetBuffRemainingTime(Buffs.SaltedEarth) < 9
-                                     && ActionReady(SaltAndDarkness))) //Cast Salt and Darkness
-                                    return OriginalHook(SaltedEarth);
+                                    && ActionReady(SaltedEarth))
+                                    return SaltedEarth;
+                                //Cast Salt and Darkness
+                                if (HasEffect(Buffs.SaltedEarth)
+                                 && GetBuffRemainingTime(Buffs.SaltedEarth) < 9
+                                 && ActionReady(SaltAndDarkness))
+                                    return OriginalHook(SaltAndDarkness);
                             }
 
                             // Shadowbringer
@@ -338,15 +340,17 @@ namespace XIVSlothCombo.Combos.PvE
                     if (gauge.DarksideTimeRemaining > 1)
                     {
                         // Salted Earth
-                        if (IsEnabled(CustomComboPreset.DRK_AoE_CDs_SaltedEarth)
-                            && (ActionReady(SaltedEarth) || ActionReady(SaltAndDarkness)))
+                        if (IsEnabled(CustomComboPreset.DRK_AoE_CDs_SaltedEarth))
                         {
+                            // Cast Salted Earth
                             if (!HasEffect(Buffs.SaltedEarth)
-                                && ActionReady(SaltedEarth) // Cast Salted Earth
-                                || (HasEffect(Buffs.SaltedEarth)
-                                 && GetBuffRemainingTime(Buffs.SaltedEarth) < 9
-                                 && ActionReady(SaltAndDarkness))) //Cast Salt and Darkness
-                                return OriginalHook(SaltedEarth);
+                                && ActionReady(SaltedEarth))
+                                return SaltedEarth;
+                            //Cast Salt and Darkness
+                            if (HasEffect(Buffs.SaltedEarth)
+                                && GetBuffRemainingTime(Buffs.SaltedEarth) < 9
+                                && ActionReady(SaltAndDarkness))
+                                return OriginalHook(SaltAndDarkness);
                         }
 
                         // Shadowbringer

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -43,6 +43,7 @@ namespace XIVSlothCombo.Combos.PvE
             Impalement = 36931,       // Under Delirium
 
             // Buffing oGCDs
+            BloodWeapon = 3625,
             Delirium = 7390,
 
             // Burst Window
@@ -184,9 +185,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                         // Delirium
                         if (IsEnabled(CustomComboPreset.DRK_ST_Delirium)
-                            && IsOffCooldown(Delirium)
-                            && LevelChecked(Delirium))
-                            return Delirium;
+                            && IsOffCooldown(BloodWeapon)
+                            && LevelChecked(BloodWeapon))
+                            return OriginalHook(Delirium);
 
                         if (IsEnabled(CustomComboPreset.DRK_ST_CDs))
                         {
@@ -333,9 +334,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Delirium
                     if (IsEnabled(CustomComboPreset.DRK_AoE_Delirium)
-                        && IsOffCooldown(Delirium)
-                        && LevelChecked(Delirium))
-                        return Delirium;
+                        && IsOffCooldown(BloodWeapon)
+                        && LevelChecked(BloodWeapon))
+                        return OriginalHook(Delirium);
 
                     if (gauge.DarksideTimeRemaining > 1)
                     {


### PR DESCRIPTION
- [X] Confirmed Disesteem is compatible with disabled Action Change on Living Shadow
- [X] Make Salt and Darkness compatible with disabled Action Change on Salted Earth
- [X] Make Blood Weapon cast instead of Delirium at lower levels