### PR TITLE
[PLD] UserConfig Tweaks

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2315,7 +2315,7 @@ namespace XIVSlothCombo.Combos
         PLD_ST_AdvancedMode_SpiritsWithin = 11006,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
-        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID, 3)]
+        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only when taking damage.\n- Will not interrupt burst phase.\n- Required gauge threshold:", PLD.JobID, 3)]
         PLD_ST_AdvancedMode_Sheltron = 11007,
 
         [ParentCombo(PLD_ST_AdvancedMode)]
@@ -2390,7 +2390,7 @@ namespace XIVSlothCombo.Combos
         PLD_AoE_AdvancedMode_BladeOfHonor = 11034,
 
         [ParentCombo(PLD_AoE_AdvancedMode)]
-        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only while in combat.\n- Will not interrupt burst phase.\n- Required HP & gauge thresholds:", PLD.JobID, 3)]
+        [CustomComboInfo("Sheltron Option", "Adds Sheltron to Advanced Mode.\n- Uses only when taking damage.\n- Will not interrupt burst phase.\n- Required gauge threshold:", PLD.JobID, 3)]
         PLD_AoE_AdvancedMode_Sheltron = 11023,
 
         // Extra Features

--- a/XIVSlothCombo/Combos/PvE/PLD.cs
+++ b/XIVSlothCombo/Combos/PvE/PLD.cs
@@ -73,16 +73,16 @@ namespace XIVSlothCombo.Combos.PvE
         public static class Config
         {
             public static UserInt
-                PLD_ST_FoF_Option = new("PLD_ST_FoF_Option", 50),
-                PLD_AoE_FoF_Option = new("PLD_AoE_FoF_Option", 50),
+                PLD_ST_FoF_Trigger = new("PLD_ST_FoF_Trigger", 0),
+                PLD_AoE_FoF_Trigger = new("PLD_AoE_FoF_Trigger", 0),
                 PLD_Intervene_HoldCharges = new("PLDKeepInterveneCharges", 1),
                 PLD_VariantCure = new("PLD_VariantCure"),
                 PLD_RequiescatOption = new("PLD_RequiescatOption"),
                 PLD_SpiritsWithinOption = new("PLD_SpiritsWithinOption"),
                 PLD_ST_SheltronOption = new("PLD_ST_SheltronOption", 50),
                 PLD_AoE_SheltronOption = new("PLD_AoE_SheltronOption", 50),
-                PLD_ST_SheltronHP = new("PLD_ST_SheltronHP", 70),
-                PLD_AoE_SheltronHP = new("PLD_AoE_SheltronHP", 70),
+                //PLD_ST_SheltronHP = new("PLD_ST_SheltronHP", 70),
+                //PLD_AoE_SheltronHP = new("PLD_AoE_SheltronHP", 70),
                 //PLD_ST_RequiescatWeave = new("PLD_ST_RequiescatWeave"),
                 //PLD_AoE_RequiescatWeave = new("PLD_AoE_RequiescatWeave"),
                 //PLD_ST_AtonementTiming = new("PLD_ST_EquilibriumTiming"),
@@ -438,7 +438,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (CanWeave(actionID) && InMeleeRange())
                         {
                             // Fight or Flight
-                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && ActionReady(FightOrFlight) && GetTargetHPPercent() >= Config.PLD_ST_FoF_Option)
+                            if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_FoF) && ActionReady(FightOrFlight) && GetTargetHPPercent() >= Config.PLD_ST_FoF_Trigger)
                             {
                                 if (!LevelChecked(Requiescat))
                                 {
@@ -473,7 +473,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Sheltron Overcap Protection
                         if (IsEnabled(CustomComboPreset.PLD_ST_AdvancedMode_Sheltron) && InCombat() && CanWeave(actionID) &&
                             LevelChecked(Sheltron) && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
-                            Gauge.OathGauge >= Config.PLD_ST_SheltronOption && PlayerHealthPercentageHp() <= Config.PLD_ST_SheltronHP)
+                            Gauge.OathGauge >= Config.PLD_ST_SheltronOption && PlayerHealthPercentageHp() < 100)
                             return OriginalHook(Sheltron);
 
                         // Holy Spirit Prioritization
@@ -589,7 +589,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (CanWeave(actionID) && InMeleeRange())
                         {
                             // Fight or Flight
-                            if (ActionReady(FightOrFlight) && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && GetTargetHPPercent() >= Config.PLD_AoE_FoF_Option &&
+                            if (ActionReady(FightOrFlight) && IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_FoF) && GetTargetHPPercent() >= Config.PLD_AoE_FoF_Trigger &&
                                 ((GetCooldownRemainingTime(Requiescat) < 0.5f && CanWeave(actionID, 1.5f)) || !LevelChecked(Requiescat)))
                                 return FightOrFlight;
 
@@ -606,7 +606,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Sheltron Overcap Protection
                         if (IsEnabled(CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron) && InCombat() && CanWeave(actionID) &&
                             LevelChecked(Sheltron) && !HasEffect(Buffs.Sheltron) && !HasEffect(Buffs.HolySheltron) &&
-                            Gauge.OathGauge >= Config.PLD_AoE_SheltronOption && PlayerHealthPercentageHp() <= Config.PLD_AoE_SheltronHP)
+                            Gauge.OathGauge >= Config.PLD_AoE_SheltronOption && PlayerHealthPercentageHp() < 100)
                             return OriginalHook(Sheltron);
                     }
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1763,19 +1763,19 @@ namespace XIVSlothCombo.Window.Functions
             }
 
             if (preset == CustomComboPreset.PLD_ST_AdvancedMode_FoF)
-                UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_ST_FoF_Option, "Target HP%", 200);
+                UserConfig.DrawSliderInt(0, 50, PLD.Config.PLD_ST_FoF_Trigger, "Target HP%", 200);
 
             if (preset == CustomComboPreset.PLD_AoE_AdvancedMode_FoF)
-                UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_AoE_FoF_Option, "Target HP%", 200);
+                UserConfig.DrawSliderInt(0, 50, PLD.Config.PLD_AoE_FoF_Trigger, "Target HP%", 200);
 
-            if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Sheltron)
-                UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_ST_SheltronHP, "Player HP%", 200);
+            //if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Sheltron)
+            //    UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_ST_SheltronHP, "Player HP%", 200);
 
             if (preset == CustomComboPreset.PLD_ST_AdvancedMode_Sheltron)
                 UserConfig.DrawSliderInt(50, 100, PLD.Config.PLD_ST_SheltronOption, "Oath Gauge", 200, 5);
 
-            if (preset == CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron)
-                UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_AoE_SheltronHP, "Player HP%", 200);
+            //if (preset == CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron)
+            //    UserConfig.DrawSliderInt(0, 100, PLD.Config.PLD_AoE_SheltronHP, "Player HP%", 200);
 
             if (preset == CustomComboPreset.PLD_AoE_AdvancedMode_Sheltron)
                 UserConfig.DrawSliderInt(50, 100, PLD.Config.PLD_AoE_SheltronOption, "Oath Gauge", 200, 5);


### PR DESCRIPTION
- Reset FoF UserConfig and made it 0% by default. Maximum value now limited to 50% (ST & AoE).
-- _Too many cases of players saying FoF stops being used X minutes into the fight because it defaults to 50%._

- Removed HP threshold slider from Sheltron (ST & AoE).
-- _Largely unnecessary. Now it triggers as long as you're taking damage and the gauge requirement is met._