### PR TITLE
VerRaise and Variant Cleanup

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -126,7 +126,7 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(RDM.Verraise, SMN.Resurrection, BLU.AngelWhisper)]
         [ConflictingCombos(SMN_Raise, RDM_Raise)]
         [ParentCombo(ALL_Caster_Menu)]
-        [CustomComboInfo("Magical Ranged DPS: Raise Feature", "Changes the class' Raise Ability into Swiftcast or Dualcast in the case of RDM.", ADV.JobID)]
+        [CustomComboInfo("Magical Ranged DPS: Raise Feature", "Changes the class' Raise Ability into Swiftcast. RDM will also show VerCure if Swiftcast is on cooldown.", ADV.JobID)]
         ALL_Caster_Raise = 100021,
         #endregion
 
@@ -2828,6 +2828,10 @@ namespace XIVSlothCombo.Combos
         [ConflictingCombos(ALL_Caster_Raise)]
         [CustomComboInfo("Verraise Feature", "Changes Swiftcast to Verraise when under the effect of Swiftcast or Dualcast.", RDM.JobID, 620)]
         RDM_Raise = 13620,
+        
+            [CustomComboInfo("Vercure Option", "If Swiftcast is on cooldown, change to Vercure to proc Dualcast.", RDM.JobID, 621)]
+            RDM_Raise_Vercure = 13621,
+        
         #endregion
 
         #region Sections 8 to 9 - Miscellaneous

--- a/XIVSlothCombo/Combos/PvE/ALL.cs
+++ b/XIVSlothCombo/Combos/PvE/ALL.cs
@@ -1,5 +1,4 @@
 ﻿using XIVSlothCombo.CustomComboNS;
-using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -72,11 +71,12 @@ namespace XIVSlothCombo.Combos.PvE
         /// <param name="actionID">action id to check weave</param>
         /// <param name="MPThreshold">Player MP less than Threshold check</param>
         /// <param name="weave">Spell Weave check by default</param>
+        /// <param name="weaveTime"> CanSpellWeave override </param>
         /// <returns></returns>
-        public static bool CanUseLucid(uint actionID, int MPThreshold, bool weave = true) =>
-            CustomComboFunctions.ActionReady(LucidDreaming)
-            && CustomComboFunctions.LocalPlayer.CurrentMp <= MPThreshold
-            && (weave && CustomComboFunctions.CanSpellWeave(actionID));
+        public static bool CanUseLucid(uint actionID, int MPThreshold, bool weave = true, double weaveTime = 0.6) =>
+            ActionReady(LucidDreaming)
+            && LocalPlayer.CurrentMp <= MPThreshold
+            && (weave && CanSpellWeave(actionID, weaveTime));
 
         internal class ALL_IslandSanctuary_Sprint : CustomCombo
         {
@@ -179,6 +179,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return actionID;
                     if (IsOffCooldown(Swiftcast))
                         return Swiftcast;
+                    if (LocalPlayer.ClassJob.Id is RDM.JobID)
+                        return RDM.Vercure;
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/ALL.cs
+++ b/XIVSlothCombo/Combos/PvE/ALL.cs
@@ -1,4 +1,5 @@
 ﻿using XIVSlothCombo.CustomComboNS;
+using static XIVSlothCombo.CustomComboNS.Functions.CustomComboFunctions;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.Combos.PvE

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -195,10 +195,7 @@ namespace XIVSlothCombo.Combos.PvE
                     InCombat())
                 {
 
-                    if (IsEnabled(CustomComboPreset.AST_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.AST_Variant_Rampart, actionID, true))
                         return Variant.VariantRampart;
 
                     Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
@@ -219,9 +216,7 @@ namespace XIVSlothCombo.Combos.PvE
                     
 
                     if (IsEnabled(CustomComboPreset.AST_DPS_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.AST_LucidDreaming &&
-                        CanSpellWeave(actionID))
+                        All.CanUseLucid(actionID, Config.AST_LucidDreaming))
                         return All.LucidDreaming;
 
 

--- a/XIVSlothCombo/Combos/PvE/BLM.cs
+++ b/XIVSlothCombo/Combos/PvE/BLM.cs
@@ -161,14 +161,10 @@ namespace XIVSlothCombo.Combos.PvE
                                 return UmbralSoul;
                         }
 
-                        if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
-                            IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
+                        if (Variant.CanCure(CustomComboPreset.BLM_Variant_Cure, Config.BLM_VariantCure))
                             return Variant.VariantCure;
 
-                        if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart) &&
-                            CanSpellWeave(actionID))
+                        if (Variant.CanRampart(CustomComboPreset.BLM_Variant_Rampart, actionID, true))
                             return Variant.VariantRampart;
 
                         // Handle movement
@@ -403,14 +399,10 @@ namespace XIVSlothCombo.Combos.PvE
                                 return UmbralSoul;
                         }
 
-                        if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
-                            IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
+                        if (Variant.CanCure(CustomComboPreset.BLM_Variant_Cure, Config.BLM_VariantCure))
                             return Variant.VariantCure;
 
-                        if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart) &&
-                            CanSpellWeave(actionID))
+                        if (Variant.CanRampart(CustomComboPreset.BLM_Variant_Rampart, actionID, true))
                             return Variant.VariantRampart;
 
                         // Handle movement
@@ -686,15 +678,10 @@ namespace XIVSlothCombo.Combos.PvE
                                 return UmbralSoul;
                         }
 
-                        if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
-                            IsEnabled(Variant.VariantCure) &&
-                            PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
+                        if (Variant.CanCure(CustomComboPreset.BLM_Variant_Cure, Config.BLM_VariantCure))
                             return Variant.VariantCure;
 
-                        if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart) &&
-                            CanSpellWeave(actionID))
+                        if (Variant.CanRampart(CustomComboPreset.BLM_Variant_Rampart, actionID, true))
                             return Variant.VariantRampart;
                     }
 
@@ -810,15 +797,10 @@ namespace XIVSlothCombo.Combos.PvE
                                 return UmbralSoul;
                         }
 
-                        if (IsEnabled(CustomComboPreset.BLM_Variant_Cure) &&
-                            IsEnabled(Variant.VariantCure) &&
-                            PlayerHealthPercentageHp() <= Config.BLM_VariantCure)
+                        if (Variant.CanCure(CustomComboPreset.BLM_Variant_Cure, Config.BLM_VariantCure))
                             return Variant.VariantCure;
 
