### PR TITLE
[VPR] No Uncoiled Fury Opener + Writhing Snap feature + Reawaken window fixes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3803,8 +3803,13 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(VPR_ST_AdvancedMode)]
         [ConflictingCombos(VPR_ReawakenLegacy)]
-        [CustomComboInfo("Level 100 Opener", "Adds the Balance opener to the rotation.\n Does not check positional choice.\n Always does Hunter's Coil first ( FLANK )", VPR.JobID)]
+        [CustomComboInfo("Level 100 Openers", "Adds the selected opener to the rotation.\n Uses the early Uncoiled Fury opener by default. \n Does not check positional choice.\n Always does Hunter's Coil first ( FLANK )", VPR.JobID)]
         VPR_ST_Opener = 30002,
+
+        [ParentCombo(VPR_ST_Opener)]
+        [ConflictingCombos(VPR_ReawakenLegacy)]
+        [CustomComboInfo("No Uncoiled Fury Opener", "Swap to the No Uncoiled Fury opener.", VPR.JobID)]
+        VPR_ST_Opener_NoUncoiledFury = 30300,
 
         #region Cooldowns ST
 
@@ -3941,6 +3946,10 @@ namespace XIVSlothCombo.Combos
         [ReplaceSkill(VPR.UncoiledFury)]
         [CustomComboInfo("Uncoiled - Twins", "Replaces Uncoiled Fury with Uncoiled Twinfang and Uncoiled Twinblood.", VPR.JobID)]
         VPR_UncoiledTwins = 30202,
+
+        [ParentCombo(VPR_UncoiledTwins)]
+        [CustomComboInfo("Uncoiled - Twins", "Replaces Uncoiled Fury with Writhing Snap when at 0 Rattling Coil stacks.", VPR.JobID)]
+        VPR_UncoiledTwins_Snap = 30400,
 
         [ReplaceSkill(VPR.Reawaken, VPR.SteelFangs)]
         [ConflictingCombos(VPR_ST_Reawaken, VPR_ST_ReawakenCombo, VPR_AoE_Reawaken, VPR_AoE_ReawakenCombo, VPR_ST_Opener)]

--- a/XIVSlothCombo/Combos/JobHelpers/VPR.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/VPR.cs
@@ -255,6 +255,224 @@ namespace XIVSlothCombo.Combos.JobHelpers
             }
         }
 
