### PR TITLE
[PLD] Full Rework (Simple/Advanced)

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2293,36 +2293,36 @@ namespace XIVSlothCombo.Combos
         PLD_ST_AdvancedMode_FoF = 11003,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode.\n- Uses only while out of melee range.\n- Yields to Holy Spirit when under Divine Might.\n- Yields to Confiteor and Blades when available.", PLD.JobID)]
-        PLD_ST_AdvancedMode_ShieldLob = 11004,
+        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
+        PLD_ST_AdvancedMode_SpiritsWithin = 11006,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
         PLD_ST_AdvancedMode_CircleOfScorn = 11005,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_ST_AdvancedMode_SpiritsWithin = 11006,
+        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
+        PLD_ST_AdvancedMode_Sheltron = 11007,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst.\n- Required gauge threshold:", PLD.JobID)]
-        PLD_ST_AdvancedMode_Sheltron = 11007,
+        [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode.\n- Uses only while out of melee range.\n- Yields to Holy Spirit when under Divine Might.\n- Yields to Confiteor and Blades when available.", PLD.JobID)]
+        PLD_ST_AdvancedMode_ShieldLob = 11004,
+
+        [ParentCombo(PLD_ST_AdvancedMode)]
+        [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode.\n- Prefers to use during Fight or Flight.\n- Will not use while moving.\n- Amount of charges to keep:", PLD.JobID)]
+        PLD_ST_AdvancedMode_Intervene = 11011,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Goring Blade Option", "Adds Goring Blade to Advanced Mode.\n- Prefers to use after Confiteor and Blades.", PLD.JobID)]
         PLD_ST_AdvancedMode_GoringBlade = 11008,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode.\n- Uses only when under Divine Might.\n- Prefers to use while out of melee range.\n- Prefers to use during Fight or Flight.\n- Yields to Sepulchre when appropriate.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
-        PLD_ST_AdvancedMode_HolySpirit = 11009,
-
-        [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
         PLD_ST_AdvancedMode_Requiescat = 11010,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode.\n- Prefers to use during Fight or Flight.\n- Will not use while moving.\n- Amount of charges to keep:", PLD.JobID)]
-        PLD_ST_AdvancedMode_Intervene = 11011,
+        [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode.\n- Uses only when under Divine Might.\n- Prefers to use while out of melee range.\n- Prefers to use during Fight or Flight.\n- Yields to Sepulchre when appropriate.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
+        PLD_ST_AdvancedMode_HolySpirit = 11009,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Atonement Option", "Adds the Atonement combo to Advanced Mode.\n- Uses Atonement as soon as possible.\n- Prefers to use Supplication after Riot Blade.\n- Prefers to use Sepulchre during Fight or Flight.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
@@ -2358,6 +2358,10 @@ namespace XIVSlothCombo.Combos
         PLD_AoE_AdvancedMode_CircleOfScorn = 11018,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
+        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
+        PLD_AoE_AdvancedMode_Sheltron = 11023,
+
+        [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
         PLD_AoE_AdvancedMode_Requiescat = 11019,
 
@@ -2377,27 +2381,23 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
         PLD_AoE_AdvancedMode_BladeOfHonor = 11034,
 
-        [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst.\n- Required gauge threshold:", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Sheltron = 11023,
-
-        [ConflictingCombos(PLD_FoFRequiescat)]
-        [ReplaceSkill(PLD.Requiescat)]
-        [CustomComboInfo("Requiescat Spender Feature", "Replaces Requiescat with Requiescat-related actions while under the effect of Requiescat.", PLD.JobID)]
-        PLD_Requiescat_Options = 11024,
-
         [ReplaceSkill(PLD.SpiritsWithin, PLD.Expiacion)]
         [CustomComboInfo("Spirits Within / Circle of Scorn Feature", "Replaces Spirits Within with Circle of Scorn when off cooldown.", PLD.JobID)]
         PLD_SpiritsWithin = 11025,
 
+        [ReplaceSkill(PLD.ShieldLob)]
+        [CustomComboInfo("Shield Lob / Holy Spirit Feature", "Replaces Shield Lob with Holy Spirit while not moving or when under Divine Might, provided there is sufficient MP to cast it.", PLD.JobID)]
+        PLD_ShieldLob_Feature = 11027,
+
+        [ConflictingCombos(PLD_FoFRequiescat)]
+        [ReplaceSkill(PLD.Requiescat)]
+        [CustomComboInfo("Requiescat Spender Feature", "Replaces Requiescat with Requiescat-related actions while under the effect of Requiescat, as well as Blade of Honor when appropriate.", PLD.JobID)]
+        PLD_Requiescat_Options = 11024,
+
         [ConflictingCombos(PLD_Requiescat_Options)]
         [ReplaceSkill(PLD.FightOrFlight)]
-        [CustomComboInfo("Fight or Flight / Requiescat Feature", "Replaces FoF with Requiescat or Blade of Honor during FoF.\nKeeps your minute-burst oGCDs on one button.", PLD.JobID)]
+        [CustomComboInfo("Fight or Flight / Requiescat Feature", "Replaces Fight or Flight with Requiescat and Blade of Honor while under the effect of Fight or Flight. Recommended to disable the in-game Fight or Flight action change setting to avoid issues.", PLD.JobID)]
         PLD_FoFRequiescat = 11026,
-
-        [ReplaceSkill(PLD.ShieldLob)]
-        [CustomComboInfo("Shield Lob / Holy Spirit Feature", "Replaces Shield Lob with Holy Spirit while not moving or when under Divine Might.", PLD.JobID)]
-        PLD_ShieldLob_Feature = 11027,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2293,36 +2293,36 @@ namespace XIVSlothCombo.Combos
         PLD_ST_AdvancedMode_FoF = 11003,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_ST_AdvancedMode_SpiritsWithin = 11006,
+        [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode.\n- Uses only while out of melee range.\n- Yields to Holy Spirit when under Divine Might.\n- Yields to Confiteor and Blades when available.", PLD.JobID)]
+        PLD_ST_AdvancedMode_ShieldLob = 11004,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
         PLD_ST_AdvancedMode_CircleOfScorn = 11005,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
+        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
+        PLD_ST_AdvancedMode_SpiritsWithin = 11006,
+
+        [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
         PLD_ST_AdvancedMode_Sheltron = 11007,
-
-        [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode.\n- Uses only while out of melee range.\n- Yields to Holy Spirit when under Divine Might.\n- Yields to Confiteor and Blades when available.", PLD.JobID)]
-        PLD_ST_AdvancedMode_ShieldLob = 11004,
-
-        [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode.\n- Prefers to use during Fight or Flight.\n- Will not use while moving.\n- Amount of charges to keep:", PLD.JobID)]
-        PLD_ST_AdvancedMode_Intervene = 11011,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Goring Blade Option", "Adds Goring Blade to Advanced Mode.\n- Prefers to use after Confiteor and Blades.", PLD.JobID)]
         PLD_ST_AdvancedMode_GoringBlade = 11008,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
+        [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode.\n- Uses only when under Divine Might.\n- Prefers to use while out of melee range.\n- Prefers to use during Fight or Flight.\n- Yields to Sepulchre when appropriate.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
+        PLD_ST_AdvancedMode_HolySpirit = 11009,
+
+        [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
         PLD_ST_AdvancedMode_Requiescat = 11010,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode.\n- Uses only when under Divine Might.\n- Prefers to use while out of melee range.\n- Prefers to use during Fight or Flight.\n- Yields to Sepulchre when appropriate.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
-        PLD_ST_AdvancedMode_HolySpirit = 11009,
+        [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode.\n- Prefers to use during Fight or Flight.\n- Will not use while moving.\n- Amount of charges to keep:", PLD.JobID)]
+        PLD_ST_AdvancedMode_Intervene = 11011,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Atonement Option", "Adds the Atonement combo to Advanced Mode.\n- Uses Atonement as soon as possible.\n- Prefers to use Supplication after Riot Blade.\n- Prefers to use Sepulchre during Fight or Flight.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
@@ -2358,10 +2358,6 @@ namespace XIVSlothCombo.Combos
         PLD_AoE_AdvancedMode_CircleOfScorn = 11018,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Sheltron = 11023,
-
-        [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
         PLD_AoE_AdvancedMode_Requiescat = 11019,
 
@@ -2381,23 +2377,27 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
         PLD_AoE_AdvancedMode_BladeOfHonor = 11034,
 
-        [ReplaceSkill(PLD.SpiritsWithin, PLD.Expiacion)]
-        [CustomComboInfo("Spirits Within / Circle of Scorn Feature", "Replaces Spirits Within with Circle of Scorn when off cooldown.", PLD.JobID)]
-        PLD_SpiritsWithin = 11025,
-
-        [ReplaceSkill(PLD.ShieldLob)]
-        [CustomComboInfo("Shield Lob / Holy Spirit Feature", "Replaces Shield Lob with Holy Spirit while not moving or when under Divine Might, provided there is sufficient MP to cast it.", PLD.JobID)]
-        PLD_ShieldLob_Feature = 11027,
+        [ParentCombo(PLD_AoE_AdvancedMode)]
+        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
+        PLD_AoE_AdvancedMode_Sheltron = 11023,
 
         [ConflictingCombos(PLD_FoFRequiescat)]
         [ReplaceSkill(PLD.Requiescat)]
         [CustomComboInfo("Requiescat Spender Feature", "Replaces Requiescat with Requiescat-related actions while under the effect of Requiescat, as well as Blade of Honor when appropriate.", PLD.JobID)]
         PLD_Requiescat_Options = 11024,
 
+        [ReplaceSkill(PLD.SpiritsWithin, PLD.Expiacion)]
+        [CustomComboInfo("Spirits Within / Circle of Scorn Feature", "Replaces Spirits Within with Circle of Scorn when off cooldown.", PLD.JobID)]
+        PLD_SpiritsWithin = 11025,
+
         [ConflictingCombos(PLD_Requiescat_Options)]
         [ReplaceSkill(PLD.FightOrFlight)]
         [CustomComboInfo("Fight or Flight / Requiescat Feature", "Replaces Fight or Flight with Requiescat and Blade of Honor while under the effect of Fight or Flight. Recommended to disable the in-game Fight or Flight action change setting to avoid issues.", PLD.JobID)]
         PLD_FoFRequiescat = 11026,
+
+        [ReplaceSkill(PLD.ShieldLob)]
+        [CustomComboInfo("Shield Lob / Holy Spirit Feature", "Replaces Shield Lob with Holy Spirit while not moving or when under Divine Might, provided there is sufficient MP to cast it.", PLD.JobID)]
+        PLD_ShieldLob_Feature = 11027,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2275,12 +2275,12 @@ namespace XIVSlothCombo.Combos
 
         [ConflictingCombos(PLD_ST_AdvancedMode)]
         [ReplaceSkill(PLD.FastBlade)]
-        [CustomComboInfo("Simple Mode - Single Target", $"Replaces Fast Blade with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID, 0)]
+        [CustomComboInfo("Simple Mode - Single Target", $"Replaces Fast Blade with an all-in-one button rotation.\nThis is the ideal option for newcomers to the job.", PLD.JobID, 0)]
         PLD_ST_SimpleMode = 11000,
 
         [ConflictingCombos(PLD_AoE_AdvancedMode)]
         [ReplaceSkill(PLD.TotalEclipse)]
-        [CustomComboInfo("Simple Mode - AoE", $"Replaces Total Eclipse with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID, 1)]
+        [CustomComboInfo("Simple Mode - AoE", $"Replaces Total Eclipse with an all-in-one button rotation.\nThis is the ideal option for newcomers to the job.", PLD.JobID, 1)]
         PLD_AoE_SimpleMode = 11001,
 
         // ST Advanced Mode

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2271,7 +2271,7 @@ namespace XIVSlothCombo.Combos
 
         #region PALADIN
 
-        //// Last value = 11034
+        // Simple Modes 11000~11001
 
         [ConflictingCombos(PLD_ST_AdvancedMode)]
         [ReplaceSkill(PLD.FastBlade)]
@@ -2283,138 +2283,146 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Mode - AoE", $"Replaces Total Eclipse with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID)]
         PLD_AoE_SimpleMode = 11001,
 
+        // ST Advanced Mode 11010~11023
+
         [ConflictingCombos(PLD_ST_SimpleMode)]
         [ReplaceSkill(PLD.FastBlade)]
         [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fast Blade with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID)]
-        PLD_ST_AdvancedMode = 11002,
+        PLD_ST_AdvancedMode = 11010,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses after Royal Authority during opener.\n- Afterward, on cooldown alongside Requiescat.\n- Uses at lower levels when appropriate.\n- Target HP must be at or above:", PLD.JobID)]
-        PLD_ST_AdvancedMode_FoF = 11003,
+        PLD_ST_AdvancedMode_FoF = 11011,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_ST_AdvancedMode_SpiritsWithin = 11006,
+        PLD_ST_AdvancedMode_SpiritsWithin = 11012,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_ST_AdvancedMode_CircleOfScorn = 11005,
+        PLD_ST_AdvancedMode_CircleOfScorn = 11013,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
-        PLD_ST_AdvancedMode_Sheltron = 11007,
+        PLD_ST_AdvancedMode_Sheltron = 11014,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode.\n- Uses only while out of melee range.\n- Yields to Holy Spirit when under Divine Might.\n- Yields to Confiteor and Blades when available.", PLD.JobID)]
-        PLD_ST_AdvancedMode_ShieldLob = 11004,
+        PLD_ST_AdvancedMode_ShieldLob = 11015,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode.\n- Prefers to use during Fight or Flight.\n- Will not use while moving.\n- Amount of charges to keep:", PLD.JobID)]
-        PLD_ST_AdvancedMode_Intervene = 11011,
+        PLD_ST_AdvancedMode_Intervene = 11016,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Goring Blade Option", "Adds Goring Blade to Advanced Mode.\n- Prefers to use after Confiteor and Blades.", PLD.JobID)]
-        PLD_ST_AdvancedMode_GoringBlade = 11008,
+        PLD_ST_AdvancedMode_GoringBlade = 11017,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
-        PLD_ST_AdvancedMode_Requiescat = 11010,
+        PLD_ST_AdvancedMode_Requiescat = 11018,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode.\n- Uses only when under Divine Might.\n- Prefers to use while out of melee range.\n- Prefers to use during Fight or Flight.\n- Yields to Sepulchre when appropriate.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
-        PLD_ST_AdvancedMode_HolySpirit = 11009,
+        PLD_ST_AdvancedMode_HolySpirit = 11019,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Atonement Option", "Adds the Atonement combo to Advanced Mode.\n- Uses Atonement as soon as possible.\n- Prefers to use Supplication after Riot Blade.\n- Prefers to use Sepulchre during Fight or Flight.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
-        PLD_ST_AdvancedMode_Atonement = 11012,
+        PLD_ST_AdvancedMode_Atonement = 11020,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID)]
-        PLD_ST_AdvancedMode_Confiteor = 11013,
+        PLD_ST_AdvancedMode_Confiteor = 11021,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID)]
-        PLD_ST_AdvancedMode_Blades = 11014,
+        PLD_ST_AdvancedMode_Blades = 11022,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
-        PLD_ST_AdvancedMode_BladeOfHonor = 11033,
+        PLD_ST_AdvancedMode_BladeOfHonor = 11023,
+
+        // AoE Advanced Mode 11050~11059
 
         [ConflictingCombos(PLD_AoE_SimpleMode)]
         [ReplaceSkill(PLD.TotalEclipse)]
         [CustomComboInfo("Advanced Mode - AoE", $"Replaces Total Eclipse with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID)]
-        PLD_AoE_AdvancedMode = 11015,
+        PLD_AoE_AdvancedMode = 11050,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses on cooldown alongside Requiescat, if learned.\n- Target HP must be at or above:", PLD.JobID)]
-        PLD_AoE_AdvancedMode_FoF = 11016,
+        PLD_AoE_AdvancedMode_FoF = 11051,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_SpiritsWithin = 11017,
+        PLD_AoE_AdvancedMode_SpiritsWithin = 11052,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_CircleOfScorn = 11018,
+        PLD_AoE_AdvancedMode_CircleOfScorn = 11053,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Sheltron = 11023,
+        PLD_AoE_AdvancedMode_Sheltron = 11054,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Requiescat = 11019,
+        PLD_AoE_AdvancedMode_Requiescat = 11055,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Holy Circle Option", "Adds Holy Circle to Advanced Mode.\n- Uses only when under Divine Might or Requiescat.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_HolyCircle = 11020,
+        PLD_AoE_AdvancedMode_HolyCircle = 11056,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Confiteor = 11021,
+        PLD_AoE_AdvancedMode_Confiteor = 11057,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Blades = 11022,
+        PLD_AoE_AdvancedMode_Blades = 11058,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_BladeOfHonor = 11034,
+        PLD_AoE_AdvancedMode_BladeOfHonor = 11059,
+
+        // Extra Features 11100~11103
 
         [ReplaceSkill(PLD.SpiritsWithin, PLD.Expiacion)]
         [CustomComboInfo("Spirits Within / Circle of Scorn Feature", "Replaces Spirits Within with Circle of Scorn when off cooldown.", PLD.JobID)]
-        PLD_SpiritsWithin = 11025,
+        PLD_SpiritsWithin = 11100,
 
         [ReplaceSkill(PLD.ShieldLob)]
         [CustomComboInfo("Shield Lob / Holy Spirit Feature", "Replaces Shield Lob with Holy Spirit while not moving or when under Divine Might, provided there is sufficient MP to cast it.", PLD.JobID)]
-        PLD_ShieldLob_Feature = 11027,
+        PLD_ShieldLob_Feature = 11101,
 
         [ConflictingCombos(PLD_FoFRequiescat)]
         [ReplaceSkill(PLD.Requiescat)]
         [CustomComboInfo("Requiescat Spender Feature", "Replaces Requiescat with Requiescat-related actions while under the effect of Requiescat, as well as Blade of Honor when appropriate.", PLD.JobID)]
-        PLD_Requiescat_Options = 11024,
+        PLD_Requiescat_Options = 11102,
 
         [ConflictingCombos(PLD_Requiescat_Options)]
         [ReplaceSkill(PLD.FightOrFlight)]
         [CustomComboInfo("Fight or Flight / Requiescat Feature", "Replaces Fight or Flight with Requiescat and Blade of Honor while under the effect of Fight or Flight. Recommended to disable the in-game Fight or Flight action change setting to avoid issues.", PLD.JobID)]
-        PLD_FoFRequiescat = 11026,
+        PLD_FoFRequiescat = 11103,
+
+        // Variant Features 11150~11152
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Spirit Dart Feature", "Uses Variant Spirit Dart whenever the debuff is not present on the target or about to expire.", PLD.JobID)]
-        PLD_Variant_SpiritDart = 11030,
+        PLD_Variant_SpiritDart = 11150,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Cure Feature", "Uses Variant Cure when the player's HP falls below the set threshold.", PLD.JobID)]
-        PLD_Variant_Cure = 11031,
+        PLD_Variant_Cure = 11151,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Ultimatum Feature", "Uses Variant Ultimatum on cooldown as long as the target is within range.", PLD.JobID)]
-        PLD_Variant_Ultimatum = 11032,
+        PLD_Variant_Ultimatum = 11152,
 
-        //// Last value = 11034
+        //// Last value = 11152
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2271,7 +2271,7 @@ namespace XIVSlothCombo.Combos
 
         #region PALADIN
 
-        // Simple Modes 11000~11001
+        //// Last value = 11034
 
         [ConflictingCombos(PLD_ST_AdvancedMode)]
         [ReplaceSkill(PLD.FastBlade)]
@@ -2283,146 +2283,138 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Mode - AoE", $"Replaces Total Eclipse with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID)]
         PLD_AoE_SimpleMode = 11001,
 
-        // ST Advanced Mode 11010~11023
-
         [ConflictingCombos(PLD_ST_SimpleMode)]
         [ReplaceSkill(PLD.FastBlade)]
         [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fast Blade with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID)]
-        PLD_ST_AdvancedMode = 11010,
+        PLD_ST_AdvancedMode = 11002,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses after Royal Authority during opener.\n- Afterward, on cooldown alongside Requiescat.\n- Uses at lower levels when appropriate.\n- Target HP must be at or above:", PLD.JobID)]
-        PLD_ST_AdvancedMode_FoF = 11011,
+        PLD_ST_AdvancedMode_FoF = 11003,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_ST_AdvancedMode_SpiritsWithin = 11012,
+        PLD_ST_AdvancedMode_SpiritsWithin = 11006,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_ST_AdvancedMode_CircleOfScorn = 11013,
+        PLD_ST_AdvancedMode_CircleOfScorn = 11005,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
-        PLD_ST_AdvancedMode_Sheltron = 11014,
+        PLD_ST_AdvancedMode_Sheltron = 11007,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode.\n- Uses only while out of melee range.\n- Yields to Holy Spirit when under Divine Might.\n- Yields to Confiteor and Blades when available.", PLD.JobID)]
-        PLD_ST_AdvancedMode_ShieldLob = 11015,
+        PLD_ST_AdvancedMode_ShieldLob = 11004,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode.\n- Prefers to use during Fight or Flight.\n- Will not use while moving.\n- Amount of charges to keep:", PLD.JobID)]
-        PLD_ST_AdvancedMode_Intervene = 11016,
+        PLD_ST_AdvancedMode_Intervene = 11011,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Goring Blade Option", "Adds Goring Blade to Advanced Mode.\n- Prefers to use after Confiteor and Blades.", PLD.JobID)]
-        PLD_ST_AdvancedMode_GoringBlade = 11017,
+        PLD_ST_AdvancedMode_GoringBlade = 11008,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
-        PLD_ST_AdvancedMode_Requiescat = 11018,
+        PLD_ST_AdvancedMode_Requiescat = 11010,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode.\n- Uses only when under Divine Might.\n- Prefers to use while out of melee range.\n- Prefers to use during Fight or Flight.\n- Yields to Sepulchre when appropriate.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
-        PLD_ST_AdvancedMode_HolySpirit = 11019,
+        PLD_ST_AdvancedMode_HolySpirit = 11009,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Atonement Option", "Adds the Atonement combo to Advanced Mode.\n- Uses Atonement as soon as possible.\n- Prefers to use Supplication after Riot Blade.\n- Prefers to use Sepulchre during Fight or Flight.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
-        PLD_ST_AdvancedMode_Atonement = 11020,
+        PLD_ST_AdvancedMode_Atonement = 11012,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID)]
-        PLD_ST_AdvancedMode_Confiteor = 11021,
+        PLD_ST_AdvancedMode_Confiteor = 11013,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID)]
-        PLD_ST_AdvancedMode_Blades = 11022,
+        PLD_ST_AdvancedMode_Blades = 11014,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
         [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
-        PLD_ST_AdvancedMode_BladeOfHonor = 11023,
-
-        // AoE Advanced Mode 11050~11059
+        PLD_ST_AdvancedMode_BladeOfHonor = 11033,
 
         [ConflictingCombos(PLD_AoE_SimpleMode)]
         [ReplaceSkill(PLD.TotalEclipse)]
         [CustomComboInfo("Advanced Mode - AoE", $"Replaces Total Eclipse with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID)]
-        PLD_AoE_AdvancedMode = 11050,
+        PLD_AoE_AdvancedMode = 11015,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses on cooldown alongside Requiescat, if learned.\n- Target HP must be at or above:", PLD.JobID)]
-        PLD_AoE_AdvancedMode_FoF = 11051,
+        PLD_AoE_AdvancedMode_FoF = 11016,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_SpiritsWithin = 11052,
+        PLD_AoE_AdvancedMode_SpiritsWithin = 11017,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_CircleOfScorn = 11053,
+        PLD_AoE_AdvancedMode_CircleOfScorn = 11018,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Sheltron = 11054,
+        PLD_AoE_AdvancedMode_Sheltron = 11023,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Requiescat = 11055,
+        PLD_AoE_AdvancedMode_Requiescat = 11019,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Holy Circle Option", "Adds Holy Circle to Advanced Mode.\n- Uses only when under Divine Might or Requiescat.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_HolyCircle = 11056,
+        PLD_AoE_AdvancedMode_HolyCircle = 11020,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Confiteor = 11057,
+        PLD_AoE_AdvancedMode_Confiteor = 11021,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_Blades = 11058,
+        PLD_AoE_AdvancedMode_Blades = 11022,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
-        PLD_AoE_AdvancedMode_BladeOfHonor = 11059,
-
-        // Extra Features 11100~11103
+        PLD_AoE_AdvancedMode_BladeOfHonor = 11034,
 
         [ReplaceSkill(PLD.SpiritsWithin, PLD.Expiacion)]
         [CustomComboInfo("Spirits Within / Circle of Scorn Feature", "Replaces Spirits Within with Circle of Scorn when off cooldown.", PLD.JobID)]
-        PLD_SpiritsWithin = 11100,
+        PLD_SpiritsWithin = 11025,
 
         [ReplaceSkill(PLD.ShieldLob)]
         [CustomComboInfo("Shield Lob / Holy Spirit Feature", "Replaces Shield Lob with Holy Spirit while not moving or when under Divine Might, provided there is sufficient MP to cast it.", PLD.JobID)]
-        PLD_ShieldLob_Feature = 11101,
+        PLD_ShieldLob_Feature = 11027,
 
         [ConflictingCombos(PLD_FoFRequiescat)]
         [ReplaceSkill(PLD.Requiescat)]
         [CustomComboInfo("Requiescat Spender Feature", "Replaces Requiescat with Requiescat-related actions while under the effect of Requiescat, as well as Blade of Honor when appropriate.", PLD.JobID)]
-        PLD_Requiescat_Options = 11102,
+        PLD_Requiescat_Options = 11024,
 
         [ConflictingCombos(PLD_Requiescat_Options)]
         [ReplaceSkill(PLD.FightOrFlight)]
         [CustomComboInfo("Fight or Flight / Requiescat Feature", "Replaces Fight or Flight with Requiescat and Blade of Honor while under the effect of Fight or Flight. Recommended to disable the in-game Fight or Flight action change setting to avoid issues.", PLD.JobID)]
-        PLD_FoFRequiescat = 11103,
-
-        // Variant Features 11150~11152
+        PLD_FoFRequiescat = 11026,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Spirit Dart Feature", "Uses Variant Spirit Dart whenever the debuff is not present on the target or about to expire.", PLD.JobID)]
-        PLD_Variant_SpiritDart = 11150,
+        PLD_Variant_SpiritDart = 11030,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Cure Feature", "Uses Variant Cure when the player's HP falls below the set threshold.", PLD.JobID)]
-        PLD_Variant_Cure = 11151,
+        PLD_Variant_Cure = 11031,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]
         [CustomComboInfo("Ultimatum Feature", "Uses Variant Ultimatum on cooldown as long as the target is within range.", PLD.JobID)]
-        PLD_Variant_Ultimatum = 11152,
+        PLD_Variant_Ultimatum = 11032,
 
-        //// Last value = 11152
+        //// Last value = 11034
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2275,140 +2275,143 @@ namespace XIVSlothCombo.Combos
 
         [ConflictingCombos(PLD_ST_AdvancedMode)]
         [ReplaceSkill(PLD.FastBlade)]
-        [CustomComboInfo("Simple Mode - Single Target", $"Replaces Fast Blade with a one-button full single target rotation.\nThis is ideal for newcomers to the job.", PLD.JobID)]
+        [CustomComboInfo("Simple Mode - Single Target", $"Replaces Fast Blade with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID)]
         PLD_ST_SimpleMode = 11000,
 
         [ConflictingCombos(PLD_AoE_AdvancedMode)]
         [ReplaceSkill(PLD.TotalEclipse)]
-        [CustomComboInfo("Simple Mode - AoE", $"Replaces Total Eclipse with a one-button full AoE rotation.\nThis is ideal for newcomers to the job.", PLD.JobID)]
+        [CustomComboInfo("Simple Mode - AoE", $"Replaces Total Eclipse with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID)]
         PLD_AoE_SimpleMode = 11001,
 
         [ConflictingCombos(PLD_ST_SimpleMode)]
         [ReplaceSkill(PLD.FastBlade)]
-        [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fast Blade with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", PLD.JobID)]
+        [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fast Blade with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID)]
         PLD_ST_AdvancedMode = 11002,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.", PLD.JobID)]
+        [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses after Royal Authority during opener.\n- Afterward, on cooldown alongside Requiescat.\n- Uses at lower levels when appropriate.\n- Target HP must be at or above:", PLD.JobID)]
         PLD_ST_AdvancedMode_FoF = 11003,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode if out of range.", PLD.JobID)]
+        [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode.\n- Uses only while out of melee range.\n- Yields to Holy Spirit when under Divine Might.\n- Yields to Confiteor and Blades when available.", PLD.JobID)]
         PLD_ST_AdvancedMode_ShieldLob = 11004,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.", PLD.JobID)]
+        [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
         PLD_ST_AdvancedMode_CircleOfScorn = 11005,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Spirits Within / Expiacion Option", "Adds Spirits Within / Expiacion to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
         PLD_ST_AdvancedMode_SpiritsWithin = 11006,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Sheltron / Holy Sheltron Option", "Adds Sheltron / Holy Sheltron to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst.\n- Required gauge threshold:", PLD.JobID)]
         PLD_ST_AdvancedMode_Sheltron = 11007,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Goring Blade Option", "Adds Goring Blade to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Goring Blade Option", "Adds Goring Blade to Advanced Mode.\n- Prefers to use after Confiteor and Blades.", PLD.JobID)]
         PLD_ST_AdvancedMode_GoringBlade = 11008,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode.\n- Uses only when under Divine Might.\n- Prefers to use while out of melee range.\n- Prefers to use during Fight or Flight.\n- Yields to Sepulchre when appropriate.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
         PLD_ST_AdvancedMode_HolySpirit = 11009,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
         PLD_ST_AdvancedMode_Requiescat = 11010,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode.\n- Prefers to use during Fight or Flight.\n- Will not use while moving.\n- Amount of charges to keep:", PLD.JobID)]
         PLD_ST_AdvancedMode_Intervene = 11011,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Atonement Option", "Adds Atonement to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Atonement Option", "Adds the Atonement combo to Advanced Mode.\n- Uses Atonement as soon as possible.\n- Prefers to use Supplication after Riot Blade.\n- Prefers to use Sepulchre during Fight or Flight.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
         PLD_ST_AdvancedMode_Atonement = 11012,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID)]
         PLD_ST_AdvancedMode_Confiteor = 11013,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Blades of Faith/Truth/Valor Option", "Adds Blades of Faith/Truth/Valor to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID)]
         PLD_ST_AdvancedMode_Blades = 11014,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode after Valor", PLD.JobID)]
+        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
         PLD_ST_AdvancedMode_BladeOfHonor = 11033,
 
         [ConflictingCombos(PLD_AoE_SimpleMode)]
         [ReplaceSkill(PLD.TotalEclipse)]
-        [CustomComboInfo("Advanced Mode - AoE", $"Replaces Total Eclipse with a one-button full AoE rotation.\nThese features are ideal if you want to customize the rotation.", PLD.JobID)]
+        [CustomComboInfo("Advanced Mode - AoE", $"Replaces Total Eclipse with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID)]
         PLD_AoE_AdvancedMode = 11015,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.", PLD.JobID)]
+        [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses on cooldown alongside Requiescat, if learned.\n- Target HP must be at or above:", PLD.JobID)]
         PLD_AoE_AdvancedMode_FoF = 11016,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Spirits Within / Expiacion Option", "Adds Spirits Within / Expiacion to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
         PLD_AoE_AdvancedMode_SpiritsWithin = 11017,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.", PLD.JobID)]
+        [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
         PLD_AoE_AdvancedMode_CircleOfScorn = 11018,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.", PLD.JobID)]
+        [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
         PLD_AoE_AdvancedMode_Requiescat = 11019,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Holy Circle Option", "Adds Holy Circle to Advanced Mode.", PLD.JobID)]
+        [CustomComboInfo("Holy Circle Option", "Adds Holy Circle to Advanced Mode.\n- Uses only when under Divine Might or Requiescat.", PLD.JobID)]
         PLD_AoE_AdvancedMode_HolyCircle = 11020,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID)]
         PLD_AoE_AdvancedMode_Confiteor = 11021,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Blades of Faith/Truth/Valor Option", "Adds Blades of Faith/Truth/Valor to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID)]
         PLD_AoE_AdvancedMode_Blades = 11022,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode after Valor", PLD.JobID)]
+        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
         PLD_AoE_AdvancedMode_BladeOfHonor = 11034,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Sheltron / Holy Sheltron Option", "Adds Sheltron / Holy Sheltron to Advanced Mode", PLD.JobID)]
+        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst.\n- Required gauge threshold:", PLD.JobID)]
         PLD_AoE_AdvancedMode_Sheltron = 11023,
-
 
         [ConflictingCombos(PLD_FoFRequiescat)]
         [ReplaceSkill(PLD.Requiescat)]
-        [CustomComboInfo("Requiescat Spender Option", "Replaces Requiescat with the selected option while having stacks of \"Requiescat\"", PLD.JobID)]
+        [CustomComboInfo("Requiescat Spender Feature", "Replaces Requiescat with Requiescat-related actions while under the effect of Requiescat.", PLD.JobID)]
         PLD_Requiescat_Options = 11024,
 
         [ReplaceSkill(PLD.SpiritsWithin, PLD.Expiacion)]
-        [CustomComboInfo("Spirits Within / Expiacion / Circle of Scorn Feature", "Replaces Spirits Within / Expiacion with Circle of Scorn when off cooldown.", PLD.JobID)]
+        [CustomComboInfo("Spirits Within / Circle of Scorn Feature", "Replaces Spirits Within with Circle of Scorn when off cooldown.", PLD.JobID)]
         PLD_SpiritsWithin = 11025,
 
         [ConflictingCombos(PLD_Requiescat_Options)]
         [ReplaceSkill(PLD.FightOrFlight)]
-        [CustomComboInfo("FoF Into Requiescat Option", "Replaces Fight or Flight with Requiescat/Imperator/Blade of Honor during FoF. Keeps your minute-burst oGCDs on one button.", PLD.JobID)]
+        [CustomComboInfo("Fight or Flight / Requiescat Feature", "Replaces FoF with Requiescat or Blade of Honor during FoF.\nKeeps your minute-burst oGCDs on one button.", PLD.JobID)]
         PLD_FoFRequiescat = 11026,
+
+        [ReplaceSkill(PLD.ShieldLob)]
+        [CustomComboInfo("Shield Lob / Holy Spirit Feature", "Replaces Shield Lob with Holy Spirit while not moving or when under Divine Might.", PLD.JobID)]
+        PLD_ShieldLob_Feature = 11027,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Spirit Dart Option", "Use Variant Spirit Dart whenever the debuff is not present or less than 3s.", PLD.JobID)]
+        [CustomComboInfo("Spirit Dart Feature", "Uses Variant Spirit Dart whenever the debuff is not present on the target or about to expire.", PLD.JobID)]
         PLD_Variant_SpiritDart = 11030,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Cure Option", "Use Variant Cure when HP is below set threshold.", PLD.JobID)]
+        [CustomComboInfo("Cure Feature", "Uses Variant Cure when the player's HP falls below the set threshold.", PLD.JobID)]
         PLD_Variant_Cure = 11031,
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Ultimatum Option", "Use Variant Ultimatum on cooldown.", PLD.JobID)]
+        [CustomComboInfo("Ultimatum Feature", "Uses Variant Ultimatum on cooldown as long as the target is within range.", PLD.JobID)]
         PLD_Variant_Ultimatum = 11032,
 
         //// Last value = 11034

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2271,133 +2271,141 @@ namespace XIVSlothCombo.Combos
 
         #region PALADIN
 
-        //// Last value = 11034
+        // Simple Modes
 
         [ConflictingCombos(PLD_ST_AdvancedMode)]
         [ReplaceSkill(PLD.FastBlade)]
-        [CustomComboInfo("Simple Mode - Single Target", $"Replaces Fast Blade with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID)]
+        [CustomComboInfo("Simple Mode - Single Target", $"Replaces Fast Blade with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID, 0)]
         PLD_ST_SimpleMode = 11000,
 
         [ConflictingCombos(PLD_AoE_AdvancedMode)]
         [ReplaceSkill(PLD.TotalEclipse)]
-        [CustomComboInfo("Simple Mode - AoE", $"Replaces Total Eclipse with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID)]
+        [CustomComboInfo("Simple Mode - AoE", $"Replaces Total Eclipse with an all-in-one button rotation.\nThis is ideal option for newcomers to the job.", PLD.JobID, 1)]
         PLD_AoE_SimpleMode = 11001,
+
+        // ST Advanced Mode
 
         [ConflictingCombos(PLD_ST_SimpleMode)]
         [ReplaceSkill(PLD.FastBlade)]
-        [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fast Blade with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID)]
+        [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fast Blade with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID, 2)]
         PLD_ST_AdvancedMode = 11002,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses after Royal Authority during opener.\n- Afterward, on cooldown alongside Requiescat.\n- Uses at lower levels when appropriate.\n- Target HP must be at or above:", PLD.JobID)]
+        [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses after Royal Authority during opener.\n- Afterward, on cooldown alongside Requiescat.\n- Uses at lower levels when appropriate.\n- Target HP must be at or above:", PLD.JobID, 0)]
         PLD_ST_AdvancedMode_FoF = 11003,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode.\n- Uses only while out of melee range.\n- Yields to Holy Spirit when under Divine Might.\n- Yields to Confiteor and Blades when available.", PLD.JobID)]
+        [CustomComboInfo("Shield Lob Option", "Adds Shield Lob to Advanced Mode.\n- Uses only while out of melee range.\n- Yields to Holy Spirit when under Divine Might.\n- Yields to Confiteor and Blades when available.", PLD.JobID, 4)]
         PLD_ST_AdvancedMode_ShieldLob = 11004,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
+        [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID, 2)]
         PLD_ST_AdvancedMode_CircleOfScorn = 11005,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
+        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID, 1)]
         PLD_ST_AdvancedMode_SpiritsWithin = 11006,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
+        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID, 3)]
         PLD_ST_AdvancedMode_Sheltron = 11007,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Goring Blade Option", "Adds Goring Blade to Advanced Mode.\n- Prefers to use after Confiteor and Blades.", PLD.JobID)]
+        [CustomComboInfo("Goring Blade Option", "Adds Goring Blade to Advanced Mode.\n- Prefers to use after Confiteor and Blades.", PLD.JobID, 6)]
         PLD_ST_AdvancedMode_GoringBlade = 11008,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode.\n- Uses only when under Divine Might.\n- Prefers to use while out of melee range.\n- Prefers to use during Fight or Flight.\n- Yields to Sepulchre when appropriate.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
+        [CustomComboInfo("Holy Spirit Option", "Adds Holy Spirit to Advanced Mode.\n- Uses only when under Divine Might.\n- Prefers to use while out of melee range.\n- Prefers to use during Fight or Flight.\n- Yields to Sepulchre when appropriate.\n- Will be prioritized if buff is expiring.", PLD.JobID, 8)]
         PLD_ST_AdvancedMode_HolySpirit = 11009,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
+        [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID, 7)]
         PLD_ST_AdvancedMode_Requiescat = 11010,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode.\n- Prefers to use during Fight or Flight.\n- Will not use while moving.\n- Amount of charges to keep:", PLD.JobID)]
+        [CustomComboInfo("Intervene Option", "Adds Intervene to Advanced Mode.\n- Prefers to use during Fight or Flight.\n- Will not use while moving.\n- Amount of charges to keep:", PLD.JobID, 5)]
         PLD_ST_AdvancedMode_Intervene = 11011,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Atonement Option", "Adds the Atonement combo to Advanced Mode.\n- Uses Atonement as soon as possible.\n- Prefers to use Supplication after Riot Blade.\n- Prefers to use Sepulchre during Fight or Flight.\n- Will be prioritized if buff is expiring.", PLD.JobID)]
+        [CustomComboInfo("Atonement Option", "Adds the Atonement combo to Advanced Mode.\n- Uses Atonement as soon as possible.\n- Prefers to use Supplication after Riot Blade.\n- Prefers to use Sepulchre during Fight or Flight.\n- Will be prioritized if buff is expiring.", PLD.JobID, 9)]
         PLD_ST_AdvancedMode_Atonement = 11012,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID)]
+        [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID, 10)]
         PLD_ST_AdvancedMode_Confiteor = 11013,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID)]
+        [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID, 11)]
         PLD_ST_AdvancedMode_Blades = 11014,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
+        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID, 12)]
         PLD_ST_AdvancedMode_BladeOfHonor = 11033,
+
+        // AoE Advanced Mode
 
         [ConflictingCombos(PLD_AoE_SimpleMode)]
         [ReplaceSkill(PLD.TotalEclipse)]
-        [CustomComboInfo("Advanced Mode - AoE", $"Replaces Total Eclipse with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID)]
+        [CustomComboInfo("Advanced Mode - AoE", $"Replaces Total Eclipse with a customizable all-in-one button rotation.\nFeatures can be toggled on or off to suit your playstyle.", PLD.JobID, 3)]
         PLD_AoE_AdvancedMode = 11015,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses on cooldown alongside Requiescat, if learned.\n- Target HP must be at or above:", PLD.JobID)]
+        [CustomComboInfo("Fight or Flight Option", "Adds Fight or Flight to Advanced Mode.\n- Uses on cooldown alongside Requiescat, if learned.\n- Target HP must be at or above:", PLD.JobID, 0)]
         PLD_AoE_AdvancedMode_FoF = 11016,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
+        [CustomComboInfo("Spirits Within Option", "Adds Spirits Within to Advanced Mode.\n- Prefers to use during Fight or Flight.", PLD.JobID, 1)]
         PLD_AoE_AdvancedMode_SpiritsWithin = 11017,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID)]
+        [CustomComboInfo("Circle of Scorn Option", "Adds Circle of Scorn to Advanced Mode.\n- Uses only when in range of the target.\n- Prefers to use during Fight or Flight.", PLD.JobID, 2)]
         PLD_AoE_AdvancedMode_CircleOfScorn = 11018,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID)]
+        [CustomComboInfo("Requiescat Option", "Adds Requiescat to Advanced Mode.\n- Uses after Fight or Flight.", PLD.JobID, 4)]
         PLD_AoE_AdvancedMode_Requiescat = 11019,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Holy Circle Option", "Adds Holy Circle to Advanced Mode.\n- Uses only when under Divine Might or Requiescat.", PLD.JobID)]
+        [CustomComboInfo("Holy Circle Option", "Adds Holy Circle to Advanced Mode.\n- Uses only when under Divine Might or Requiescat.", PLD.JobID, 5)]
         PLD_AoE_AdvancedMode_HolyCircle = 11020,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID)]
