### PR TITLE
Make General/Multi-job Rows have the same height as other Rows

### DIFF
--- a/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvEFeatures.cs
@@ -51,7 +51,8 @@ namespace XIVSlothCombo.Window.Tabs
                         IDalamudTextureWrap? icon = Icons.GetJobIcon(id);
                         using (var disabled = ImRaii.Disabled(DisabledJobsPVE.Any(x => x == id)))
                         {
-                            if (ImGui.Selectable($"###{header}", OpenJob == jobName, ImGuiSelectableFlags.None, icon == null ? new Vector2(0) : new Vector2(0, (icon.Size.Y / 2f).Scale())))
+                            if (ImGui.Selectable($"###{header}", OpenJob == jobName, ImGuiSelectableFlags.None,
+                                    icon == null ? new Vector2(0, 32f.Scale()) : new Vector2(0, (icon.Size.Y / 2f).Scale())))
                             {
                                 OpenJob = jobName;
                             }

--- a/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
+++ b/XIVSlothCombo/Window/Tabs/PvPFeatures.cs
@@ -55,7 +55,8 @@ namespace XIVSlothCombo.Window.Tabs
                         IDalamudTextureWrap? icon = Icons.GetJobIcon(id);
                         using (var disabled = ImRaii.Disabled(DisabledJobsPVP.Any(x => x == id)))
                         {
-                            if (ImGui.Selectable($"###{header}", OpenJob == jobName, ImGuiSelectableFlags.None, icon == null ? new Vector2(0) : new Vector2(0, (icon.Size.Y / 2f).Scale())))
+                            if (ImGui.Selectable($"###{header}", OpenJob == jobName, ImGuiSelectableFlags.None,
+                                    icon == null ? new Vector2(0, 32f.Scale()) : new Vector2(0, (icon.Size.Y / 2f).Scale())))
                             {
                                 OpenJob = jobName;
                             }


### PR DESCRIPTION
Currently the General/Multi-job Rows under PVE/PVP are easy to miss, as they have no icon and therefore are only the height of the text.

This PR simply adds a minimum size of 32px (scaled with font) to rows without icons, to make these rows consistent with Job Rows, hopefully making them easier to spot.