+        internal class VPROpenerLogicNoUncoiledFury
+        {
+            private static bool HasCooldowns()
+            {
+                if (GetRemainingCharges(Vicewinder) < 2)
+                    return false;
+
+                if (!ActionReady(SerpentsIre))
+                    return false;
+
+                return true;
+            }
+
+            private static uint OpenerLevel => 100;
+
+            public uint PrePullStep = 0;
+
+            public uint OpenerStep = 0;
+
+            public static bool LevelChecked => LocalPlayer.Level >= OpenerLevel;
+
+            private static bool CanOpener => HasCooldowns() && LevelChecked;
+
+            private OpenerState currentState = OpenerState.PrePull;
+
+            public OpenerState CurrentState
+            {
+                get
+                {
+                    return currentState;
+                }
+                set
+                {
+                    if (value != currentState)
+                    {
+                        if (value == OpenerState.PrePull)
+                        {
+                            Svc.Log.Debug($"Entered PrePull Opener");
+                        }
+                        if (value == OpenerState.InOpener) OpenerStep = 1;
+                        if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                        {
+                            if (value == OpenerState.FailedOpener)
+                                Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                            ResetOpener();
+                        }
+                        if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                        currentState = value;
+                    }
+                }
+            }
+
+            private bool DoPrePullSteps(ref uint actionID)
+            {
+                if (!LevelChecked)
+                    return false;
+
+                if (CanOpener && PrePullStep == 0)
+                {
+                    PrePullStep = 1;
+                }
+
+                if (!HasCooldowns())
+                {
+                    PrePullStep = 0;
+                }
+
+                if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+                {
+                    if (WasLastAction(ReavingFangs) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                    else if (PrePullStep == 1) actionID = ReavingFangs;
+
+                    if (ActionWatching.CombatActions.Count > 2 && InCombat())
+                        CurrentState = OpenerState.FailedOpener;
+
+                    return true;
+                }
+                PrePullStep = 0;
+                return false;
+            }
+
+            private bool DoOpener(ref uint actionID)
+            {
+                if (!LevelChecked)
+                    return false;
+
+                if (currentState == OpenerState.InOpener)
+                {
+                    if (WasLastAction(SerpentsIre) && OpenerStep == 1) OpenerStep++;
+                    else if (OpenerStep == 1) actionID = SerpentsIre;
+
+                    if (WasLastAction(SwiftskinsSting) && OpenerStep == 2) OpenerStep++;
+                    else if (OpenerStep == 2) actionID = SwiftskinsSting;
+
+                    if (WasLastAction(Vicewinder) && OpenerStep == 3) OpenerStep++;
+                    else if (OpenerStep == 3) actionID = Vicewinder;
+
+                    if (WasLastAction(HuntersCoil) && OpenerStep == 4) OpenerStep++;
+                    else if (OpenerStep == 4) actionID = HuntersCoil;
+
+                    if (WasLastAction(TwinfangBite) && OpenerStep == 5) OpenerStep++;
+                    else if (OpenerStep == 5) actionID = TwinfangBite;
+
+                    if (WasLastAction(TwinbloodBite) && OpenerStep == 6) OpenerStep++;
+                    else if (OpenerStep == 6) actionID = TwinbloodBite;
+
+                    if (WasLastAction(SwiftskinsCoil) && OpenerStep == 7) OpenerStep++;
+                    else if (OpenerStep == 7) actionID = SwiftskinsCoil;
+
+                    if (WasLastAction(TwinbloodBite) && OpenerStep == 8) OpenerStep++;
+                    else if (OpenerStep == 8) actionID = TwinbloodBite;
+
+                    if (WasLastAction(TwinfangBite) && OpenerStep == 9) OpenerStep++;
+                    else if (OpenerStep == 9) actionID = TwinfangBite;
+
+                    if (WasLastAction(Reawaken) && OpenerStep == 10) OpenerStep++;
+                    else if (OpenerStep == 10) actionID = Reawaken;
+
+                    if (WasLastAction(FirstGeneration) && OpenerStep == 11) OpenerStep++;
+                    else if (OpenerStep == 11) actionID = FirstGeneration;
+
+                    if (WasLastAction(FirstLegacy) && OpenerStep == 12) OpenerStep++;
+                    else if (OpenerStep == 12) actionID = FirstLegacy;
+
+                    if (WasLastAction(SecondGeneration) && OpenerStep == 13) OpenerStep++;
+                    else if (OpenerStep == 13) actionID = SecondGeneration;
+
+                    if (WasLastAction(SecondLegacy) && OpenerStep == 14) OpenerStep++;
+                    else if (OpenerStep == 14) actionID = SecondLegacy;
+
+                    if (WasLastAction(ThirdGeneration) && OpenerStep == 15) OpenerStep++;
+                    else if (OpenerStep == 15) actionID = ThirdGeneration;
+
+                    if (WasLastAction(ThirdLegacy) && OpenerStep == 16) OpenerStep++;
+                    else if (OpenerStep == 16) actionID = ThirdLegacy;
+
+                    if (WasLastAction(FourthGeneration) && OpenerStep == 17) OpenerStep++;
+                    else if (OpenerStep == 17) actionID = FourthGeneration;
+
+                    if (WasLastAction(FourthLegacy) && OpenerStep == 18) OpenerStep++;
+                    else if (OpenerStep == 18) actionID = FourthLegacy;
+
+                    if (WasLastAction(Ouroboros) && OpenerStep == 19) OpenerStep++;
+                    else if (OpenerStep == 19) actionID = Ouroboros;
+
+                    if (WasLastAction(HindstingStrike) && OpenerStep == 20) OpenerStep++;
+                    else if (OpenerStep == 20) actionID = HindstingStrike;
+
+                    if (WasLastAction(DeathRattle) && OpenerStep == 21) OpenerStep++;
+                    else if (OpenerStep == 21) actionID = DeathRattle;
+
+                    if (WasLastAction(Vicewinder) && OpenerStep == 22) OpenerStep++;
+                    else if (OpenerStep == 22) actionID = Vicewinder;
+
+                    if (WasLastAction(HuntersCoil) && OpenerStep == 23) OpenerStep++;
+                    else if (OpenerStep == 23) actionID = HuntersCoil;
+
+                    if (WasLastAction(TwinfangBite) && OpenerStep == 24) OpenerStep++;
+                    else if (OpenerStep == 24) actionID = TwinfangBite;
+
+                    if (WasLastAction(TwinbloodBite) && OpenerStep == 25) OpenerStep++;
+                    else if (OpenerStep == 25) actionID = TwinbloodBite;
+
+                    if (WasLastAction(SwiftskinsCoil) && OpenerStep == 26) OpenerStep++;
+                    else if (OpenerStep == 26) actionID = SwiftskinsCoil;
+
+                    if (WasLastAction(TwinbloodBite) && OpenerStep == 27) OpenerStep++;
+                    else if (OpenerStep == 27) actionID = TwinbloodBite;
+
+                    if (WasLastAction(TwinfangBite) && OpenerStep == 28) CurrentState = OpenerState.OpenerFinished;
+                    else if (OpenerStep == 28) actionID = TwinfangBite;
+
+                    if (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5)
+                        CurrentState = OpenerState.FailedOpener;
+
+                    if (((actionID == SerpentsIre && IsOnCooldown(SerpentsIre)) ||
+                        (actionID == Vicewinder && GetRemainingCharges(Vicewinder) < 2)) && ActionWatching.TimeSinceLastAction.TotalSeconds >= 3)
+                    {
+                        CurrentState = OpenerState.FailedOpener;
+                        return false;
+                    }
+                    return true;
+                }
+                return false;
+            }
+
+            private void ResetOpener()
+            {
+                PrePullStep = 0;
+                OpenerStep = 0;
+            }
+
+            public bool DoFullOpener(ref uint actionID)
+            {
+                if (!LevelChecked)
+                    return false;
+
+                if (CurrentState == OpenerState.PrePull)
+                    if (DoPrePullSteps(ref actionID))
+                        return true;
+
+                if (CurrentState == OpenerState.InOpener)
+                {
+                    if (DoOpener(ref actionID))
+                        return true;
+                }
+
+                if (!InCombat())
+                {
+                    ResetOpener();
+                    CurrentState = OpenerState.PrePull;
+                }
+                return false;
+            }
+        }
+
         internal class VPRCheckRattlingCoils
         {
             public static bool HasRattlingCoilStack(VPRGauge gauge)

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -347,6 +347,7 @@ namespace XIVSlothCombo.Combos.PvE
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.VPR_ST_AdvancedMode;
             internal static VPROpenerLogic VPROpener = new();
+            internal static VPROpenerLogicNoUncoiledFury VPROpener2 = new();
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -368,6 +369,13 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.VPR_ST_Opener))
                     {
                         if (VPROpener.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // No UF Opener for VPR
+                    if (IsEnabled(CustomComboPreset.VPR_ST_Opener) && IsEnabled(CustomComboPreset.VPR_ST_Opener_NoUncoiledFury))
+                    {
+                        if (VPROpener2.DoFullOpener(ref actionID))
                             return actionID;
                     }
 
@@ -1044,6 +1052,8 @@ namespace XIVSlothCombo.Combos.PvE
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
+                VPRGauge? gauge = GetJobGauge<VPRGauge>();
+
                 if (actionID is UncoiledFury)
                 {
                     if (HasEffect(Buffs.PoisedForTwinfang))
@@ -1051,6 +1061,9 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (HasEffect(Buffs.PoisedForTwinblood))
                         return OriginalHook(Twinblood);
+
+                    if (IsEnabled(CustomComboPreset.VPR_UncoiledTwins_Snap) && gauge.RattlingCoilStacks == 0)
+                        return WrithingSnap;
                 }
                 return actionID;
             }

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -605,15 +605,11 @@ namespace XIVSlothCombo.Combos.PvE
                         gauge.SerpentOffering >= 50 &&
                         GetCooldownRemainingTime(SerpentsIre) is >= 50 and <= 65) ||
                         (SerpentsIreUsed is 4 &&
-                        (gauge.SerpentOffering >= 95 ||
+                        (gauge.SerpentOffering >= 90 ||
                         (gauge.SerpentOffering >= 50 && WasLastWeaponskill(Ouroboros)) ||
                         (gauge.SerpentOffering >= 50 && WasLastWeaponskill(FourthGeneration) && !LevelChecked(Ouroboros))) &&
                         GetCooldownRemainingTime(SerpentsIre) is >= 45 and <= 90) ||
                         gauge.SerpentOffering >= 60 && GetCooldownRemainingTime(SerpentsIre) is >= 65 and <= 95)
