### PR TITLE
AST Changes, Sage overcap fix, Sch opener fix

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3092,9 +3092,9 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Rhizomata Feature", "Replaces Addersgall skills with Rhizomata when empty.", SGE.JobID, 600, "", "")]
         SGE_Rhizo = 14037,
 
-        [ReplaceSkill(SGE.Druochole)]
-        [CustomComboInfo("Druochole to Taurochole Feature", "Upgrades Druochole to Taurochole when Taurochole is available.", SGE.JobID, 700, "", "")]
-        SGE_DruoTauro = 14038,
+        [ReplaceSkill(SGE.Taurochole)]
+        [CustomComboInfo("Taurochole to Druochole Feature", "Turns Taurochole to Druochole when Taurochole is on cooldown.", SGE.JobID, 700, "", "")]
+        SGE_TauroDruo = 14038,
 
         [ReplaceSkill(SGE.Pneuma)]
         [CustomComboInfo("Zoe Pneuma Feature", "Places Zoe on top of Pneuma when both actions are on cooldown.", SGE.JobID, 701, "", "")] //Temporary to keep the order

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -201,7 +201,7 @@ namespace XIVSlothCombo.Combos
         AST_DPS_AutoDraw = 1011,
 
         [ParentCombo(AST_ST_DPS)]
-        [CustomComboInfo("Card Play Weave Option", "Weaves your Balance or Arrow card (best used with Quick Target Cards)", AST.JobID, 6)]
+        [CustomComboInfo("Card Play Weave Option", "Weaves your Balance or Spear card (best used with Quick Target Cards)", AST.JobID, 6)]
         AST_DPS_AutoPlay = 1037,
 
         [ParentCombo(AST_ST_DPS)]
@@ -240,7 +240,7 @@ namespace XIVSlothCombo.Combos
         AST_AOE_AutoDraw = 1044,
 
         [ParentCombo(AST_AOE_DPS)]
-        [CustomComboInfo("Card Play Weave Option", "Weaves your Balance or Arrow card (best used with Quick Target Cards)", AST.JobID, 6)]
+        [CustomComboInfo("Card Play Weave Option", "Weaves your Balance or Spear card (best used with Quick Target Cards)", AST.JobID, 6)]
         AST_AOE_AutoPlay = 1045,
 
         [ParentCombo(AST_AOE_DPS)]
@@ -279,12 +279,20 @@ namespace XIVSlothCombo.Combos
         AST_ST_SimpleHeals_Exaltation = 1028,
 
         [ParentCombo(AST_ST_SimpleHeals)]
-        [CustomComboInfo("The Spire Option", "Adds The Spire when the card has been drawn", AST.JobID)]
+        [CustomComboInfo("The Spire Option", "Adds The Spire (Shield)  when the card has been drawn", AST.JobID)]
         AST_ST_SimpleHeals_Spire = 1030,
 
         [ParentCombo(AST_ST_SimpleHeals)]
-        [CustomComboInfo("The Ewer Option", "Adds The Ewer when the card has been drawn", AST.JobID)]
+        [CustomComboInfo("The Ewer Option", "Adds The Ewer (Heal over time) when the card has been drawn", AST.JobID)]
         AST_ST_SimpleHeals_Ewer = 1032,
+
+        [ParentCombo(AST_ST_SimpleHeals)]
+        [CustomComboInfo("The Arrow Option", "Adds The Arrow (increased healing)  when the card has been drawn", AST.JobID)]
+        AST_ST_SimpleHeals_Arrow = 1049,
+
+        [ParentCombo(AST_ST_SimpleHeals)]
+        [CustomComboInfo("The Bole Option", "Adds The Bole (Reduced Damage) when the card has been drawn", AST.JobID)]
+        AST_ST_SimpleHeals_Bole = 1050,
 
         [ReplaceSkill(AST.AspectedHelios)]
         [CustomComboInfo("Simple Heals (AoE)", "Replaces Aspected Helios with a one button healing replacement.", AST.JobID, 3, "", "")]