+        [CustomComboInfo("Confiteor Option", "Adds Confiteor to Advanced Mode.\n- Uses after Requiescat.", PLD.JobID, 6)]
         PLD_AoE_AdvancedMode_Confiteor = 11021,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID)]
+        [CustomComboInfo("Blade of Faith/Truth/Valor Option", "Adds Blade of Faith/Truth/Valor to Advanced Mode.\n- Uses after Confiteor.", PLD.JobID, 7)]
         PLD_AoE_AdvancedMode_Blades = 11022,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID)]
+        [CustomComboInfo("Blade of Honor Option", "Adds Blade of Honor to Advanced Mode.\n- Uses after Blade of Valor.", PLD.JobID, 8)]
         PLD_AoE_AdvancedMode_BladeOfHonor = 11034,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID)]
+        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID, 3)]
         PLD_AoE_AdvancedMode_Sheltron = 11023,
+
+        // Extra Features
 
         [ConflictingCombos(PLD_FoFRequiescat)]
         [ReplaceSkill(PLD.Requiescat)]
-        [CustomComboInfo("Requiescat Spender Feature", "Replaces Requiescat with Requiescat-related actions while under the effect of Requiescat, as well as Blade of Honor when appropriate.", PLD.JobID)]
+        [CustomComboInfo("Requiescat Spender Feature", "Replaces Requiescat with Requiescat-related actions while under the effect of Requiescat, as well as Blade of Honor when appropriate.", PLD.JobID, 6)]
         PLD_Requiescat_Options = 11024,
 
         [ReplaceSkill(PLD.SpiritsWithin, PLD.Expiacion)]