-                        return true;
-
-                    // 5min failsafe
-                    if (SerpentsIreUsed == 3 && gauge.SerpentOffering >= 90)
                         return true;
 
                     // overcap protection

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -612,8 +612,8 @@ namespace XIVSlothCombo.Combos.PvE
                         return true;
 
                     // overcap protection
-                    if (gauge.SerpentOffering >= 95 && GetCooldownRemainingTime(SerpentsIre) < 50)
-                        return true;
+                    if (SerpentsIreUsed <= 3 && gauge.SerpentOffering >= 95 && GetCooldownRemainingTime(SerpentsIre) < 50)
+                        return true; 
                 }
                 return false;
             }

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -365,13 +365,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is SteelFangs)
                 {
-                    // Opener for VPR
-                    if (IsEnabled(CustomComboPreset.VPR_ST_Opener))
-                    {
-                        if (VPROpener.DoFullOpener(ref actionID))
-                            return actionID;
-                    }
-
                     // No UF Opener for VPR
                     if (IsEnabled(CustomComboPreset.VPR_ST_Opener) && IsEnabled(CustomComboPreset.VPR_ST_Opener_NoUncoiledFury))
                     {
@@ -379,6 +372,13 @@ namespace XIVSlothCombo.Combos.PvE
                             return actionID;
                     }
 
+                    // Opener for VPR
+                    if (IsEnabled(CustomComboPreset.VPR_ST_Opener))
+                    {
+                        if (VPROpener.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+               
                     //All Weaves
                     if (CanWeave(actionID))
                     {
@@ -603,16 +603,22 @@ namespace XIVSlothCombo.Combos.PvE
                     // odd minutes
                     if (((SerpentsIreUsed <= 3 || SerpentsIreUsed > 4) &&
                         gauge.SerpentOffering >= 50 &&
-                        GetCooldownRemainingTime(SerpentsIre) is >= 50 and <= 90) ||
+                        GetCooldownRemainingTime(SerpentsIre) is >= 50 and <= 65) ||
                         (SerpentsIreUsed is 4 &&
                         (gauge.SerpentOffering >= 95 ||
                         (gauge.SerpentOffering >= 50 && WasLastWeaponskill(Ouroboros)) ||
                         (gauge.SerpentOffering >= 50 && WasLastWeaponskill(FourthGeneration) && !LevelChecked(Ouroboros))) &&
-                        GetCooldownRemainingTime(SerpentsIre) is >= 45 and <= 90))
+                        GetCooldownRemainingTime(SerpentsIre) is >= 45 and <= 90) ||
+                        gauge.SerpentOffering >= 60 && GetCooldownRemainingTime(SerpentsIre) is >= 65 and <= 95)
+                        return true;
+
+                    // 5min failsafe
+                    if (SerpentsIreUsed == 3 && gauge.SerpentOffering >= 90)
                         return true;
 
                     // overcap protection
-                    if (SerpentsIreUsed <= 3 && gauge.SerpentOffering >= 95 && GetCooldownRemainingTime(SerpentsIre) < 50)
+                    if (SerpentsIreUsed is < 3 or > 3 && gauge.SerpentOffering >= 95 && GetCooldownRemainingTime(SerpentsIre) < 50 && 
+                        (WasLastWeaponskill(SwiftskinsSting) || WasLastWeaponskill(HuntersSting)))
                         return true; 
                 }
                 return false;

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -594,7 +594,7 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     //even minutes
                     if ((WasLastAbility(SerpentsIre) && HasEffect(Buffs.ReadyToReawaken)) ||
-                        (gauge.SerpentOffering >= 50 && WasLastWeaponskill(Ouroboros)) ||
+                        (gauge.SerpentOffering >= 50 && WasLastWeaponskill(Ouroboros)) && GetCooldownRemainingTime(SerpentsIre) >= 90 ||
                         (gauge.SerpentOffering >= 50 && WasLastWeaponskill(FourthGeneration) && !LevelChecked(Ouroboros)) ||
                         HasEffect(Buffs.ReadyToReawaken) ||
                         (gauge.SerpentOffering >= 95 && WasLastAbility(SerpentsIre)))