@@ -335,7 +343,7 @@ namespace XIVSlothCombo.Combos
         AST_Cards_QuickTargetCards_TargetExtra = 1031,
         #endregion
 
-        // Last value = 1048
+        // Last value = 1050
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -175,20 +175,15 @@ namespace XIVSlothCombo.Combos
 
         #region ASTROLOGIAN
 
-        #region DPS
-        [ReplaceSkill(AST.Malefic, AST.Malefic2, AST.Malefic3, AST.Malefic4, AST.FallMalefic, AST.Combust, AST.Combust2, AST.Combust3, AST.Gravity, AST.Gravity2)]
-        [CustomComboInfo("DPS Feature", "Replaces Malefic or Combust with options below", AST.JobID)]
+        #region ST DPS
+        [ReplaceSkill(AST.Malefic, AST.Malefic2, AST.Malefic3, AST.Malefic4, AST.FallMalefic, AST.Combust, AST.Combust2, AST.Combust3)]
+        [CustomComboInfo("ST DPS Feature", "Replaces Malefic or Combust with options below", AST.JobID)]
         AST_ST_DPS = 1004,
 
         [ParentCombo(AST_ST_DPS)]
         [CustomComboInfo("Combust Uptime Option", "Adds Combust to the DPS feature if it's not present on current target, or is about to expire.", AST.JobID)]
         AST_ST_DPS_CombustUptime = 1018,
-
-        [ReplaceSkill(AST.Gravity, AST.Gravity2)]
-        [ParentCombo(AST_ST_DPS)]
-        [CustomComboInfo("AoE DPS Option", "Every option below (Lucid/AutoDraws/etc) will also be added to Gravity", AST.JobID, 1, "", "")]
-        AST_AoE_DPS = 1013,
-
+              
         [ParentCombo(AST_ST_DPS)]
         [CustomComboInfo("Lightspeed Weave Option", "Adds Lightspeed", AST.JobID, 2, "", "")]
         AST_DPS_LightSpeed = 1020,
@@ -216,6 +211,46 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(AST_ST_DPS)]
         [CustomComboInfo("Oracle Option", "Adds Oracle after Divination", AST.JobID)]
         AST_DPS_Oracle = 1015,
+
+        [ParentCombo(AST_ST_DPS)]
+        [CustomComboInfo("Opener Option lvl 100", "Use the Balance opener. Have a deck of cards pulled and umbral draw off cooldown. It WILL use a lightspeed charge", AST.JobID, 11, "", "")]
+        AST_ST_DPS_Opener = 1040,
+
+        #endregion
+
+        #region AOE DPS
+        [ReplaceSkill(AST.Gravity, AST.Gravity2)]
+        [CustomComboInfo("AOE DPS Feature", "Replaces Gravity with options below", AST.JobID)]
+        AST_AOE_DPS = 1041,    
+
+        [ParentCombo(AST_AOE_DPS)]
+        [CustomComboInfo("Lightspeed Weave Option", "Adds Lightspeed", AST.JobID, 2, "", "")]
+        AST_AOE_LightSpeed = 1048,
+
+        [ParentCombo(AST_AOE_DPS)]
+        [CustomComboInfo("Lucid Dreaming Weave Option", "Adds Lucid Dreaming when MP drops below slider value", AST.JobID, 3, "", "")]
+        AST_AOE_Lucid = 1042,
+
+        [ParentCombo(AST_AOE_DPS)]
+        [CustomComboInfo("Divination Weave Option", "Adds Divination", AST.JobID, 4, "", "")]
+        AST_AOE_Divination = 1043,
+
+        [ParentCombo(AST_AOE_DPS)]
+        [CustomComboInfo("Card Draw Weave Option", "Draws your cards", AST.JobID, 5, "", "")]
+        AST_AOE_AutoDraw = 1044,
+
+        [ParentCombo(AST_AOE_DPS)]
+        [CustomComboInfo("Card Play Weave Option", "Weaves your Balance or Arrow card (best used with Quick Target Cards)", AST.JobID, 6)]
+        AST_AOE_AutoPlay = 1045,
+
+        [ParentCombo(AST_AOE_DPS)]
+        [CustomComboInfo("Lord of Crowns Weave Option", "Adds Lord Of Crowns", AST.JobID, 10, "", "")]
+        AST_AOE_LazyLord = 1046,
+
+        [ParentCombo(AST_AOE_DPS)]
+        [CustomComboInfo("Oracle Option", "Adds Oracle after Divination", AST.JobID)]
+        AST_AOE_Oracle = 1047,       
+
         #endregion
 
         #region Healing