-        [CustomComboInfo("Spirits Within / Circle of Scorn Feature", "Replaces Spirits Within with Circle of Scorn when off cooldown.", PLD.JobID)]
+        [CustomComboInfo("Spirits Within / Circle of Scorn Feature", "Replaces Spirits Within with Circle of Scorn when off cooldown.", PLD.JobID, 4)]
         PLD_SpiritsWithin = 11025,
 
         [ConflictingCombos(PLD_Requiescat_Options)]
         [ReplaceSkill(PLD.FightOrFlight)]
-        [CustomComboInfo("Fight or Flight / Requiescat Feature", "Replaces Fight or Flight with Requiescat and Blade of Honor while under the effect of Fight or Flight. Recommended to disable the in-game Fight or Flight action change setting to avoid issues.", PLD.JobID)]
+        [CustomComboInfo("Fight or Flight / Requiescat Feature", "Replaces Fight or Flight with Requiescat and Blade of Honor while under the effect of Fight or Flight. Recommended to disable the in-game Fight or Flight action change setting to avoid issues.", PLD.JobID, 7)]
         PLD_FoFRequiescat = 11026,
 
         [ReplaceSkill(PLD.ShieldLob)]
-        [CustomComboInfo("Shield Lob / Holy Spirit Feature", "Replaces Shield Lob with Holy Spirit while not moving or when under Divine Might, provided there is sufficient MP to cast it.", PLD.JobID)]
+        [CustomComboInfo("Shield Lob / Holy Spirit Feature", "Replaces Shield Lob with Holy Spirit while not moving or when under Divine Might, provided there is sufficient MP to cast it.", PLD.JobID, 5)]
         PLD_ShieldLob_Feature = 11027,
