### PR TITLE
[DRK] Update Opener, fix action combos are on

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1006,10 +1006,10 @@ namespace XIVSlothCombo.Combos
 
         #region DARK KNIGHT
 
-        #region Souleater (Single Target) Combo
+        #region Advanced Single Target Combo
 
-        [ReplaceSkill(DRK.Souleater)]
-        [CustomComboInfo("Souleater Combo", "Replace Souleater with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Advanced Dark Knight)", DRK.JobID)]
+        [ReplaceSkill(DRK.HardSlash)]
+        [CustomComboInfo("Advanced Single Target Combo", "Replace Hard Slash with its combo chain. \nIf all sub options are selected will turn into a full one button rotation (Advanced Dark Knight)", DRK.JobID)]
         DRK_ST_Combo = 5001,
 
         #region Buff Options

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1097,10 +1097,10 @@ namespace XIVSlothCombo.Combos
         #endregion
         // Last value = 5015
 
-        #region Stalwart Soul (Multi Target) Combo
+        #region Advanced Multi Target Combo
 
-        [ReplaceSkill(DRK.StalwartSoul)]
-        [CustomComboInfo("Stalwart Soul Combo", "Replace Stalwart Soul with its combo chain.", DRK.JobID)]
+        [ReplaceSkill(DRK.Unleash)]
+        [CustomComboInfo("Advanced Multi Target Combo", "Replace Unleash with its combo chain.", DRK.JobID)]
         DRK_AoE_Combo = 5016,
 
         #region Buff Options

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -84,9 +84,9 @@ namespace XIVSlothCombo.Combos.PvE
         public static class Config
         {
             public static readonly UserInt
-                DRK_ST_ManaSpenderPooling = new("DRK_ST_ManaSpenderPooling"),
-                DRK_ST_LivingDeadThreshold = new("DRK_ST_LivingDeadThreshold"),
-                DRK_AoE_LivingDeadThreshold = new("DRK_AoE_LivingDeadThreshold"),
+                DRK_ST_ManaSpenderPooling = new("DRK_ST_ManaSpenderPooling", 3000),
+                DRK_ST_LivingDeadThreshold = new("DRK_ST_LivingDeadThreshold", 10),
+                DRK_AoE_LivingDeadThreshold = new("DRK_AoE_LivingDeadThreshold", 40),
                 DRK_VariantCure = new("DRKVariantCure");
         }
 

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -148,7 +148,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                     //Mana Features
                     if (IsEnabled(CustomComboPreset.DRK_ST_ManaOvercap)
-                        && ((CombatEngageDuration().TotalSeconds > 4 && CombatEngageDuration().TotalSeconds < 10 && gauge.DarksideTimeRemaining == 0) // Initial Darkside upping
+                        && ((CombatEngageDuration().TotalSeconds > 4 // todo: we want this immediately now
+                             && CombatEngageDuration().TotalSeconds < 10
+                             && gauge.DarksideTimeRemaining == 0) // Initial Darkside upping
                             || CombatEngageDuration().TotalSeconds >= 10))
                     {
                         // Spend mana to limit when not near even minute burst windows

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -182,9 +182,9 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.DRK_ST_Delirium)
                             && IsOffCooldown(BloodWeapon)
                             && LevelChecked(BloodWeapon)
-                            && ((CombatEngageDuration().TotalSeconds < 10 // Opening Delirium
+                            && ((CombatEngageDuration().TotalSeconds < 8 // Opening Delirium
                                     && WasLastWeaponskill(Souleater))
-                                || CombatEngageDuration().TotalSeconds > 10)) // Regular Delirium
+                                || CombatEngageDuration().TotalSeconds > 8)) // Regular Delirium
                             return OriginalHook(Delirium);
 
                         if (IsEnabled(CustomComboPreset.DRK_ST_CDs)

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -275,14 +275,14 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
-        internal class DRK_StalwartSoul_Combo : CustomCombo
+        internal class DRK_AoE_Combo : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRK_AoE_Combo;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 // Bail if not looking at the replaced action
-                if (actionID != StalwartSoul) return actionID;
+                if (actionID != Unleash) return actionID;
 
                 var gauge = GetJobGauge<DRKGauge>();
                 var hpRemaining = PluginConfiguration.GetCustomIntValue(Config.DRK_AoE_LivingDeadThreshold);

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -207,7 +207,7 @@ namespace XIVSlothCombo.Combos.PvE
                                     return SaltedEarth;
                                 //Cast Salt and Darkness
                                 if (HasEffect(Buffs.SaltedEarth)
-                                 && GetBuffRemainingTime(Buffs.SaltedEarth) < 9
+                                 && GetBuffRemainingTime(Buffs.SaltedEarth) < 7
                                  && ActionReady(SaltAndDarkness))
                                     return OriginalHook(SaltAndDarkness);
                             }

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -187,7 +187,9 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.DRK_ST_Delirium)
                             && IsOffCooldown(BloodWeapon)
                             && LevelChecked(BloodWeapon)
