### PR TITLE
VPR No Rattling Opener

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2342,20 +2342,6 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Mode - AoE", $"Replaces Fire II in Red with a one-button full single target rotation.\nThis is ideal for newcomers to the job.", PCT.JobID)]
         PCT_AoE_SimpleMode = 20001,
 
-        [ReplaceSkill(PCT.FireInRed)]
-        [ConflictingCombos(CombinedAetherhues, PCT_ST_SimpleMode)]
-        [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fire in Red with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", PCT.JobID)]
-        PCT_ST_AdvancedMode = 20005,
-
-        [ReplaceSkill(PCT.FireIIinRed)]
-        [ConflictingCombos(CombinedAetherhues, PCT_AoE_SimpleMode)]
-        [CustomComboInfo("Advanced Mode - AoE", $"Replaces Fire II in Red with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", PCT.JobID)]
-        PCT_AoE_AdvancedMode = 20006,
-
-        [ParentCombo(PCT_ST_AdvancedMode)]
-        [CustomComboInfo("Openers", $"Adds openers based on level.", PCT.JobID)]
-        PCT_ST_Advanced_Openers = 20007,
-
         [ReplaceSkill(PCT.FireInRed, PCT.FireIIinRed)]
         [ConflictingCombos(PCT_ST_SimpleMode, PCT_AoE_SimpleMode)]
         [CustomComboInfo("Combined Aetherhues Feature", "Combines aetherhue actions onto one button for their respective target types.", PCT.JobID)]
@@ -3819,6 +3805,11 @@ namespace XIVSlothCombo.Combos
         [ConflictingCombos(VPR_ReawakenLegacy)]
         [CustomComboInfo("Level 100 Opener", "Adds the Balance opener to the rotation.\n Does not check positional choice.\n Always does Hunter's Coil first ( FLANK )", VPR.JobID)]
         VPR_ST_Opener = 30002,
+
+        [ParentCombo(VPR_ST_Opener)]
+        [ConflictingCombos(VPR_ReawakenLegacy)]
+        [CustomComboInfo("Level 100 Opener No Rattling", "Adds the No Rattling opener to the rotation.\n Does not check positional choice.\n Always does Hunter's Coil first ( FLANK )", VPR.JobID)]
+        VPR_ST_Opener_NoRattling = 30300,
 
         #region Cooldowns ST
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2262,6 +2262,20 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Simple Mode - AoE", $"Replaces Fire II in Red with a one-button full single target rotation.\nThis is ideal for newcomers to the job.", PCT.JobID)]
         PCT_AoE_SimpleMode = 20001,
 
+        [ReplaceSkill(PCT.FireInRed)]
+        [ConflictingCombos(CombinedAetherhues, PCT_ST_SimpleMode)]
+        [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fire in Red with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", PCT.JobID)]
+        PCT_ST_AdvancedMode = 20005,
+
+        [ReplaceSkill(PCT.FireIIinRed)]
+        [ConflictingCombos(CombinedAetherhues, PCT_AoE_SimpleMode)]
+        [CustomComboInfo("Advanced Mode - AoE", $"Replaces Fire II in Red with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", PCT.JobID)]
+        PCT_AoE_AdvancedMode = 20006,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Openers", $"Adds openers based on level.", PCT.JobID)]
+        PCT_ST_Advanced_Openers = 20007,
+
         [ReplaceSkill(PCT.FireInRed, PCT.FireIIinRed)]
         [ConflictingCombos(PCT_ST_SimpleMode, PCT_AoE_SimpleMode)]
         [CustomComboInfo("Combined Aetherhues Feature", "Combines aetherhue actions onto one button for their respective target types.", PCT.JobID)]

--- a/XIVSlothCombo/Combos/JobHelpers/MCH.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/MCH.cs
@@ -8,7 +8,7 @@ using XIVSlothCombo.Data;
 
 namespace XIVSlothCombo.Combos.JobHelpers
 {
-    internal class MCHOpenerLogic : MCH
+    internal class MCHOpenerLogic100 : MCH
     {
         private static bool HasCooldowns()
         {
@@ -16,6 +16,9 @@ namespace XIVSlothCombo.Combos.JobHelpers
                 return false;
 
             if (CustomComboFunctions.GetRemainingCharges(DoubleCheck) < 3)
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(Drill) < 2)
                 return false;
 
             if (!CustomComboFunctions.ActionReady(Chainsaw))
@@ -257,6 +260,949 @@ namespace XIVSlothCombo.Combos.JobHelpers
             return false;
         }
     }
+
+    internal class MCHOpenerLogic96 : MCH
+    {
+        private static bool HasCooldowns()
+        {
+            if (CustomComboFunctions.GetRemainingCharges(CheckMate) < 3)
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(DoubleCheck) < 3)
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(Drill) < 2)
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Chainsaw))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Wildfire))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(BarrelStabilizer))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Excavator))
+                return false;
+
+            return true;
+        }
+
+        private static uint OpenerLevel => 96;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.HasEffect(Buffs.Reassembled) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = Reassemble;
+
+                if (ActionWatching.CombatActions.Count > 2 && CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (CustomComboFunctions.WasLastAction(AirAnchor) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = AirAnchor;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = Drill;
+
+                if (CustomComboFunctions.WasLastAction(BarrelStabilizer) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = BarrelStabilizer;
+
+                if (CustomComboFunctions.WasLastAction(Chainsaw) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = Chainsaw;
+
+                if (CustomComboFunctions.WasLastAction(Excavator) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = Excavator;
+
+                if (CustomComboFunctions.WasLastAction(AutomatonQueen) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = AutomatonQueen;
+
+                if (CustomComboFunctions.WasLastAction(Reassemble) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = Reassemble;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = Drill;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(Wildfire) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = Wildfire;
+
+                if (CustomComboFunctions.WasLastAction(HeatedSplitShot) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = HeatedSplitShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(Hypercharge) && OpenerStep == 15) OpenerStep++;
+                else if (OpenerStep == 15) actionID = Hypercharge;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 16) OpenerStep++;
+                else if (OpenerStep == 16) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 17) OpenerStep++;
+                else if (OpenerStep == 17) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 18) OpenerStep++;
+                else if (OpenerStep == 18) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 19) OpenerStep++;
+                else if (OpenerStep == 19) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 20) OpenerStep++;
+                else if (OpenerStep == 20) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 21) OpenerStep++;
+                else if (OpenerStep == 21) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 22) OpenerStep++;
+                else if (OpenerStep == 22) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 23) OpenerStep++;
+                else if (OpenerStep == 23) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 24) OpenerStep++;
+                else if (OpenerStep == 24) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 25) OpenerStep++;
+                else if (OpenerStep == 25) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 26) OpenerStep++;
+                else if (OpenerStep == 26) actionID = Drill;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 27) OpenerStep++;
+                else if (OpenerStep == 27) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 28) OpenerStep++;
+                else if (OpenerStep == 28) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(HeatedSlugShot) && OpenerStep == 29) OpenerStep++;
+                else if (OpenerStep == 29) actionID = HeatedSlugShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 30) OpenerStep++;
+                else if (OpenerStep == 30) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(HeatedCleanShot) && OpenerStep == 31) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 31) actionID = HeatedCleanShot;
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5)
+                    CurrentState = OpenerState.FailedOpener;
+
+                if (((actionID == CheckMate && CustomComboFunctions.GetRemainingCharges(CheckMate) < 3) ||
+                       (actionID == Chainsaw && CustomComboFunctions.IsOnCooldown(Chainsaw)) ||
+                       (actionID == Wildfire && CustomComboFunctions.IsOnCooldown(Wildfire)) ||
+                       (actionID == BarrelStabilizer && CustomComboFunctions.IsOnCooldown(BarrelStabilizer)) ||
+                       (actionID == BarrelStabilizer && CustomComboFunctions.IsOnCooldown(Excavator)) ||
+                       (actionID == DoubleCheck && CustomComboFunctions.GetRemainingCharges(DoubleCheck) < 3)) && ActionWatching.TimeSinceLastAction.TotalSeconds >= 3)
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+
+    internal class MCHOpenerLogic94 : MCH
+    {
+        private static bool HasCooldowns()
+        {
+            if (CustomComboFunctions.GetRemainingCharges(CheckMate) < 3)
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(DoubleCheck) < 3)
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(Drill) < 2)
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Chainsaw))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Wildfire))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(BarrelStabilizer))
+                return false;
+
+            return true;
+        }
+
+        private static uint OpenerLevel => 94;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.HasEffect(Buffs.Reassembled) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = Reassemble;
+
+                if (ActionWatching.CombatActions.Count > 2 && CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (CustomComboFunctions.WasLastAction(AirAnchor) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = AirAnchor;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = Drill;
+
+                if (CustomComboFunctions.WasLastAction(BarrelStabilizer) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = BarrelStabilizer;
+
+                if (CustomComboFunctions.WasLastAction(HeatedSplitShot) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HeatedSplitShot;
+
+                if (CustomComboFunctions.WasLastAction(HeatedSlugShot) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = HeatedSlugShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(HeatedCleanShot) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = HeatedCleanShot;
+
+                if (CustomComboFunctions.WasLastAction(Reassemble) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = Reassemble;
+
+                if (CustomComboFunctions.WasLastAction(Wildfire) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = Wildfire;
+
+                if (CustomComboFunctions.WasLastAction(Chainsaw) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = Chainsaw;
+
+                if (CustomComboFunctions.WasLastAction(AutomatonQueen) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = AutomatonQueen;
+
+                if (CustomComboFunctions.WasLastAction(Hypercharge) && OpenerStep == 15) OpenerStep++;
+                else if (OpenerStep == 15) actionID = Hypercharge;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 16) OpenerStep++;
+                else if (OpenerStep == 16) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 17) OpenerStep++;
+                else if (OpenerStep == 17) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 18) OpenerStep++;
+                else if (OpenerStep == 18) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 19) OpenerStep++;
+                else if (OpenerStep == 19) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 20) OpenerStep++;
+                else if (OpenerStep == 20) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 21) OpenerStep++;
+                else if (OpenerStep == 21) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 22) OpenerStep++;
+                else if (OpenerStep == 22) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 23) OpenerStep++;
+                else if (OpenerStep == 23) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 24) OpenerStep++;
+                else if (OpenerStep == 24) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 25) OpenerStep++;
+                else if (OpenerStep == 25) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 26) OpenerStep++;
+                else if (OpenerStep == 26) actionID = Drill;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 27) OpenerStep++;
+                else if (OpenerStep == 27) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 28) OpenerStep++;
+                else if (OpenerStep == 28) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 29) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 29) actionID = Drill;
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5)
+                    CurrentState = OpenerState.FailedOpener;
+
+                if (((actionID == CheckMate && CustomComboFunctions.GetRemainingCharges(CheckMate) < 3) ||
+                       (actionID == Chainsaw && CustomComboFunctions.IsOnCooldown(Chainsaw)) ||
+                       (actionID == Wildfire && CustomComboFunctions.IsOnCooldown(Wildfire)) ||
+                       (actionID == BarrelStabilizer && CustomComboFunctions.IsOnCooldown(BarrelStabilizer)) ||
+                       (actionID == DoubleCheck && CustomComboFunctions.GetRemainingCharges(DoubleCheck) < 3)) && ActionWatching.TimeSinceLastAction.TotalSeconds >= 3)
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+
+    internal class MCHOpenerLogic92 : MCH
+    {
+        private static bool HasCooldowns()
+        {
+            if (CustomComboFunctions.GetRemainingCharges(CheckMate) < 3)
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(DoubleCheck) < 3)
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Chainsaw))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Wildfire))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(BarrelStabilizer))
+                return false;
+
+            return true;
+        }
+
+        private static uint OpenerLevel => 92;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.HasEffect(Buffs.Reassembled) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = Reassemble;
+
+                if (ActionWatching.CombatActions.Count > 2 && CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (CustomComboFunctions.WasLastAction(AirAnchor) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = AirAnchor;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = Drill;
+
+                if (CustomComboFunctions.WasLastAction(BarrelStabilizer) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = BarrelStabilizer;
+
+                if (CustomComboFunctions.WasLastAction(HeatedSplitShot) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HeatedSplitShot;
+
+                if (CustomComboFunctions.WasLastAction(HeatedSlugShot) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = HeatedSlugShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(HeatedCleanShot) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = HeatedCleanShot;
+
+                if (CustomComboFunctions.WasLastAction(Reassemble) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = Reassemble;
+
+                if (CustomComboFunctions.WasLastAction(Wildfire) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = Wildfire;
+
+                if (CustomComboFunctions.WasLastAction(Chainsaw) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = Chainsaw;
+
+                if (CustomComboFunctions.WasLastAction(AutomatonQueen) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = AutomatonQueen;
+
+                if (CustomComboFunctions.WasLastAction(Hypercharge) && OpenerStep == 15) OpenerStep++;
+                else if (OpenerStep == 15) actionID = Hypercharge;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 16) OpenerStep++;
+                else if (OpenerStep == 16) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 17) OpenerStep++;
+                else if (OpenerStep == 17) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 18) OpenerStep++;
+                else if (OpenerStep == 18) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 19) OpenerStep++;
+                else if (OpenerStep == 19) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 20) OpenerStep++;
+                else if (OpenerStep == 20) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 21) OpenerStep++;
+                else if (OpenerStep == 21) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 22) OpenerStep++;
+                else if (OpenerStep == 22) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 23) OpenerStep++;
+                else if (OpenerStep == 23) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 24) OpenerStep++;
+                else if (OpenerStep == 24) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 25) OpenerStep++;
+                else if (OpenerStep == 25) actionID = CheckMate;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 26) OpenerStep++;
+                else if (OpenerStep == 26) actionID = Drill;
+
+                if (CustomComboFunctions.WasLastAction(DoubleCheck) && OpenerStep == 27) OpenerStep++;
+                else if (OpenerStep == 27) actionID = DoubleCheck;
+
+                if (CustomComboFunctions.WasLastAction(CheckMate) && OpenerStep == 28) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 28) actionID = CheckMate;
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5)
+                    CurrentState = OpenerState.FailedOpener;
+
+                if (((actionID == CheckMate && CustomComboFunctions.GetRemainingCharges(CheckMate) < 3) ||
+                       (actionID == Chainsaw && CustomComboFunctions.IsOnCooldown(Chainsaw)) ||
+                       (actionID == Wildfire && CustomComboFunctions.IsOnCooldown(Wildfire)) ||
+                       (actionID == BarrelStabilizer && CustomComboFunctions.IsOnCooldown(BarrelStabilizer)) ||
+                       (actionID == DoubleCheck && CustomComboFunctions.GetRemainingCharges(DoubleCheck) < 3)) && ActionWatching.TimeSinceLastAction.TotalSeconds >= 3)
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+
+    internal class MCHOpenerLogic90 : MCH
+    {
+        private static bool HasCooldowns()
+        {
+            if (CustomComboFunctions.GetRemainingCharges(Ricochet) < 3)
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(GaussRound) < 3)
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Chainsaw))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(Wildfire))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(BarrelStabilizer))
+                return false;
+
+            return true;
+        }
+
+        private static uint OpenerLevel => 90;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.HasEffect(Buffs.Reassembled) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = Reassemble;
+
+                if (ActionWatching.CombatActions.Count > 2 && CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (CustomComboFunctions.WasLastAction(AirAnchor) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = AirAnchor;
+
+                if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = Ricochet;
+
+                if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = GaussRound;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = Drill;
+
+                if (CustomComboFunctions.WasLastAction(BarrelStabilizer) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = BarrelStabilizer;
+
+                if (CustomComboFunctions.WasLastAction(HeatedSplitShot) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HeatedSplitShot;
+
+                if (CustomComboFunctions.WasLastAction(HeatedSlugShot) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = HeatedSlugShot;
+
+                if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = GaussRound;
+
+                if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = Ricochet;
+
+                if (CustomComboFunctions.WasLastAction(HeatedCleanShot) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = HeatedCleanShot;
+
+                if (CustomComboFunctions.WasLastAction(Reassemble) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = Reassemble;
+
+                if (CustomComboFunctions.WasLastAction(Wildfire) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = Wildfire;
+
+                if (CustomComboFunctions.WasLastAction(Chainsaw) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = Chainsaw;
+
+                if (CustomComboFunctions.WasLastAction(AutomatonQueen) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = AutomatonQueen;
+
+                if (CustomComboFunctions.WasLastAction(Hypercharge) && OpenerStep == 15) OpenerStep++;
+                else if (OpenerStep == 15) actionID = Hypercharge;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 16) OpenerStep++;
+                else if (OpenerStep == 16) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 17) OpenerStep++;
+                else if (OpenerStep == 17) actionID = Ricochet;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 18) OpenerStep++;
+                else if (OpenerStep == 18) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 19) OpenerStep++;
+                else if (OpenerStep == 19) actionID = GaussRound;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 20) OpenerStep++;
+                else if (OpenerStep == 20) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 21) OpenerStep++;
+                else if (OpenerStep == 21) actionID = Ricochet;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 22) OpenerStep++;
+                else if (OpenerStep == 22) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 23) OpenerStep++;
+                else if (OpenerStep == 23) actionID = GaussRound;
+
+                if (CustomComboFunctions.WasLastAction(BlazingShot) && OpenerStep == 24) OpenerStep++;
+                else if (OpenerStep == 24) actionID = BlazingShot;
+
+                if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 25) OpenerStep++;
+                else if (OpenerStep == 25) actionID = Ricochet;
+
+                if (CustomComboFunctions.WasLastAction(Drill) && OpenerStep == 26) OpenerStep++;
+                else if (OpenerStep == 26) actionID = Drill;
+
+                if (CustomComboFunctions.WasLastAction(GaussRound) && OpenerStep == 27) OpenerStep++;
+                else if (OpenerStep == 27) actionID = GaussRound;
+
+                if (CustomComboFunctions.WasLastAction(Ricochet) && OpenerStep == 28) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 28) actionID = Ricochet;
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5)
+                    CurrentState = OpenerState.FailedOpener;
+
+                if (((actionID == Ricochet && CustomComboFunctions.GetRemainingCharges(Ricochet) < 3) ||
+                       (actionID == Chainsaw && CustomComboFunctions.IsOnCooldown(Chainsaw)) ||
+                       (actionID == Wildfire && CustomComboFunctions.IsOnCooldown(Wildfire)) ||
+                       (actionID == BarrelStabilizer && CustomComboFunctions.IsOnCooldown(BarrelStabilizer)) ||
+                       (actionID == GaussRound && CustomComboFunctions.GetRemainingCharges(GaussRound) < 3)) && ActionWatching.TimeSinceLastAction.TotalSeconds >= 3)
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    return false;
+                }
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+
     internal static class MCHExtensions
     {
         private static uint lastBattery = 0;

--- a/XIVSlothCombo/Combos/JobHelpers/PCT.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/PCT.cs
@@ -1,0 +1,758 @@
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using ECommons.DalamudServices;
+using XIVSlothCombo.Combos.JobHelpers.Enums;
+using XIVSlothCombo.Combos.PvE;
+using XIVSlothCombo.CustomComboNS.Functions;
+using XIVSlothCombo.Data;
+
+namespace XIVSlothCombo.Combos.JobHelpers
+{
+    internal class PCTOpenerLogic100 : PCT
+    {
+        private static bool HasCooldowns()
+        {
+            if (CustomComboFunctions.GetRemainingCharges(SteelMuse) < 2)
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(ScenicMuse))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(MogoftheAges))
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(LivingMuse) < 3)
+                return false;
+
+            return true;
+        }
+
+        private static uint OpenerLevel => 100;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.WasLastAction(RainbowDrip) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = RainbowDrip;
+
+                if (ActionWatching.CombatActions.Count > 2 && CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = StrikingMuse;
+
+                if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = HolyInWhite;
+
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = PomMuse;
+
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = WingMotif;
+
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = StarryMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = WingedMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = HammerBrush;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = MogoftheAges;
+
+                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = PolishingHammer;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = SubtractivePalette;
+
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = BlizzardinCyan;
+
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = StoneinYellow;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = ThunderinMagenta;
+
+                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == 15) OpenerStep++;
+                else if (OpenerStep == 15) actionID = CometinBlack;
+
+                if (CustomComboFunctions.WasLastAction(StarPrism) && OpenerStep == 16) OpenerStep++;
+                else if (OpenerStep == 16) actionID = StarPrism;
+
+                if (CustomComboFunctions.WasLastAction(RainbowDrip) && OpenerStep == 17) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 17) actionID = RainbowDrip;
+
+                if (CustomComboFunctions.WasLastAction(All.Sleep))
+                    CurrentState = OpenerState.FailedOpener;
+
+                if (actionID == RainbowDrip && CustomComboFunctions.IsOnCooldown(ScenicMuse))
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    return false;
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+
+    internal class PCTOpenerLogic92 : PCT
+    {
+        private static bool HasCooldowns()
+        {
+            if (CustomComboFunctions.GetRemainingCharges(SteelMuse) < 2)
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(ScenicMuse))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(MogoftheAges))
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(LivingMuse) < 2)
+                return false;
+
+            return true;
+        }
+
+        private static uint OpenerLevel => 92;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.WasLastAction(RainbowDrip) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = RainbowDrip;
+
+                if (ActionWatching.CombatActions.Count > 2 && CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = StrikingMuse;
+
+                if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = HolyInWhite;
+
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = PomMuse;
+
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = WingMotif;
+
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = StarryMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = WingedMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = HammerBrush;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = MogoftheAges;
+
+                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = PolishingHammer;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = SubtractivePalette;
+
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = BlizzardinCyan;
+
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = StoneinYellow;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = ThunderinMagenta;
+
+                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == 15) OpenerStep++;
+                else if (OpenerStep == 15) actionID = CometinBlack;
+
+                if (CustomComboFunctions.WasLastAction(FireInRed) && OpenerStep == 16) OpenerStep++;
+                else if (OpenerStep == 16) actionID = FireInRed;
+
+                if (CustomComboFunctions.WasLastAction(RainbowDrip) && OpenerStep == 17) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 17) actionID = RainbowDrip;
+
+                if (CustomComboFunctions.WasLastAction(All.Sleep))
+                    CurrentState = OpenerState.FailedOpener;
+
+                if (actionID == RainbowDrip && CustomComboFunctions.IsOnCooldown(ScenicMuse))
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    return false;
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+
+    internal class PCTOpenerLogic90 : PCT
+    {
+        private static bool HasCooldowns()
+        {
+            if (CustomComboFunctions.GetRemainingCharges(SteelMuse) < 2)
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(ScenicMuse))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(MogoftheAges))
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(LivingMuse) < 2)
+                return false;
+
+            return true;
+        }
+
+        private static uint OpenerLevel => 90;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.WasLastAction(FireInRed) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = FireInRed;
+
+                if (ActionWatching.CombatActions.Count > 2 && CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = StrikingMuse;
+
+                if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = AeroInGreen;
+
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = PomMuse;
+
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = WingMotif;
+
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = StarryMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = WingedMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = HammerBrush;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = MogoftheAges;
+
+                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = PolishingHammer;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = SubtractivePalette;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = ThunderinMagenta;
+
+                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = CometinBlack;
+
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = BlizzardinCyan;
+
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 15) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 15) actionID = StoneinYellow;
+
+                if (actionID == StoneinYellow && CustomComboFunctions.IsOnCooldown(ScenicMuse))
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    return false;
+                }
+
+                if (CustomComboFunctions.WasLastAction(All.Swiftcast))
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+
+    internal class PCTOpenerLogic70 : PCT
+    {
+        private static bool HasCooldowns()
+        {
+            if (!CustomComboFunctions.ActionReady(SteelMuse))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(ScenicMuse))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(MogoftheAges))
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(LivingMuse) < 2)
+                return false;
+
+            return true;
+        }
+
+        private static uint OpenerLevel => 70;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.WasLastAction(FireInRed) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = FireInRed;
+
+                if (ActionWatching.CombatActions.Count > 2 && CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = StrikingMuse;
+
+                if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = AeroInGreen;
+
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = PomMuse;
+
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = WingMotif;
+
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = StarryMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = WingedMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = MogoftheAges;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = SubtractivePalette;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = ThunderinMagenta;
+
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = BlizzardinCyan;
+
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 14) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 14) actionID = StoneinYellow;
+
+                if (actionID == StoneinYellow && CustomComboFunctions.IsOnCooldown(ScenicMuse))
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    return false;
+                }
+
+                if (CustomComboFunctions.WasLastAction(All.Swiftcast))
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }        
+}