+
+        // Variant Features
 
         [Variant]
         [VariantParent(PLD_ST_SimpleMode, PLD_ST_AdvancedMode, PLD_AoE_SimpleMode, PLD_AoE_AdvancedMode)]

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -73,14 +73,16 @@ namespace XIVSlothCombo.Combos.PvE
         public static class Config
         {
             public static UserInt
-                PLD_ST_FoF_Option = new("PLD_ST_FoF_Option"),
-                PLD_AoE_FoF_Option = new("PLD_AoE_FoF_Option"),
-                PLD_Intervene_HoldCharges = new("PLDKeepInterveneCharges"),
+                PLD_ST_FoF_Option = new("PLD_ST_FoF_Option", 50),
+                PLD_AoE_FoF_Option = new("PLD_AoE_FoF_Option", 50),
+                PLD_Intervene_HoldCharges = new("PLDKeepInterveneCharges", 1),
                 PLD_VariantCure = new("PLD_VariantCure"),
                 PLD_RequiescatOption = new("PLD_RequiescatOption"),
                 PLD_SpiritsWithinOption = new("PLD_SpiritsWithinOption"),
-                PLD_ST_SheltronOption = new("PLD_ST_SheltronOption"),
-                PLD_AoE_SheltronOption = new("PLD_AoE_SheltronOption"),
+                PLD_ST_SheltronOption = new("PLD_ST_SheltronOption", 50),
+                PLD_AoE_SheltronOption = new("PLD_AoE_SheltronOption", 50),
+                PLD_ST_SheltronHP = new("PLD_ST_SheltronHP", 70),
+                PLD_AoE_SheltronHP = new("PLD_AoE_SheltronHP", 70),
                 //PLD_ST_RequiescatWeave = new("PLD_ST_RequiescatWeave"),
                 //PLD_AoE_RequiescatWeave = new("PLD_AoE_RequiescatWeave"),
                 //PLD_ST_AtonementTiming = new("PLD_ST_EquilibriumTiming"),
@@ -471,7 +473,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Sheltron Overcap Protection
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) && InCombat() && CanWeave(actionID) &&
                             LevelChecked(Sheltron) && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
-                            Gauge.OathGauge >= Config.PLD_ST_SheltronOption)
+                            Gauge.OathGauge >= Config.PLD_ST_SheltronOption && PlayerHealthPercentageHp() <= Config.PLD_ST_SheltronHP)
                             return OriginalHook(Sheltron);
 
                         // Holy Spirit Prioritization
@@ -604,7 +606,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Sheltron Overcap Protection
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron) && InCombat() && CanWeave(actionID) &&
                             LevelChecked(Sheltron) && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
-                            Gauge.OathGauge >= Config.PLD_AoE_SheltronOption)
+                            Gauge.OathGauge >= Config.PLD_AoE_SheltronOption && PlayerHealthPercentageHp() <= Config.PLD_AoE_SheltronHP)
                             return OriginalHook(Sheltron);
                     }
 