-                        if (IsEnabled(CustomComboPreset.BLM_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart) &&
-                            CanSpellWeave(actionID))
+                        if (Variant.CanRampart(CustomComboPreset.BLM_Variant_Rampart, actionID, true))
                             return Variant.VariantRampart;
 
                         // Weave Buffs

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -6,6 +6,7 @@ using System;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using static FFXIVClientStructs.FFXIV.Client.UI.AddonJobHudBRD0;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -81,8 +82,9 @@ namespace XIVSlothCombo.Combos.PvE
                 BRD_NoWasteHPPercentage = "noWasteHpPercentage",
                 BRD_AoENoWasteHPPercentage = "AoENoWasteHpPercentage",
                 BRD_STSecondWindThreshold = "BRD_STSecondWindThreshold",
-                BRD_AoESecondWindThreshold = "BRD_AoESecondWindThreshold",
-                BRD_VariantCure = "BRD_VariantCure";
+                BRD_AoESecondWindThreshold = "BRD_AoESecondWindThreshold";
+            public static UserInt
+                BRD_VariantCure = new("BRD_VariantCure");
         }
 
         #region Song status
@@ -344,13 +346,10 @@ namespace XIVSlothCombo.Combos.PvE
                     int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
                     bool isEnemyHealthHigh = !IsEnabled(CustomComboPreset.BRD_AoE_Simple_NoWaste) || GetTargetHPPercent() > targetHPThreshold;
 
