### PR TITLE
WHM Divine benison overcap protection

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3968,6 +3968,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(WHM_ST_MainCombo)]
         [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to the single target combo when below set MP value.", WHM.JobID, 18, "", "")]
         WHM_ST_MainCombo_Lucid = 19006,
+        
+        [ParentCombo(WHM_ST_MainCombo)]
+        [CustomComboInfo("Divine Benison Option", "Adds Divine Benison to the single target combo to prevent overcap at 2 charges. Must use reaction to assign target.", WHM.JobID, 18, "", "")]
+        WHM_ST_MainCombo_Benison = 19021,
 
         #endregion
 
@@ -4000,6 +4004,10 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(WHM_AoE_DPS)]
         [CustomComboInfo("Lucid Dreaming Option", "Adds Lucid Dreaming to the AoE combo when below the set MP value if you are moving or it can be weaved without GCD delay.", WHM.JobID, 26, "", "")]
         WHM_AoE_DPS_Lucid = 19191,
+
+        [ParentCombo(WHM_AoE_DPS)]
+        [CustomComboInfo("Divine Benison Option", "Adds Divine Benison to the holy spam to prevent overcap at 2 charges. Must use reaction to assign target.", WHM.JobID, 18, "", "")]
+        WHM_AOE_Benison = 19022,
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3970,7 +3970,7 @@ namespace XIVSlothCombo.Combos
         WHM_ST_MainCombo_Lucid = 19006,
         
         [ParentCombo(WHM_ST_MainCombo)]
-        [CustomComboInfo("Divine Benison Option", "Adds Divine Benison to the single target combo to prevent overcap at 2 charges. Must use reaction to assign target.", WHM.JobID, 18, "", "")]
+        [CustomComboInfo("Divine Benison Option", "Adds Divine Benison to the single target combo to prevent overcap at 2 charges. \nTo be used in conjunction with Redirect/Reaction/etc.", WHM.JobID, 18, "", "")]
         WHM_ST_MainCombo_Benison = 19021,
 
         #endregion
@@ -4006,7 +4006,7 @@ namespace XIVSlothCombo.Combos
         WHM_AoE_DPS_Lucid = 19191,
 
         [ParentCombo(WHM_AoE_DPS)]
-        [CustomComboInfo("Divine Benison Option", "Adds Divine Benison to the holy spam to prevent overcap at 2 charges. Must use reaction to assign target.", WHM.JobID, 18, "", "")]
+        [CustomComboInfo("Divine Benison Option", "Adds Divine Benison to the holy spam to prevent overcap at 2 charges. \nTo be used in conjunction with Redirect/Reaction/etc.", WHM.JobID, 18, "", "")]
         WHM_AOE_Benison = 19022,
 
         #endregion

--- a/XIVSlothCombo/Combos/PvE/WHM.cs
+++ b/XIVSlothCombo/Combos/PvE/WHM.cs
@@ -246,7 +246,7 @@ namespace XIVSlothCombo.Combos.PvE
                         bool lucidReady = ActionReady(All.LucidDreaming) && LevelChecked(All.LucidDreaming) && LocalPlayer.CurrentMp <= Config.WHM_STDPS_Lucid;
                         bool pomReady = LevelChecked(PresenceOfMind) && IsOffCooldown(PresenceOfMind);
                         bool assizeReady = LevelChecked(Assize) && IsOffCooldown(Assize);
-                        bool benisonReady = LevelChecked(DivineBenison) && ActionReady(DivineBenison) && GetRemainingCharges(DivineBenison) >= 2;
+                        bool benisonReady = GetRemainingCharges(DivineBenison) >= 2;
                         bool pomEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_PresenceOfMind);
                         bool assizeEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Assize);
                         bool lucidEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Lucid);
@@ -441,7 +441,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     bool liliesFullNoBlood = gauge.Lily == 3 && gauge.BloodLily < 3;
                     bool liliesNearlyFull = gauge.Lily == 2 && gauge.LilyTimer >= 17000;
-                    bool benisonReady = LevelChecked(DivineBenison) && ActionReady(DivineBenison) && GetRemainingCharges(DivineBenison) >= 2;
+                    bool benisonReady = GetRemainingCharges(DivineBenison) >= 2;
                     bool benisonEnabled = IsEnabled(CustomComboPreset.WHM_AOE_Benison);
 
                     if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Assize) && ActionReady(Assize))

--- a/XIVSlothCombo/Combos/PvE/WHM.cs
+++ b/XIVSlothCombo/Combos/PvE/WHM.cs
@@ -246,9 +246,11 @@ namespace XIVSlothCombo.Combos.PvE
                         bool lucidReady = ActionReady(All.LucidDreaming) && LevelChecked(All.LucidDreaming) && LocalPlayer.CurrentMp <= Config.WHM_STDPS_Lucid;
                         bool pomReady = LevelChecked(PresenceOfMind) && IsOffCooldown(PresenceOfMind);
                         bool assizeReady = LevelChecked(Assize) && IsOffCooldown(Assize);
+                        bool benisonReady = LevelChecked(DivineBenison) && ActionReady(DivineBenison) && GetRemainingCharges(DivineBenison) >= 2;
                         bool pomEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_PresenceOfMind);
                         bool assizeEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Assize);
                         bool lucidEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Lucid);
+                        bool benisonEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Benison);
 
                         if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_Rampart) &&
                             IsEnabled(Variant.VariantRampart) &&
@@ -260,6 +262,8 @@ namespace XIVSlothCombo.Combos.PvE
                             return PresenceOfMind;
                         if (assizeEnabled && assizeReady)
                             return Assize;
+                        if (benisonEnabled && benisonReady)
+                            return DivineBenison;
                         if (lucidEnabled && lucidReady)
                             return All.LucidDreaming;
                     }
@@ -437,9 +441,11 @@ namespace XIVSlothCombo.Combos.PvE
 
                     bool liliesFullNoBlood = gauge.Lily == 3 && gauge.BloodLily < 3;
                     bool liliesNearlyFull = gauge.Lily == 2 && gauge.LilyTimer >= 17000;
+                    bool benisonReady = LevelChecked(DivineBenison) && ActionReady(DivineBenison) && GetRemainingCharges(DivineBenison) >= 2;
+                    bool benisonEnabled = IsEnabled(CustomComboPreset.WHM_AOE_Benison);
 
                     if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Assize) && ActionReady(Assize))
-                        return Assize;
+                        return Assize;                            
 
                     if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_Rampart) &&
                         IsEnabled(Variant.VariantRampart) &&
@@ -457,6 +463,8 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_PresenceOfMind) && ActionReady(PresenceOfMind))
                             return PresenceOfMind;
+                        if (benisonEnabled && benisonReady)
+                            return DivineBenison;
                         if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Lucid) && ActionReady(All.LucidDreaming) &&
                             LocalPlayer.CurrentMp <= Config.WHM_AoEDPS_Lucid)
                             return All.LucidDreaming;


### PR DESCRIPTION
Added DB overcap protection at 2 charges to the single target and holy spam combos. 
ST will weave easily. 
Aoe will weave when moving or typically when rapture overcap happens because holy spam itself doesn't give a weave window. 

Will only work for 88 and above as it is designed to retain one charge at all times to not get too automatey. 