--- a/XIVSlothCombo/Combos/JobHelpers/VPR.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/VPR.cs
@@ -255,6 +255,224 @@ namespace XIVSlothCombo.Combos.JobHelpers
             }
         }
 
+        internal class VPROpenerLogicNoRattling
+        {
+            private static bool HasCooldowns()
+            {
+                if (GetRemainingCharges(Vicewinder) < 2)
+                    return false;
+
+                if (!ActionReady(SerpentsIre))
+                    return false;
+
+                return true;
+            }
+
+            private static uint OpenerLevel => 100;
+
+            public uint PrePullStep = 0;
+
+            public uint OpenerStep = 0;
+
+            public static bool LevelChecked => LocalPlayer.Level >= OpenerLevel;
+
+            private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+            private OpenerState currentState = OpenerState.PrePull;
+
+            public OpenerState CurrentState
+            {
+                get
+                {
+                    return currentState;
+                }
+                set
+                {
+                    if (value != currentState)
+                    {
+                        if (value == OpenerState.PrePull)
+                        {
+                            Svc.Log.Debug($"Entered PrePull Opener");
+                        }
+                        if (value == OpenerState.InOpener) OpenerStep = 1;
+                        if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                        {
+                            if (value == OpenerState.FailedOpener)
+                                Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                            ResetOpener();
+                        }
+                        if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                        currentState = value;
+                    }
+                }
+            }
+
+            private bool DoPrePullSteps(ref uint actionID)
+            {
+                if (!LevelChecked)
+                    return false;
+
+                if (CanOpener && PrePullStep == 0)
+                {
+                    PrePullStep = 1;
+                }
+
+                if (!HasCooldowns())
+                {
+                    PrePullStep = 0;
+                }
+
+                if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+                {
+                    if (WasLastAction(ReavingFangs) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                    else if (PrePullStep == 1) actionID = ReavingFangs;
+
+                    if (ActionWatching.CombatActions.Count > 2 && InCombat())
+                        CurrentState = OpenerState.FailedOpener;
+
+                    return true;
+                }
+                PrePullStep = 0;
+                return false;
+            }
+
+            private bool DoOpener(ref uint actionID)
+            {
+                if (!LevelChecked)
+                    return false;
+
+                if (currentState == OpenerState.InOpener)
+                {
+                    if (WasLastAction(SerpentsIre) && OpenerStep == 1) OpenerStep++;
+                    else if (OpenerStep == 1) actionID = SerpentsIre;
+
+                    if (WasLastAction(SwiftskinsSting) && OpenerStep == 2) OpenerStep++;
+                    else if (OpenerStep == 2) actionID = SwiftskinsSting;
+
+                    if (WasLastAction(Vicewinder) && OpenerStep == 3) OpenerStep++;
+                    else if (OpenerStep == 3) actionID = Vicewinder;
+
+                    if (WasLastAction(HuntersCoil) && OpenerStep == 4) OpenerStep++;
+                    else if (OpenerStep == 4) actionID = HuntersCoil;
+
+                    if (WasLastAction(TwinfangBite) && OpenerStep == 5) OpenerStep++;
+                    else if (OpenerStep == 5) actionID = TwinfangBite;
+
+                    if (WasLastAction(TwinbloodBite) && OpenerStep == 6) OpenerStep++;
+                    else if (OpenerStep == 6) actionID = TwinbloodBite;
+
+                    if (WasLastAction(SwiftskinsCoil) && OpenerStep == 7) OpenerStep++;
+                    else if (OpenerStep == 7) actionID = SwiftskinsCoil;
+
+                    if (WasLastAction(TwinbloodBite) && OpenerStep == 8) OpenerStep++;
+                    else if (OpenerStep == 8) actionID = TwinbloodBite;
+
+                    if (WasLastAction(TwinfangBite) && OpenerStep == 9) OpenerStep++;
+                    else if (OpenerStep == 9) actionID = TwinfangBite;
+
+                    if (WasLastAction(Reawaken) && OpenerStep == 10) OpenerStep++;
+                    else if (OpenerStep == 10) actionID = Reawaken;
+
+                    if (WasLastAction(FirstGeneration) && OpenerStep == 11) OpenerStep++;
+                    else if (OpenerStep == 11) actionID = FirstGeneration;
+
+                    if (WasLastAction(FirstLegacy) && OpenerStep == 12) OpenerStep++;
+                    else if (OpenerStep == 12) actionID = FirstLegacy;
+
+                    if (WasLastAction(SecondGeneration) && OpenerStep == 13) OpenerStep++;
+                    else if (OpenerStep == 13) actionID = SecondGeneration;
+
+                    if (WasLastAction(SecondLegacy) && OpenerStep == 14) OpenerStep++;
+                    else if (OpenerStep == 14) actionID = SecondLegacy;
+
+                    if (WasLastAction(ThirdGeneration) && OpenerStep == 15) OpenerStep++;
+                    else if (OpenerStep == 15) actionID = ThirdGeneration;
+
+                    if (WasLastAction(ThirdLegacy) && OpenerStep == 16) OpenerStep++;
+                    else if (OpenerStep == 16) actionID = ThirdLegacy;
+
+                    if (WasLastAction(FourthGeneration) && OpenerStep == 17) OpenerStep++;
+                    else if (OpenerStep == 17) actionID = FourthGeneration;
+
+                    if (WasLastAction(FourthLegacy) && OpenerStep == 18) OpenerStep++;
+                    else if (OpenerStep == 18) actionID = FourthLegacy;
+
+                    if (WasLastAction(Ouroboros) && OpenerStep == 19) OpenerStep++;
+                    else if (OpenerStep == 19) actionID = Ouroboros;
+
+                    if (WasLastAction(HindstingStrike) && OpenerStep == 20) OpenerStep++;
+                    else if (OpenerStep == 20) actionID = HindstingStrike;
+
+                    if (WasLastAction(DeathRattle) && OpenerStep == 21) OpenerStep++;
+                    else if (OpenerStep == 21) actionID = DeathRattle;
+
+                    if (WasLastAction(Vicewinder) && OpenerStep == 22) OpenerStep++;
+                    else if (OpenerStep == 22) actionID = Vicewinder;
+
+                    if (WasLastAction(HuntersCoil) && OpenerStep == 23) OpenerStep++;
+                    else if (OpenerStep == 23) actionID = HuntersCoil;
+
+                    if (WasLastAction(TwinfangBite) && OpenerStep == 24) OpenerStep++;
+                    else if (OpenerStep == 24) actionID = TwinfangBite;
+
+                    if (WasLastAction(TwinbloodBite) && OpenerStep == 25) OpenerStep++;
+                    else if (OpenerStep == 25) actionID = TwinbloodBite;
+
+                    if (WasLastAction(SwiftskinsCoil) && OpenerStep == 26) OpenerStep++;
+                    else if (OpenerStep == 26) actionID = SwiftskinsCoil;
+
+                    if (WasLastAction(TwinbloodBite) && OpenerStep == 27) OpenerStep++;
+                    else if (OpenerStep == 27) actionID = TwinbloodBite;
+
+                    if (WasLastAction(TwinfangBite) && OpenerStep == 28) CurrentState = OpenerState.OpenerFinished;
+                    else if (OpenerStep == 28) actionID = TwinfangBite;
+
+                    if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5)
+                        CurrentState = OpenerState.FailedOpener;
+
+                    if (((actionID == SerpentsIre && IsOnCooldown(SerpentsIre)) ||
+                        (actionID == Vicewinder && GetRemainingCharges(Vicewinder) < 2)) && ActionWatching.TimeSinceLastAction.TotalSeconds >= 3)
+                    {
+                        CurrentState = OpenerState.FailedOpener;
+                        return false;
+                    }
+                    return true;
+                }
+                return false;
+            }
+
+            private void ResetOpener()
+            {
+                PrePullStep = 0;
+                OpenerStep = 0;
+            }
+
+            public bool DoFullOpener(ref uint actionID)
+            {
+                if (!LevelChecked)
+                    return false;
+
+                if (CurrentState == OpenerState.PrePull)
+                    if (DoPrePullSteps(ref actionID))
+                        return true;
+
+                if (CurrentState == OpenerState.InOpener)
+                {
+                    if (DoOpener(ref actionID))
+                        return true;
+                }
+
+                if (!InCombat())
+                {
+                    ResetOpener();
+                    CurrentState = OpenerState.PrePull;
+                }
+                return false;
+            }
+        }
+
         internal class VPRCheckRattlingCoils
         {
             public static bool HasRattlingCoilStack(VPRGauge gauge)

--- a/XIVSlothCombo/Combos/PvE/MCH.cs
+++ b/XIVSlothCombo/Combos/PvE/MCH.cs
@@ -98,7 +98,10 @@ namespace XIVSlothCombo.Combos.PvE
         internal class MCH_ST_SimpleMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_ST_SimpleMode;
-            internal static MCHOpenerLogic MCHOpener = new();
+            internal static MCHOpenerLogic100 MCHOpener100 = new();
+            internal static MCHOpenerLogic96 MCHOpener96 = new();
+            internal static MCHOpenerLogic92 MCHOpener92 = new();
+            internal static MCHOpenerLogic90 MCHOpener90 = new();
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -124,9 +127,33 @@ namespace XIVSlothCombo.Combos.PvE
                         CanWeave(actionID))
                         return Variant.VariantRampart;
 