-                    if (IsEnabled(CustomComboPreset.BRD_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.BRD_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.BRD_Variant_Cure, Config.BRD_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.BRD_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        canWeave)
+                    if (Variant.CanRampart(CustomComboPreset.BRD_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     if (IsEnabled(CustomComboPreset.BRD_AoE_Simple_Songs) && canWeave)
@@ -672,13 +671,10 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.BRD_Simple_Interrupt) && canInterrupt)
                         return All.HeadGraze;
 
-                    if (IsEnabled(CustomComboPreset.BRD_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.BRD_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.BRD_Variant_Cure, Config.BRD_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.BRD_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        canWeave)
+                    if (Variant.CanRampart(CustomComboPreset.BRD_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     if (IsEnabled(CustomComboPreset.BRD_Simple_Song) && isEnemyHealthHigh)

--- a/XIVSlothCombo/Combos/PvE/Content/Variant.cs
+++ b/XIVSlothCombo/Combos/PvE/Content/Variant.cs
@@ -1,4 +1,5 @@
 ﻿using XIVSlothCombo.Services;
+using static XIVSlothCombo.CustomComboNS.Functions.CustomComboFunctions;
 
 namespace XIVSlothCombo.Combos.PvE.Content
 {
@@ -8,9 +9,12 @@ namespace XIVSlothCombo.Combos.PvE.Content
             VariantUltimatum = 29730,
             VariantRaise = 29731,
             VariantRaise2 = 29734;
+
+        //The following actions change ID based on Location
         //1069 = The Sil'dihn Subterrane
         //1137 = Mount Rokkon
         //1176 = Aloalo Island
+
         public static uint VariantCure => Service.ClientState.TerritoryType switch
         {
             1069 => 29729,
@@ -46,5 +50,39 @@ namespace XIVSlothCombo.Combos.PvE.Content
             public const ushort
                 SustainedDamage = 3359;
         }
+
+        /// <summary>
+        /// Checks to see if Variant Ultimatum can be used
+        /// </summary>
+        /// <param name="preset">The class/job preset</param>
+        /// <returns>Boolean stating if Ultimatum can be used</returns>
+        public static bool CanUltimatum(CustomComboPreset preset) =>
+            IsEnabled(preset) &&
+            IsEnabled(VariantUltimatum) &&
+            IsOffCooldown(VariantUltimatum);
+
+        /// <summary>
+        /// Checks to see if Variant Rampart can be used
+        /// </summary>
+        /// <param name="preset">The class/job preset</param>
+        /// <param name="actionID">Original actionID to check for Weaving</param>
+        /// <param name="caster">Is this for a caster? If so, use CanSpellWeave instead of CanWeave</param>
+        /// <returns>Boolean stating if Rampart can be used</returns>
+        public static bool CanRampart(CustomComboPreset preset, uint actionID, bool caster = false) =>
+            IsEnabled(preset) &&
+            IsEnabled(VariantRampart) &&
+            IsOffCooldown(VariantRampart) &&
+            ((!caster && CanWeave(actionID)) || (caster && CanSpellWeave(actionID)));
+
+        /// <summary>
+        /// Checks to see if Variant Cure can be used
+        /// </summary>
+        /// <param name="preset">The class/job preset</param>
+        /// <param name="HPPercent">The HP Percent Threshold to activate</param>
+        /// <returns></returns>
+        public static bool CanCure(CustomComboPreset preset, int HPPercent) =>
+            IsEnabled(preset) &&
+            IsEnabled(VariantCure) &&
+            PlayerHealthPercentageHp() <= HPPercent;
     }
 }

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -2,6 +2,7 @@
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Services;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -119,8 +120,8 @@ namespace XIVSlothCombo.Combos.PvE
                 DNCSimpleAoEPanicHealWindPercent = "DNCSimpleAoEPanicHealWindPercent";      // Second Wind      player HP% threshold
             #endregion
 
-            public const string
-                DNCVariantCurePercent = "DNCVariantCurePercent";                            // Variant Cure     player HP% threshold
+            public static UserInt
+                DNCVariantCurePercent = new("DNCVariantCurePercent");                            // Variant Cure     player HP% threshold
         }
 
         internal class DNC_DanceComboReplacer : CustomCombo
@@ -362,16 +363,11 @@ namespace XIVSlothCombo.Combos.PvE
                     return All.HeadGraze;
 
                 // Variant Cure
-                if (IsEnabled(CustomComboPreset.DNC_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= GetOptionValue(Config.DNCVariantCurePercent))
+                if (Variant.CanCure(CustomComboPreset.DNC_Variant_Cure, Config.DNCVariantCurePercent))
                     return Variant.VariantCure;
 
                 // Variant Rampart
-                if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave(actionID))
+                if (Variant.CanRampart(CustomComboPreset.DNC_Variant_Rampart, actionID))
                     return Variant.VariantRampart;
 
                 if (CanWeave(actionID) && !WasLastWeaponskill(TechnicalFinish4))
@@ -657,15 +653,10 @@ namespace XIVSlothCombo.Combos.PvE
                     !HasEffect(Buffs.TechnicalFinish))
                     return All.HeadGraze;
 
-                if (IsEnabled(CustomComboPreset.DNC_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= GetOptionValue(Config.DNCVariantCurePercent))
+                if (Variant.CanCure(CustomComboPreset.DNC_Variant_Cure, Config.DNCVariantCurePercent))
                     return Variant.VariantCure;
 
-                if (IsEnabled(CustomComboPreset.DNC_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanWeave(actionID))
+                if (Variant.CanRampart(CustomComboPreset.DNC_Variant_Rampart, actionID))
                     return Variant.VariantRampart;
 
                 if (CanWeave(actionID) && !WasLastWeaponskill(TechnicalFinish4))

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -111,9 +111,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is TrueThrust)
                 {
-                    if (IsEnabled(CustomComboPreset.DRG_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= Config.DRG_Variant_Cure)
+                    if (Variant.CanCure(CustomComboPreset.DRG_Variant_Cure, Config.DRG_Variant_Cure))
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DRG_Variant_Rampart) &&
@@ -272,9 +270,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is TrueThrust)
                 {
-                    if (IsEnabled(CustomComboPreset.DRG_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= Config.DRG_Variant_Cure)
+                    if (Variant.CanCure(CustomComboPreset.DRG_Variant_Cure, Config.DRG_Variant_Cure))
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DRG_Variant_Rampart) &&
@@ -469,9 +465,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is DoomSpike)
                 {
-                    if (IsEnabled(CustomComboPreset.DRG_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= Config.DRG_Variant_Cure)
+                    if (Variant.CanCure(CustomComboPreset.DRG_Variant_Cure, Config.DRG_Variant_Cure))
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DRG_Variant_Rampart) &&
@@ -587,9 +581,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is DoomSpike)
                 {
-                    if (IsEnabled(CustomComboPreset.DRG_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= Config.DRG_Variant_Cure)
+                    if (Variant.CanCure(CustomComboPreset.DRG_Variant_Cure, Config.DRG_Variant_Cure))
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.DRG_Variant_Rampart) &&

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -4,6 +4,7 @@ using Dalamud.Game.ClientState.Statuses;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 
 namespace XIVSlothCombo.Combos.PvE
 {
@@ -85,8 +86,9 @@ namespace XIVSlothCombo.Combos.PvE
             public const string
                 DRK_ST_ManaSpenderPooling = "DRK_ST_ManaSpenderPooling",
                 DRK_ST_LivingDeadThreshold = "DRK_ST_LivingDeadThreshold",
-                DRK_AoE_LivingDeadThreshold = "DRK_AoE_LivingDeadThreshold",
-                DRK_VariantCure = "DRKVariantCure";
+                DRK_AoE_LivingDeadThreshold = "DRK_AoE_LivingDeadThreshold";
+            public static UserInt
+                DRK_VariantCure = new("DRKVariantCure");
         }
 
         // todo: chop down very long ifs
@@ -105,9 +107,7 @@ namespace XIVSlothCombo.Combos.PvE
                 var hpRemaining = PluginConfiguration.GetCustomIntValue(Config.DRK_ST_LivingDeadThreshold);
 
                 // Variant Cure - Heal: Priority to save your life
-                if (IsEnabled(CustomComboPreset.DRK_Variant_Cure)
-                    && IsEnabled(Variant.VariantCure)
-                    && PlayerHealthPercentageHp() <= GetOptionValue(Config.DRK_VariantCure))
+                if (Variant.CanCure(CustomComboPreset.DRK_Variant_Cure, Config.DRK_VariantCure))
                     return Variant.VariantCure;
 
                 // Unmend Option
@@ -141,9 +141,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantSpiritDart;
 
                     // Variant Ultimatum - AoE Agro stun
-                    if (IsEnabled(CustomComboPreset.DRK_Variant_Ultimatum)
-                        && IsEnabled(Variant.VariantUltimatum)
-                        && IsOffCooldown(Variant.VariantUltimatum))
+                    if (Variant.CanUltimatum(CustomComboPreset.DRK_Variant_Ultimatum))
                         return Variant.VariantUltimatum;
 
                     //Mana Features
@@ -289,9 +287,7 @@ namespace XIVSlothCombo.Combos.PvE
                 var hpRemaining = PluginConfiguration.GetCustomIntValue(Config.DRK_AoE_LivingDeadThreshold);
 
                 // Variant Cure - Heal: Priority to save your life
-                if (IsEnabled(CustomComboPreset.DRK_Variant_Cure)
-                    && IsEnabled(Variant.VariantCure)
-                    && PlayerHealthPercentageHp() <= GetOptionValue(Config.DRK_VariantCure))
+                if (Variant.CanCure(CustomComboPreset.DRK_Variant_Cure, Config.DRK_VariantCure))
                     return Variant.VariantCure;
 
                 // Disesteem
@@ -314,9 +310,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Variant.VariantSpiritDart;
 
                     // Variant Ultimatum - AoE Agro stun
-                    if (IsEnabled(CustomComboPreset.DRK_Variant_Ultimatum)
-                        && IsEnabled(Variant.VariantUltimatum)
-                        && IsOffCooldown(Variant.VariantUltimatum))
+                    if (Variant.CanUltimatum(CustomComboPreset.DRK_Variant_Ultimatum))
                         return Variant.VariantUltimatum;
 
                     // Mana Features

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -5,6 +5,7 @@ using FFXIVClientStructs.FFXIV.Client.UI;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Data;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -69,8 +70,8 @@ namespace XIVSlothCombo.Combos.PvE
 
         public static class Config
         {
-            public const string
-                GNB_VariantCure = "GNB_VariantCure";
+            public static UserInt
+                GNB_VariantCure = new("GNB_VariantCure");
         }
 
         internal class GNB_ST_MainCombo : CustomCombo
@@ -86,7 +87,7 @@ namespace XIVSlothCombo.Combos.PvE
                     float GCD = GetCooldown(KeenEdge).CooldownTotal; // GCD is 2.5sks only
 
                     // Variant Cure
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.GNB_Variant_Cure, Config.GNB_VariantCure))
                         return Variant.VariantCure;
 
                     // Ranged option
@@ -125,7 +126,7 @@ namespace XIVSlothCombo.Combos.PvE
                             (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                             return Variant.VariantSpiritDart;
 
-                        if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
+                        if (Variant.CanUltimatum(CustomComboPreset.GNB_Variant_Ultimatum))
                             return Variant.VariantUltimatum;
 
                         if (IsEnabled(CustomComboPreset.GNB_ST_MainCombo_CooldownsGroup))
@@ -494,7 +495,7 @@ namespace XIVSlothCombo.Combos.PvE
                     var gauge = GetJobGauge<GNBGauge>();
                     float GCD = GetCooldown(KeenEdge).CooldownTotal; // GCD is 2.5sks only
 
-                    if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.GNB_Variant_Cure, Config.GNB_VariantCure))
                         return Variant.VariantCure;
 
                     if (InCombat())
