### PR TITLE
[Functions] TargetNeedsPositionals() Fix

### DIFF
--- a/XIVSlothCombo/CustomCombo/Functions/Target.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Target.cs
@@ -179,6 +179,7 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         public static bool TargetNeedsPositionals()
         {
             if (!HasBattleTarget()) return false;
+            if (TargetHasEffectAny(3808)) return false; // Directional Disregard Effect (Patch 7.01)
             if (ActionWatching.BNpcSheet.TryGetValue(CurrentTarget.DataId, out var bnpc) && !bnpc.Unknown10) return true;
             return false;
         }


### PR DESCRIPTION
Added check for new status effect that nullifies directional requirements to `TargetNeedsPositionals()`.