@@ -280,7 +315,7 @@ namespace XIVSlothCombo.Combos
         AST_Raise_Alternative = 1003,
 
         [Variant]
-        [VariantParent(AST_ST_DPS_CombustUptime, AST_AoE_DPS)]
+        [VariantParent(AST_ST_DPS_CombustUptime)]
         [CustomComboInfo("Spirit Dart Option", "Use Variant Spirit Dart whenever the debuff is not present or less than 3s.", AST.JobID)]
         AST_Variant_SpiritDart = 1035,
 
@@ -300,7 +335,7 @@ namespace XIVSlothCombo.Combos
         AST_Cards_QuickTargetCards_TargetExtra = 1031,
         #endregion
 
-        // Last value = 1039
+        // Last value = 1048
 
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -190,6 +190,15 @@ namespace XIVSlothCombo.Combos.PvE
 
                 bool AlternateMode = GetIntOptionAsBool(Config.AST_DPS_AltMode); //(0 or 1 radio values)
                 if (((!AlternateMode && MaleficList.Contains(actionID)) ||
+                    (AlternateMode && CombustList.ContainsKey(actionID)) ||
+                    (IsEnabled(CustomComboPreset.AST_AoE_DPS) && GravityList.Contains(actionID))) &&
+                    !InCombat())
+
+                    if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
+                        ActionReady(OriginalHook(AstralDraw)) && !InCombat())
+                        return OriginalHook(AstralDraw);
+
+                if (((!AlternateMode && MaleficList.Contains(actionID)) ||
                      (AlternateMode && CombustList.ContainsKey(actionID)) ||
                      (IsEnabled(CustomComboPreset.AST_AoE_DPS) && GravityList.Contains(actionID))) &&
                     InCombat())

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -147,6 +147,11 @@ namespace XIVSlothCombo.Combos.PvE
                 AST_QuickTarget_SkipRezWeakness = new("AST_QuickTarget_SkipRezWeakness"),
                 AST_ST_SimpleHeals_Adv = new("AST_ST_SimpleHeals_Adv"),
                 AST_ST_SimpleHeals_UIMouseOver = new("AST_ST_SimpleHeals_UIMouseOver"),
+                AST_ST_SimpleHeals_WeaveDignity = new("AST_ST_SimpleHeals_WeaveDignity"),
+                AST_ST_SimpleHeals_WeaveIntersection = new("AST_ST_SimpleHeals_WeaveIntersection"),
+                AST_ST_SimpleHeals_WeaveEwer = new("AST_ST_SimpleHeals_WeaveEwer"),
+                AST_ST_SimpleHeals_WeaveSpire = new("AST_ST_SimpleHeals_WeaveSpire"),
+                AST_ST_SimpleHeals_WeaveExalt = new("AST_ST_SimpleHeals_WeaveExalt"),
                 AST_AoE_SimpleHeals_WeaveLady = new("AST_AoE_SimpleHeals_WeaveLady"),
                 AST_AoE_SimpleHeals_Opposition = new("AST_AoE_SimpleHeals_Opposition"),
                 AST_AoE_SimpleHeals_Horoscope = new("AST_AoE_SimpleHeals_Horoscope"),