@@ -507,7 +508,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                                 return Variant.VariantSpiritDart;
 
-                            if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
+                            if (Variant.CanUltimatum(CustomComboPreset.GNB_Variant_Ultimatum))
                                 return Variant.VariantUltimatum;
 
                             if (IsEnabled(CustomComboPreset.GNB_AoE_NoMercy) && ActionReady(NoMercy))

--- a/XIVSlothCombo/Combos/PvE/MCH.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH.cs
@@ -113,15 +113,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is SplitShot or HeatedSplitShot)
                 {
-                    if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
+                    if (Variant.CanCure(CustomComboPreset.MCH_Variant_Cure, Config.MCH_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.MCH_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     // Opener for MCH
@@ -310,14 +305,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is SplitShot or HeatedSplitShot)
                 {
-                    if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= Config.MCH_VariantCure)
+                    if (Variant.CanCure(CustomComboPreset.MCH_Variant_Cure, Config.MCH_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.MCH_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     // Opener for MCH
@@ -530,18 +521,13 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is SpreadShot or Scattergun)
                 {
-                    if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
-                     IsEnabled(Variant.VariantCure) &&
-                     PlayerHealthPercentageHp() <= GetOptionValue(Config.MCH_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.MCH_Variant_Cure, Config.MCH_VariantCure))
                         return Variant.VariantCure;
 
                     if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower))
                         return OriginalHook(11);
 
-                    if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.MCH_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     //Full Metal Field
@@ -619,18 +605,13 @@ namespace XIVSlothCombo.Combos.PvE
                     bool reassembledChainsaw = (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled[2] && HasEffect(Buffs.Reassembled)) || (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled[2] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_AoE_ReassemblePool) || (!IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble));
                     bool reassembledExcavator = (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && Config.MCH_AoE_Reassembled[3] && HasEffect(Buffs.Reassembled)) || (IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble) && !Config.MCH_AoE_Reassembled[3] && !HasEffect(Buffs.Reassembled)) || (!HasEffect(Buffs.Reassembled) && GetRemainingCharges(Reassemble) <= Config.MCH_AoE_ReassemblePool) || (!IsEnabled(CustomComboPreset.MCH_AoE_Adv_Reassemble));
 
-                    if (IsEnabled(CustomComboPreset.MCH_Variant_Cure) &&
-                     IsEnabled(Variant.VariantCure) &&
-                     PlayerHealthPercentageHp() <= GetOptionValue(Config.MCH_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.MCH_Variant_Cure, Config.MCH_VariantCure))
                         return Variant.VariantCure;
 
                     if (HasEffect(Buffs.Flamethrower) || JustUsed(Flamethrower))
                         return OriginalHook(11);
 
-                    if (IsEnabled(CustomComboPreset.MCH_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.MCH_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     //Full Metal Field

--- a/XIVSlothCombo/Combos/PvE/MNK.cs
+++ b/XIVSlothCombo/Combos/PvE/MNK.cs
@@ -5,6 +5,7 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -92,8 +93,9 @@ namespace XIVSlothCombo.Combos.PvE
                 MNK_STSecondWindThreshold = "MNK_STSecondWindThreshold",
                 MNK_STBloodbathThreshold = "MNK_STBloodbathThreshold",
                 MNK_AoESecondWindThreshold = "MNK_AoESecondWindThreshold",
-                MNK_AoEBloodbathThreshold = "MNK_AoEBloodbathThreshold",
-                MNK_VariantCure = "MNK_VariantCure";
+                MNK_AoEBloodbathThreshold = "MNK_AoEBloodbathThreshold";
+            public static UserInt
+                MNK_VariantCure = new("MNK_VariantCure");
         }
 
         internal class MNK_AoE_SimpleMode : CustomCombo
@@ -130,15 +132,13 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
-                    if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.MNK_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.MNK_Variant_Cure, Config.MNK_VariantCure))
                         return Variant.VariantCure;
 
                     // Buffs
                     if (inCombat && canWeave)
                     {
-                        if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart))
+                        if (Variant.CanRampart(CustomComboPreset.MNK_Variant_Rampart, actionID))
                             return Variant.VariantRampart;
 
                         if (IsEnabled(CustomComboPreset.MNK_AoE_Simple_CDs))
@@ -363,7 +363,7 @@ namespace XIVSlothCombo.Combos.PvE
                     var lunarNadi = gauge.Nadi == Nadi.LUNAR;
                     var solarNadi = gauge.Nadi == Nadi.SOLAR;
 
-                    if (IsEnabled(CustomComboPreset.MNK_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.MNK_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.MNK_Variant_Cure, Config.MNK_VariantCure))
                         return Variant.VariantCure;
 
                     // Opener for MNK
@@ -482,10 +482,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // Buffs
                     if (inCombat && !inOpener)
                     {
-                        if (IsEnabled(CustomComboPreset.MNK_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart) &&
-                            canWeave)
+                        if (Variant.CanRampart(CustomComboPreset.MNK_Variant_Rampart, actionID))
                             return Variant.VariantRampart;
 
                         if (IsEnabled(CustomComboPreset.MNK_ST_Simple_CDs))

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -3,6 +3,7 @@ using Dalamud.Game.ClientState.Statuses;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Data;
 using XIVSlothCombo.Extensions;
 using static XIVSlothCombo.Combos.JobHelpers.NIN;
@@ -128,8 +129,9 @@ namespace XIVSlothCombo.Combos.PvE
                 BloodbathThresholdST = "BloodbathThresholdST",
                 SecondWindThresholdAoE = "SecondWindThresholdAoE",
                 ShadeShiftThresholdAoE = "ShadeShiftThresholdAoE",
-                BloodbathThresholdAoE = "BloodbathThresholdAoE",
-                NIN_VariantCure = "NIN_VariantCure";
+                BloodbathThresholdAoE = "BloodbathThresholdAoE";
+            public static UserInt
+                NIN_VariantCure = new("NIN_VariantCure");
         }
 
         internal class NIN_ST_AdvancedMode : CustomCombo
@@ -203,7 +205,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return actionID;
                     }
 
-                    if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.NIN_Variant_Cure, Config.NIN_VariantCure))
                         return Variant.VariantCure;
 
                     if (InCombat() && !InMeleeRange())
