### PR TITLE
VPR: add option to separate dreadwinder/dens ogcds from combo

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3779,7 +3779,7 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         [ReplaceSkill(VPR.Dreadwinder)]
-        [CustomComboInfo("Dreadwinder - Coils", "Replaces Dreadwinder with the Coils.\n Also adds Twinfang and Twinblood to the button.", VPR.JobID)]
+        [CustomComboInfo("Dreadwinder - Coils", "Replaces Dreadwinder with Hunter's/Swiftskin's Coils.", VPR.JobID)]
         VPR_DreadwinderCoils = 30200,
 
         [ReplaceSkill(VPR.PitofDread)]
@@ -3801,6 +3801,14 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(VPR.SerpentsTail)]
         [CustomComboInfo("Combined Combo Ability Feature", "Combines Serpent's Tail, Twinfang, and Twinblood to one button.", VPR.JobID)]
         VPR_TwinTails = 30205,
+
+        [ParentCombo(VPR_DreadwinderCoils)]
+        [CustomComboInfo("Include Twin Combo Actions", "Also add Twinfang and Twinblood to the button.", VPR.JobID)]
+        VPR_DreadwinderCoils_oGCDs = 30206,
+
+        [ParentCombo(VPR_PitOfDreadDens)]
+        [CustomComboInfo("Include Twin Combo Actions", "Also add Twinfang and Twinblood to the button.", VPR.JobID)]
+        VPR_PitOfDreadDens_oGCDs = 30207,
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3783,7 +3783,7 @@ namespace XIVSlothCombo.Combos
         VPR_DreadwinderCoils = 30200,
 
         [ReplaceSkill(VPR.PitofDread)]
-        [CustomComboInfo("Pit Of Dread - Dens", "Replaces Pits Of Dread with the Dens.\n Also adds Twinfang and Twinblood to the button.", VPR.JobID)]
+        [CustomComboInfo("Pit Of Dread - Dens", "Replaces Pit Of Dread with Hunter's/Swiftskin's Dens.", VPR.JobID)]
         VPR_PitOfDreadDens = 30201,
 
         [ReplaceSkill(VPR.UncoiledFury)]
@@ -3803,11 +3803,11 @@ namespace XIVSlothCombo.Combos
         VPR_TwinTails = 30205,
 
         [ParentCombo(VPR_DreadwinderCoils)]
-        [CustomComboInfo("Include Twin Combo Actions", "Also add Twinfang and Twinblood to the button.", VPR.JobID)]
+        [CustomComboInfo("Include Twin Combo Actions", "Adds Twinfang and Twinblood to the button.", VPR.JobID)]
         VPR_DreadwinderCoils_oGCDs = 30206,
 
         [ParentCombo(VPR_PitOfDreadDens)]
-        [CustomComboInfo("Include Twin Combo Actions", "Also add Twinfang and Twinblood to the button.", VPR.JobID)]
+        [CustomComboInfo("Include Twin Combo Actions", "Adds Twinfang and Twinblood to the button.", VPR.JobID)]
         VPR_PitOfDreadDens_oGCDs = 30207,
 
         #endregion

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -915,11 +915,14 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     if (WasLastWeaponskill(HuntersCoil) || WasLastWeaponskill(SwiftskinsCoil))
                     {
-                        if (HasEffect(Buffs.HuntersVenom))
-                            return OriginalHook(Twinfang);
+                        if (IsEnabled(CustomComboPreset.VPR_DreadwinderCoils_oGCDs))
+                        {
+                            if (HasEffect(Buffs.HuntersVenom))
+                                return OriginalHook(Twinfang);
 
-                        if (HasEffect(Buffs.SwiftskinsVenom))
-                            return OriginalHook(Twinblood);
+                            if (HasEffect(Buffs.SwiftskinsVenom))
+                                return OriginalHook(Twinblood);
+                        }
                     }
 
                     if (positionalChoice is 0)
@@ -957,7 +960,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is PitofDread)
                 {
-                    if (WasLastWeaponskill(HuntersDen) || WasLastWeaponskill(SwiftskinsDen))
+                    if (IsEnabled(CustomComboPreset.VPR_PitOfDreadDens_oGCDs) && (WasLastWeaponskill(HuntersDen) || WasLastWeaponskill(SwiftskinsDen)))
                     {
                         if (HasEffect(Buffs.FellhuntersVenom))
                             return OriginalHook(Twinfang);

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -913,16 +913,14 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is Dreadwinder)
                 {
-                    if (WasLastWeaponskill(HuntersCoil) || WasLastWeaponskill(SwiftskinsCoil))
+                    if (IsEnabled(CustomComboPreset.VPR_DreadwinderCoils_oGCDs) &&
+                        (WasLastWeaponskill(HuntersCoil) || WasLastWeaponskill(SwiftskinsCoil)))
                     {
-                        if (IsEnabled(CustomComboPreset.VPR_DreadwinderCoils_oGCDs))
-                        {
-                            if (HasEffect(Buffs.HuntersVenom))
-                                return OriginalHook(Twinfang);
+                        if (HasEffect(Buffs.HuntersVenom))
+                            return OriginalHook(Twinfang);
 
-                            if (HasEffect(Buffs.SwiftskinsVenom))
-                                return OriginalHook(Twinblood);
-                        }
+                        if (HasEffect(Buffs.SwiftskinsVenom))
+                            return OriginalHook(Twinblood);
                     }
 
                     if (positionalChoice is 0)
@@ -960,7 +958,8 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is PitofDread)
                 {
-                    if (IsEnabled(CustomComboPreset.VPR_PitOfDreadDens_oGCDs) && (WasLastWeaponskill(HuntersDen) || WasLastWeaponskill(SwiftskinsDen)))
+                    if (IsEnabled(CustomComboPreset.VPR_PitOfDreadDens_oGCDs) && 
+                        (WasLastWeaponskill(HuntersDen) || WasLastWeaponskill(SwiftskinsDen)))
                     {
                         if (HasEffect(Buffs.FellhuntersVenom))
                             return OriginalHook(Twinfang);


### PR DESCRIPTION
Makes the inclusion of Twinfand and Twinblood optional in the Dreadwinder/Pit of Dread replacement selections (for those of us who like to keep our oGCDs on a different button)

Before:
![image](https://github.com/user-attachments/assets/50696319-f353-44da-943f-e05881d23169)

After:
![image](https://github.com/user-attachments/assets/296b093c-88be-4c1a-835d-77645182d2de)