@@ -603,12 +603,16 @@ namespace XIVSlothCombo.Combos.PvE
                     // odd minutes
                     if (((SerpentsIreUsed <= 3 || SerpentsIreUsed > 4) &&
                         gauge.SerpentOffering >= 50 &&
-                        GetCooldownRemainingTime(SerpentsIre) is >= 50 and <= 65) ||
+                        GetCooldownRemainingTime(SerpentsIre) is >= 50 and <= 90) ||
                         (SerpentsIreUsed is 4 &&
                         (gauge.SerpentOffering >= 95 ||
                         (gauge.SerpentOffering >= 50 && WasLastWeaponskill(Ouroboros)) ||
                         (gauge.SerpentOffering >= 50 && WasLastWeaponskill(FourthGeneration) && !LevelChecked(Ouroboros))) &&
                         GetCooldownRemainingTime(SerpentsIre) is >= 45 and <= 90))
+                        return true;
+
+                    // overcap protection
+                    if (gauge.SerpentOffering >= 95 && GetCooldownRemainingTime(SerpentsIre) < 50)
                         return true;
                 }
                 return false;


### PR DESCRIPTION
Adds an opener that doesn't use Uncoiled Fury, allowing the user to manually use Rattling Coil stacks for ranged uptime during heavy early downtime fights.

Adds a feature to replace Uncoiled Fury with Writhing Snap when at 0 Rattling Coil stacks.