@@ -238,9 +240,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (canWeave && !inMudraState)
                     {
-                        if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart))
+                        if (Variant.CanRampart(CustomComboPreset.NIN_Variant_Rampart, actionID))
                             return Variant.VariantRampart;
 
                         if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Mug_AlignBefore) &&
@@ -469,14 +469,12 @@ namespace XIVSlothCombo.Combos.PvE
                             return actionID;
                     }
 
-                    if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.NIN_Variant_Cure, Config.NIN_VariantCure))
                         return Variant.VariantCure;
 
                     if (canWeave && !inMudraState)
                     {
-                        if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart))
+                        if (Variant.CanRampart(CustomComboPreset.NIN_Variant_Rampart, actionID))
                             return Variant.VariantRampart;
 
                         if (IsEnabled(CustomComboPreset.NIN_AoE_AdvancedMode_Bunshin) && Bunshin.LevelChecked() && IsOffCooldown(Bunshin) && gauge.Ninki >= bunshingPool)
@@ -608,7 +606,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return actionID;
                     }
 
-                    if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.NIN_Variant_Cure, Config.NIN_VariantCure))
                         return Variant.VariantCure;
 
                     if (mudraState.CastHyoshoRanryu(ref actionID))
@@ -727,7 +725,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return actionID;
                     }
 
-                    if (IsEnabled(CustomComboPreset.NIN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.NIN_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.NIN_Variant_Cure, Config.NIN_VariantCure))
                         return Variant.VariantCure;
 
                     if (HasEffect(Buffs.Kassatsu))
@@ -758,9 +756,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (canWeave)
                     {
-                        if (IsEnabled(CustomComboPreset.NIN_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart))
+                        if (Variant.CanRampart(CustomComboPreset.NIN_Variant_Rampart, actionID))
                             return Variant.VariantRampart;
 
                         if (IsOffCooldown(Bunshin) && gauge.Ninki >= 50 && Bunshin.LevelChecked())

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -112,8 +112,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     // Criterion Stuff
-                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
+                    if (Variant.CanCure(CustomComboPreset.PLD_Variant_Cure, Config.PLD_VariantCure))
                         return Variant.VariantCure;
 
                     if (HasBattleTarget())
@@ -129,8 +128,7 @@ namespace XIVSlothCombo.Combos.PvE
                                     (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                                     return Variant.VariantSpiritDart;
 
-                                if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) &&
-                                    IsOffCooldown(Variant.VariantUltimatum))
+                                if (Variant.CanUltimatum(CustomComboPreset.PLD_Variant_Ultimatum))
                                     return Variant.VariantUltimatum;
 
                                 // Requiescat Usage: After Fight or Flight
@@ -261,8 +259,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is TotalEclipse)
                 {
                     // Criterion Stuff
-                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
+                    if (Variant.CanCure(CustomComboPreset.PLD_Variant_Cure, Config.PLD_VariantCure))
                         return Variant.VariantCure;
 
                     if (HasBattleTarget())
@@ -276,8 +273,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                                 return Variant.VariantSpiritDart;
 
-                            if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) &&
-                                IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
+                            if (Variant.CanUltimatum(CustomComboPreset.PLD_Variant_Ultimatum))
                                 return Variant.VariantUltimatum;
 
                             // Requiescat Usage: After Fight or Flight
@@ -363,8 +359,7 @@ namespace XIVSlothCombo.Combos.PvE
                     #endregion
 
                     // Criterion Stuff
-                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
+                    if (Variant.CanCure(CustomComboPreset.PLD_Variant_Cure, Config.PLD_VariantCure))
                         return Variant.VariantCure;
 
                     if (HasBattleTarget())
@@ -380,8 +375,7 @@ namespace XIVSlothCombo.Combos.PvE
                                     (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                                     return Variant.VariantSpiritDart;
 
-                                if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) &&
-                                    IsOffCooldown(Variant.VariantUltimatum))
+                                if (Variant.CanUltimatum(CustomComboPreset.PLD_Variant_Ultimatum))
                                     return Variant.VariantUltimatum;
 
                                 // Requiescat Usage: After Fight or Flight
@@ -534,8 +528,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is TotalEclipse)
                 {
                     // Criterion Stuff
-                    if (IsEnabled(CustomComboPreset.PLD_Variant_Cure) && IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= Config.PLD_VariantCure)
+                    if (Variant.CanCure(CustomComboPreset.PLD_Variant_Cure, Config.PLD_VariantCure))
                         return Variant.VariantCure;
 
                     if (HasBattleTarget())
@@ -549,8 +542,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                                 return Variant.VariantSpiritDart;
 
-                            if (IsEnabled(CustomComboPreset.PLD_Variant_Ultimatum) &&
-                                IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
+                            if (Variant.CanUltimatum(CustomComboPreset.PLD_Variant_Ultimatum))
                                 return Variant.VariantUltimatum;
 
                             // Requiescat Usage: After Fight or Flight

--- a/XIVSlothCombo/Combos/PvE/RDM.cs
+++ b/XIVSlothCombo/Combos/PvE/RDM.cs
@@ -165,15 +165,10 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is Jolt or Jolt2 or Jolt3)
                 {
                     //VARIANTS
-                    if (IsEnabled(CustomComboPreset.RDM_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.RDM_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.RDM_Variant_Cure, Config.RDM_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.RDM_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.RDM_Variant_Rampart, actionID, true))
                         return Variant.VariantRampart;
 
                     //RDM_BALANCE_OPENER
@@ -623,15 +618,10 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 //VARIANTS
-                if (IsEnabled(CustomComboPreset.RDM_Variant_Cure) &&
-                    IsEnabled(Variant.VariantCure) &&
-                    PlayerHealthPercentageHp() <= GetOptionValue(Config.RDM_VariantCure))
+                if (Variant.CanCure(CustomComboPreset.RDM_Variant_Cure, Config.RDM_VariantCure))
                     return Variant.VariantCure;
 
-                if (IsEnabled(CustomComboPreset.RDM_Variant_Rampart) &&
-                    IsEnabled(Variant.VariantRampart) &&
-                    IsOffCooldown(Variant.VariantRampart) &&
-                    CanSpellWeave(actionID))
+                if (Variant.CanRampart(CustomComboPreset.RDM_Variant_Rampart, actionID, true))
                     return Variant.VariantRampart;
 
                 // LUCID
@@ -820,7 +810,7 @@ namespace XIVSlothCombo.Combos.PvE
         RDM_Verraise
         Swiftcast combos to Verraise when:
         -Swiftcast is on cooldown.
-        -Swiftcast is available, but we we have Dualcast (Dualcasting Verraise)
+        -Swiftcast is available, but we have Dualcast (Dualcasting Verraise)
         Using this variation other than the alternate feature style, as Verraise is level 63
         and swiftcast is unlocked way earlier and in theory, on a hotbar somewhere
         */
@@ -834,10 +824,16 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(All.Buffs.Swiftcast) && IsEnabled(CustomComboPreset.SMN_Variant_Raise) && IsEnabled(Variant.VariantRaise))
                         return Variant.VariantRaise;
 
-                    if (LevelChecked(Verraise) &&
-                        (GetCooldownRemainingTime(All.Swiftcast) > 0 ||     // Condition 1: Swiftcast is on cooldown
-                        HasEffect(Buffs.Dualcast)))                              // Condition 2: Swiftcast is available, but we have Dualcast)
-                        return Verraise;
+                    if (LevelChecked(Verraise))
+                    {
+                        bool schwifty = HasEffect(All.Buffs.Swiftcast);
+                        if (schwifty || HasEffect(Buffs.Dualcast)) return Verraise;
+                        if (IsEnabled(CustomComboPreset.RDM_Raise_Vercure) &&
+                           !schwifty && 
+                           IsOnCooldown(All.Swiftcast))
+                        return Vercure;
+                    }
+
                 }
 
                 // Else we just exit normally and return Swiftcast