@@ -687,15 +689,10 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is FightOrFlight)
                 {
                     if (IsOffCooldown(FightOrFlight))
-                    {
                         return OriginalHook(FightOrFlight);
-                    }
 
-                    if (IsOffCooldown(Requiescat) || 
-                        (LevelChecked(BladeOfHonor) && (HasEffect(Buffs.Requiescat) || HasEffect(Buffs.BladeOfHonor))))
-                    {
+                    if (IsOffCooldown(Requiescat) || (LevelChecked(BladeOfHonor) && (HasEffect(Buffs.Requiescat) || HasEffect(Buffs.BladeOfHonor))))
                         return OriginalHook(Requiescat);
-                    }
 
                     return OriginalHook(FightOrFlight);
                 }

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -73,31 +73,41 @@ namespace XIVSlothCombo.Combos.PvE
         public static class Config
         {
             public static UserInt
+                PLD_ST_FoF_Option = new("PLD_ST_FoF_Option"),
+                PLD_AoE_FoF_Option = new("PLD_AoE_FoF_Option"),
                 PLD_Intervene_HoldCharges = new("PLDKeepInterveneCharges"),
                 PLD_VariantCure = new("PLD_VariantCure"),
                 PLD_RequiescatOption = new("PLD_RequiescatOption"),
                 PLD_SpiritsWithinOption = new("PLD_SpiritsWithinOption"),
-                PLD_SheltronOption = new("PLD_SheltronOption"),
-                PLD_ST_RequiescatWeave = new("PLD_ST_RequiescatWeave"),
-                PLD_AoE_RequiescatWeave = new("PLD_AoE_RequiescatWeave"),
-                PLD_ST_AtonementTiming = new("PLD_ST_EquilibriumTiming"),
-                PLD_ST_DivineMightTiming = new("PLD_ST_DivineMightTiming");
-            public static UserBool
-                PLD_Intervene_MeleeOnly = new("PLD_Intervene_MeleeOnly");
+                PLD_ST_SheltronOption = new("PLD_ST_SheltronOption"),
+                PLD_AoE_SheltronOption = new("PLD_AoE_SheltronOption"),
+                //PLD_ST_RequiescatWeave = new("PLD_ST_RequiescatWeave"),
+                //PLD_AoE_RequiescatWeave = new("PLD_AoE_RequiescatWeave"),
+                //PLD_ST_AtonementTiming = new("PLD_ST_EquilibriumTiming"),
+                //PLD_ST_DivineMightTiming = new("PLD_ST_DivineMightTiming"),
+                PLD_Intervene_MeleeOnly = new ("PLD_Intervene_MeleeOnly", 1),
+                PLD_ShieldLob_SubOption = new ("PLD_ShieldLob_SubOption", 1);
         }
 
         internal class PLD_ST_SimpleMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PLD_ST_SimpleMode;
+            internal static int RoyalAuthorityCount => ActionWatching.CombatActions.Count(x => x == OriginalHook(RageOfHalone));
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
                 if (actionID is FastBlade)
                 {
+                    #region Types
+                    bool hasDivineMight = HasEffect(Buffs.DivineMight);
+                    bool inAtonementStarter = HasEffect(Buffs.AtonementReady);
+                    bool inAtonementFinisher = HasEffect(Buffs.SepulchreReady);
+                    bool inBurstPhase = LevelChecked(BladeOfFaith) && RoyalAuthorityCount > 0;
                     bool inAtonementPhase = HasEffect(Buffs.AtonementReady) || HasEffect(Buffs.SupplicationReady) || HasEffect(Buffs.SepulchreReady);
                     bool isAtonementExpiring = (HasEffect(Buffs.AtonementReady) && GetBuffRemainingTime(Buffs.AtonementReady) < 10) ||
                                                 (HasEffect(Buffs.SupplicationReady) && GetBuffRemainingTime(Buffs.SupplicationReady) < 10) ||
                                                 (HasEffect(Buffs.SepulchreReady) && GetBuffRemainingTime(Buffs.SepulchreReady) < 10);
+                    #endregion
 
                     // Criterion Stuff
                     if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
@@ -106,25 +116,25 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (HasBattleTarget())
                     {
-                        // Criterion Stuff
-                        if (CanWeave(actionID))
-                        {
-                            Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-
-                            if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
-                                (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                                return Variant.VariantSpiritDart;
-
-                            if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) &&
-                                IsOffCooldown(Variant.VariantUltimatum))
-                                return Variant.VariantUltimatum;
-                        }
-
                         if (InMeleeRange())
                         {
-                            // Requiescat Usage: After Fight or Flight
-                            if (ActionReady(Requiescat) && CanWeave(actionID) && JustUsed(FightOrFlight, 8f))
-                                return OriginalHook(Requiescat);
+                            if (CanWeave(actionID))
+                            {
+                                // Criterion Stuff
+                                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+
+                                if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
+                                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                                    return Variant.VariantSpiritDart;
+
+                                if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) &&
+                                    IsOffCooldown(Variant.VariantUltimatum))
+                                    return Variant.VariantUltimatum;
+
+                                // Requiescat Usage: After Fight or Flight
+                                if (ActionReady(Requiescat) && JustUsed(FightOrFlight, 8f))
+                                    return OriginalHook(Requiescat);
+                            }
 
                             // Goring Blade Usage: No Requiescat / After Requiescat
                             if (HasEffect(Buffs.GoringBladeReady) && (!LevelChecked(Requiescat) || (IsOnCooldown(Requiescat) &&
@@ -181,10 +191,10 @@ namespace XIVSlothCombo.Combos.PvE
                                     // Levels 26-67
                                     else if (lastComboActionID is RiotBlade)
                                         return FightOrFlight;
-                        }
+                                }
 
                                 // Levels 68+
-                                else if (IsOffCooldown(Requiescat) && lastComboActionID is RoyalAuthority)
+                                else if (GetCooldownRemainingTime(Requiescat) < 0.5f && CanWeave(actionID, 1.5f) && (lastComboActionID is RoyalAuthority || inBurstPhase))
                                     return FightOrFlight;
                             }
 
@@ -199,13 +209,24 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Atonement Usage: During Burst / Before Expiring / Before Refreshing
-                        if (inAtonementPhase && InMeleeRange() && (HasEffect(Buffs.FightOrFlight) || isAtonementExpiring || lastComboActionID is RiotBlade))
+                        // Holy Spirit Prioritization
+                        if (hasDivineMight && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                        {
+                            // Delay Sepulchre (Before Burst Starts) / Prefer Sepulchre (Before Burst Ends)
+                            if (inAtonementFinisher && (GetCooldownRemainingTime(FightOrFlight) < 6 || GetBuffRemainingTime(Buffs.FightOrFlight) > 3))
+                                return HolySpirit;
+
+                            // Fit in Burst (When Sepulchre Unavailable)
+                            if (!inAtonementFinisher && HasEffect(Buffs.FightOrFlight) && GetBuffRemainingTime(Buffs.FightOrFlight) < 3)
+                                return HolySpirit;
+                        }
+
+                        // Atonement Usage: During Burst / Before Expiring / Before Refreshing / Spend Starter
+                        if (inAtonementPhase && InMeleeRange() && (JustUsed(FightOrFlight, 30f) || isAtonementExpiring || lastComboActionID is RiotBlade || inAtonementStarter))
                             return OriginalHook(Atonement);
 
-
                         // Holy Spirit Usage: During Burst / Outside Melee / Before Expiring / Before Refreshing
-                        if (HasEffect(Buffs.DivineMight) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp && (HasEffect(Buffs.FightOrFlight) ||
+                        if (hasDivineMight && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp && (JustUsed(FightOrFlight, 30f) ||
                             !InMeleeRange() || GetBuffRemainingTime(Buffs.DivineMight) < 10 || lastComboActionID is RiotBlade))
                             return HolySpirit;
 
@@ -242,64 +263,67 @@ namespace XIVSlothCombo.Combos.PvE
                         PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
                         return Variant.VariantCure;
 
-                    // Criterion Stuff
-                    if (CanWeave(actionID))
+                    if (HasBattleTarget())
                     {
-                        Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-
-                        if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
-                            (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                            return Variant.VariantSpiritDart;
-
-                        if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) &&
-                            IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
-                            return Variant.VariantUltimatum;
-                    }
-
-                    // Requiescat
-                    if (ActionReady(Requiescat) && CanWeave(actionID) && JustUsed(FightOrFlight, 8f) && HasBattleTarget() && InMeleeRange())
-                        return OriginalHook(Requiescat);
-
-                    // Burst Phase
-                    if (HasEffect(Buffs.FightOrFlight))
-                    {
-                        // oGCDs
-                        if (CanWeave(actionID))
+                        if (InMeleeRange() && CanWeave(actionID))
                         {
-                            if (ActionReady(CircleOfScorn))
-                                return CircleOfScorn;
+                            // Criterion Stuff
+                            Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
 
-                            if (HasBattleTarget())
+                            if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
+                                (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                                return Variant.VariantSpiritDart;
+
+                            if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) &&
+                                IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
+                                return Variant.VariantUltimatum;
+
+                            // Requiescat Usage: After Fight or Flight
+                            if (ActionReady(Requiescat) && JustUsed(FightOrFlight, 8f))
+                                return OriginalHook(Requiescat);
+                        }
+
+                        // Burst Phase
+                        if (HasEffect(Buffs.FightOrFlight))
+                        {
+                            if (CanWeave(actionID))
                             {
-                                if (ActionReady(SpiritsWithin) && InMeleeRange())
-                                    return OriginalHook(SpiritsWithin);
+                                // Melee oGCDs
+                                if (InMeleeRange())
+                                {
+                                    if (ActionReady(CircleOfScorn))
+                                        return CircleOfScorn;
+
+                                    if (ActionReady(SpiritsWithin))
+                                        return OriginalHook(SpiritsWithin);
+                                }
 
                                 // Blade of Honor
                                 if (OriginalHook(Requiescat) == BladeOfHonor)
                                     return OriginalHook(Requiescat);
                             }
+
+                            // Confiteor & Blades
+                            if (HasEffect(Buffs.Requiescat) && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp &&
+                                (HasEffect(Buffs.ConfiteorReady) || OriginalHook(Confiteor) != Confiteor))
+                                return OriginalHook(Confiteor);
                         }
 
-                        // Confiteor & Blades
-                        if (HasEffect(Buffs.Requiescat) && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp &&
-                            HasBattleTarget() && (HasEffect(Buffs.ConfiteorReady) || OriginalHook(Confiteor) != Confiteor))
-                            return OriginalHook(Confiteor);
-                    }
-
-                    if (CanWeave(actionID))
-                    {
-                        // Fight or Flight
-                        if (ActionReady(FightOrFlight) && (IsOffCooldown(Requiescat) || !LevelChecked(Requiescat)))
-                            return FightOrFlight;
-
-                        // oGCDs
-                        if (GetCooldownRemainingTime(FightOrFlight) > 15)
+                        // Melee oGCDs
+                        if (CanWeave(actionID) && InMeleeRange())
                         {
-                            if (ActionReady(CircleOfScorn))
-                                return CircleOfScorn;
+                            // Fight or Flight
+                            if (ActionReady(FightOrFlight) && ((GetCooldownRemainingTime(Requiescat) < 0.5f && CanWeave(actionID, 1.5f)) || !LevelChecked(Requiescat)))
+                                return FightOrFlight;
 
-                            if (ActionReady(SpiritsWithin) && InMeleeRange() && HasBattleTarget())
-                                return OriginalHook(SpiritsWithin);
+                            if (GetCooldownRemainingTime(FightOrFlight) > 15)
+                            {
+                                if (ActionReady(CircleOfScorn))
+                                    return CircleOfScorn;
+
+                                if (ActionReady(SpiritsWithin))
+                                    return OriginalHook(SpiritsWithin);
+                            }
                         }
                     }
 
@@ -310,8 +334,6 @@ namespace XIVSlothCombo.Combos.PvE
                     // Basic Combo
                     if (comboTime > 0 && lastComboActionID is TotalEclipse && LevelChecked(Prominence))
                         return Prominence;
-
-                    return actionID;
                 }
 
                 return actionID;
@@ -321,225 +343,179 @@ namespace XIVSlothCombo.Combos.PvE
         internal class PLD_ST_AdvancedMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PLD_ST_AdvancedMode;
+            internal static int RoyalAuthorityCount => ActionWatching.CombatActions.Count(x => x == OriginalHook(RageOfHalone));
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
                 if (actionID is FastBlade)
                 {
-                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
+                    #region Types
+                    bool hasDivineMight = HasEffect(Buffs.DivineMight);
+                    bool inAtonementStarter = HasEffect(Buffs.AtonementReady);
+                    bool inAtonementFinisher = HasEffect(Buffs.SepulchreReady);
+                    bool inBurstPhase = LevelChecked(BladeOfFaith) && RoyalAuthorityCount > 0;
+                    bool inAtonementPhase = HasEffect(Buffs.AtonementReady) || HasEffect(Buffs.SupplicationReady) || HasEffect(Buffs.SepulchreReady);
+                    bool isAtonementExpiring = (HasEffect(Buffs.AtonementReady) && GetBuffRemainingTime(Buffs.AtonementReady) < 10) ||
+                                                (HasEffect(Buffs.SupplicationReady) && GetBuffRemainingTime(Buffs.SupplicationReady) < 10) ||
+                                                (HasEffect(Buffs.SepulchreReady) && GetBuffRemainingTime(Buffs.SepulchreReady) < 10);
+                    #endregion
+
+                    // Criterion Stuff
+                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
                         PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
                         return Variant.VariantCure;
 
                     if (HasBattleTarget())
                     {
-                        if (!InMeleeRange() && !HasEffect(Buffs.Requiescat))
+                        if (InMeleeRange())
                         {
-                            // HS when out of range
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                                (!IsMoving || HasEffect(Buffs.DivineMight)) &&
-                                HolySpirit.LevelChecked() &&
-                                GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                return HolySpirit;
-
-                            // Shield lob uptime only if unable to stop and HS
-                            // (arguably better to delay by less than a whole GCD and just stop moving to cast)
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_ShieldLob) &&
-                                ShieldLob.LevelChecked() &&
-                                ((HolySpirit.LevelChecked() && GetResourceCost(HolySpirit) > LocalPlayer.CurrentMp) || (!HolySpirit.LevelChecked()) || IsMoving))
-                                return ShieldLob;
-                        }
-
-                        if (CanWeave(actionID))
-                        {
-                            Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
-
-                            if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) &&
-                                IsEnabled(Variant.VariantSpiritDart) &&
-                                (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                                return Variant.VariantSpiritDart;
-
-                            if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) &&
-                                IsEnabled(Variant.VariantUltimatum) &&
-                                IsOffCooldown(Variant.VariantUltimatum))
-                                return Variant.VariantUltimatum;
-
-                            // (Holy) Sheltron overcap protection
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) &&
-                                Sheltron.LevelChecked() &&
-                                !HasEffect(Buffs.Sheltron) &&
-                                !HasEffect(Buffs.HolySheltron) &&
-                                Gauge.OathGauge >= Config.PLD_SheltronOption)
-                                return OriginalHook(Sheltron);
-                        }
-
-                        // Requiescat inside burst (checking for FoF buff causes a late weave and can misalign over long fights with some ping)
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
-                            (WasLastAbility(FightOrFlight) || JustUsed(FightOrFlight, 6f)) && ActionReady(Requiescat))
-                        {
-                            if ((Config.PLD_ST_RequiescatWeave == 0 && CanWeave(actionID) ||
-                                (Config.PLD_ST_RequiescatWeave == 1 && CanDelayedWeave(actionID, 2.0, 0.6)))) // These weave timings make no sense but they work for some reason
-                                return OriginalHook(Requiescat);
-                        }
-
-                        // Actions under FoF burst
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && HasEffect(Buffs.FightOrFlight))
-                        {
-                            if (CanWeave(actionID) && !WasLastAbility(FightOrFlight))
+                            if (CanWeave(actionID))
                             {
+                                // Criterion Stuff
+                                Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+
+                                if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
+                                    (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                                    return Variant.VariantSpiritDart;
+
+                                if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) &&
+                                    IsOffCooldown(Variant.VariantUltimatum))
+                                    return Variant.VariantUltimatum;
+
+                                // Requiescat Usage: After Fight or Flight
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) &&
+                                    ActionReady(Requiescat) && JustUsed(FightOrFlight, 8f))
+                                    return OriginalHook(Requiescat);
+                            }
+
+                            // Goring Blade Usage: No Requiescat / After Requiescat
+                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
+                                HasEffect(Buffs.GoringBladeReady) && (!LevelChecked(Requiescat) || (IsOnCooldown(Requiescat) &&
+                                !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
+                                return GoringBlade;
+                        }
+
+                        // Burst Phase
+                        if (HasEffect(Buffs.FightOrFlight))
+                        {
+                            if (CanWeave(actionID))
+                            {
+                                // Melee oGCDs
                                 if (InMeleeRange())
                                 {
-                                    if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
-                                        ActionReady(CircleOfScorn))
+                                    if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) && ActionReady(CircleOfScorn))
                                         return CircleOfScorn;
 
-                                    if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
-                                        ActionReady(OriginalHook(SpiritsWithin)))
+                                    if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) && ActionReady(SpiritsWithin))
                                         return OriginalHook(SpiritsWithin);
                                 }
 
                                 if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Intervene) &&
