### PR TITLE
Update the GitHub Actions File to Remove Warnings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: windows-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         submodules: recursive
     - name: Setup MSBuild
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v2
     - name: Download Dalamud
       run: |
         Invoke-WebRequest -Uri https://goatcorp.github.io/dalamud-distrib/latest.zip -OutFile latest.zip
@@ -48,7 +48,7 @@ jobs:
     if: "contains(toJSON(github.event.commits.*.message), '[PUSH]')"
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
       with:
         repository: ${{ env.PERSONAL_PLUGIN_REPO }}
         token: ${{ secrets.XIVCOMBO_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ env:
   RELEASE_DIR: XIVSlothCombo\bin\Release\XIVSlothCombo
   PERSONAL_PLUGIN_REPO: Nik-Potokar/MyDalamudPlugins
   PR_PLUGIN_REPO: Nik-Potokar/MyDalamudPlugins
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: true
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
         dotnet build --configuration Release
       env: 
         DOTNET_CLI_TELEMETRY_OPTOUT: true
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v4
       with:
         name: PluginRepoZip
         path: ${{ env.RELEASE_DIR }}
@@ -51,7 +51,7 @@ jobs:
       with:
         repository: ${{ env.PERSONAL_PLUGIN_REPO }}
         token: ${{ secrets.XIVCOMBO_TOKEN }}
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v4
       with:
         name: PluginRepoZip
         path: plugins/${{ env.INTERNAL_NAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ env:
   RELEASE_DIR: XIVSlothCombo\bin\Release\XIVSlothCombo
   PERSONAL_PLUGIN_REPO: Nik-Potokar/MyDalamudPlugins
   PR_PLUGIN_REPO: Nik-Potokar/MyDalamudPlugins
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE20: true
 
 jobs:
   build:


### PR DESCRIPTION
posted as a draft to allow anyone to voice comments or concerns before i convert it to a full pull request
i don't want to take the risk of this being merged before things are tested
I completely understand any hesitation to merging this commit
any testing that anyone would like to be done to lay to rest any fears about broken compatibility from the updated actions are fine with me, there is no rush to have this merged from my point of view
feel free to comment any tests or checks that should be done to make sure nothing is broken


list of changed actions:
1. changed actions/checkout from v2 to v4
2. changed microsoft/setup-msbuild from v1.0.2 to v2
3. changed actions/upload-artifact from v2 to v4
4. changed actions/download-artifact from v2 to v4