### PR TITLE
[WHM] Prioritize Raise in Swiftcast>Raise Feature

### DIFF
--- a/XIVSlothCombo/Combos/PvE/WHM.cs
+++ b/XIVSlothCombo/Combos/PvE/WHM.cs
@@ -172,7 +172,9 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     bool thinAirReady = !HasEffect(Buffs.ThinAir) && LevelChecked(ThinAir) && HasCharges(ThinAir);
 
-                    if (HasEffect(All.Buffs.Swiftcast))
+                    if (!LevelChecked(All.Swiftcast))
+                        return Raise;
+                    if (IsOnCooldown(All.Swiftcast))
                         return IsEnabled(CustomComboPreset.WHM_ThinAirRaise) && thinAirReady
                             ? ThinAir
                             : Raise;

--- a/XIVSlothCombo/Combos/PvE/WHM.cs
+++ b/XIVSlothCombo/Combos/PvE/WHM.cs
@@ -172,9 +172,7 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     bool thinAirReady = !HasEffect(Buffs.ThinAir) && LevelChecked(ThinAir) && HasCharges(ThinAir);
 
-                    if (!LevelChecked(All.Swiftcast))
-                        return Raise;
-                    if (IsOnCooldown(All.Swiftcast))
+                    if (!ActionReady(All.Swiftcast))
                         return IsEnabled(CustomComboPreset.WHM_ThinAirRaise) && thinAirReady
                             ? ThinAir
                             : Raise;


### PR DESCRIPTION
ActionReady checks Swiftcast instead of checking whether the buff is active. This is so that Raise is still presented after Swiftcast buff is used/lost, in case a hardcast raise is necessary.