-                            && CombatEngageDuration().TotalSeconds > 5)
+                            && ((CombatEngageDuration().TotalSeconds < 10 // Opening Delirium
+                                    && WasLastWeaponskill(Souleater))
+                                || CombatEngageDuration().TotalSeconds > 10)) // Regular Delirium
                             return OriginalHook(Delirium);
 
                         if (IsEnabled(CustomComboPreset.DRK_ST_CDs))

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -185,7 +185,8 @@ namespace XIVSlothCombo.Combos.PvE
                         // Delirium
                         if (IsEnabled(CustomComboPreset.DRK_ST_Delirium)
                             && IsOffCooldown(BloodWeapon)
-                            && LevelChecked(BloodWeapon))
+                            && LevelChecked(BloodWeapon)
+                            && CombatEngageDuration().TotalSeconds > 5)
                             return OriginalHook(Delirium);
 
                         if (IsEnabled(CustomComboPreset.DRK_ST_CDs))
@@ -205,12 +206,16 @@ namespace XIVSlothCombo.Combos.PvE
                             }
 
                             // Shadowbringer
-                            // todo: simplify this to make it easier to read
                             if (LevelChecked(Shadowbringer)
                                 && IsEnabled(CustomComboPreset.DRK_ST_CDs_Shadowbringer))
                             {
-                                if ((GetRemainingCharges(Shadowbringer) > 0 && IsNotEnabled(CustomComboPreset.DRK_ST_CDs_ShadowbringerBurst)) || // Dump
-                                    (IsEnabled(CustomComboPreset.DRK_ST_CDs_ShadowbringerBurst) && GetRemainingCharges(Shadowbringer) > 0 && gauge.ShadowTimeRemaining > 1 && IsOnCooldown(Delirium))) // Burst
+                                if ((GetRemainingCharges(Shadowbringer) > 0
+                                     && IsNotEnabled(CustomComboPreset.DRK_ST_CDs_ShadowbringerBurst)) // Dump
+                                    ||
+                                    (IsEnabled(CustomComboPreset.DRK_ST_CDs_ShadowbringerBurst)
+                                     && GetRemainingCharges(Shadowbringer) > 0
+                                     && gauge.ShadowTimeRemaining > 1
+                                     && IsOnCooldown(Delirium))) // Burst
                                     return Shadowbringer;
                             }
 

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -4,6 +4,7 @@ using Dalamud.Game.ClientState.Statuses;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -82,11 +83,11 @@ namespace XIVSlothCombo.Combos.PvE
         [SuppressMessage("ReSharper", "InconsistentNaming")]
         public static class Config
         {
-            public const string
-                DRK_ST_ManaSpenderPooling = "DRK_ST_ManaSpenderPooling",
-                DRK_ST_LivingDeadThreshold = "DRK_ST_LivingDeadThreshold",
-                DRK_AoE_LivingDeadThreshold = "DRK_AoE_LivingDeadThreshold",
-                DRK_VariantCure = "DRKVariantCure";
+            public static readonly UserInt
+                DRK_ST_ManaSpenderPooling = new("DRK_ST_ManaSpenderPooling"),
+                DRK_ST_LivingDeadThreshold = new("DRK_ST_LivingDeadThreshold"),
+                DRK_AoE_LivingDeadThreshold = new("DRK_AoE_LivingDeadThreshold"),
+                DRK_VariantCure = new("DRKVariantCure");
         }
 
         internal class DRK_ST_Combo : CustomCombo
@@ -99,8 +100,8 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID != HardSlash) return actionID;
 
                 var gauge = GetJobGauge<DRKGauge>();
-                var mpRemaining = PluginConfiguration.GetCustomIntValue(Config.DRK_ST_ManaSpenderPooling);
-                var hpRemaining = PluginConfiguration.GetCustomIntValue(Config.DRK_ST_LivingDeadThreshold);
+                var mpRemaining = Config.DRK_ST_ManaSpenderPooling;
+                var hpRemaining = Config.DRK_ST_LivingDeadThreshold;
 
                 // Variant Cure - Heal: Priority to save your life
                 if (IsEnabled(CustomComboPreset.DRK_Variant_Cure)
@@ -290,7 +291,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID != Unleash) return actionID;
 
                 var gauge = GetJobGauge<DRKGauge>();
-                var hpRemaining = PluginConfiguration.GetCustomIntValue(Config.DRK_AoE_LivingDeadThreshold);
+                var hpRemaining = Config.DRK_AoE_LivingDeadThreshold;
 
                 // Variant Cure - Heal: Priority to save your life
                 if (IsEnabled(CustomComboPreset.DRK_Variant_Cure)

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -192,7 +192,11 @@ namespace XIVSlothCombo.Combos.PvE
                                 || CombatEngageDuration().TotalSeconds > 10)) // Regular Delirium
                             return OriginalHook(Delirium);
 