@@ -366,6 +371,12 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Benefic2)
                 {
+                    var canDignity = (Config.AST_ST_SimpleHeals_WeaveDignity && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveDignity;
+                    var canIntersect = (Config.AST_ST_SimpleHeals_WeaveIntersection && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveIntersection;
+                    var canExalt = (Config.AST_ST_SimpleHeals_WeaveExalt && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveExalt;
+                    var canEwer = (Config.AST_ST_SimpleHeals_WeaveEwer && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveEwer;
+                    var canSpire = (Config.AST_ST_SimpleHeals_WeaveSpire && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveSpire;
+
                     //Grab our target (Soft->Hard->Self)
                     IGameObject? healTarget = GetHealTarget(Config.AST_ST_SimpleHeals_Adv && Config.AST_ST_SimpleHeals_UIMouseOver);
 
@@ -374,31 +385,32 @@ namespace XIVSlothCombo.Combos.PvE
                         HasCleansableDebuff(healTarget))
                         return All.Esuna;
 
-                    if ((IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Spire) &&
+                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Spire) &&
                         Gauge.DrawnCards[2] == CardType.SPIRE &&
                         GetTargetHPPercent(healTarget) <= Config.AST_Spire &&
-                        CanSpellWeave(actionID))
-                        ||
-                        (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Ewer) &&
+                        canSpire)
+                        return OriginalHook(Play3);
+
+                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Ewer) &&
                         Gauge.DrawnCards[2] == CardType.EWER &&
                         GetTargetHPPercent(healTarget) <= Config.AST_Ewer &&
-                        CanSpellWeave(actionID)))
+                        canEwer)
                         return OriginalHook(Play3);
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity) &&
                         ActionReady(EssentialDignity) &&
                         GetTargetHPPercent(healTarget) <= Config.AST_EssentialDignity &&
-                        CanSpellWeave(actionID))
+                        canDignity)
                         return EssentialDignity;
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Exaltation) &&
                         ActionReady(Exaltation) &&
-                        CanSpellWeave(actionID))
+                        canExalt)
                         return Exaltation;
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_CelestialIntersection) &&
                         ActionReady(CelestialIntersection) &&
-                        CanSpellWeave(actionID) &&
+                        canIntersect &&
                         !(healTarget as IBattleChara)!.HasShield())
                         return CelestialIntersection;
 

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -135,6 +135,8 @@ namespace XIVSlothCombo.Combos.PvE
                 AST_EssentialDignity = new("ASTCustomEssentialDignity", 50),
                 AST_Spire = new("AST_Spire", 80),
                 AST_Ewer = new("AST_Ewer", 80),
+                AST_Arrow = new("AST_Arrow", 80),
+                AST_Bole = new("AST_Bole", 80),
                 AST_ST_SimpleHeals_Esuna = new("AST_ST_SimpleHeals_Esuna", 100),
                 AST_DPS_AltMode = new("AST_DPS_AltMode"),
                 AST_DPS_DivinationOption = new("AST_DPS_DivinationOption"),
@@ -153,6 +155,8 @@ namespace XIVSlothCombo.Combos.PvE
                 AST_ST_SimpleHeals_WeaveIntersection = new("AST_ST_SimpleHeals_WeaveIntersection"),
                 AST_ST_SimpleHeals_WeaveEwer = new("AST_ST_SimpleHeals_WeaveEwer"),
                 AST_ST_SimpleHeals_WeaveSpire = new("AST_ST_SimpleHeals_WeaveSpire"),
+                AST_ST_SimpleHeals_WeaveArrow = new("AST_ST_SimpleHeals_WeaveArrow"),
+                AST_ST_SimpleHeals_WeaveBole = new("AST_ST_SimpleHeals_WeaveBole"),
                 AST_ST_SimpleHeals_WeaveExalt = new("AST_ST_SimpleHeals_WeaveExalt"),
                 AST_AoE_SimpleHeals_WeaveLady = new("AST_AoE_SimpleHeals_WeaveLady"),
                 AST_AoE_SimpleHeals_Opposition = new("AST_AoE_SimpleHeals_Opposition"),
