### PR TITLE
[BRD] Encore fix and cleanup/match to balance standard

### DIFF
--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -423,22 +423,15 @@ namespace XIVSlothCombo.Combos.PvE
                         bool ragingReady = LevelChecked(RagingStrikes) && IsOffCooldown(RagingStrikes);
                         bool battleVoiceReady = LevelChecked(BattleVoice) && IsOffCooldown(BattleVoice);
                         bool barrageReady = LevelChecked(Barrage) && IsOffCooldown(Barrage);
-                        bool firstMinute = CombatEngageDuration().Minutes == 0;
-                        bool restOfFight = CombatEngageDuration().Minutes > 0;
-
-                        if (!openerFinished && (!JustUsed(WanderersMinuet) || HasEffect(Buffs.BattleVoice)))
-                        {
-                            if (ragingReady && ((canWeaveBuffs && firstMinute) || (canWeaveDelayed && restOfFight)) &&
-                                (GetCooldownElapsed(BattleVoice) >= 2.3 || battleVoiceReady || !LevelChecked(BattleVoice)))
-                                return RagingStrikes;
-                        }
-                        else if (openerFinished)
-                        {
-                            if (ragingReady && ((canWeaveBuffs && firstMinute) || (canWeaveDelayed && restOfFight)) &&
-                            (HasEffect(Buffs.BattleVoice) || battleVoiceReady || !LevelChecked(BattleVoice)))
-                                return RagingStrikes;
-
-                        }
+                        //Raging and BV before Finale to minimize drift
+                        if (canWeaveBuffs && ragingReady)
+                            return RagingStrikes;
+                        if (canWeaveBuffs && battleVoiceReady)
+                            return BattleVoice;
+                        if (canWeaveBuffs && IsEnabled(CustomComboPreset.BRD_Simple_BuffsRadiant) && radiantReady &&
+                           (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet))
+                           && HasEffect(Buffs.BattleVoice))
+                            return RadiantFinale;
 
                         if (canWeaveBuffs && barrageReady && !HasEffect(Buffs.HawksEye) && HasEffect(Buffs.RagingStrikes))
                         {
@@ -448,28 +441,10 @@ namespace XIVSlothCombo.Combos.PvE
                                 return Barrage;
                             else if (!LevelChecked(BattleVoice) && HasEffect(Buffs.RagingStrikes))
                                 return Barrage;
-                        }
 
-                        if (canWeaveBuffs && IsEnabled(CustomComboPreset.BRD_Simple_BuffsRadiant) && radiantReady &&
-                            (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet)) &&
-                            (battleVoiceReady || GetCooldownRemainingTime(BattleVoice) < 0.7) &&
-                            (GetBuffRemainingTime(Buffs.RagingStrikes) <= 16.5 || openerFinished))
-                        {
-                            if (!JustUsed(RagingStrikes))
-                                return RadiantFinale;
                         }
-
-                        if (canWeaveBuffs && battleVoiceReady &&
-                            ((GetBuffRemainingTime(Buffs.RagingStrikes) <= 16.5 || GetBuffRemainingTime(Buffs.RadiantFinale) <= 16.5) || openerFinished) && (IsOnCooldown(RagingStrikes) || IsOnCooldown(RadiantFinale)))
-                        {
-                            if (!JustUsed(RagingStrikes))
-                                return BattleVoice;
-                        }
-
                     }
-
-                    if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
-                        return OriginalHook(RadiantEncore);
+                    
 
                     if (canWeave)
                     {
@@ -533,6 +508,9 @@ namespace XIVSlothCombo.Combos.PvE
                             else if (rainOfDeathCharges > 0)
                                 return OriginalHook(RainOfDeath);
                         }
+                        //Moved Below ogcds as it was preventing them from happening. 
+                        if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
+                            return OriginalHook(RadiantEncore);
 
                         // healing - please move if not appropriate priority
                         if (IsEnabled(CustomComboPreset.BRD_ST_SecondWind))
@@ -756,7 +734,7 @@ namespace XIVSlothCombo.Combos.PvE
                         bool ragingReady = LevelChecked(RagingStrikes) && IsOffCooldown(RagingStrikes);
                         bool battleVoiceReady = LevelChecked(BattleVoice) && IsOffCooldown(BattleVoice);
                         bool barrageReady = LevelChecked(Barrage) && IsOffCooldown(Barrage);
-
+                        //Raging and BV before Finale to minimize drift
                         if (canWeaveBuffs && ragingReady)
                             return RagingStrikes;
                         if (canWeaveBuffs && battleVoiceReady)
@@ -767,9 +745,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return RadiantFinale;                        
 
                         if (canWeaveBuffs && barrageReady && !HasEffect(Buffs.HawksEye) && HasEffect(Buffs.RagingStrikes))
