### PR TITLE
[VPR] Vicewinder Dynamic First Coil Selection

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3701,6 +3701,10 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Vicewinder Combo", "Adds Swiftskin's Coil and Hunter's Coil to the rotation.", VPR.JobID)]
         VPR_ST_VicewinderCombo = 30007,
 
+        [ParentCombo(VPR_ST_VicewinderCombo)]
+        [CustomComboInfo("Dynamic First Coil", "Uses Hunter's Coil first if you are on the flank, and Swiftskin's Coil first if you are on the rear.\nDefaults to your selection if you are elsewhere.", VPR.JobID)]
+        VPR_ST_DynamicFirstCoil = 30013,
+
         #endregion
 
         [ParentCombo(VPR_ST_AdvancedMode)]
@@ -3810,6 +3814,10 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(VPR.Vicewinder)]
         [CustomComboInfo("Vicewinder - Coils", "Replaces Vicewinder with Hunter's/Swiftskin's Coils.", VPR.JobID)]
         VPR_VicewinderCoils = 30200,
+
+        [ParentCombo(VPR_VicewinderCoils)]
+        [CustomComboInfo("Dynamic First Coil", "Uses Hunter's Coil first if you are on the flank, and Swiftskin's Coil first if you are on the rear.\nDefaults to your selection if you are elsewhere.", VPR.JobID)]
+        VPR_DynamicFirstCoil = 30209,
 
         [ParentCombo(VPR_VicewinderCoils)]
         [CustomComboInfo("Dynamic True North Option", "Adds True North when you are not in the correct position for the enhanced potency bonus.", VPR.JobID)]

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -436,6 +436,9 @@ namespace XIVSlothCombo.Combos.PvE
                                     trueNorthReady)
                                     return All.TrueNorth;
 
+                                if (IsEnabled(CustomComboPreset.VPR_ST_DynamicFirstCoil) && OnTargetsFlank())
+                                    return HuntersCoil;
+
                                 return SwiftskinsCoil;
                             }
                         }
@@ -450,6 +453,9 @@ namespace XIVSlothCombo.Combos.PvE
                                 if (IsEnabled(CustomComboPreset.VPR_TrueNorthDynamic) &&
                                     trueNorthReady)
                                     return All.TrueNorth;
+
+                                if (IsEnabled(CustomComboPreset.VPR_ST_DynamicFirstCoil) && OnTargetsRear())
+                                    return SwiftskinsCoil;
 
                                 return HuntersCoil;
                             }
@@ -1014,6 +1020,10 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.VPR_VicewinderCoilsTN) &&
                                 trueNorthReady && !OnTargetsRear() && HasEffect(Buffs.FlankstungVenom))
                                 return All.TrueNorth;
+
+                            if (IsEnabled(CustomComboPreset.VPR_DynamicFirstCoil) && OnTargetsFlank())
+                                return HuntersCoil;
+
                             return SwiftskinsCoil;
                         }
                     }
@@ -1033,6 +1043,9 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsEnabled(CustomComboPreset.VPR_VicewinderCoilsTN) &&
                                     trueNorthReady && !OnTargetsFlank() && HasEffect(Buffs.FlankstungVenom))
                                 return All.TrueNorth;
+
+                            if (IsEnabled(CustomComboPreset.VPR_DynamicFirstCoil) && OnTargetsRear())
+                                return SwiftskinsCoil;
 
                             return HuntersCoil;
                         }

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -441,6 +441,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 return SwiftskinsCoil;
                             }
+
+                            if (IsEnabled(CustomComboPreset.VPR_ST_DynamicFirstCoil) && HuntersCoilReady)
+                                return SwiftskinsCoil;
                         }
 
                         if (positionalChoice is 1)
@@ -459,6 +462,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                                 return HuntersCoil;
                             }
+
+                            if (IsEnabled(CustomComboPreset.VPR_ST_DynamicFirstCoil) && SwiftskinsCoilReady)
+                                return HuntersCoil;
                         }
                     }
 
@@ -1026,6 +1032,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                             return SwiftskinsCoil;
                         }
+
+                        if (IsEnabled(CustomComboPreset.VPR_DynamicFirstCoil) && HuntersCoilReady)
+                            return SwiftskinsCoil;
                     }
 
                     if (positionalChoice is 1)
@@ -1049,6 +1058,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                             return HuntersCoil;
                         }
+
+                        if (IsEnabled(CustomComboPreset.VPR_DynamicFirstCoil) && SwiftskinsCoilReady)
+                            return HuntersCoil;
                     }
                 }
                 return actionID;


### PR DESCRIPTION
Adds a feature to dynamically select whether Hunter or Swiftskin's Coil should be used after Vicewinder based on current position, defaulting to the selected Rear/Flank First option if player is not on rear or flank.
Option added to Advanced ST and standalone Vicewinder combo feature -- simple mode untouched.