-                    // Opener for MCH
-                    if (MCHOpener.DoFullOpener(ref actionID))
-                        return actionID;
+                    // Opener for MCH 90
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && !LevelChecked(CheckMate))
+                    {
+                        if (MCHOpener90.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // Opener for MCH 92
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && LevelChecked(CheckMate) && !LevelChecked(Excavator))
+                    {
+                        if (MCHOpener92.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // Opener for MCH 96
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && LevelChecked(Excavator) && !LevelChecked(FullMetalField))
+                    {
+                        if (MCHOpener96.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // Opener for MCH 100
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && LevelChecked(FullMetalField))
+                    {
+                        if (MCHOpener100.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
 
                     // Interrupt
                     if (interruptReady)
@@ -295,7 +322,10 @@ namespace XIVSlothCombo.Combos.PvE
         internal class MCH_ST_AdvancedMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.MCH_ST_AdvancedMode;
-            internal static MCHOpenerLogic MCHOpener = new();
+            internal static MCHOpenerLogic100 MCHOpener100 = new();
+            internal static MCHOpenerLogic96 MCHOpener96 = new();
+            internal static MCHOpenerLogic92 MCHOpener92 = new();
+            internal static MCHOpenerLogic90 MCHOpener90 = new();
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -320,10 +350,31 @@ namespace XIVSlothCombo.Combos.PvE
                         CanWeave(actionID))
                         return Variant.VariantRampart;
 
-                    // Opener for MCH
-                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener))
+                    // Opener for MCH 90
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && !LevelChecked(CheckMate))
                     {
-                        if (MCHOpener.DoFullOpener(ref actionID))
+                        if (MCHOpener90.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // Opener for MCH 92
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && LevelChecked(CheckMate) && !LevelChecked(Excavator))
+                    {
+                        if (MCHOpener92.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // Opener for MCH 96
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && LevelChecked(Excavator) && !LevelChecked(FullMetalField))
+                    {
+                        if (MCHOpener96.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // Opener for MCH 100
+                    if (IsEnabled(CustomComboPreset.MCH_ST_Adv_Opener) && LevelChecked(FullMetalField))
+                    {
+                        if (MCHOpener100.DoFullOpener(ref actionID))
                             return actionID;
                     }
 

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -1,4 +1,5 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using XIVSlothCombo.Combos.JobHelpers;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Extensions;
@@ -11,15 +12,25 @@ namespace XIVSlothCombo.Combos.PvE
 
         public const uint
             BlizzardinCyan = 34653,
+            StoneinYellow = 34654,
             BlizzardIIinCyan = 34659,
             ClawMotif = 34666,
             ClawedMuse = 34672,
             CometinBlack = 34663,
             CreatureMotif = 34689,
             FireInRed = 34650,
+            AeroInGreen = 34651,
+            WaterInBlue = 34652,
             FireIIinRed = 34656,
+            HammerMotif = 34668,
+            WingedMuse = 34671,
+            StrikingMuse = 34674,
+            StarryMuse = 34675,
             HammerStamp = 34678,
+            HammerBrush = 34679,
+            PolishingHammer = 34680,
             HolyInWhite = 34662,
+            StarrySkyMotif = 34669,
             LandscapeMotif = 34691,
             LivingMuse = 35347,
             MawMotif = 34667,
@@ -163,6 +174,164 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
+        internal class PCT_ST_AdvancedMode : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_ST_AdvancedMode;
+            internal static PCTOpenerLogic100 PCTOpener100 = new();
+            internal static PCTOpenerLogic92 PCTOpener92 = new();
+            internal static PCTOpenerLogic90 PCTOpener90 = new();
+            internal static PCTOpenerLogic70 PCTOpener70 = new();
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+            {
+                if (actionID is FireInRed)
+                {
+                    var gauge = GetJobGauge<PCTGauge>();
+                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardinCyan)) : CanSpellWeave(OriginalHook(FireInRed)) || CanSpellWeave(OriginalHook(HammerStamp));
+
+                    if (CreatureMotif.LevelChecked() && !InCombat() && gauge.CreatureMotifDrawn is false)
+                        return OriginalHook(CreatureMotif);
+
+                    if (CreatureMotif.LevelChecked() && ClawMotif.LevelChecked() && !InCombat() && gauge.CreatureMotifDrawn is false)
+                        return OriginalHook(CreatureMotif);
+
+                    if (WeaponMotif.LevelChecked() && !InCombat() && gauge.WeaponMotifDrawn is false)
+                        return OriginalHook(WeaponMotif);
+
+                    if (LandscapeMotif.LevelChecked() && !InCombat() && gauge.LandscapeMotifDrawn is false)
+                        return OriginalHook(LandscapeMotif);
+
+                    // Opener for PCT 70
+                    if (IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers) && LevelChecked(LandscapeMotif) && !LevelChecked(RainbowDrip) && !LevelChecked(PolishingHammer))
+                    {
+                        if (PCTOpener70.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // Opener for PCT 90
+                    if (IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers) && LevelChecked(PolishingHammer) && !LevelChecked(RainbowDrip))
+                    {
+                        if (PCTOpener90.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // Opener for PCT 92
+                    if (IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers) && LevelChecked(RainbowDrip) && !LevelChecked(StarPrism))
+                    {
+                        if (PCTOpener92.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // Opener for PCT 100
+                    if (IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers) && LevelChecked(StarPrism))
+                    {
+                        if (PCTOpener100.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    if (LevelChecked(RainbowDrip) && !InCombat() && HasBattleTarget() &&
+                        gauge.CreatureMotifDrawn && gauge.WeaponMotifDrawn && gauge.LandscapeMotifDrawn)
+                        return OriginalHook(RainbowDrip);
+
+                    if (ScenicMuse.LevelChecked() && InCombat() && HasBattleTarget() && gauge.LandscapeMotifDrawn && IsOffCooldown(ScenicMuse))
+                        return OriginalHook(ScenicMuse);
+
+                    if (HasEffect(Buffs.Starstruck))
+                        return OriginalHook(StarPrism);
+
+                    if (HasEffect(Buffs.RainbowBright))
+                        return OriginalHook(RainbowDrip);
+
+                    if (IsMoving && InCombat())
+                    {
+                        if (HasEffect(Buffs.HammerTime))
+                            return OriginalHook(HammerStamp);
+
+                        if (gauge.Paint >= 1 && !HasEffect(Buffs.MonochromeTones))
+                            return OriginalHook(HolyInWhite);
+                    }
+
+                    if (HasEffect(Buffs.StarryMuse))
+                    {
+                        if (gauge.Paint > 0 && HasEffect(Buffs.MonochromeTones) && !canWeave)
+                            return OriginalHook(CometinBlack);
+
+                        if (HasEffect(Buffs.SubtractiveSpectrum) && !HasEffect(Buffs.SubtractivePalette) && canWeave)
+                            return OriginalHook(SubtractivePalette);
+
+                        if (canWeave && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)))
+                            return OriginalHook(MogoftheAges);
+
+                        if (canWeave && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && GetBuffRemainingTime(Buffs.StarryMuse) >= 15f)
+                            return OriginalHook(SteelMuse);
+
+                        if (canWeave && gauge.CreatureMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && canWeave)
+                            return OriginalHook(LivingMuse);
+
+                        if (HasEffect(Buffs.HammerTime))
+                            return OriginalHook(HammerStamp);
+
+                        if (HasEffect(Buffs.SubtractivePalette))
+                            return OriginalHook(BlizzardinCyan);
+
+                        return actionID;
+                    }
+
+                    if (gauge.Paint > 0 && HasEffect(Buffs.MonochromeTones) && gauge.PalleteGauge >= 100)
+                        return OriginalHook(CometinBlack);
+
+                    if (gauge.PalleteGauge >= 100 && !HasEffect(Buffs.SubtractivePalette) && canWeave)
+                        return OriginalHook(SubtractivePalette);
+
+                    if (HasEffect(Buffs.HammerTime))
+                        return OriginalHook(HammerStamp);
+
+                    if (InCombat())
+                    {
+                        if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                        {
+                            if (LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)
+                                return OriginalHook(LandscapeMotif);
+
+                            if (LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn)
+                                return OriginalHook(CreatureMotif);
+
+                            if (LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn)
+                                return OriginalHook(WeaponMotif);
+                        }
+
+                        if (gauge.LandscapeMotifDrawn && gauge.WeaponMotifDrawn && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(MogoftheAges) && IsOffCooldown(ScenicMuse) && canWeave)
+                            return OriginalHook(ScenicMuse);
+
+                        if (MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldown(LivingMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || !ScenicMuse.LevelChecked()) && canWeave)
+                            return OriginalHook(MogoftheAges);
+
+                        if (!HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()) && canWeave)
+                            return OriginalHook(SteelMuse);
+
+                        if (gauge.CreatureMotifDrawn && (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) || GetCooldown(LivingMuse).CooldownRemaining > GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse) || !ScenicMuse.LevelChecked()) && HasCharges(OriginalHook(LivingMuse)) && canWeave)
+                            return OriginalHook(LivingMuse);
+
+                        if (!HasEffect(Buffs.StarryMuse))
+                        {
+                            if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
+                                return OriginalHook(LandscapeMotif);
+
+                            if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                                return OriginalHook(CreatureMotif);
+
+                            if (WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                                return OriginalHook(WeaponMotif);
+                        }
+                    }
+
+                    if (HasEffect(Buffs.SubtractivePalette))
+                        return OriginalHook(BlizzardinCyan);
+                }
+                return actionID;
+            }
+        }
+
         internal class PCT_AoE_SimpleMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_AoE_SimpleMode;
@@ -248,6 +417,108 @@ namespace XIVSlothCombo.Combos.PvE
                         return OriginalHook(CometinBlack);
 
                     if (gauge.Paint > 0)
+                        return OriginalHook(HolyInWhite);
+
+                    if (HasEffect(Buffs.SubtractivePalette))
+                        return OriginalHook(BlizzardIIinCyan);
+
+                }
+                return actionID;
+            }
+        }
+
+        internal class PCT_AoE_AdvancedMode : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_AoE_AdvancedMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+            {
+                if (actionID is FireIIinRed)
+                {
+                    var gauge = GetJobGauge<PCTGauge>();
+                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardinCyan)) : CanSpellWeave(OriginalHook(FireInRed));
+
+                    if (ScenicMuse.LevelChecked() && InCombat() && HasBattleTarget() && canWeave && gauge.LandscapeMotifDrawn is true && IsOffCooldown(ScenicMuse))
+                        return OriginalHook(ScenicMuse);
+
+                    if (HasEffect(Buffs.Starstruck))
+                        return OriginalHook(StarPrism);
+
+                    if (HasEffect(Buffs.RainbowBright))
+                        return OriginalHook(RainbowDrip);
+
+                    if (IsMoving && InCombat())
+                    {
+                        if (HasEffect(Buffs.HammerTime))
+                            return OriginalHook(HammerStamp);
+
+                        if (gauge.Paint >= 1 && !HasEffect(Buffs.MonochromeTones))
+                            return OriginalHook(HolyInWhite);
+                    }
+
+                    if (HasEffect(Buffs.StarryMuse))
+                    {
+                        if (gauge.Paint > 0 && HasEffect(Buffs.MonochromeTones) && !canWeave)
+                            return OriginalHook(CometinBlack);
+
+                        if (HasEffect(Buffs.SubtractiveSpectrum) && !HasEffect(Buffs.SubtractivePalette) && canWeave)
+                            return OriginalHook(SubtractivePalette);
+
+                        if (canWeave && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)))
+                            return OriginalHook(MogoftheAges);
+
+                        if (canWeave && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && GetBuffRemainingTime(Buffs.StarryMuse) >= 15f)
+                            return OriginalHook(SteelMuse);
+
+                        if (gauge.CreatureMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && canWeave)
+                            return OriginalHook(LivingMuse);
+
+                        if (HasEffect(Buffs.HammerTime) && !canWeave)
+                            return OriginalHook(HammerStamp);
+
+                        if (HasEffect(Buffs.SubtractivePalette))
+                            return OriginalHook(BlizzardIIinCyan);
+
+                        return actionID;
+                    }
+
+                    if (gauge.Paint > 0 && HasEffect(Buffs.MonochromeTones) && gauge.PalleteGauge >= 50)
+                        return OriginalHook(CometinBlack);
+
+                    if (gauge.PalleteGauge >= 50 && !HasEffect(Buffs.SubtractivePalette) && canWeave)
+                        return OriginalHook(SubtractivePalette);
+
+                    if (HasEffect(Buffs.HammerTime) && !canWeave)
+                        return OriginalHook(HammerStamp);
+
+                    if (InCombat())
+                    {
+                        if (gauge.LandscapeMotifDrawn && gauge.WeaponMotifDrawn && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(MogoftheAges) && IsOffCooldown(ScenicMuse) && canWeave)
+                            return OriginalHook(ScenicMuse);
+
+                        if (MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldown(LivingMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || !ScenicMuse.LevelChecked()) && canWeave)
+                            return OriginalHook(MogoftheAges);
+
+                        if (!HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()) && canWeave)
+                            return OriginalHook(SteelMuse);
+
+                        if (gauge.CreatureMotifDrawn && (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) || GetCooldown(LivingMuse).CooldownRemaining > GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse) || !ScenicMuse.LevelChecked()) && HasCharges(OriginalHook(LivingMuse)) && canWeave)
+                            return OriginalHook(LivingMuse);
+                    }
+
+                    if (CreatureMotif.LevelChecked() && !InCombat() && gauge.CreatureMotifDrawn is false)
+                        return OriginalHook(CreatureMotif);
+
+                    if (CreatureMotif.LevelChecked() && ClawMotif.LevelChecked() && !InCombat() && gauge.CreatureMotifDrawn is false)
+                        return OriginalHook(CreatureMotif);
+
+                    if (WeaponMotif.LevelChecked() && !InCombat() && gauge.WeaponMotifDrawn is false)
+                        return OriginalHook(WeaponMotif);
+
+                    if (LandscapeMotif.LevelChecked() && !InCombat() && gauge.LandscapeMotifDrawn is false)
+                        return OriginalHook(LandscapeMotif);
+
+                    if (gauge.Paint > 0 && !HasEffect(Buffs.MonochromeTones))
                         return OriginalHook(HolyInWhite);
 
                     if (HasEffect(Buffs.SubtractivePalette))

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -117,6 +117,7 @@ namespace XIVSlothCombo.Combos.PvE
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VPR_ST_SimpleMode;
             internal static VPROpenerLogic VPROpener = new();