--- a/XIVSlothCombo/Combos/PvE/RPR.cs
+++ b/XIVSlothCombo/Combos/PvE/RPR.cs
@@ -125,15 +125,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is Slice)
                 {
-                    if (IsEnabled(CustomComboPreset.RPR_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.RPR_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.RPR_Variant_Cure, Config.RPR_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.RPR_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.RPR_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     if (RPROpener.DoFullOpener(ref actionID))
@@ -289,15 +284,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is Slice)
                 {
-                    if (IsEnabled(CustomComboPreset.RPR_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.RPR_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.RPR_Variant_Cure, Config.RPR_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.RPR_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.RPR_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     if (IsEnabled(CustomComboPreset.RPR_ST_Opener))
@@ -466,15 +456,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is SpinningScythe)
                 {
-                    if (IsEnabled(CustomComboPreset.RPR_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.RPR_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.RPR_Variant_Cure, Config.RPR_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.RPR_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.RPR_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     if (LevelChecked(WhorlOfDeath) &&
@@ -557,15 +542,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is SpinningScythe)
                 {
-                    if (IsEnabled(CustomComboPreset.RPR_Variant_Cure) &&
-                        IsEnabled(Variant.VariantCure) &&
-                        PlayerHealthPercentageHp() <= GetOptionValue(Config.RPR_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.RPR_Variant_Cure, Config.RPR_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.RPR_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.RPR_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     if (IsEnabled(CustomComboPreset.RPR_AoE_WoD) &&

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -3,6 +3,7 @@ using Dalamud.Game.ClientState.JobGauge.Types;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -82,8 +83,9 @@ namespace XIVSlothCombo.Combos.PvE
                 SAM_STBloodbathThreshold = "SAM_STBloodbathThreshold",
                 SAM_AoESecondWindThreshold = "SAM_AoESecondWindThreshold",
                 SAM_AoEBloodbathThreshold = "SAM_AoEBloodbathThreshold",
-                SAM_ST_ExecuteThreshold = "SAM_ST_ExecuteThreshold",
-                SAM_VariantCure = "SAM_VariantCure";
+                SAM_ST_ExecuteThreshold = "SAM_ST_ExecuteThreshold";
+            public static UserInt
+                SAM_VariantCure = new("SAM_VariantCure");
         }
 
         internal class SAM_ST_YukikazeCombo : CustomCombo
@@ -288,13 +290,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (!inOpener)
                         {
-                            if (IsEnabled(CustomComboPreset.SAM_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SAM_VariantCure))
+                            if (Variant.CanCure(CustomComboPreset.SAM_Variant_Cure, Config.SAM_VariantCure))
                                 return Variant.VariantCure;
 
-                            if (IsEnabled(CustomComboPreset.SAM_Variant_Rampart) &&
-                                IsEnabled(Variant.VariantRampart) &&
-                                IsOffCooldown(Variant.VariantRampart) &&
-                                CanWeave(actionID))
+                            if (Variant.CanRampart(CustomComboPreset.SAM_Variant_Rampart, actionID))
                                 return Variant.VariantRampart;
 
                             //Death desync check
@@ -651,13 +650,10 @@ namespace XIVSlothCombo.Combos.PvE
                     var gauge = GetJobGauge<SAMGauge>();
                     var SamAOEKenkiOvercapAmount = PluginConfiguration.GetCustomIntValue(Config.SAM_AoE_KenkiOvercapAmount);
 
-                    if (IsEnabled(CustomComboPreset.SAM_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SAM_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.SAM_Variant_Cure, Config.SAM_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.SAM_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.SAM_Variant_Rampart, actionID))
                         return Variant.VariantRampart;
 
                     //oGCD Features

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -486,7 +486,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid) &&
-                        All.CanUseLucid(actionID, 1000))
+                        All.CanUseLucid(actionID, Config.SCH_AoE_Heal_LucidOption))
                         return All.LucidDreaming;
 
                     // Indomitability

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -343,10 +343,7 @@ namespace XIVSlothCombo.Combos.PvE
                         openerState = OpenerState.InOpener;
                     }
 
-                    if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_Rampart) && 
-                        IsEnabled(Variant.VariantRampart) && 
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.SCH_DPS_Variant_Rampart, actionID, true))
                         return Variant.VariantRampart;
 
                     // Dissipation
@@ -363,9 +360,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SCH_DPS_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_ST_DPS_LucidOption &&
-                        CanSpellWeave(actionID))
+                        All.CanUseLucid(actionID,Config.SCH_ST_DPS_LucidOption))
                         return All.LucidDreaming;
 
                     //Target based options
@@ -444,10 +439,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is ArtOfWar or ArtOfWarII)
                 {
-                    if (IsEnabled(CustomComboPreset.SCH_DPS_Variant_Rampart) && 
-                        IsEnabled(Variant.VariantRampart) && 
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.SCH_DPS_Variant_Rampart, actionID, true))
                         return Variant.VariantRampart;
 
                     Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);
@@ -466,9 +458,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SCH_AoE_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_AoE_LucidOption &&
-                        CanSpellWeave(actionID))
+                        All.CanUseLucid(actionID,Config.SCH_AoE_LucidOption))
                         return All.LucidDreaming;
                 }
                 return actionID;
@@ -496,8 +486,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SCH_AoE_Heal_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp < 1000)
+                        All.CanUseLucid(actionID, 1000))
                         return All.LucidDreaming;
 
                     // Indomitability