-                                    OriginalHook(Intervene).LevelChecked() &&
-                                    !WasLastAction(Intervene) &&
-                                    GetRemainingCharges(Intervene) > Config.PLD_Intervene_HoldCharges &&
-                                    GetCooldownRemainingTime(CircleOfScorn) > 3 &&
-                                    GetCooldownRemainingTime(OriginalHook(CircleOfScorn)) > 3 &&
-                                    ((Config.PLD_Intervene_MeleeOnly && InMeleeRange()) || (!Config.PLD_Intervene_MeleeOnly)))
-                                    return OriginalHook(Intervene);
-                            }
+                                    LevelChecked(Intervene) && GetRemainingCharges(Intervene) > Config.PLD_Intervene_HoldCharges && !IsMoving && !WasLastAction(Intervene) &&
+                                    ((Config.PLD_Intervene_MeleeOnly == 1 && InMeleeRange()) || (GetTargetDistance() == 0 && Config.PLD_Intervene_MeleeOnly == 2)))
+                                    return Intervene;
 
-                            // New Goring Blade
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
-                                InMeleeRange() && HasEffect(Buffs.GoringBladeReady) && (!BladeOfHonor.LevelChecked() ||
-                                (IsOnCooldown(Requiescat) && !HasEffect(Buffs.Requiescat) && OriginalHook(Requiescat) != BladeOfHonor)))
-                                // To accomodate native action change settings, do not use "OriginalHook" here
-                                return GoringBlade;
+                                // Blade of Honor
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_BladeOfHonor) && OriginalHook(Requiescat) == BladeOfHonor)
+                                    return OriginalHook(Requiescat);
+                            }
 
                             if (HasEffect(Buffs.Requiescat))
                             {
                                 // Confiteor & Blades
-                                if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
-                                    HasEffect(Buffs.ConfiteorReady))
-                                    ||
-                                    (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
-                                    BladeOfFaith.LevelChecked() &&
-                                    OriginalHook(Confiteor) != Confiteor &&
-                                    GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp))
+                                if (GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp && ((HasEffect(Buffs.ConfiteorReady) && IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor)) ||
+                                    (OriginalHook(Confiteor) != Confiteor) && IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades)))
                                     return OriginalHook(Confiteor);
 
-                                // HS when Confiteor not unlocked or Confiteor used
-                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                                    GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                                // Pre-Blades
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
                                     return HolySpirit;
                             }
-                            
-                            // Blade of Honor after Confi Combo (Weave).
-                            if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_BladeOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
-                                // To accomodate native action change settings, do not use "OriginalHook" here
-                                return BladeOfHonor;
-
-                            // HS under DM
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                                HasEffect(Buffs.DivineMight) &&
-                                GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                                return HolySpirit;
-
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
-                                (HasEffect(Buffs.AtonementReady) || HasEffect(Buffs.SepulchreReady) || HasEffect(Buffs.SupplicationReady)))
-                                return OriginalHook(Atonement);
                         }
 
-                        // FoF (Starts burst)
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) &&
-                            ActionReady(FightOrFlight) && CanWeave(actionID) &&
-                            ActionWatching.CombatActions.Where(x => x == OriginalHook(RoyalAuthority)).Any()) // Check RA has been used for opener exception
-                            return FightOrFlight;
-
-                        // CoS/SW outside of burst
-                        if (CanWeave(actionID, 0.6) &&
-                            (!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 ||
-                            IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF)) && InMeleeRange())
+                        if (CanWeave(actionID) && InMeleeRange())
                         {
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) &&
-                                ActionReady(CircleOfScorn))
-                                return CircleOfScorn;
-
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) &&
-                                ActionReady(OriginalHook(SpiritsWithin)))
-                                return OriginalHook(SpiritsWithin);
-                        }
-
-                        //Req without FoF
-                        if (IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Requiescat) && CanWeave(actionID)) && ActionReady(Requiescat))
-                            return OriginalHook(Requiescat);
-
-                        // Blade of Honor after Confi Combo (Weave).
-                        if ((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_BladeOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)) && IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
-                            // To accomodate native action change settings, do not use "OriginalHook" here
-                            return BladeOfHonor;
-                        
-                        
-                        // Confiteor & Blades
-                        if (((IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Confiteor) &&
-                            Confiteor.LevelChecked() &&
-                            HasEffect(Buffs.ConfiteorReady))
-                            ||
-                            (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Blades) &&
-                            BladeOfFaith.LevelChecked() &&
-                            HasEffect(Buffs.Requiescat) &&
-                            OriginalHook(Confiteor) != Confiteor &&
-                            GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp)))
-                            return OriginalHook(Confiteor);
-
-                        // Goring on cooldown (burst features disabled) -- Goring Blade is only available with FoF
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_GoringBlade) &&
-                            HasEffect(Buffs.GoringBladeReady) &&
-                            IsNotEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF))
-                            // To accomodate native action change settings, do not use "OriginalHook" here
-                            return GoringBlade;
-
-                        //Req HS
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                            HasEffect(Buffs.Requiescat) &&
-                            GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
-                            return HolySpirit;
-
-                        // Base combo
-                        if (comboTime > 0)
-                        {
-                            if (lastComboActionID is FastBlade &&
-                                RiotBlade.LevelChecked())
-                                return RiotBlade;
-
-                            // Insert Atonement/Holy Spirit before end of basic combo for "Late Spend" option
-                            if (lastComboActionID is RiotBlade && RageOfHalone.LevelChecked())
+                            // Fight or Flight
+                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && ActionReady(FightOrFlight) && GetTargetHPPercent() >= Config.PLD_ST_FoF_Option)
                             {
-                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
-                                    (HasEffect(Buffs.AtonementReady) || HasEffect(Buffs.SepulchreReady) || HasEffect(Buffs.SupplicationReady)) && InMeleeRange() && 
-                                    (Config.PLD_ST_AtonementTiming == 2 || (Config.PLD_ST_AtonementTiming == 3 && ActionWatching.CombatActions.Count(x => x == FightOrFlight) % 2 == 0)))
-                                    return OriginalHook(Atonement);
+                                if (!LevelChecked(Requiescat))
+                                {
+                                    if (!LevelChecked(RageOfHalone))
+                                    {
+                                        // Levels 1-25
+                                        if (lastComboActionID is FastBlade)
+                                            return FightOrFlight;
+                                    }
 
-                                return (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                                    HasEffect(Buffs.DivineMight) &&
-                                    GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp &&
-                                    (Config.PLD_ST_DivineMightTiming == 2 || (Config.PLD_ST_DivineMightTiming == 3 && ActionWatching.CombatActions.Count(x => x == FightOrFlight) % 2 == 1)))
-                                    ? HolySpirit
-                                    : OriginalHook(RageOfHalone);
+                                    // Levels 26-67
+                                    else if (lastComboActionID is RiotBlade)
+                                        return FightOrFlight;
+                                }
+
+                                // Levels 68+
+                                else if (GetCooldownRemainingTime(Requiescat) < 0.5f && CanWeave(actionID, 1.5f) && (lastComboActionID is RoyalAuthority || inBurstPhase))
+                                    return FightOrFlight;
+                            }
+
+                            // Melee oGCDs
+                            if (GetCooldownRemainingTime(FightOrFlight) > 15)
+                            {
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_CircleOfScorn) && ActionReady(CircleOfScorn))
+                                    return CircleOfScorn;
+
+                                if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_SpiritsWithin) && ActionReady(SpiritsWithin))
+                                    return OriginalHook(SpiritsWithin);
                             }
                         }
 