-                        {
-                            uint bloodletterCharges = GetRemainingCharges(Bloodletter);
-                                                        
+                        {   
                             if (LevelChecked(RadiantFinale) && HasEffect(Buffs.RadiantFinale))
                                 return Barrage;
                             else if (LevelChecked(BattleVoice) && HasEffect(Buffs.BattleVoice))

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -432,8 +432,8 @@ namespace XIVSlothCombo.Combos.PvE
                            (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet))
                            && HasEffect(Buffs.BattleVoice))
                             return RadiantFinale;
-
-                        if (canWeaveBuffs && barrageReady && !HasEffect(Buffs.HawksEye) && HasEffect(Buffs.RagingStrikes))
+                        //removed requirement to not have hawks eye, it is better to maybe lose 60 potency than allow it to drift a 1000 potency gain out of the window
+                        if (canWeaveBuffs && barrageReady && HasEffect(Buffs.RagingStrikes))
                         {
                             if (LevelChecked(RadiantFinale) && HasEffect(Buffs.RadiantFinale))
                                 return Barrage;
@@ -742,9 +742,9 @@ namespace XIVSlothCombo.Combos.PvE
                         if (canWeaveBuffs && IsEnabled(CustomComboPreset.BRD_Simple_BuffsRadiant) && radiantReady &&
                            (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet))
                            && HasEffect(Buffs.BattleVoice))
-                            return RadiantFinale;                        
-
-                        if (canWeaveBuffs && barrageReady && !HasEffect(Buffs.HawksEye) && HasEffect(Buffs.RagingStrikes))
+                            return RadiantFinale;
+                        //removed requirement to not have hawks eye, it is better to maybe lose 60 potency than allow it to drift a 1000 potency gain out of the window
+                        if (canWeaveBuffs && barrageReady && HasEffect(Buffs.RagingStrikes))
                         {   
                             if (LevelChecked(RadiantFinale) && HasEffect(Buffs.RadiantFinale))
                                 return Barrage;

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -769,10 +769,8 @@ namespace XIVSlothCombo.Combos.PvE
                         if (canWeaveBuffs && barrageReady && !HasEffect(Buffs.HawksEye) && HasEffect(Buffs.RagingStrikes))
                         {
                             uint bloodletterCharges = GetRemainingCharges(Bloodletter);
-
-                            if (LevelChecked(Bloodletter) && bloodletterCharges > 2 && HasEffect(Buffs.RagingStrikes))
-                                return OriginalHook(Bloodletter);
-                            else if (LevelChecked(RadiantFinale) && HasEffect(Buffs.RadiantFinale))
+                                                        
+                            if (LevelChecked(RadiantFinale) && HasEffect(Buffs.RadiantFinale))
                                 return Barrage;
                             else if (LevelChecked(BattleVoice) && HasEffect(Buffs.BattleVoice))
                                 return Barrage;

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -481,7 +481,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
 
-                        if (LevelChecked(Bloodletter) && ((!openerFinished && IsOnCooldown(RagingStrikes)) || openerFinished))
+                        if (LevelChecked(Bloodletter) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)) && ((!openerFinished && IsOnCooldown(RagingStrikes)) || openerFinished))
                         {
                             uint rainOfDeathCharges = GetRemainingCharges(RainOfDeath);
 
@@ -790,7 +790,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
 
-                        if (LevelChecked(Bloodletter) && ((!openerFinished && IsOnCooldown(RagingStrikes)) || openerFinished))
+                        if (LevelChecked(Bloodletter) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)) && ((!openerFinished && IsOnCooldown(RagingStrikes)) || openerFinished))
                         {
                             uint bloodletterCharges = GetRemainingCharges(Bloodletter);
 

--- a/XIVSlothCombo/CustomCombo/CustomCombo.cs
+++ b/XIVSlothCombo/CustomCombo/CustomCombo.cs
@@ -57,7 +57,7 @@ namespace XIVSlothCombo.CustomComboNS
         {
             newActionID = 0;
 
-            if (ActionManager.Instance()->QueuedActionType == ActionType.Action && ActionManager.Instance()->QueuedActionId != actionID)
+            if (!Svc.ClientState.IsPvP && ActionManager.Instance()->QueuedActionType == ActionType.Action && ActionManager.Instance()->QueuedActionId != actionID)
                 return false;
 
             if (!IsEnabled(Preset))


### PR DESCRIPTION
Fixed issue with Encore not letting the weaves happen, moved encore down. Fixes #1674

Change the song switching logic to use pitch perfect to get rid of stacks as it was occasionally if luck was against you, changing to mage's with rep stacks. It was set to use WM again, which even with action change setup wasn't working. 

Cleaned up the Buff section heavily. Removed the complicated logic that was slowing the use of the 3 main buffs and causing massive drift. Using buffs RS and BV first to reduce risk of drift. 

Added Empyreal arrow cd check to bloodletter of 1 second, so BL wont late weave blocking an empy for a second or so. 

Mimiced in the aoe section.

