### PR TITLE
[BRD] Fixes and Cleanup

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -621,22 +621,22 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(BRD_StraightShotUpgrade, BRD_ST_oGCD, BRD_IronJaws, BRD_IronJaws_Alternate, BRD_ST_AdvMode)]
-        [CustomComboInfo("Simple Bard Feature", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
+        [CustomComboInfo("Simple Mode - Single Target", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
         BRD_ST_SimpleMode = 3036,
 
         [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD, BRD_AoE_AdvMode)]
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
-        [CustomComboInfo("Simple AoE Bard Feature", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
+        [CustomComboInfo("Simple Mode - AoE", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
         BRD_AoE_SimpleMode = 3035,
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(BRD_StraightShotUpgrade, BRD_ST_oGCD, BRD_IronJaws, BRD_IronJaws_Alternate, BRD_ST_SimpleMode)]
-        [CustomComboInfo("Advanced Bard Feature", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
+        [CustomComboInfo("Advanced Mode - Single Target", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
         BRD_ST_AdvMode = 3009,
 
         [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD, BRD_AoE_SimpleMode)]
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
-        [CustomComboInfo("Advanced AoE Bard Feature", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
+        [CustomComboInfo("Advanced Mode - AoE", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
         BRD_AoE_AdvMode = 3015,
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
@@ -649,7 +649,7 @@ namespace XIVSlothCombo.Combos
         BRD_DoTMaintainance = 3002,
 
         [ParentCombo(BRD_StraightShotUpgrade)]
-        [CustomComboInfo("Apex Arrow Feature", "Replaces Burst Shot with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
+        [CustomComboInfo("Apex Arrow Option", "Replaces Burst Shot with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
         BRD_ApexST = 3034,
 
         [ReplaceSkill(BRD.IronJaws)]
@@ -663,7 +663,7 @@ namespace XIVSlothCombo.Combos
         BRD_IronJaws_Alternate = 3004,
 
         [ParentCombo(BRD_AoE_Combo)]
-        [CustomComboInfo("Ladonsbite/Quick Nock to Apex Arrow Feature", "Replaces Ladonsbite and Quick Nock with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
+        [CustomComboInfo("Apex Arrow Option", "Replaces Ladonsbite and Quick Nock with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
         BRD_Apex = 3005,
 
         [ReplaceSkill(BRD.Bloodletter)]
@@ -678,7 +678,7 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
         [ConflictingCombos(BRD_AoE_AdvMode, BRD_AoE_SimpleMode)]
-        [CustomComboInfo("AoE Combo Feature", "Replaces Quick Nock/Ladonsbite with Shadowbite when ready.", BRD.JobID)]
+        [CustomComboInfo("Quick Nock Feature", "Replaces Quick Nock/Ladonsbite with Shadowbite when ready.", BRD.JobID)]
         BRD_AoE_Combo = 3008,
                 
         [ParentCombo(BRD_ST_AdvMode)]
@@ -690,7 +690,7 @@ namespace XIVSlothCombo.Combos
         BRD_Adv_Song = 3011,
 
         [ParentCombo(BRD_AoE_oGCD)]
-        [CustomComboInfo("Songs Feature", "Adds Songs onto AoE oGCD Feature.", BRD.JobID)]
+        [CustomComboInfo("Songs Option", "Adds Songs onto AoE oGCD Feature.", BRD.JobID)]
         BRD_oGCDSongs = 3012,
 
         [ReplaceSkill(BRD.Barrage)]
@@ -702,7 +702,7 @@ namespace XIVSlothCombo.Combos
         BRD_OneButtonSongs = 3014,
                 
         [ParentCombo(BRD_AoE_AdvMode)]
-        [CustomComboInfo("AoE Bard Song Option", "Weave Songs on the Advanced AoE.", BRD.JobID)]
+        [CustomComboInfo("Bard Song Option", "Weave Songs on the Advanced AoE.", BRD.JobID)]
         BRD_AoE_Adv_Songs = 3016,
 
         [ParentCombo(BRD_ST_AdvMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -619,16 +619,24 @@ namespace XIVSlothCombo.Combos
         #region BARD
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
+        [ConflictingCombos(BRD_StraightShotUpgrade, BRD_DoTMaintainance, BRD_ST_oGCD, BRD_IronJawsApex)]
+        [CustomComboInfo("Simple Bard Feature", "Adds every single target ability to one button,\nIf there are DoTs on target, Simple Bard will try to maintain their uptime.", BRD.JobID)]
+        BRD_ST_SimpleMode = 3009,
+
+        [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD)]
+        [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
+        [CustomComboInfo("Simple AoE Bard Feature", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
+        BRD_AoE_SimpleMode = 3015,
+
+        [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(BRD_ST_SimpleMode)]
         [CustomComboInfo("Heavy Shot into Straight Shot Feature", "Replaces Heavy Shot/Burst Shot with Straight Shot/Refulgent Arrow when procced.", BRD.JobID)]
         BRD_StraightShotUpgrade = 3001,
-
-        [ConflictingCombos(BRD_ST_SimpleMode)]
+                
         [ParentCombo(BRD_StraightShotUpgrade)]
         [CustomComboInfo("DoT Maintenance Option", "Enabling this option will make Heavy Shot into Straight Shot refresh your DoTs on your current.", BRD.JobID)]
         BRD_DoTMaintainance = 3002,
 
-        [ConflictingCombos(BRD_ST_SimpleMode)]
         [ParentCombo(BRD_StraightShotUpgrade)]
         [CustomComboInfo("Apex Arrow Feature", "Replaces Burst Shot with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
         BRD_ApexST = 3034,
@@ -643,18 +651,17 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Iron Jaws Alternate Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.", BRD.JobID)]
         BRD_IronJaws_Alternate = 3004,
 
-        [ReplaceSkill(BRD.Ladonsbite, BRD.QuickNock)]
-        [ConflictingCombos(BRD_ST_SimpleMode)]
+        [ParentCombo(BRD_AoE_Combo)]
         [CustomComboInfo("Ladonsbite/Quick Nock to Apex Arrow Feature", "Replaces Ladonsbite and Quick Nock with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
         BRD_Apex = 3005,
 
         [ReplaceSkill(BRD.Bloodletter)]
         [ConflictingCombos(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter (+ Songs rotation) depending on their CD.", BRD.JobID)]
+        [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter/Heartbreakshot (+ Songs rotation) depending on their CD.", BRD.JobID)]
         BRD_ST_oGCD = 3006,
 
         [ReplaceSkill(BRD.RainOfDeath)]
-        [ConflictingCombos(BRD_AoE_Combo)]
+        [ConflictingCombos(BRD_AoE_SimpleMode)]
         [CustomComboInfo("AoE oGCD Feature", "All AoE oGCD's on Rain of Death depending on their CD.", BRD.JobID)]
         BRD_AoE_oGCD = 3007,
 
@@ -662,12 +669,7 @@ namespace XIVSlothCombo.Combos
         [ConflictingCombos(BRD_AoE_SimpleMode)]
         [CustomComboInfo("AoE Combo Feature", "Replaces Quick Nock/Ladonsbite with Shadowbite when ready.", BRD.JobID)]
         BRD_AoE_Combo = 3008,
-
-        [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
-        [ConflictingCombos(BRD_StraightShotUpgrade, BRD_DoTMaintainance, BRD_Apex, BRD_ST_oGCD, BRD_IronJawsApex)]
-        [CustomComboInfo("Simple Bard Feature", "Adds every single target ability to one button,\nIf there are DoTs on target, Simple Bard will try to maintain their uptime.", BRD.JobID)]
-        BRD_ST_SimpleMode = 3009,
-
+                
         [ParentCombo(BRD_ST_SimpleMode)]
         [CustomComboInfo("Simple Bard DoTs Option", "This option will make Simple Bard apply DoTs if none are present on the target.", BRD.JobID)]
         BRD_Simple_DoT = 3010,
@@ -680,17 +682,14 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Songs Feature", "Adds Songs onto AoE oGCD Feature.", BRD.JobID)]
         BRD_oGCDSongs = 3012,
 
+        [ReplaceSkill(BRD.Barrage)]
         [CustomComboInfo("Bard Buffs Feature", "Adds Raging Strikes and Battle Voice onto Barrage.", BRD.JobID)]
         BRD_Buffs = 3013,
 
         [ReplaceSkill(BRD.WanderersMinuet)]
         [CustomComboInfo("One Button Songs Feature", "Add Mage's Ballad and Army's Paeon to Wanderer's Minuet depending on cooldowns.", BRD.JobID)]
         BRD_OneButtonSongs = 3014,
-
-        [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
-        [CustomComboInfo("Simple AoE Bard Feature", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
-        BRD_AoE_SimpleMode = 3015,
-
+                
         [ParentCombo(BRD_AoE_SimpleMode)]
         [CustomComboInfo("Simple AoE Bard Song Option", "Weave Songs on the Simple AoE.", BRD.JobID)]
         BRD_AoE_Simple_Songs = 3016,
@@ -723,7 +722,6 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Pooling Option", "Pools Bloodletter charges to allow for optimum burst phases, will also keep sidewinder in the buff window during wanderers.", BRD.JobID)]
         BRD_Simple_Pooling = 3023,
 
-        [ConflictingCombos(BRD_ST_SimpleMode)]
         [ParentCombo(BRD_IronJaws)]
         [CustomComboInfo("Iron Jaws Apex Option", "Adds Apex and Blast Arrow to Iron Jaws when available.", BRD.JobID)]
         BRD_IronJawsApex = 3024,

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -620,21 +620,21 @@ namespace XIVSlothCombo.Combos
         #region BARD
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
-        [ConflictingCombos(BRD_StraightShotUpgrade, BRD_ST_oGCD, BRD_IronJaws, BRD_IronJaws_Alternate, BRD_ST_AdvMode)]
+        [ConflictingCombos(BRD_ST_AdvMode)]
         [CustomComboInfo("Simple Mode - Single Target", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
         BRD_ST_SimpleMode = 3036,
 
-        [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD, BRD_AoE_AdvMode)]
+        [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_AdvMode)]
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
         [CustomComboInfo("Simple Mode - AoE", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
         BRD_AoE_SimpleMode = 3035,
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
-        [ConflictingCombos(BRD_StraightShotUpgrade, BRD_ST_oGCD, BRD_IronJaws, BRD_IronJaws_Alternate, BRD_ST_SimpleMode)]
+        [ConflictingCombos(BRD_ST_SimpleMode)]
         [CustomComboInfo("Advanced Mode - Single Target", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
         BRD_ST_AdvMode = 3009,
 
-        [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD, BRD_AoE_SimpleMode)]
+        [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_SimpleMode)]
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
         [CustomComboInfo("Advanced Mode - AoE", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
         BRD_AoE_AdvMode = 3015,
@@ -653,12 +653,12 @@ namespace XIVSlothCombo.Combos
         BRD_ApexST = 3034,
 
         [ReplaceSkill(BRD.IronJaws)]
-        [ConflictingCombos(BRD_IronJaws_Alternate, BRD_ST_AdvMode, BRD_ST_SimpleMode)]
+        [ConflictingCombos(BRD_IronJaws_Alternate)]
         [CustomComboInfo("Iron Jaws Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nAlternates between the two if Iron Jaws isn't available.", BRD.JobID)]
         BRD_IronJaws = 3003,
 
         [ReplaceSkill(BRD.IronJaws)]
-        [ConflictingCombos(BRD_IronJaws, BRD_ST_AdvMode, BRD_ST_SimpleMode)]
+        [ConflictingCombos(BRD_IronJaws)]
         [CustomComboInfo("Iron Jaws Alternate Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.", BRD.JobID)]
         BRD_IronJaws_Alternate = 3004,
 
@@ -667,12 +667,10 @@ namespace XIVSlothCombo.Combos
         BRD_Apex = 3005,
 
         [ReplaceSkill(BRD.Bloodletter)]
-        [ConflictingCombos(BRD_ST_AdvMode, BRD_ST_SimpleMode)]
         [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter/Heartbreakshot (+ Songs rotation) depending on their CD.", BRD.JobID)]
         BRD_ST_oGCD = 3006,
 
-        [ReplaceSkill(BRD.RainOfDeath)]
-        [ConflictingCombos(BRD_AoE_AdvMode, BRD_AoE_SimpleMode)]
+        [ReplaceSkill(BRD.RainOfDeath)]       
         [CustomComboInfo("AoE oGCD Feature", "All AoE oGCD's on Rain of Death depending on their CD.", BRD.JobID)]
         BRD_AoE_oGCD = 3007,
 
@@ -705,6 +703,14 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Bard Song Option", "Weave Songs on the Advanced AoE.", BRD.JobID)]
         BRD_AoE_Adv_Songs = 3016,
 
+        [ParentCombo(BRD_AoE_AdvMode)]
+        [CustomComboInfo("oGcd Option", "Weave Sidewinder, Empyreal arrow, Rain of death, and Pitch perfect when available.", BRD.JobID)]
+        BRD_AoE_Adv_oGCD = 3037,
+
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("oGcd Option", "Weave Sidewinder, Empyreal arrow, Rain of death, and Pitch perfect when available.", BRD.JobID)]
+        BRD_ST_Adv_oGCD = 3038,
+
         [ParentCombo(BRD_ST_AdvMode)]
         [CustomComboInfo("Buffs Option", "Adds buffs onto the Advanced Bard feature.", BRD.JobID)]
         BRD_Adv_Buffs = 3017,
@@ -721,8 +727,13 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID)]
         BRD_Adv_Interrupt = 3020,
 
-        [CustomComboInfo("Disable Apex Arrow Feature", "Removes Apex Arrow from Adv Bard and AoE Feature.", BRD.JobID)]
-        BRD_RemoveApexArrow = 3021,
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow and Blast shot", BRD.JobID)]
+        BRD_ST_ApexArrow = 3021,
+
+        [ParentCombo(BRD_AoE_AdvMode)]
+        [CustomComboInfo("Apex Arrow Option", "Adds Apex Arrow and Blast shot", BRD.JobID)]
+        BRD_Aoe_ApexArrow = 3039,
 
         //[ConflictingCombos(BardoGCDSingleTargetFeature)]
         //[ParentCombo(SimpleBardFeature)]
@@ -770,7 +781,7 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(BRD_AoE_AdvMode)]
         [CustomComboInfo("AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
         BRD_AoE_Adv_NoWaste = 3033,
-        // Last value = 3036
+        // Last value = 3038
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -618,15 +618,20 @@ namespace XIVSlothCombo.Combos
 
         #region BARD
 
+        [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD, BRD_AoE_AdvMode)]
+        [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
+        [CustomComboInfo("Simple AoE Bard Feature", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
+        BRD_AoE_SimpleMode = 3035,
+
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(BRD_StraightShotUpgrade, BRD_DoTMaintainance, BRD_ST_oGCD, BRD_IronJawsApex)]
         [CustomComboInfo("Simple Bard Feature", "Adds every single target ability to one button,\nIf there are DoTs on target, Simple Bard will try to maintain their uptime.", BRD.JobID)]
         BRD_ST_SimpleMode = 3009,
 
-        [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD)]
+        [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD, BRD_AoE_SimpleMode)]
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
-        [CustomComboInfo("Simple AoE Bard Feature", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
-        BRD_AoE_SimpleMode = 3015,
+        [CustomComboInfo("Advanced AoE Bard Feature", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
+        BRD_AoE_AdvMode = 3015,
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
         [ConflictingCombos(BRD_ST_SimpleMode)]
@@ -661,12 +666,12 @@ namespace XIVSlothCombo.Combos
         BRD_ST_oGCD = 3006,
 
         [ReplaceSkill(BRD.RainOfDeath)]
-        [ConflictingCombos(BRD_AoE_SimpleMode)]
+        [ConflictingCombos(BRD_AoE_AdvMode, BRD_AoE_SimpleMode)]
         [CustomComboInfo("AoE oGCD Feature", "All AoE oGCD's on Rain of Death depending on their CD.", BRD.JobID)]
         BRD_AoE_oGCD = 3007,
 
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
-        [ConflictingCombos(BRD_AoE_SimpleMode)]
+        [ConflictingCombos(BRD_AoE_AdvMode, BRD_AoE_SimpleMode)]
         [CustomComboInfo("AoE Combo Feature", "Replaces Quick Nock/Ladonsbite with Shadowbite when ready.", BRD.JobID)]
         BRD_AoE_Combo = 3008,
                 
@@ -690,9 +695,9 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("One Button Songs Feature", "Add Mage's Ballad and Army's Paeon to Wanderer's Minuet depending on cooldowns.", BRD.JobID)]
         BRD_OneButtonSongs = 3014,
                 
-        [ParentCombo(BRD_AoE_SimpleMode)]
-        [CustomComboInfo("Simple AoE Bard Song Option", "Weave Songs on the Simple AoE.", BRD.JobID)]
-        BRD_AoE_Simple_Songs = 3016,
+        [ParentCombo(BRD_AoE_AdvMode)]
+        [CustomComboInfo("AoE Bard Song Option", "Weave Songs on the Advanced AoE.", BRD.JobID)]
+        BRD_AoE_Adv_Songs = 3016,
 
         [ParentCombo(BRD_ST_SimpleMode)]
         [CustomComboInfo("Simple Buffs Option", "Adds buffs onto the Simple Bard feature.", BRD.JobID)]
@@ -738,27 +743,27 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID)]
         BRD_ST_SecondWind = 3028,
 
-        [ParentCombo(BRD_AoE_SimpleMode)]
+        [ParentCombo(BRD_AoE_AdvMode)]
         [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID)]
         BRD_AoE_SecondWind = 3029,
 
         [Variant]
-        [VariantParent(BRD_ST_SimpleMode, BRD_AoE_SimpleMode)]
+        [VariantParent(BRD_ST_SimpleMode, BRD_AoE_AdvMode)]
         [CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown.", BRD.JobID)]
         BRD_Variant_Rampart = 3030,
 
         [Variant]
-        [VariantParent(BRD_ST_SimpleMode, BRD_AoE_SimpleMode)]
+        [VariantParent(BRD_ST_SimpleMode, BRD_AoE_AdvMode)]
         [CustomComboInfo("Cure Option", "Use Variant Cure when HP is below set threshold.", BRD.JobID)]
         BRD_Variant_Cure = 3031,
 
-        [ParentCombo(BRD_AoE_Simple_Songs)]
-        [CustomComboInfo("Simple AoE Buffs Option", "Adds buffs onto the Simple AoE Bard feature.", BRD.JobID)]
-        BRD_AoE_Simple_Buffs = 3032,
+        [ParentCombo(BRD_AoE_Adv_Songs)]
+        [CustomComboInfo("AoE Buffs Option", "Adds buffs onto the Advance AoE Bard feature.", BRD.JobID)]
+        BRD_AoE_Adv_Buffs = 3032,
 
-        [ParentCombo(BRD_AoE_SimpleMode)]
-        [CustomComboInfo("Simple AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
-        BRD_AoE_Simple_NoWaste = 3033,
+        [ParentCombo(BRD_AoE_AdvMode)]
+        [CustomComboInfo("AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
+        BRD_AoE_Adv_NoWaste = 3033,
         // Last value = 3034
 
         #endregion

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -628,6 +628,11 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("DoT Maintenance Option", "Enabling this option will make Heavy Shot into Straight Shot refresh your DoTs on your current.", BRD.JobID)]
         BRD_DoTMaintainance = 3002,
 
+        [ConflictingCombos(BRD_ST_SimpleMode)]
+        [ParentCombo(BRD_StraightShotUpgrade)]
+        [CustomComboInfo("Apex Arrow Feature", "Replaces Burst Shot with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
+        BRD_ApexST = 3034,
+
         [ReplaceSkill(BRD.IronJaws)]
         [ConflictingCombos(BRD_IronJaws_Alternate)]
         [CustomComboInfo("Iron Jaws Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nAlternates between the two if Iron Jaws isn't available.", BRD.JobID)]
@@ -638,9 +643,9 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Iron Jaws Alternate Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.", BRD.JobID)]
         BRD_IronJaws_Alternate = 3004,
 
-        [ReplaceSkill(BRD.BurstShot, BRD.QuickNock)]
+        [ReplaceSkill(BRD.Ladonsbite, BRD.QuickNock)]
         [ConflictingCombos(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Burst Shot/Quick Nock to Apex Arrow Feature", "Replaces Burst Shot and Quick Nock with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
+        [CustomComboInfo("Ladonsbite/Quick Nock to Apex Arrow Feature", "Replaces Ladonsbite and Quick Nock with Apex Arrow when gauge is full and Blast Arrow when you are Blast Arrow ready.", BRD.JobID)]
         BRD_Apex = 3005,
 
         [ReplaceSkill(BRD.Bloodletter)]
@@ -756,7 +761,7 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(BRD_AoE_SimpleMode)]
         [CustomComboInfo("Simple AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
         BRD_AoE_Simple_NoWaste = 3033,
-        // Last value = 3033
+        // Last value = 3034
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1,6 +1,7 @@
 ﻿using XIVSlothCombo.Attributes;
 using XIVSlothCombo.Combos.PvE;
 using XIVSlothCombo.Combos.PvP;
+using static XIVSlothCombo.Combos.PvE.BRD;
 
 namespace XIVSlothCombo.Combos
 {
@@ -618,15 +619,20 @@ namespace XIVSlothCombo.Combos
 
         #region BARD
 
+        [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
+        [ConflictingCombos(BRD_StraightShotUpgrade, BRD_ST_oGCD, BRD_IronJaws, BRD_IronJaws_Alternate, BRD_ST_AdvMode)]
+        [CustomComboInfo("Simple Bard Feature", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
+        BRD_ST_SimpleMode = 3036,
+
         [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD, BRD_AoE_AdvMode)]
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
         [CustomComboInfo("Simple AoE Bard Feature", "Weaves oGCDs onto Quick Nock/Ladonsbite.", BRD.JobID)]
         BRD_AoE_SimpleMode = 3035,
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
-        [ConflictingCombos(BRD_StraightShotUpgrade, BRD_DoTMaintainance, BRD_ST_oGCD, BRD_IronJawsApex)]
-        [CustomComboInfo("Simple Bard Feature", "Adds every single target ability to one button,\nIf there are DoTs on target, Simple Bard will try to maintain their uptime.", BRD.JobID)]
-        BRD_ST_SimpleMode = 3009,
+        [ConflictingCombos(BRD_StraightShotUpgrade, BRD_ST_oGCD, BRD_IronJaws, BRD_IronJaws_Alternate, BRD_ST_SimpleMode)]
+        [CustomComboInfo("Advanced Bard Feature", "Adds every single target ability to one button,\nIf there are DoTs on target, will try to maintain their uptime.", BRD.JobID)]
+        BRD_ST_AdvMode = 3009,
 
         [ConflictingCombos(BRD_AoE_Combo, BRD_AoE_oGCD, BRD_AoE_SimpleMode)]
         [ReplaceSkill(BRD.QuickNock, BRD.Ladonsbite)]
@@ -634,7 +640,7 @@ namespace XIVSlothCombo.Combos
         BRD_AoE_AdvMode = 3015,
 
         [ReplaceSkill(BRD.HeavyShot, BRD.BurstShot)]
-        [ConflictingCombos(BRD_ST_SimpleMode)]
+        [ConflictingCombos(BRD_ST_AdvMode, BRD_ST_SimpleMode)]
         [CustomComboInfo("Heavy Shot into Straight Shot Feature", "Replaces Heavy Shot/Burst Shot with Straight Shot/Refulgent Arrow when procced.", BRD.JobID)]
         BRD_StraightShotUpgrade = 3001,
                 
@@ -647,12 +653,12 @@ namespace XIVSlothCombo.Combos
         BRD_ApexST = 3034,
 
         [ReplaceSkill(BRD.IronJaws)]
-        [ConflictingCombos(BRD_IronJaws_Alternate)]
+        [ConflictingCombos(BRD_IronJaws_Alternate, BRD_ST_AdvMode, BRD_ST_SimpleMode)]
         [CustomComboInfo("Iron Jaws Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nAlternates between the two if Iron Jaws isn't available.", BRD.JobID)]
         BRD_IronJaws = 3003,
 
         [ReplaceSkill(BRD.IronJaws)]
-        [ConflictingCombos(BRD_IronJaws)]
+        [ConflictingCombos(BRD_IronJaws, BRD_ST_AdvMode, BRD_ST_SimpleMode)]
         [CustomComboInfo("Iron Jaws Alternate Feature", "Iron Jaws is replaced with Caustic Bite/Stormbite if one or both are not up.\nIron Jaws will only show up when debuffs are about to expire.", BRD.JobID)]
         BRD_IronJaws_Alternate = 3004,
 
@@ -661,7 +667,7 @@ namespace XIVSlothCombo.Combos
         BRD_Apex = 3005,
 
         [ReplaceSkill(BRD.Bloodletter)]
-        [ConflictingCombos(BRD_ST_SimpleMode)]
+        [ConflictingCombos(BRD_ST_AdvMode, BRD_ST_SimpleMode)]
         [CustomComboInfo("Single Target oGCD Feature", "All oGCD's on Bloodletter/Heartbreakshot (+ Songs rotation) depending on their CD.", BRD.JobID)]
         BRD_ST_oGCD = 3006,
 
@@ -675,13 +681,13 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("AoE Combo Feature", "Replaces Quick Nock/Ladonsbite with Shadowbite when ready.", BRD.JobID)]
         BRD_AoE_Combo = 3008,
                 
-        [ParentCombo(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Simple Bard DoTs Option", "This option will make Simple Bard apply DoTs if none are present on the target.", BRD.JobID)]
-        BRD_Simple_DoT = 3010,
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Bard DoTs Option", "This option will make Bard apply DoTs if none are present on the target.", BRD.JobID)]
+        BRD_Adv_DoT = 3010,
 
-        [ParentCombo(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Simple Bard Songs Option", "This option adds the Bard's Songs to the Simple Bard Feature.", BRD.JobID)]
-        BRD_Simple_Song = 3011,
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Bard Songs Option", "This option adds the Bard's Songs to the Advanced Bard Feature.", BRD.JobID)]
+        BRD_Adv_Song = 3011,
 
         [ParentCombo(BRD_AoE_oGCD)]
         [CustomComboInfo("Songs Feature", "Adds Songs onto AoE oGCD Feature.", BRD.JobID)]
@@ -699,23 +705,23 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("AoE Bard Song Option", "Weave Songs on the Advanced AoE.", BRD.JobID)]
         BRD_AoE_Adv_Songs = 3016,
 
-        [ParentCombo(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Simple Buffs Option", "Adds buffs onto the Simple Bard feature.", BRD.JobID)]
-        BRD_Simple_Buffs = 3017,
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Buffs Option", "Adds buffs onto the Advanced Bard feature.", BRD.JobID)]
+        BRD_Adv_Buffs = 3017,
 
-        [ParentCombo(BRD_Simple_Buffs)]
-        [CustomComboInfo("Simple Buffs - Radiant Option", "Adds Radiant Finale to the Simple Buffs feature.", BRD.JobID)]
-        BRD_Simple_BuffsRadiant = 3018,
+        [ParentCombo(BRD_Adv_Buffs)]
+        [CustomComboInfo("Buffs - Radiant Option", "Adds Radiant Finale to theBuffs feature.", BRD.JobID)]
+        BRD_Adv_BuffsRadiant = 3018,
 
-        [ParentCombo(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Simple No Waste Option", "Adds enemy health checking on mobs for buffs, DoTs and Songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
-        BRD_Simple_NoWaste = 3019,
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("No Waste Option", "Adds enemy health checking on mobs for buffs, DoTs and Songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
+        BRD_Adv_NoWaste = 3019,
 
-        [ParentCombo(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Simple Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID)]
-        BRD_Simple_Interrupt = 3020,
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Interrupt Option", "Uses interrupt during the rotation if applicable.", BRD.JobID)]
+        BRD_Adv_Interrupt = 3020,
 
-        [CustomComboInfo("Disable Apex Arrow Feature", "Removes Apex Arrow from Simple Bard and AoE Feature.", BRD.JobID)]
+        [CustomComboInfo("Disable Apex Arrow Feature", "Removes Apex Arrow from Adv Bard and AoE Feature.", BRD.JobID)]
         BRD_RemoveApexArrow = 3021,
 
         //[ConflictingCombos(BardoGCDSingleTargetFeature)]
@@ -723,23 +729,23 @@ namespace XIVSlothCombo.Combos
         //[CustomComboInfo("Simple Opener", "Adds the optimum opener to simple bard.\nThis conflicts with pretty much everything outside of simple bard options due to the nature of the opener.", BRD.JobID)]
         //BardSimpleOpener = 3022,
 
-        [ParentCombo(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Simple Pooling Option", "Pools Bloodletter charges to allow for optimum burst phases, will also keep sidewinder in the buff window during wanderers.", BRD.JobID)]
-        BRD_Simple_Pooling = 3023,
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Pooling Option", "Pools Bloodletter charges to allow for optimum burst phases, will also keep sidewinder in the buff window during wanderers.", BRD.JobID)]
+        BRD_Adv_Pooling = 3023,
 
         [ParentCombo(BRD_IronJaws)]
         [CustomComboInfo("Iron Jaws Apex Option", "Adds Apex and Blast Arrow to Iron Jaws when available.", BRD.JobID)]
         BRD_IronJawsApex = 3024,
 
-        [ParentCombo(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Simple Raging Jaws Option", "Enable the snapshotting of DoTs, within the remaining time of Raging Strikes below:", BRD.JobID)]
-        BRD_Simple_RagingJaws = 3025,
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Raging Jaws Option", "Enable the snapshotting of DoTs, within the remaining time of Raging Strikes below:", BRD.JobID)]
+        BRD_Adv_RagingJaws = 3025,
 
         //[ParentCombo(BRD_AoE_Simple_Songs)]
         //[CustomComboInfo("Exclude Wanderer's Minuet Option", "Dont use Wanderer's Minuet.", BRD.JobID)]
         //BRD_AoE_Simple_SongsExcludeWM = 3027,
 
-        [ParentCombo(BRD_ST_SimpleMode)]
+        [ParentCombo(BRD_ST_AdvMode)]
         [CustomComboInfo("Second Wind Option", "Uses Second Wind when below set HP percentage.", BRD.JobID)]
         BRD_ST_SecondWind = 3028,
 
@@ -748,12 +754,12 @@ namespace XIVSlothCombo.Combos
         BRD_AoE_SecondWind = 3029,
 
         [Variant]
-        [VariantParent(BRD_ST_SimpleMode, BRD_AoE_AdvMode)]
+        [VariantParent(BRD_ST_AdvMode, BRD_AoE_AdvMode)]
         [CustomComboInfo("Rampart Option", "Use Variant Rampart on cooldown.", BRD.JobID)]
         BRD_Variant_Rampart = 3030,
 
         [Variant]
-        [VariantParent(BRD_ST_SimpleMode, BRD_AoE_AdvMode)]
+        [VariantParent(BRD_ST_AdvMode, BRD_AoE_AdvMode)]
         [CustomComboInfo("Cure Option", "Use Variant Cure when HP is below set threshold.", BRD.JobID)]
         BRD_Variant_Cure = 3031,
 
@@ -764,7 +770,7 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(BRD_AoE_AdvMode)]
         [CustomComboInfo("AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
         BRD_AoE_Adv_NoWaste = 3033,
-        // Last value = 3034
+        // Last value = 3036
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -715,7 +715,7 @@ namespace XIVSlothCombo.Combos
         //BardSimpleOpener = 3022,
 
         [ParentCombo(BRD_ST_SimpleMode)]
-        [CustomComboInfo("Simple Pooling Option", "Pools Bloodletter charges to allow for optimum burst phases.", BRD.JobID)]
+        [CustomComboInfo("Simple Pooling Option", "Pools Bloodletter charges to allow for optimum burst phases, will also keep sidewinder in the buff window during wanderers.", BRD.JobID)]
         BRD_Simple_Pooling = 3023,
 
         [ConflictingCombos(BRD_ST_SimpleMode)]

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -951,7 +951,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool songMage = gauge.Song == Song.MAGE;
                     bool songArmy = gauge.Song == Song.ARMY;
                     int targetHPThreshold = PluginConfiguration.GetCustomIntValue(Config.BRD_AoENoWasteHPPercentage);
-                    bool isEnemyHealthHigh = GetTargetHPPercent() > 5;
+                    bool isEnemyHealthHigh = GetTargetHPPercent() > 1;
 
                     if (IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= 50)
                         return Variant.VariantCure;
@@ -1156,7 +1156,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool songMage = gauge.Song == Song.MAGE;
                     bool songArmy = gauge.Song == Song.ARMY;
                     bool canInterrupt = CanInterruptEnemy() && IsOffCooldown(All.HeadGraze);
-                    bool isEnemyHealthHigh = GetTargetHPPercent() > 5;
+                    bool isEnemyHealthHigh = GetTargetHPPercent() > 1;
 
                     if (!InCombat() && (inOpener || openerFinished))
                     {

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -301,18 +301,15 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is RainOfDeath)
                 {
                     BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    bool songWanderer = gauge.Song == Song.WANDERER;
-                    bool empyrealReady = LevelChecked(EmpyrealArrow) && IsOffCooldown(EmpyrealArrow);
-                    bool bloodletterReady = LevelChecked(Bloodletter) && IsOffCooldown(Bloodletter);
-                    bool sidewinderReady = LevelChecked(Sidewinder) && IsOffCooldown(Sidewinder);
+                    bool songWanderer = gauge.Song == Song.WANDERER;                    
 
                     if (LevelChecked(WanderersMinuet) && songWanderer && gauge.Repertoire == 3)
                         return OriginalHook(WanderersMinuet);
-                    if (empyrealReady)
+                    if (ActionReady(EmpyrealArrow))
                         return EmpyrealArrow;
-                    if (bloodletterReady)
+                    if (ActionReady(RainOfDeath))
                         return RainOfDeath;
-                    if (sidewinderReady)
+                    if (ActionReady(Sidewinder))
                         return Sidewinder;
                 }
 
@@ -360,8 +357,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             bool minuetReady = IsOffCooldown(WanderersMinuet);
                             bool balladReady = IsOffCooldown(MagesBallad);
-                            bool paeonReady = IsOffCooldown(ArmysPaeon);
-                            bool empyrealReady = LevelChecked(EmpyrealArrow) && IsOffCooldown(EmpyrealArrow);
+                            bool paeonReady = IsOffCooldown(ArmysPaeon);                            
 
                             if (canWeave)
                             {
@@ -391,7 +387,7 @@ namespace XIVSlothCombo.Combos.PvE
                                     if (songTimerInSeconds <= 3 && paeonReady)
                                     {
                                         // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
-                                        if (empyrealReady)
+                                        if (ActionReady(EmpyrealArrow))
                                             return EmpyrealArrow;
                                         return ArmysPaeon;
                                     }
@@ -448,21 +444,19 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (canWeave)
                     {
-                        bool empyrealReady = LevelChecked(EmpyrealArrow) && IsOffCooldown(EmpyrealArrow);
-                        bool sidewinderReady = LevelChecked(Sidewinder) && IsOffCooldown(Sidewinder);
                         float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
                         float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
                         float ragingCD = GetCooldownRemainingTime(RagingStrikes);
                         float radiantCD = GetCooldownRemainingTime(RadiantFinale);
 
-                        if (empyrealReady && ((!openerFinished && IsOnCooldown(RagingStrikes) || (!openerFinished && JustUsed(WanderersMinuet)) || (openerFinished && battleVoiceCD >= 3.5) || !IsEnabled(CustomComboPreset.BRD_Simple_Buffs))))
+                        if (ActionReady(EmpyrealArrow))
                             return EmpyrealArrow;
 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
                             (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)))
                             return OriginalHook(PitchPerfect);
 
-                        if (sidewinderReady)
+                        if (ActionReady(Sidewinder))
                         {
                             if (IsEnabled(CustomComboPreset.BRD_Simple_Pooling))
                             {
@@ -553,11 +547,8 @@ namespace XIVSlothCombo.Combos.PvE
                     bool songWanderer = gauge.Song == Song.WANDERER;
                     bool minuetReady = LevelChecked(WanderersMinuet) && IsOffCooldown(WanderersMinuet);
                     bool balladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
-                    bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);
-                    bool empyrealReady = LevelChecked(EmpyrealArrow) && IsOffCooldown(EmpyrealArrow);
-                    bool bloodletterReady = LevelChecked(Bloodletter) && IsOffCooldown(Bloodletter);
-                    bool sidewinderReady = LevelChecked(Sidewinder) && IsOffCooldown(Sidewinder);
-
+                    bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);                    
+                    
                     if (IsEnabled(CustomComboPreset.BRD_oGCDSongs) &&
                         (gauge.SongTimer < 1 || songArmy))
                     {
@@ -570,12 +561,12 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     if (songWanderer && gauge.Repertoire == 3)
-                        return OriginalHook(WanderersMinuet);
-                    if (empyrealReady)
+                        return OriginalHook(PitchPerfect);
+                    if (ActionReady(EmpyrealArrow))
                         return EmpyrealArrow;
-                    if (bloodletterReady)
+                    if (ActionReady(Bloodletter))
                         return OriginalHook(Bloodletter);
-                    if (sidewinderReady)
+                    if (ActionReady(Sidewinder))
                         return Sidewinder;
                 }
 
@@ -641,10 +632,7 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         openerFinished = false;
                     }
-
-                    if (!IsEnabled(CustomComboPreset.BRD_Simple_NoWaste))
-                        openerFinished = true;
-
+                                        
                     if (IsEnabled(CustomComboPreset.BRD_Simple_Interrupt) && canInterrupt)
                         return All.HeadGraze;
 
@@ -668,9 +656,8 @@ namespace XIVSlothCombo.Combos.PvE
                             bool minuetReady = IsOffCooldown(WanderersMinuet);
                             bool balladReady = IsOffCooldown(MagesBallad);
                             bool paeonReady = IsOffCooldown(ArmysPaeon);
-                            bool empyrealReady = LevelChecked(EmpyrealArrow) && IsOffCooldown(EmpyrealArrow);
-
-                            if (empyrealReady && !openerFinished && JustUsed(WanderersMinuet))
+                            
+                            if (ActionReady(EmpyrealArrow) && JustUsed(WanderersMinuet))
                                 return EmpyrealArrow;
 
                             if (canWeave)
@@ -701,7 +688,7 @@ namespace XIVSlothCombo.Combos.PvE
                                     if (songTimerInSeconds <= 3 && paeonReady)
                                     {
                                         // Special case for Empyreal Arrow: it must be cast before you change to it to avoid drift!
-                                        if (empyrealReady)
+                                        if (ActionReady(EmpyrealArrow))
                                             return EmpyrealArrow;
                                         return ArmysPaeon;
                                     }
@@ -756,21 +743,19 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (canWeave)
                     {
-                        bool empyrealReady = LevelChecked(EmpyrealArrow) && IsOffCooldown(EmpyrealArrow);
-                        bool sidewinderReady = LevelChecked(Sidewinder) && IsOffCooldown(Sidewinder);
                         float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
                         float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
                         float ragingCD = GetCooldownRemainingTime(RagingStrikes);
                         float radiantCD = GetCooldownRemainingTime(RadiantFinale);
 
-                        if (empyrealReady && ((!openerFinished && IsOnCooldown(RagingStrikes) || (!openerFinished && JustUsed(WanderersMinuet)) || (openerFinished && battleVoiceCD >= 3.5) || !IsEnabled(CustomComboPreset.BRD_Simple_Buffs))))
+                        if (ActionReady(EmpyrealArrow))
                             return EmpyrealArrow;
 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
                             (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)))
                             return OriginalHook(PitchPerfect);
 
-                        if (sidewinderReady)
+                        if (ActionReady(Sidewinder))
                         {
                             if (IsEnabled(CustomComboPreset.BRD_Simple_Pooling))
                             {
@@ -788,7 +773,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
 
-                        if (LevelChecked(Bloodletter) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
+                        if (ActionReady(Bloodletter) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
                         {
                             uint bloodletterCharges = GetRemainingCharges(Bloodletter);
 
@@ -985,7 +970,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return ArmysPaeon;
 
                 }
-
+                
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -153,16 +153,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is IronJaws)
                 {
-                    if (IsEnabled(CustomComboPreset.BRD_IronJawsApex) && LevelChecked(ApexArrow))
-                    {
-                        BRDGauge? gauge = GetJobGauge<BRDGauge>();
-
-                        if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
-                            return BlastArrow;
-                        if (gauge.SoulVoice == 100 && IsOffCooldown(ApexArrow))
-                            return ApexArrow;
-                    }
-
+                    
                     if (!LevelChecked(IronJaws))
                     {
                         Status? venomous = FindTargetEffect(Debuffs.VenomousBite);
@@ -206,6 +197,16 @@ namespace XIVSlothCombo.Combos.PvE
                         return CausticBite;
                     if (LevelChecked(Stormbite))
                         return Stormbite;
+
+                    if (IsEnabled(CustomComboPreset.BRD_IronJawsApex) && LevelChecked(ApexArrow))
+                    {
+                        BRDGauge? gauge = GetJobGauge<BRDGauge>();
+
+                        if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
+                            return BlastArrow;
+                        if (gauge.SoulVoice == 100 && IsOffCooldown(ApexArrow))
+                            return ApexArrow;
+                    }
                 }
 
                 return actionID;
@@ -419,7 +420,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
                     
 
-                    if (canWeave)
+                    if (canWeave && IsEnabled(CustomComboPreset.BRD_AoE_Adv_oGCD))
                     {
                         float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
                         float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
@@ -476,7 +477,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(RainOfDeath);
                         }
                         //Moved Below ogcds as it was preventing them from happening. 
-                        if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
+                        if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f && IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs))
                             return OriginalHook(RadiantEncore);
 
                         // healing - please move if not appropriate priority
@@ -493,7 +494,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (wideVolleyReady)
                         return OriginalHook(WideVolley);
-                    if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100 && !IsEnabled(CustomComboPreset.BRD_RemoveApexArrow))
+                    if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100 && IsEnabled(CustomComboPreset.BRD_Aoe_ApexArrow))
                         return ApexArrow;
                     if (blastArrowReady)
                         return BlastArrow;
@@ -560,7 +561,7 @@ namespace XIVSlothCombo.Combos.PvE
                         BRDGauge? gauge = GetJobGauge<BRDGauge>();
                         bool blastReady = LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady);
 
-                        if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100 && !IsEnabled(CustomComboPreset.BRD_RemoveApexArrow))
+                        if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
                             return ApexArrow;
                         if (blastReady)
                             return BlastArrow;
@@ -720,7 +721,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }                                             
                     }                                      
                     
-                    if (canWeave)
+                    if (canWeave && IsEnabled(CustomComboPreset.BRD_ST_Adv_oGCD))
                     {
                         float battleVoiceCD = GetCooldownRemainingTime(BattleVoice);
                         float empyrealCD = GetCooldownRemainingTime(EmpyrealArrow);
@@ -788,7 +789,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
                     //Moved below weaves bc roobert says it is blocking his weaves from happening
-                    if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f)
+                    if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f && IsEnabled(CustomComboPreset.BRD_Adv_BuffsRadiant))
                         return OriginalHook(RadiantEncore);
 
                     if (isEnemyHealthHigh)
@@ -855,7 +856,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
-                    if (!IsEnabled(CustomComboPreset.BRD_RemoveApexArrow))
+                    if (IsEnabled(CustomComboPreset.BRD_ST_ApexArrow))
                     {
                         if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
                             return BlastArrow;

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -496,11 +496,11 @@ namespace XIVSlothCombo.Combos.PvE
                         return OriginalHook(WideVolley);
                     if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100 && IsEnabled(CustomComboPreset.BRD_Aoe_ApexArrow))
                         return ApexArrow;
-                    if (blastArrowReady)
+                    if (blastArrowReady && IsEnabled(CustomComboPreset.BRD_Aoe_ApexArrow))
                         return BlastArrow;
-                    if (resonantArrowReady)
+                    if (resonantArrowReady && IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs))
                         return ResonantArrow;
-                    if (HasEffect(Buffs.RadiantEncoreReady))
+                    if (HasEffect(Buffs.RadiantEncoreReady) && IsEnabled(CustomComboPreset.BRD_AoE_Adv_Buffs))
                         return OriginalHook(RadiantEncore);
 
                 }
@@ -879,7 +879,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
                         return OriginalHook(StraightShot);
 
-                    if (HasEffect(Buffs.ResonantArrowReady))
+                    if (HasEffect(Buffs.ResonantArrowReady) && IsEnabled(CustomComboPreset.BRD_Adv_Buffs))
                         return ResonantArrow;
 
                 }

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -43,6 +43,7 @@ namespace XIVSlothCombo.Combos.PvE
             BlastArrow = 25784,
             RadiantFinale = 25785,
             WideVolley = 36974,
+            HeartbreakShot = 36975,
             ResonantArrow = 36976,
             RadiantEncore = 36977;
 
@@ -272,27 +273,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                 return actionID;
             }
-        }
-
-        internal class BRD_Apex : CustomCombo
-        {
-            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_Apex;
-
-            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-            {
-                if (actionID is QuickNock)
-                {
-                    BRDGauge? gauge = GetJobGauge<BRDGauge>();
-
-                    if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
-                        return ApexArrow;
-                    if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
-                        return BlastArrow;
-                }
-
-                return actionID;
-            }
-        }
+        }    
 
         internal class BRD_AoE_oGCD : CustomCombo
         {
@@ -546,7 +527,7 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
-                if (actionID is Bloodletter)
+                if (actionID is Bloodletter or HeartbreakShot)
                 {
                     BRDGauge? gauge = GetJobGauge<BRDGauge>();
                     bool songArmy = gauge.Song == Song.ARMY;
@@ -555,8 +536,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool balladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
                     bool paeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);                    
                     
-                    if (IsEnabled(CustomComboPreset.BRD_oGCDSongs) &&
-                        (gauge.SongTimer < 1 || songArmy))
+                    if (gauge.SongTimer < 1 || songArmy)
                     {
                         if (minuetReady)
                             return WanderersMinuet;
@@ -570,10 +550,11 @@ namespace XIVSlothCombo.Combos.PvE
                         return OriginalHook(PitchPerfect);
                     if (ActionReady(EmpyrealArrow))
                         return EmpyrealArrow;
-                    if (ActionReady(Bloodletter))
-                        return OriginalHook(Bloodletter);
                     if (ActionReady(Sidewinder))
                         return Sidewinder;
+                    if (ActionReady(Bloodletter))
+                        return OriginalHook(Bloodletter);
+                    
                 }
 
                 return actionID;
@@ -926,12 +907,9 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is Barrage)
                 {
-                    bool ragingReady = LevelChecked(RagingStrikes) && IsOffCooldown(RagingStrikes);
-                    bool battleVoiceReady = LevelChecked(BattleVoice) && IsOffCooldown(BattleVoice);
-
-                    if (ragingReady)
+                    if (ActionReady(RagingStrikes))
                         return RagingStrikes;
-                    if (battleVoiceReady)
+                    if (ActionReady(BattleVoice))
                         return BattleVoice;
                 }
 
@@ -948,18 +926,15 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     // Doesn't display the lowest cooldown song if they have been used out of order and are all on cooldown.
                     BRDGauge? gauge = GetJobGauge<BRDGauge>();
-                    int songTimerInSeconds = gauge.SongTimer / 1000;
-                    bool wanderersMinuetReady = LevelChecked(WanderersMinuet) && IsOffCooldown(WanderersMinuet);
-                    bool magesBalladReady = LevelChecked(MagesBallad) && IsOffCooldown(MagesBallad);
-                    bool armysPaeonReady = LevelChecked(ArmysPaeon) && IsOffCooldown(ArmysPaeon);
+                    int songTimerInSeconds = gauge.SongTimer / 1000;                    
 
-                    if (wanderersMinuetReady || (gauge.Song == Song.WANDERER && songTimerInSeconds > 11))
+                    if (ActionReady(WanderersMinuet) || (gauge.Song == Song.WANDERER && songTimerInSeconds > 11))
                         return WanderersMinuet;
 
-                    if (magesBalladReady || (gauge.Song == Song.MAGE && songTimerInSeconds > 2))
+                    if (ActionReady(MagesBallad) || (gauge.Song == Song.MAGE && songTimerInSeconds > 2))
                         return MagesBallad;
 
-                    if (armysPaeonReady || (gauge.Song == Song.ARMY && songTimerInSeconds > 2))
+                    if (ActionReady(ArmysPaeon) || (gauge.Song == Song.ARMY && songTimerInSeconds > 2))
                         return ArmysPaeon;
 
                 }

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -481,7 +481,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
 
-                        if (LevelChecked(Bloodletter) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)) && ((!openerFinished && IsOnCooldown(RagingStrikes)) || openerFinished))
+                        if (LevelChecked(RainOfDeath) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
                         {
                             uint rainOfDeathCharges = GetRemainingCharges(RainOfDeath);
 
@@ -790,7 +790,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
 
-                        if (LevelChecked(Bloodletter) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)) && ((!openerFinished && IsOnCooldown(RagingStrikes)) || openerFinished))
+                        if (LevelChecked(Bloodletter) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)))
                         {
                             uint bloodletterCharges = GetRemainingCharges(Bloodletter);
 

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -459,11 +459,10 @@ namespace XIVSlothCombo.Combos.PvE
                             return EmpyrealArrow;
 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)) &&
-                            ((!openerFinished && IsOnCooldown(RagingStrikes)) || (openerFinished && battleVoiceCD >= 3.5)))
+                            (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)))
                             return OriginalHook(PitchPerfect);
 
-                        if (sidewinderReady && ((!openerFinished && IsOnCooldown(RagingStrikes)) || (openerFinished && battleVoiceCD >= 3.5) || !IsEnabled(CustomComboPreset.BRD_AoE_Simple_Songs)))
+                        if (sidewinderReady)
                         {
                             if (IsEnabled(CustomComboPreset.BRD_Simple_Pooling))
                             {
@@ -768,11 +767,10 @@ namespace XIVSlothCombo.Combos.PvE
                             return EmpyrealArrow;
 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)) &&
-                            ((!openerFinished && IsOnCooldown(RagingStrikes)) || (openerFinished && battleVoiceCD >= 3.5)))
+                            (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)))
                             return OriginalHook(PitchPerfect);
 
-                        if (sidewinderReady && ((!openerFinished && IsOnCooldown(RagingStrikes)) || (openerFinished && battleVoiceCD >= 3.5) || !IsEnabled(CustomComboPreset.BRD_Simple_Buffs)))
+                        if (sidewinderReady)
                         {
                             if (IsEnabled(CustomComboPreset.BRD_Simple_Pooling))
                             {

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -396,7 +396,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (canWeaveDelayed && ActionReady(RadiantFinale) &&
                            (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet))
-                           && (battleVoiceCD < 2 || ActionReady(BattleVoice)) && (ragingCD < 2 || ActionReady(RagingStrikes)))
+                           && (battleVoiceCD < 3 || ActionReady(BattleVoice)) && (ragingCD < 3 || ActionReady(RagingStrikes)))
                             return RadiantFinale;
 
                         if (canWeaveBuffs && ActionReady(BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
@@ -698,7 +698,7 @@ namespace XIVSlothCombo.Combos.PvE
                                                 
                         if (canWeaveDelayed && IsEnabled(CustomComboPreset.BRD_Adv_BuffsRadiant) && radiantReady &&
                            (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet))
-                           && (battleVoiceCD < 2 || ActionReady(BattleVoice)) && (ragingCD < 2 || ActionReady(RagingStrikes)))
+                           && (battleVoiceCD < 3 || ActionReady(BattleVoice)) && (ragingCD < 3 || ActionReady(RagingStrikes)))
                             return RadiantFinale;
                                                
                         if (canWeaveBuffs && battleVoiceReady && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
@@ -1022,7 +1022,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (canWeaveDelayed && ActionReady(RadiantFinale) &&
                            (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet))
-                           && (battleVoiceCD < 2 || ActionReady(BattleVoice)) && (ragingCD < 2 || ActionReady(RagingStrikes)))
+                           && (battleVoiceCD < 3 || ActionReady(BattleVoice)) && (ragingCD < 3 || ActionReady(RagingStrikes)))
                             return RadiantFinale;
 
                         if (canWeaveBuffs && ActionReady(BattleVoice) && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))
@@ -1252,7 +1252,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (canWeaveDelayed && radiantReady &&
                            (Array.TrueForAll(gauge.Coda, SongIsNotNone) || Array.Exists(gauge.Coda, SongIsWandererMinuet))
-                           && (battleVoiceCD < 2 || ActionReady(BattleVoice)) && (ragingCD < 2 || ActionReady(RagingStrikes)))
+                           && (battleVoiceCD < 3 || ActionReady(BattleVoice)) && (ragingCD < 3 || ActionReady(RagingStrikes)))
                             return RadiantFinale;
 
                         if (canWeaveBuffs && battleVoiceReady && (HasEffect(Buffs.RadiantFinale) || !LevelChecked(RadiantFinale)))

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -100,16 +100,7 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is HeavyShot or BurstShot)
                 {
-                    if (IsEnabled(CustomComboPreset.BRD_ApexST))
-                    {
-                        BRDGauge? gauge = GetJobGauge<BRDGauge>();
-
-                        if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
-                            return ApexArrow;
-                        if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
-                            return BlastArrow;
-                    }
-
+                    
                     if (IsEnabled(CustomComboPreset.BRD_DoTMaintainance))
                     {
                         bool venomous = TargetHasEffect(Debuffs.VenomousBite);
@@ -133,6 +124,16 @@ namespace XIVSlothCombo.Combos.PvE
                                 return Windbite;
                         }
                     }
+
+                    if (IsEnabled(CustomComboPreset.BRD_ApexST))
+                        {
+                            BRDGauge? gauge = GetJobGauge<BRDGauge>();
+
+                            if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
+                                return ApexArrow;
+                            if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
+                                return BlastArrow;
+                        }
 
                     if (HasEffect(Buffs.HawksEye))
                         return LevelChecked(RefulgentArrow)

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -90,7 +90,7 @@ namespace XIVSlothCombo.Combos.PvE
         internal static bool SongIsWandererMinuet(Song value) => value == Song.WANDERER;
         #endregion
 
-        // Replace HS/BS with SS/RA when procced.
+        // Replace HS/BS with SS/RA when procced, Apex feature added. 
         internal class BRD_StraightShotUpgrade : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.BRD_StraightShotUpgrade;
@@ -99,11 +99,11 @@ namespace XIVSlothCombo.Combos.PvE
             {
                 if (actionID is HeavyShot or BurstShot)
                 {
-                    if (IsEnabled(CustomComboPreset.BRD_Apex))
+                    if (IsEnabled(CustomComboPreset.BRD_ApexST))
                     {
                         BRDGauge? gauge = GetJobGauge<BRDGauge>();
 
-                        if (!IsEnabled(CustomComboPreset.BRD_RemoveApexArrow) && gauge.SoulVoice == 100)
+                        if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
                             return ApexArrow;
                         if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
                             return BlastArrow;
@@ -284,8 +284,10 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     BRDGauge? gauge = GetJobGauge<BRDGauge>();
 
-                    if (!IsEnabled(CustomComboPreset.BRD_RemoveApexArrow) && LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
+                    if (LevelChecked(ApexArrow) && gauge.SoulVoice == 100)
                         return ApexArrow;
+                    if (LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady))
+                        return BlastArrow;
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1423,10 +1423,10 @@ namespace XIVSlothCombo.Window.Functions
             // ====================================================================================
             #region BARD
 
-            if (preset == CustomComboPreset.BRD_Simple_RagingJaws)
+            if (preset == CustomComboPreset.BRD_Adv_RagingJaws)
                 UserConfig.DrawSliderInt(3, 5, BRD.Config.BRD_RagingJawsRenewTime, "Remaining time (In seconds)");
 
-            if (preset == CustomComboPreset.BRD_Simple_NoWaste)
+            if (preset == CustomComboPreset.BRD_Adv_NoWaste)
                 UserConfig.DrawSliderInt(1, 10, BRD.Config.BRD_NoWasteHPPercentage, "Remaining target HP percentage");
 
             if (preset == CustomComboPreset.BRD_AoE_Adv_NoWaste)

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1429,7 +1429,7 @@ namespace XIVSlothCombo.Window.Functions
             if (preset == CustomComboPreset.BRD_Simple_NoWaste)
                 UserConfig.DrawSliderInt(1, 10, BRD.Config.BRD_NoWasteHPPercentage, "Remaining target HP percentage");
 
-            if (preset == CustomComboPreset.BRD_AoE_Simple_NoWaste)
+            if (preset == CustomComboPreset.BRD_AoE_Adv_NoWaste)
                 UserConfig.DrawSliderInt(1, 10, BRD.Config.BRD_AoENoWasteHPPercentage, "Remaining target HP percentage");
 
             if (preset == CustomComboPreset.BRD_ST_SecondWind)

--- a/XIVSlothCombo/XIVSlothCombo.csproj
+++ b/XIVSlothCombo/XIVSlothCombo.csproj
@@ -4,7 +4,7 @@
 	<PropertyGroup>
 		<Authors>Team Sloth</Authors>
 		<Company>-</Company>
-		<Version>3.2.0.5</Version>
+		<Version>3.2.0.6</Version>
 		<!-- This is the version that will be used when pushing to the repo.-->
 		<Description>XIVCombo for lazy players</Description>
 		<Copyright>Copyleft attick 2021 thanks attick UwU</Copyright>


### PR DESCRIPTION
Fixed pitch perfect issue, not using the skill when buffs are not on cd. Rptd via discord

Also fixed rain of death level check? Fixes #1692 

Fixed st ogcd button, added heartbreak shot. 

Removed the no waste setting turning off opener at the beginning of st combo. It was preventing Initial Empyreal arrow from going off before buffs for standard opener. 

Updated the buff section to tie all 3 buffs together to minimize them drifting apart. getting around 10 seconds of drift over 20 mins now with buffs together.

Rewrote the dot section to be more clear. Ragingjaws is operational, but don't trust xivanalysis as it is looking for it to hit all 3 buffs not just raging. There is a slider for that. set it to 4-5 if that is a problem. fixes #1719 

Apex arrow feature was redundant and not working for heavy shot like it was supposed to do. I split it into st and aoe versions and added it to the features heavy shot to straight shot, and its aoe equivalent with quick nock. 

Reordered the selections about on the config screen, didnt change numbers, only moved simple modes to the top. 

cleanup of unnecessary level check bools using action ready and use of the openerfinished tags. 
Empyreal arrow
Bloodletter
Sidewinder
single button songs section
single button buffs section

Simple modes have been renamed advanced modes. They now have all additions as options. 
With no boxes checked, it functions as heavy to straightshot, or the aoecombo features. All boxes checked it matches simple mode. Added ogcd and apex arrow options instead of them being forced.

Real simple modes have been added at the top