@@ -560,9 +549,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SCH_ST_Heal_Lucid) &&
-                        ActionReady(All.LucidDreaming) &&
-                        LocalPlayer.CurrentMp <= Config.SCH_ST_Heal_LucidOption &&
-                        CanSpellWeave(actionID))
+                        All.CanUseLucid(actionID, Config.SCH_ST_Heal_LucidOption))
                         return All.LucidDreaming;
 
                     //Grab our target (Soft->Hard->Self)

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -217,10 +217,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (!HasEffect(Buffs.Eukrasia))
                     {
                         // Variant Rampart
-                        if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart) &&
-                            CanSpellWeave(actionID))
+                        if (Variant.CanRampart(CustomComboPreset.SGE_DPS_Variant_Rampart, actionID, true))
                             return Variant.VariantRampart;
 
                         // Variant Spirit Dart
@@ -233,8 +230,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         // Lucid Dreaming
                         if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Lucid) &&
-                            ActionReady(All.LucidDreaming) && CanSpellWeave(Dosis) &&
-                            LocalPlayer.CurrentMp <= Config.SGE_AoE_DPS_Lucid)
+                            All.CanUseLucid(actionID, Config.SGE_AoE_DPS_Lucid))
                             return All.LucidDreaming;
 
                         // Rhizomata
@@ -327,15 +323,11 @@ namespace XIVSlothCombo.Combos.PvE
 
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Lucid) &&
-                        ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) &&
-                        LocalPlayer.CurrentMp <= Config.SGE_ST_DPS_Lucid)
+                        All.CanUseLucid(actionID, Config.SGE_ST_DPS_Lucid))
                         return All.LucidDreaming;
 
                     // Variant
-                    if (IsEnabled(CustomComboPreset.SGE_DPS_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.SGE_DPS_Variant_Rampart, actionID, true))
                         return Variant.VariantRampart;
 
                     // Rhizomata

--- a/XIVSlothCombo/Combos/PvE/SMN.cs
+++ b/XIVSlothCombo/Combos/PvE/SMN.cs
@@ -142,8 +142,10 @@ namespace XIVSlothCombo.Combos.PvE
                 SMN_BurstPhase = "SMN_BurstPhase",
                 SMN_PrimalChoice = "SMN_PrimalChoice",
                 SMN_SwiftcastPhase = "SMN_SwiftcastPhase",
-                SMN_Burst_Delay = "SMN_Burst_Delay",
-                SMN_VariantCure = "SMN_VariantCure";
+                SMN_Burst_Delay = "SMN_Burst_Delay";
+
+            public static UserInt
+                SMN_VariantCure = new("SMN_VariantCure");
 
             public static UserBoolArray
                 SMN_ST_Egi_AstralFlow = new("SMN_ST_Egi_AstralFlow");
@@ -249,13 +251,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is Ruin or Ruin2 or Outburst or Tridisaster)
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.SMN_Variant_Cure, Config.SMN_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.SMN_Variant_Rampart, actionID, true))
                         return Variant.VariantRampart;
 
                     if (CanSpellWeave(actionID))
@@ -425,13 +424,10 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is Ruin or Ruin2 or Outburst or Tridisaster)
                 {
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.SMN_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.SMN_Variant_Cure, Config.SMN_VariantCure))
                         return Variant.VariantCure;
 
-                    if (IsEnabled(CustomComboPreset.SMN_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart) &&
-                        CanSpellWeave(actionID))
+                    if (Variant.CanRampart(CustomComboPreset.SMN_Variant_Rampart, actionID, true))
                         return Variant.VariantRampart;
 
                     if (CanSpellWeave(actionID))

--- a/XIVSlothCombo/Combos/PvE/WAR.cs
+++ b/XIVSlothCombo/Combos/PvE/WAR.cs
@@ -3,6 +3,7 @@ using Dalamud.Game.ClientState.Statuses;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -64,11 +65,12 @@ namespace XIVSlothCombo.Combos.PvE
                 WAR_SurgingRefreshRange = "WarSurgingRefreshRange",
                 WAR_KeepOnslaughtCharges = "WarKeepOnslaughtCharges",
                 WAR_KeepInfuriateCharges = "WarKeepInfuriateCharges",
-                WAR_VariantCure = "WAR_VariantCure",
                 WAR_FellCleaveGauge = "WAR_FellCleaveGauge",
                 WAR_DecimateGauge = "WAR_DecimateGauge",
                 WAR_InfuriateSTGauge = "WAR_InfuriateSTGauge",
                 WAR_InfuriateAoEGauge = "WAR_InfuriateAoEGauge";
+            public static UserInt
+                WAR_VariantCure = new("WAR_VariantCure");
         }
 
         // Replace Storm's Path with Storm's Path combo and overcap feature on main combo to fellcleave
@@ -88,7 +90,7 @@ namespace XIVSlothCombo.Combos.PvE
                     var infuriateGauge = PluginConfiguration.GetCustomIntValue(Config.WAR_InfuriateSTGauge);
                     float GCD = GetCooldown(HeavySwing).CooldownTotal;
 
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.WAR_Variant_Cure, Config.WAR_VariantCure))
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.WAR_ST_StormsPath_RangedUptime) && LevelChecked(Tomahawk) && !InMeleeRange() && HasBattleTarget())
@@ -112,7 +114,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                                 return Variant.VariantSpiritDart;
 
-                            if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
+                            if (Variant.CanUltimatum(CustomComboPreset.WAR_Variant_Ultimatum))
                                 return Variant.VariantUltimatum;
 
 
@@ -216,7 +218,7 @@ namespace XIVSlothCombo.Combos.PvE
                     var decimateGaugeSpend = PluginConfiguration.GetCustomIntValue(Config.WAR_DecimateGauge);
                     var infuriateGauge = PluginConfiguration.GetCustomIntValue(Config.WAR_InfuriateAoEGauge);
 
-                    if (IsEnabled(CustomComboPreset.WAR_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.WAR_VariantCure))
+                    if (Variant.CanCure(CustomComboPreset.WAR_Variant_Cure, Config.WAR_VariantCure))
                         return Variant.VariantCure;
 
                     if (IsEnabled(CustomComboPreset.WAR_AoE_Overpower_Infuriate) && InCombat() && ActionReady(Infuriate) && !HasEffect(Buffs.NascentChaos) && !HasEffect(Buffs.InnerReleaseStacks) && gauge <= infuriateGauge && CanWeave(actionID))