+            internal static VPROpenerLogicNoRattling VPROpener2 = new();
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -135,6 +136,13 @@ namespace XIVSlothCombo.Combos.PvE
                     // Opener for VPR
                     if (VPROpener.DoFullOpener(ref actionID))
                         return actionID;
+
+                    // No Rattling Opener for VPR
+                    if (IsEnabled(CustomComboPreset.VPR_ST_Opener) && IsEnabled(CustomComboPreset.VPR_ST_Opener_NoRattling))
+                    {
+                        if (VPROpener2.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
 
                     //All Weaves
                     if (CanWeave(actionID))
@@ -347,6 +355,7 @@ namespace XIVSlothCombo.Combos.PvE
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VPR_ST_AdvancedMode;
             internal static VPROpenerLogic VPROpener = new();
+            internal static VPROpenerLogicNoRattling VPROpener2 = new();
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -368,6 +377,13 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.VPR_ST_Opener))
                     {
                         if (VPROpener.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // No Rattling Opener for VPR
+                    if (IsEnabled(CustomComboPreset.VPR_ST_Opener) && IsEnabled(CustomComboPreset.VPR_ST_Opener_NoRattling))
+                    {
+                        if (VPROpener2.DoFullOpener(ref actionID))
                             return actionID;
                     }
 


### PR DESCRIPTION
Adds an opener that doesn't use Uncoiled Fury, useful for fights with heavy downtime during the opener, letting you choose exactly when to spend your Rattling Coil stacks for ranged uptime.