@@ -525,6 +529,8 @@ namespace XIVSlothCombo.Combos.PvE
                     var canExalt = (Config.AST_ST_SimpleHeals_WeaveExalt && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveExalt;
                     var canEwer = (Config.AST_ST_SimpleHeals_WeaveEwer && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveEwer;
                     var canSpire = (Config.AST_ST_SimpleHeals_WeaveSpire && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveSpire;
+                    var canBole = (Config.AST_ST_SimpleHeals_WeaveBole && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveBole;
+                    var canArrow = (Config.AST_ST_SimpleHeals_WeaveArrow && CanSpellWeave(actionID)) || !Config.AST_ST_SimpleHeals_WeaveArrow;
 
                     //Grab our target (Soft->Hard->Self)
                     IGameObject? healTarget = GetHealTarget(Config.AST_ST_SimpleHeals_Adv && Config.AST_ST_SimpleHeals_UIMouseOver);
@@ -545,6 +551,18 @@ namespace XIVSlothCombo.Combos.PvE
                         GetTargetHPPercent(healTarget) <= Config.AST_Ewer &&
                         canEwer)
                         return OriginalHook(Play3);
+
+                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Arrow) &&
+                        Gauge.DrawnCards[1] == CardType.ARROW &&
+                        GetTargetHPPercent(healTarget) <= Config.AST_Arrow &&
+                        canArrow)
+                        return OriginalHook(Play2);
+                    
+                    if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_Bole) &&
+                        Gauge.DrawnCards[1] == CardType.BOLE &&
+                        GetTargetHPPercent(healTarget) <= Config.AST_Bole &&
+                        canBole)
+                        return OriginalHook(Play2);
 
                     if (IsEnabled(CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity) &&
                         ActionReady(EssentialDignity) &&

--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 using XIVSlothCombo.Combos.PvE.Content;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.CustomComboNS.Functions;
+using XIVSlothCombo.Data;
+using System.Linq;
 using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -312,6 +314,7 @@ namespace XIVSlothCombo.Combos.PvE
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SCH_DPS;
 
             internal OpenerState openerState = OpenerState.PreOpener;
+            internal static int BroilCount => ActionWatching.CombatActions.Count(x => x == OriginalHook(Broil));
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -334,7 +337,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         openerState = OpenerState.PreOpener;
                     }
-                    else if (Gauge.HasAetherflow())
+                    else if (BroilCount > 1)
                     {
                         openerState = OpenerState.PostOpener;
                     }