@@ -236,7 +238,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 (sustainedDamage is null || sustainedDamage?.RemainingTime <= 3))
                                 return Variant.VariantSpiritDart;
 
-                            if (IsEnabled(CustomComboPreset.WAR_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && IsOffCooldown(Variant.VariantUltimatum))
+                            if (Variant.CanUltimatum(CustomComboPreset.WAR_Variant_Ultimatum))
                                 return Variant.VariantUltimatum;
 
                             if (IsEnabled(CustomComboPreset.WAR_AoE_Overpower_InnerRelease) && CanWeave(actionID) && IsOffCooldown(OriginalHook(Berserk)) && LevelChecked(Berserk))

--- a/XIVSlothCombo/Combos/PvE/WHM.cs
+++ b/XIVSlothCombo/Combos/PvE/WHM.cs
@@ -243,24 +243,20 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (CanSpellWeave(actionID))
                     {
-                        bool lucidReady = ActionReady(All.LucidDreaming) && LevelChecked(All.LucidDreaming) && LocalPlayer.CurrentMp <= Config.WHM_STDPS_Lucid;
                         bool pomReady = LevelChecked(PresenceOfMind) && IsOffCooldown(PresenceOfMind);
                         bool assizeReady = LevelChecked(Assize) && IsOffCooldown(Assize);
                         bool pomEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_PresenceOfMind);
                         bool assizeEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Assize);
-                        bool lucidEnabled = IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Lucid);
 
-                        if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_Rampart) &&
-                            IsEnabled(Variant.VariantRampart) &&
-                            IsOffCooldown(Variant.VariantRampart) &&
-                            CanSpellWeave(actionID))
+                        if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart, actionID, true))
                             return Variant.VariantRampart;
 
                         if (pomEnabled && pomReady)
                             return PresenceOfMind;
                         if (assizeEnabled && assizeReady)
                             return Assize;
-                        if (lucidEnabled && lucidReady)
+                        if (IsEnabled(CustomComboPreset.WHM_ST_MainCombo_Lucid) && 
+                            All.CanUseLucid(actionID, Config.WHM_STDPS_Lucid))
                             return All.LucidDreaming;
                     }
 
@@ -318,7 +314,6 @@ namespace XIVSlothCombo.Combos.PvE
                     WHMGauge? gauge = GetJobGauge<WHMGauge>();
                     bool thinAirReady = LevelChecked(ThinAir) && !HasEffect(Buffs.ThinAir) && GetRemainingCharges(ThinAir) > Config.WHM_AoEHeals_ThinAir;
                     var canWeave = CanSpellWeave(actionID, 0.3);
-                    bool lucidReady = ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= Config.WHM_AoEHeals_Lucid;
                     bool plenaryReady = ActionReady(PlenaryIndulgence) && (!Config.WHM_AoEHeals_PlenaryWeave || (Config.WHM_AoEHeals_PlenaryWeave && canWeave));
                     bool divineCaressReady = ActionReady(DivineCaress) && HasEffect(Buffs.DivineGrace);
                     bool assizeReady = ActionReady(Assize) && (!Config.WHM_AoEHeals_AssizeWeave || (Config.WHM_AoEHeals_AssizeWeave && canWeave));
@@ -333,7 +328,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.WHM_AoEHeals_DivineCaress) && divineCaressReady)
                         return OriginalHook(DivineCaress);
 
-                    if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Lucid) && canWeave && lucidReady)
+                    if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Lucid) && All.CanUseLucid(actionID, Config.WHM_AoEHeals_Lucid, true, 0.3))
                         return All.LucidDreaming;
 
                     if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Misery) && gauge.BloodLily == 3)
@@ -380,7 +375,6 @@ namespace XIVSlothCombo.Combos.PvE
                     IGameObject? healTarget = GetHealTarget(Config.WHM_STHeals_UIMouseOver);
                     bool canWeave = CanSpellWeave(actionID, 0.3);
                     bool thinAirReady = LevelChecked(ThinAir) && !HasEffect(Buffs.ThinAir) && GetRemainingCharges(ThinAir) > Config.WHM_STHeals_ThinAir;
-                    bool lucidReady = ActionReady(All.LucidDreaming) && LocalPlayer.CurrentMp <= Config.WHM_STHeals_Lucid;
                     bool tetraReady = ActionReady(Tetragrammaton) && (!Config.WHM_STHeals_TetraWeave || (Config.WHM_STHeals_TetraWeave && canWeave)) && GetTargetHPPercent(healTarget) <= Config.WHM_STHeals_TetraHP;
                     bool benisonReady = ActionReady(DivineBenison) && (!Config.WHM_STHeals_BenisonWeave || (Config.WHM_STHeals_BenisonWeave && canWeave)) && GetTargetHPPercent(healTarget) <= Config.WHM_STHeals_BenisonHP;
                     bool aquaReady = ActionReady(Aquaveil) && (!Config.WHM_STHeals_AquaveilWeave || (Config.WHM_STHeals_AquaveilWeave && canWeave)) && GetTargetHPPercent(healTarget) <= Config.WHM_STHeals_AquaveilHP;
@@ -398,7 +392,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.WHM_STHeals_Tetragrammaton) && tetraReady)
                         return Tetragrammaton;
 
-                    if (IsEnabled(CustomComboPreset.WHM_STHeals_Lucid) && canWeave && lucidReady)
+                    if (IsEnabled(CustomComboPreset.WHM_STHeals_Lucid) && All.CanUseLucid(actionID, Config.WHM_STHeals_Lucid))
                         return All.LucidDreaming;
 
                     if (IsEnabled(CustomComboPreset.WHM_STHeals_Benison) && benisonReady && FindEffectOnMember(Buffs.DivineBenison, healTarget) is null)
@@ -441,9 +435,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Assize) && ActionReady(Assize))
                         return Assize;
 
-                    if (IsEnabled(CustomComboPreset.WHM_DPS_Variant_Rampart) &&
-                        IsEnabled(Variant.VariantRampart) &&
-                        IsOffCooldown(Variant.VariantRampart))
+                    if (Variant.CanRampart(CustomComboPreset.WHM_DPS_Variant_Rampart, actionID, true))
                         return Variant.VariantRampart;
 
                     Status? sustainedDamage = FindTargetEffect(Variant.Debuffs.SustainedDamage);


### PR DESCRIPTION
- Both VerRaise features (ALL/RDM) support a VerCure to trigger dualcast if Swiftcast is unavailable
- All.CanUseLucid used in a few more spots
- Added CanCure CanRampart CanUltimatum to Variant.cs. Updated all classes.  Will do Spirit Dart later