-                        // Atonement between basic combos for "Early Spend" option
+                        // Sheltron Overcap Protection
+                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) && InCombat() &&
+                            LevelChecked(Sheltron) && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
+                            Gauge.OathGauge >= Config.PLD_ST_SheltronOption)
+                            return OriginalHook(Sheltron);
+
+                        // Holy Spirit Prioritization
+                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) && hasDivineMight && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp)
+                        {
+                            // Delay Sepulchre (Before Burst Starts) / Prefer Sepulchre (Before Burst Ends)
+                            if (inAtonementFinisher && (GetCooldownRemainingTime(FightOrFlight) < 6 || GetBuffRemainingTime(Buffs.FightOrFlight) > 3))
+                                return HolySpirit;
+
+                            // Fit in Burst (When Sepulchre Unavailable)
+                            if (!inAtonementFinisher && HasEffect(Buffs.FightOrFlight) && GetBuffRemainingTime(Buffs.FightOrFlight) < 3)
+                                return HolySpirit;
+                        }
+
+                        // Atonement Usage: During Burst / Before Expiring / Before Refreshing / Spend Starter
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Atonement) &&
-                            (HasEffect(Buffs.AtonementReady) || HasEffect(Buffs.SepulchreReady) || HasEffect(Buffs.SupplicationReady)) && InMeleeRange() &&
-                            (Config.PLD_ST_AtonementTiming == 1 || (Config.PLD_ST_AtonementTiming == 3 && ActionWatching.CombatActions.Count(x => x == FightOrFlight) % 2 == 1)))
+                            inAtonementPhase && InMeleeRange() && (JustUsed(FightOrFlight, 30f) || isAtonementExpiring || lastComboActionID is RiotBlade || inAtonementStarter))
                             return OriginalHook(Atonement);
 
-                        // Holy Spirit between basic combos for "Early Spend" option
+                        // Holy Spirit Usage: During Burst / Outside Melee / Before Expiring / Before Refreshing
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit) &&
-                            HasEffect(Buffs.DivineMight) &&
-                            GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp &&
-                            (Config.PLD_ST_DivineMightTiming == 1 || (Config.PLD_ST_DivineMightTiming == 3 && ActionWatching.CombatActions.Count(x => x == FightOrFlight) % 2 == 0)))
+                            hasDivineMight && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp && (JustUsed(FightOrFlight, 30f) ||
+                            !InMeleeRange() || GetBuffRemainingTime(Buffs.DivineMight) < 10 || lastComboActionID is RiotBlade))
                             return HolySpirit;
+
+                        // Out of Range Options: Shield Lob / Holy Spirit (Not Moving)
+                        if (!InMeleeRange() && IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_ShieldLob))
+                        {
+                            if (!IsMoving && LevelChecked(HolySpirit) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp && Config.PLD_ShieldLob_SubOption == 2)
+                                return HolySpirit;
+
+                            if (LevelChecked(ShieldLob))
+                                return ShieldLob;
+                        }
+
+                        // Basic Combo
+                        if (comboTime > 0)
+                        {
+                            if (lastComboActionID is FastBlade && LevelChecked(RiotBlade))
+                                return RiotBlade;
+
+                            if (lastComboActionID is RiotBlade && LevelChecked(RageOfHalone))
+                                return OriginalHook(RageOfHalone);
+                        }
                     }
                 }
 
@@ -555,128 +531,91 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is TotalEclipse)
                 {
-                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
+                    // Criterion Stuff
+                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
+                        PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
                         return Variant.VariantCure;
 
-                    if (CanWeave(actionID))
+                    if (HasBattleTarget())
                     {
-                        Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
+                        if (InMeleeRange() && CanWeave(actionID))
+                        {
+                            // Criterion Stuff
+                            Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
 
-                        if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
-                            (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
-                            return Variant.VariantSpiritDart;
+                            if (IsEnabled(CustomComboPreset.PLD_Variant_SpiritDart) && IsEnabled(Variant.VariantSpiritDart) &&
+                                (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
+                                return Variant.VariantSpiritDart;
 
-                        if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
-                            return Variant.VariantUltimatum;
+                            if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) &&
+                                IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
+                                return Variant.VariantUltimatum;
 
-                        // (Holy) Sheltron overcap protection
-                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron) &&
-                            Sheltron.LevelChecked() && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
-                            Gauge.OathGauge >= Config.PLD_SheltronOption)
+                            // Requiescat Usage: After Fight or Flight
+                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) && ActionReady(Requiescat) && JustUsed(FightOrFlight, 8f))
+                                return OriginalHook(Requiescat);
+                        }
+
+                        // Burst Phase
+                        if (HasEffect(Buffs.FightOrFlight))
+                        {
+                            if (CanWeave(actionID))
+                            {
+                                // Melee oGCDs
+                                if (InMeleeRange())
+                                {
+                                    if (ActionReady(CircleOfScorn) && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn))
+                                        return CircleOfScorn;
+
+                                    if (ActionReady(SpiritsWithin) && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin))
+                                        return OriginalHook(SpiritsWithin);
+                                }
+
+                                // Blade of Honor
+                                if (OriginalHook(Requiescat) == BladeOfHonor && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladeOfHonor))
+                                    return OriginalHook(Requiescat);
+                            }
+
+                            // Confiteor & Blades
+                            if (HasEffect(Buffs.Requiescat) && GetResourceCost(Confiteor) <= LocalPlayer.CurrentMp &&
+                                ((HasEffect(Buffs.ConfiteorReady) && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor)) ||
+                                (OriginalHook(Confiteor) != Confiteor && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades))))
+                                return OriginalHook(Confiteor);
+                        }
+
+                        // Melee oGCDs
+                        if (CanWeave(actionID) && InMeleeRange())
+                        {
+                            // Fight or Flight
+                            if (ActionReady(FightOrFlight) && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && GetTargetHPPercent() >= Config.PLD_AoE_FoF_Option &&
+                                ((GetCooldownRemainingTime(Requiescat) < 0.5f && CanWeave(actionID, 1.5f)) || !LevelChecked(Requiescat)))
+                                return FightOrFlight;
+
+                            if (GetCooldownRemainingTime(FightOrFlight) > 15)
+                            {
+                                if (ActionReady(CircleOfScorn) && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn))
+                                    return CircleOfScorn;
+
+                                if (ActionReady(SpiritsWithin) && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin))
+                                    return OriginalHook(SpiritsWithin);
+                            }
+                        }
+
+                        // Sheltron Overcap Protection
+                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron) && InCombat() &&
+                            LevelChecked(Sheltron) && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
+                            Gauge.OathGauge >= Config.PLD_AoE_SheltronOption)
                             return OriginalHook(Sheltron);
                     }
 
-                    // Requiescat inside burst (checking for FoF buff causes a late weave and can misalign over long fights with some ping)
-                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) &&
-                        (WasLastAbility(FightOrFlight) || JustUsed(FightOrFlight,6f)) && ActionReady(Requiescat))
-                    {
-                        if ((Config.PLD_AoE_RequiescatWeave == 0 && CanWeave(actionID) ||
-                            (Config.PLD_AoE_RequiescatWeave == 1 && CanDelayedWeave(actionID, 2.0, 0.6))))
-                            return Requiescat;
-                    }
-
-                    // Actions under FoF burst
-                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && HasEffect(Buffs.FightOrFlight))
-                    {
-                        if (CanWeave(actionID) && !WasLastAbility(FightOrFlight))
-                        {
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) &&
-                                ActionReady(CircleOfScorn))
-                                return CircleOfScorn;
-
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) &&
-                                ActionReady(OriginalHook(SpiritsWithin)))
-                                return OriginalHook(SpiritsWithin);
-                        }
-                        
-                        if (HasEffect(Buffs.Requiescat))
-                        {
-                            // Confiteor & Blades
-                            if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
-                                HasEffect(Buffs.ConfiteorReady))
-                                ||
-                                (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) &&
-                                BladeOfFaith.LevelChecked() &&
-                                OriginalHook(Confiteor) != Confiteor &&
-                                GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp))
-                                return OriginalHook(Confiteor);
-
-                            // HC when Confiteor not unlocked
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
-                                GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
-                                return HolyCircle;
-                        }
-
-                        // Blade of Honor after Confi Combo (Weave).
-                        if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladeOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
-                            // To accomodate native action change settings, do not use "OriginalHook" here
-                            return BladeOfHonor;
-
-                        // HC under DM/Req
-                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) &&
-                            (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)) &&
-                            GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp &&
-                            HolyCircle.LevelChecked())
-                            return HolyCircle;
-                    }
-
-                    if (CanWeave(actionID))
-                    {
-                        // FoF (Starts burst)
-                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && ActionReady(FightOrFlight))
-                            return FightOrFlight;
-
-                        // Usage outside of burst (desync for Req, 30s windows for CoS/SW)
-                        if ((!WasLastAction(FightOrFlight) && GetCooldownRemainingTime(FightOrFlight) >= 15 || IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF)) &&
-                            !ActionWatching.WasLast2ActionsAbilities())
-                        {
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat) && ActionReady(Requiescat))
-                                return OriginalHook(Requiescat);
-
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_CircleOfScorn) && ActionReady(CircleOfScorn))
-                                return CircleOfScorn;
-
-                            if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_SpiritsWithin) &&
-                                ActionReady(OriginalHook(SpiritsWithin)))
-                                return OriginalHook(SpiritsWithin);
-                        }
-                    }
-
-                    // Confiteor & Blades
-                    if (((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Confiteor) &&
-                        Confiteor.LevelChecked() && HasEffect(Buffs.ConfiteorReady))
-                        ||
-                        (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Blades) &&
-                        BladeOfFaith.LevelChecked() && HasEffect(Buffs.Requiescat) &&
-                        OriginalHook(Confiteor) != Confiteor &&
-                        GetResourceCost(OriginalHook(Confiteor)) <= LocalPlayer.CurrentMp)) &&
-                        IsNotEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF))
-                        return OriginalHook(Confiteor);
-
-                    // Blade of Honor after Confi Combo (Weave).
-                    if ((IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_BladeOfHonor) && CanWeave(actionID) && HasEffect(Buffs.BladeOfHonor)))
-                        // To accomodate native action change settings, do not use "OriginalHook" here
-                        return BladeOfHonor;
-
-                    // HS under DM (outside of burst)
-                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && HasEffect(Buffs.DivineMight) &&
-                        GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp && LevelChecked(HolyCircle))
+                    // Holy Circle
+                    if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_HolyCircle) && LevelChecked(HolyCircle) && GetResourceCost(HolyCircle) <= LocalPlayer.CurrentMp &&
+                        (HasEffect(Buffs.DivineMight) || HasEffect(Buffs.Requiescat)))
                         return HolyCircle;
 
-                    if (comboTime > 0 && lastComboActionID is TotalEclipse && Prominence.LevelChecked())
+                    // Basic Combo
+                    if (comboTime > 0 && lastComboActionID is TotalEclipse && LevelChecked(Prominence))
                         return Prominence;
-
-                    return actionID;
                 }
 
                 return actionID;
@@ -759,6 +698,22 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     return OriginalHook(FightOrFlight);
+                }
+
+                return actionID;
+            }
+        }
+
+        internal class PLD_ShieldLob_HolySpirit : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PLD_ShieldLob_Feature;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+            {
+                if (actionID is ShieldLob)
+                {
+                    if (LevelChecked(HolySpirit) && GetResourceCost(HolySpirit) <= LocalPlayer.CurrentMp && (!IsMoving || HasEffect(Buffs.DivineMight)))
+                        return HolySpirit;
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -469,7 +469,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // Sheltron Overcap Protection
-                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) && InCombat() &&
+                        if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) && InCombat() && CanWeave(actionID) &&
                             LevelChecked(Sheltron) && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
                             Gauge.OathGauge >= Config.PLD_ST_SheltronOption)
                             return OriginalHook(Sheltron);
@@ -602,7 +602,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // Sheltron Overcap Protection
-                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron) && InCombat() &&
+                        if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron) && InCombat() && CanWeave(actionID) &&
                             LevelChecked(Sheltron) && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
                             Gauge.OathGauge >= Config.PLD_AoE_SheltronOption)
                             return OriginalHook(Sheltron);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1769,13 +1769,19 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_AoE_FoF_Option, "Target HP%", 200);
 
             if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Sheltron)
-                UserConfig.DrawSliderInt(50, 100, PLD.Config.PLD_ST_SheltronOption, "Oath Gauge", sliderIncrement: 5);
+                UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_ST_SheltronHP, "Player HP%", 200);
+
+            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Sheltron)
+                UserConfig.DrawSliderInt(50, 100, PLD.Config.PLD_ST_SheltronOption, "Oath Gauge", 200, 5);
 
             if (preset == CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron)