@@ -388,7 +391,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             // If CS is available and usable, or if the Impact Buff is on Player
                             if (ActionReady(ChainStratagem) &&
-                                !TargetHasEffectAny(Debuffs.ChainStratagem) &&
+                                !TargetHasEffectAny(Debuffs.ChainStratagem) && (openerState == OpenerState.PostOpener) &&
                                 GetTargetHPPercent() > Config.SCH_ST_DPS_ChainStratagemOption &&
                                 InCombat() &&
                                 CanSpellWeave(actionID))

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -187,9 +187,9 @@ namespace XIVSlothCombo.Combos.PvE
          */
         internal class SGE_DruoTauro : CustomCombo
         {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_DruoTauro;
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_TauroDruo;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-                => actionID is Druochole && ActionReady(Taurochole) ? Taurochole : actionID;
+                => actionID is Taurochole && IsOnCooldown(Taurochole) ? Druochole : actionID;
         }
 
         /*

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1226,6 +1226,21 @@ namespace XIVSlothCombo.Window.Functions
             if (preset is CustomComboPreset.AST_DPS_LightSpeed)
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_DPS_LightSpeedOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
 
+            //AOE added
+            if (preset is CustomComboPreset.AST_AOE_Lucid)
+                UserConfig.DrawSliderInt(4000, 9500, AST.Config.AST_LucidDreaming, "Set value for your MP to be at or under for this feature to work", 150, SliderIncrements.Hundreds);
+            
+            if (preset is CustomComboPreset.AST_AOE_Divination)
+                UserConfig.DrawSliderInt(0, 100, AST.Config.AST_AOE_DivinationOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
+
+            if (preset is CustomComboPreset.AST_AOE_LightSpeed)
+                UserConfig.DrawSliderInt(0, 100, AST.Config.AST_AOE_LightSpeedOption, "Stop using at Enemy HP %. Set to Zero to disable this check.");
+                        
+            if (preset is CustomComboPreset.AST_AOE_AutoDraw)
+            {
+                UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_AOE_DPS_OverwriteCards, "Overwrite Non-DPS Cards", "Will draw even if you have healing cards remaining.");
+            }
+            //end aoe added
 
             if (preset is CustomComboPreset.AST_ST_SimpleHeals)
             {

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1277,6 +1277,16 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_Ewer, "Set percentage value");
                 UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_ST_SimpleHeals_WeaveEwer, "Only Weave", "Will only weave this action.");
             }
+            if (preset is CustomComboPreset.AST_ST_SimpleHeals_Bole)
+            {
+                UserConfig.DrawSliderInt(0, 100, AST.Config.AST_Bole, "Set percentage value");
+                UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_ST_SimpleHeals_WeaveBole, "Only Weave", "Will only weave this action.");
+            }
+            if (preset is CustomComboPreset.AST_ST_SimpleHeals_Arrow)
+            {
+                UserConfig.DrawSliderInt(0, 100, AST.Config.AST_Arrow, "Set percentage value");
+                UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_ST_SimpleHeals_WeaveArrow, "Only Weave", "Will only weave this action.");
+            }
             if (preset is CustomComboPreset.AST_ST_SimpleHeals_Esuna)
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_ST_SimpleHeals_Esuna, "Stop using when below HP %. Set to Zero to disable this check");
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1242,17 +1242,28 @@ namespace XIVSlothCombo.Window.Functions
             }
 
             if (preset is CustomComboPreset.AST_ST_SimpleHeals_EssentialDignity)
+            {
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_EssentialDignity, "Set percentage value");
+                UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_ST_SimpleHeals_WeaveDignity, "Only Weave", "Will only weave this action.");
+            }
+            if (preset is CustomComboPreset.AST_ST_SimpleHeals_CelestialIntersection)
+                UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_ST_SimpleHeals_WeaveIntersection, "Only Weave", "Will only weave this action.");
+
+            if (preset is CustomComboPreset.AST_ST_SimpleHeals_Exaltation)
+                UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_ST_SimpleHeals_WeaveExalt, "Only Weave", "Will only weave this action.");
 
             if (preset is CustomComboPreset.AST_ST_SimpleHeals_Spire)
+            { 
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_Spire, "Set percentage value");
-
+                UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_ST_SimpleHeals_WeaveSpire, "Only Weave", "Will only weave this action.");
+            }
             if (preset is CustomComboPreset.AST_ST_SimpleHeals_Ewer)
+            {  
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_Ewer, "Set percentage value");
-
+                UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_ST_SimpleHeals_WeaveEwer, "Only Weave", "Will only weave this action.");
+            }
             if (preset is CustomComboPreset.AST_ST_SimpleHeals_Esuna)
                 UserConfig.DrawSliderInt(0, 100, AST.Config.AST_ST_SimpleHeals_Esuna, "Stop using when below HP %. Set to Zero to disable this check");
-
 
             if (preset is CustomComboPreset.AST_AoE_SimpleHeals_LazyLady)
                 UserConfig.DrawAdditionalBoolChoice(AST.Config.AST_AoE_SimpleHeals_WeaveLady, "Only Weave", "Will only weave this action.");


### PR DESCRIPTION
Puts draw, out of combat, on top of the dps combos, so you can more easily draw pre pull without another button needed. 

Added ST opener per balance. Will only use one lightspeed delayedweave after combust

Due to this needed to also split ST and aoe into 2 sections. 

Added weave only options to st heals
Dignity, intersection, Ewer, Spire, exaltation

Added Bole and Arrow to st heals, with weave only and health % options. 

Fixed card weave to properly state Balance/spear instead of balance/arrow

Sage overcap fix. Changed the druo to tauro feature into tauro to druo feature. Functionally the same just swapping buttons on a healer bar. But it prevents the overcap from
1 wasting tauro on overcap since it is the tank dr cd
2 blowing 2 charges using a druo and tauro at the same time on overcap

Fixes https://github.com/Nik-Potokar/XIVSlothCombo/issues/1629
Fixes #1611
Fixes #1562 
Fixes https://github.com/Nik-Potokar/XIVSlothCombo/issues/1508
Fixes #1657