-                        if (IsEnabled(CustomComboPreset.DRK_ST_CDs))
+                        if (IsEnabled(CustomComboPreset.DRK_ST_CDs)
+                            && ((CombatEngageDuration().TotalSeconds < 10 // Opening CDs
+                                 && !HasEffect(Buffs.Scorn)
+                                 && IsOnCooldown(LivingShadow))
+                                || CombatEngageDuration().TotalSeconds > 10)) // Regular CDs
                         {
                             // Salted Earth
                             if (IsEnabled(CustomComboPreset.DRK_ST_CDs_SaltedEarth))

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -148,8 +148,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     //Mana Features
                     if (IsEnabled(CustomComboPreset.DRK_ST_ManaOvercap)
-                        && ((CombatEngageDuration().TotalSeconds > 4 // todo: we want this immediately now
-                             && CombatEngageDuration().TotalSeconds < 10
+                        && ((CombatEngageDuration().TotalSeconds < 10
                              && gauge.DarksideTimeRemaining == 0) // Initial Darkside upping
                             || CombatEngageDuration().TotalSeconds >= 10))
                     {

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -89,16 +89,14 @@ namespace XIVSlothCombo.Combos.PvE
                 DRK_VariantCure = "DRKVariantCure";
         }
 
-        // todo: chop down very long ifs
-
-        internal class DRK_Souleater_Combo : CustomCombo
+        internal class DRK_ST_Combo : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.DRK_ST_Combo;
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 // Bail if not looking at the replaced action
-                if (actionID != Souleater) return actionID;
+                if (actionID != HardSlash) return actionID;
 
                 var gauge = GetJobGauge<DRKGauge>();
                 var mpRemaining = PluginConfiguration.GetCustomIntValue(Config.DRK_ST_ManaSpenderPooling);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1495,10 +1495,10 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 3000, DRK.Config.DRK_ST_ManaSpenderPooling, "How much MP to save (0 = Use All)", 150, SliderIncrements.Thousands);
 
             if (preset == CustomComboPreset.DRK_ST_CDs_LivingShadow && enabled)
-                UserConfig.DrawSliderInt(0, 30, DRK.Config.DRK_ST_LivingDeadThreshold, "Stop Using When Target HP% is at or Below (Set to 0 to Disable This Check)", SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(0, 30, DRK.Config.DRK_ST_LivingDeadThreshold, "Stop Using When Target HP% is at or Below (Set to 0 to Disable This Check)", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DRK_AoE_CDs_LivingShadow && enabled)
-                UserConfig.DrawSliderInt(0, 75, DRK.Config.DRK_AoE_LivingDeadThreshold, "Stop Using When Target HP% is at or Below (Set to 0 to Disable This Check)", SliderIncrements.Fives);
+                UserConfig.DrawSliderInt(0, 60, DRK.Config.DRK_AoE_LivingDeadThreshold, "Stop Using When Target HP% is at or Below (Set to 0 to Disable This Check)", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DRKPvP_Burst)
                 UserConfig.DrawSliderInt(1, 100, DRKPvP.Config.ShadowbringerThreshold, "HP% to be at or above to use Shadowbringer");

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1495,10 +1495,10 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 3000, DRK.Config.DRK_ST_ManaSpenderPooling, "How much MP to save (0 = Use All)", 150, SliderIncrements.Thousands);
 
             if (preset == CustomComboPreset.DRK_ST_CDs_LivingShadow && enabled)
-                UserConfig.DrawSliderInt(0, 100, DRK.Config.DRK_ST_LivingDeadThreshold, "Stop Using When Target HP% is at or Below (Set to 0 to Disable This Check)");
+                UserConfig.DrawSliderInt(0, 30, DRK.Config.DRK_ST_LivingDeadThreshold, "Stop Using When Target HP% is at or Below (Set to 0 to Disable This Check)", SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DRK_AoE_CDs_LivingShadow && enabled)
-                UserConfig.DrawSliderInt(0, 100, DRK.Config.DRK_AoE_LivingDeadThreshold, "Stop Using When Target HP% is at or Below (Set to 0 to Disable This Check)");
+                UserConfig.DrawSliderInt(0, 75, DRK.Config.DRK_AoE_LivingDeadThreshold, "Stop Using When Target HP% is at or Below (Set to 0 to Disable This Check)", SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DRKPvP_Burst)
                 UserConfig.DrawSliderInt(1, 100, DRKPvP.Config.ShadowbringerThreshold, "HP% to be at or above to use Shadowbringer");


### PR DESCRIPTION
- [X] Update Opener to 1st GCD (fixes #1608)
- [X] Move both combos to the first action in the chain (fixes #1136)
- [X] ~~Implement strict JobHelper Opener with option~~ Unnecessary
- [X] Reduced the possible ranges for Living Dead's thresholds, added stepping to them - both to make the sliders slightly easier to use
- [X] Moved to `UserInt`s directly, with suggested defaults