-                UserConfig.DrawSliderInt(50, 100, PLD.Config.PLD_AoE_SheltronOption, "Oath Gauge", sliderIncrement: 5);
+                UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_AoE_SheltronHP, "Player HP%", 200);
 
-            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Intervene && enabled)
-                UserConfig.DrawSliderInt(0, 1, PLD.Config.PLD_Intervene_HoldCharges, "Charges");
+            if (preset == CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron)
+                UserConfig.DrawSliderInt(50, 100, PLD.Config.PLD_AoE_SheltronOption, "Oath Gauge", 200, 5);
+
+            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Intervene)
+                UserConfig.DrawSliderInt(0, 1, PLD.Config.PLD_Intervene_HoldCharges, "Charges", 200);
 
             if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Intervene)
             {

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1735,25 +1735,26 @@ namespace XIVSlothCombo.Window.Functions
             if (preset == CustomComboPreset.PLD_Requiescat_Options)
             {
                 UserConfig.DrawRadioButton(PLD.Config.PLD_RequiescatOption, "Confiteor", "", 1);
-                UserConfig.DrawRadioButton(PLD.Config.PLD_RequiescatOption, "Blades of Faith/Truth/Valor", "", 2);
-                UserConfig.DrawRadioButton(PLD.Config.PLD_RequiescatOption, "Confiteor & Blades of Faith/Truth/Valor", "", 3);
+                UserConfig.DrawRadioButton(PLD.Config.PLD_RequiescatOption, "Blade of Faith/Truth/Valor", "", 2);
+                UserConfig.DrawRadioButton(PLD.Config.PLD_RequiescatOption, "Confiteor & Blade of Faith/Truth/Valor", "", 3);
                 UserConfig.DrawRadioButton(PLD.Config.PLD_RequiescatOption, "Holy Spirit", "", 4);
                 UserConfig.DrawRadioButton(PLD.Config.PLD_RequiescatOption, "Holy Circle", "", 5);
             }
 
-            if (preset is CustomComboPreset.PLD_ST_AdvancedMode_Requiescat)
-            {
-                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_ST_RequiescatWeave, "Standard Weave", "Weaves Requiescat immediately after Fight or Flight for a standard burst window.", 0, 150, ImGuiColors.ParsedGreen);
-                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_ST_RequiescatWeave, "Late Weave", "Late-weaves Requiescat after Fight or Flight.\nEnsures Requiescat's damage falls under the Fight or Flight buff, but may lead to misalignment in longer fights.", 1, 150, ImGuiColors.DalamudYellow);
-                ImGui.Spacing();
-            }
+            // Removed Requiescat weaving options pending further assessment - Kaeris
+            //if (preset is CustomComboPreset.PLD_ST_AdvancedMode_Requiescat)
+            //{
+            //    UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_ST_RequiescatWeave, "Standard Weave", "Weaves Requiescat immediately after Fight or Flight for a standard burst window.", 0, 150, ImGuiColors.ParsedGreen);
+            //    UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_ST_RequiescatWeave, "Late Weave", "Late-weaves Requiescat after Fight or Flight.\nEnsures Requiescat's damage falls under the Fight or Flight buff, but may lead to misalignment in longer fights.", 1, 150, ImGuiColors.DalamudYellow);
+            //    ImGui.Spacing();
+            //}
 
-            if (preset is CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat)
-            {
-                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_AoE_RequiescatWeave, "Standard Weave", "Weaves Requiescat immediately after Fight or Flight for a standard burst window.", 0, 150, ImGuiColors.ParsedGreen);
-                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_AoE_RequiescatWeave, "Late Weave", "Late-weaves Requiescat after Fight or Flight.\nEnsures Requiescat's damage falls under the Fight or Flight buff, but may lead to misalignment in longer fights.", 1, 150, ImGuiColors.DalamudYellow);
-                ImGui.Spacing();
-            }
+            //if (preset is CustomComboPreset.PLD_AoE_AdvancedMode_Requiescat)
+            //{
+            //    UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_AoE_RequiescatWeave, "Standard Weave", "Weaves Requiescat immediately after Fight or Flight for a standard burst window.", 0, 150, ImGuiColors.ParsedGreen);
+            //    UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_AoE_RequiescatWeave, "Late Weave", "Late-weaves Requiescat after Fight or Flight.\nEnsures Requiescat's damage falls under the Fight or Flight buff, but may lead to misalignment in longer fights.", 1, 150, ImGuiColors.DalamudYellow);
+            //    ImGui.Spacing();
+            //}
 
             if (preset == CustomComboPreset.PLD_SpiritsWithin)
             {
@@ -1761,33 +1762,50 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawRadioButton(PLD.Config.PLD_SpiritsWithinOption, "Prioritize Spirits Within / Expiacion", "", 2);
             }
 
-            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Sheltron || preset == CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron)
-            {
-                UserConfig.DrawSliderInt(50, 100, PLD.Config.PLD_SheltronOption, "Minimum Oath gauge required.", sliderIncrement: 5);
-            }
+            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_FoF)
+                UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_ST_FoF_Option, "Target HP%", 200);
+
+            if (preset == CustomComboPreset.PLD_AoE_AdvancedMode_FoF)
+                UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_AoE_FoF_Option, "Target HP%", 200);
+
+            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Sheltron)
+                UserConfig.DrawSliderInt(50, 100, PLD.Config.PLD_ST_SheltronOption, "Oath Gauge", sliderIncrement: 5);
+
+            if (preset == CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron)
+                UserConfig.DrawSliderInt(50, 100, PLD.Config.PLD_AoE_SheltronOption, "Oath Gauge", sliderIncrement: 5);
 
             if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Intervene && enabled)
-                UserConfig.DrawSliderInt(0, 1, PLD.Config.PLD_Intervene_HoldCharges, "How many charges to keep ready? (0 = Use all)");
+                UserConfig.DrawSliderInt(0, 1, PLD.Config.PLD_Intervene_HoldCharges, "Charges");
 
             if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Intervene)
-                UserConfig.DrawAdditionalBoolChoice(PLD.Config.PLD_Intervene_MeleeOnly, "Melee Only", "Only uses Intervene whilst in melee range");
+            {
+                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_Intervene_MeleeOnly, "Melee Range", "Uses Intervene while within melee range.\nMay result in minor movement.", 1);
+                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_Intervene_MeleeOnly, "No Movement", "Only uses Intervene when it would not result in movement (zero distance).", 2);
+            }
+
+            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_ShieldLob)
+            {
+                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_ShieldLob_SubOption, "Shield Lob Only", "Uses only Shield Lob.", 1);
+                UserConfig.DrawHorizontalRadioButton(PLD.Config.PLD_ShieldLob_SubOption, "Hardcast Holy Spirit", "Attempts to hardcast Holy Spirit when not moving.\nOtherwise uses Shield Lob.", 2);
+            }
 
             if (preset == CustomComboPreset.PLD_Variant_Cure)
-                UserConfig.DrawSliderInt(1, 100, PLD.Config.PLD_VariantCure, "HP% to be at or under", 200);
+                UserConfig.DrawSliderInt(1, 100, PLD.Config.PLD_VariantCure, "Player HP%", 200);
 
-            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Atonement)
-            {
-                UserConfig.DrawRadioButton(PLD.Config.PLD_ST_AtonementTiming, "Early Spend", "Uses Atonement before restarting the basic combo.", 1);
-                UserConfig.DrawRadioButton(PLD.Config.PLD_ST_AtonementTiming, "Late Spend", "Uses Atonement before the end of the basic combo.", 2);
-                UserConfig.DrawRadioButton(PLD.Config.PLD_ST_AtonementTiming, "Alternate Spend", "Switches between early and and late depending on how often Flight or Fight is used.", 3);
-            }
+            // New logic handles early/late spend for Atonement and Holy Spirit automatically - Kaeris
+            //if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Atonement)
+            //{
+            //    UserConfig.DrawRadioButton(PLD.Config.PLD_ST_AtonementTiming, "Early Spend", "Uses Atonement before restarting the basic combo.", 1);
+            //    UserConfig.DrawRadioButton(PLD.Config.PLD_ST_AtonementTiming, "Late Spend", "Uses Atonement before the end of the basic combo.", 2);
+            //    UserConfig.DrawRadioButton(PLD.Config.PLD_ST_AtonementTiming, "Alternate Spend", "Switches between early and and late depending on how often Flight or Fight is used.", 3);
+            //}
 
-            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit)
-            {
-                UserConfig.DrawRadioButton(PLD.Config.PLD_ST_DivineMightTiming, "Early Spend", "When under the effect of Divine Might, use Holy Spirit before restarting the basic combo.", 1);
-                UserConfig.DrawRadioButton(PLD.Config.PLD_ST_DivineMightTiming, "Late Spend", "When under the effect of Divine Might, uses Holy Spirit before the end of the basic combo.", 2);
-                UserConfig.DrawRadioButton(PLD.Config.PLD_ST_DivineMightTiming, "Alternate Spend", "When under the effect of Divine Might, switches between early and late depending on how often Flight or Fight is used.", 3);
-            }
+            //if (preset == CustomComboPreset.PLD_ST_AdvancedMode_HolySpirit)
+            //{
+            //    UserConfig.DrawRadioButton(PLD.Config.PLD_ST_DivineMightTiming, "Early Spend", "When under the effect of Divine Might, use Holy Spirit before restarting the basic combo.", 1);
+            //    UserConfig.DrawRadioButton(PLD.Config.PLD_ST_DivineMightTiming, "Late Spend", "When under the effect of Divine Might, uses Holy Spirit before the end of the basic combo.", 2);
+            //    UserConfig.DrawRadioButton(PLD.Config.PLD_ST_DivineMightTiming, "Alternate Spend", "When under the effect of Divine Might, switches between early and late depending on how often Flight or Fight is used.", 3);
+            //}
 
             #endregion
             // ====================================================================================


### PR DESCRIPTION
- Improved Fight or Flight Logic (ST / AoE)
-- Added target HP% slider option.
-- Only fires if there is enough time to doubleweave Requiescat (if learned).
-- Adjusts for Requiescat coming off cooldown within the next GCD.
-- Now uses it appropriately at lower levels.

- Improved Holy Spirit Logic (ST)
-- Prioritizes delaying Sepulchre before FoF starts.
-- Prioritizes Sepulchre before FoF ends if available.
-- Prioritizes using during FoF, or delays before refreshing Divine Might as a spare out-of-range option.
-- Uses automatically when out of melee range and no better actions are available.

- Improved Atonement Logic (ST)
-- Uses first Atonement as soon as possible.
-- Delays Supplication until after Riot Blade.
-- Prioritizes using Supplication/Sepulchre inside FoF.

- Improved Sheltron Logic (ST / AoE)
-- Uses only in combat and will not interrupt the burst logic.
-- Separated gauge slider values for ST/AoE modes.
-- Added player HP% slider option.

- Improved Shield Lob Logic (ST)
-- If chosen, will attempt to hardcast Holy Spirit when out of range and not moving.
-- If not learned, moving or without sufficient MP, falls back to Shield Lob.

- New: Shield Lob / Holy Spirit Feature (Replaces Shield Lob)
-- If enabled, will cast Holy Spirit when under Divine Might (instant) or when not moving (hardcast).
-- Must have learned Holy Spirit and enough MP to cast, otherwise falls back to Shield Lob.

- Fixes:
-- Intervene will no longer be used when moving (ST).
-- Sheltron will now respect CanWeave requirement.
-- Shield Lob and Holy Spirit will no longer block the entire logic when moving out of melee range.
-- Confiteor and Blades will still be used if you are forced out of melee range during burst phase.
-- Variant Spirit Dart, Variant Ultimatum and Circle of Scorn will no longer be used out of melee range.
-- Prominence will no longer prevent oGCDs or Holy Circle from executing properly in AoE modes.

- Changes:
-- Reorganized order of toggles to maintain consistency between modes.
-- Holy Spirit removed from AoE modes. Why are you spamming a single-target action in AoE mode?
-- Disabled Atonement/Requiescat weaving options as they are handled automatically by the new logic.
-- Added "No Movement" option for Intervene, will only use Intervene when it would not move the character.

- Revisited all toggle descriptions and added concise descriptions.
- Streamlined condition checks to avoid redundancy.

Fixes https://github.com/Nik-Potokar/XIVSlothCombo/issues/1459
Fixes https://github.com/Nik-Potokar/XIVSlothCombo/issues/1559