### PR TITLE
[SAM] Standalone Combo Adjustments

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3201,33 +3201,35 @@ namespace XIVSlothCombo.Combos
 
         #region SAMURAI
 
-        #region Yukikaze/Kasha Combos
+        #region Yukikaze/Kasha/Gekko Combos
 
         [ReplaceSkill(SAM.Yukikaze)]
-        [ConflictingCombos(SAM_ST_Yukikaze)]
         [CustomComboInfo("Yukikaze Combo", "Replace Yukikaze with its combo chain.", SAM.JobID)]
         SAM_ST_YukikazeCombo = 15000,
 
         [ReplaceSkill(SAM.Kasha)]
-        [ConflictingCombos(SAM_ST_Kasha)]
         [CustomComboInfo("Kasha Combo", "Replace Kasha with its combo chain.", SAM.JobID)]
         SAM_ST_KashaCombo = 15001,
+
+        [ReplaceSkill(SAM.Gekko)]
+        [CustomComboInfo("Gekko Combo", "Replace Gekko with its combo chain.", SAM.JobID)]
+        SAM_ST_GekkoCombo = 15010,
         #endregion
 
         #region  Simple ST
 
-        [ReplaceSkill(SAM.Gekko)]
+        [ReplaceSkill(SAM.Hakaze, SAM.Gyofu)]
         [ConflictingCombos(SAM_ST_AdvancedMode)]
-        [CustomComboInfo("Simple Mode - Single Target", "Replaces Gekko with a one-button full single target rotation.\nThis is ideal for newcomers to the job.", SAM.JobID)]
+        [CustomComboInfo("Simple Mode - Single Target", "Replaces Hakaze/Gyofu with a one-button full single target rotation.\nThis is ideal for newcomers to the job.", SAM.JobID)]
         SAM_ST_SimpleMode = 15002,
 
         #endregion
 
         #region Advanced ST
 
-        [ReplaceSkill(SAM.Gekko)]
+        [ReplaceSkill(SAM.Hakaze, SAM.Gyofu)]
         [ConflictingCombos(SAM_ST_SimpleMode)]
-        [CustomComboInfo("Advanced Mode - Single Target", "Replaces Gekko with a full one-button single target rotation.\nThese features are ideal if you want to customize the rotation.", SAM.JobID)]
+        [CustomComboInfo("Advanced Mode - Single Target", "Replaces Hakaze/Gyofu with a full one-button single target rotation.\nThese features are ideal if you want to customize the rotation.", SAM.JobID)]
         SAM_ST_AdvancedMode = 15003,
 
         [ParentCombo(SAM_ST_AdvancedMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3233,17 +3233,14 @@ namespace XIVSlothCombo.Combos
         SAM_ST_AdvancedMode = 15003,
 
         [ParentCombo(SAM_ST_AdvancedMode)]
-        [ConflictingCombos(SAM_ST_YukikazeCombo)]
         [CustomComboInfo("Yukikaze Combo", "Adds Yukikaze combo to the rotation.", SAM.JobID)]
         SAM_ST_Yukikaze = 15004,
 
         [ParentCombo(SAM_ST_AdvancedMode)]
-        [ConflictingCombos(SAM_ST_KashaCombo)]
         [CustomComboInfo("Kasha Combo", "Adds Kasha combo to the rotation.", SAM.JobID)]
         SAM_ST_Kasha = 15005,
 
         [ParentCombo(SAM_ST_AdvancedMode)]
-        [ConflictingCombos(SAM_GyotenYaten)]
         [CustomComboInfo("Level 100 Opener", "Adds the Balance opener to the rotation.", SAM.JobID)]
         SAM_ST_Opener = 15006,
 
@@ -3290,7 +3287,6 @@ namespace XIVSlothCombo.Combos
         SAM_ST_CDs_Shoha = 15019,
 
         [ParentCombo(SAM_ST_CDs)]
-        [ConflictingCombos(SAM_Shinten_Shoha_Senei)]
         [CustomComboInfo("Senei Option", "Adds Senei to the rotation.", SAM.JobID)]
         SAM_ST_CDs_Senei = 15020,
 
@@ -3317,10 +3313,13 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Oka Combo", "Replace Oka with its combo chain.", SAM.JobID)]
         SAM_AoE_OkaCombo = 15100,
 
-        [ParentCombo(SAM_AoE_OkaCombo)]
-        [ConflictingCombos(SAM_AoE_Oka)]
-        [CustomComboInfo("Oka Two Target Rotation Feature", "Adds the Yukikaze combo, Mangetsu combo, Senei, Shinten, and Shoha to Oka combo.\nUsed for two targets only and when Lv86 and above.", SAM.JobID)]
-        SAM_AoE_OkaCombo_TwoTarget = 15101,
+        //[ParentCombo(SAM_AoE_OkaCombo)]
+        //[CustomComboInfo("Oka Two Target Rotation Feature", "Adds the Yukikaze combo, Mangetsu combo, Senei, Shinten, and Shoha to Oka combo.\nUsed for two targets only and when Lv86 and above.", SAM.JobID)]
+        //SAM_AoE_OkaCombo_TwoTarget = 15101,
+
+        [ReplaceSkill(SAM.Mangetsu)]
+        [CustomComboInfo("Mangetsu Combo", "Replace Mangetsu with its combo chain.", SAM.JobID)]
+        SAM_AoE_MangetsuCombo = 15101,
 
         #endregion
 
@@ -3328,7 +3327,7 @@ namespace XIVSlothCombo.Combos
 
         [ReplaceSkill(SAM.Fuga, SAM.Fuko)]
         [ConflictingCombos(SAM_AoE_AdvancedMode)]
-        [CustomComboInfo("Simple Mode - AoE", "Replaces Fugo/Fuko with a one-button full single target rotation.\nThis is ideal for newcomers to the job.", SAM.JobID)]
+        [CustomComboInfo("Simple Mode - AoE", "Replaces Fuga/Fuko with a one-button full single target rotation.\nThis is ideal for newcomers to the job.", SAM.JobID)]
         SAM_AoE_SimpleMode = 15102,
 
         #endregion
@@ -3341,7 +3340,6 @@ namespace XIVSlothCombo.Combos
         SAM_AoE_AdvancedMode = 15103,
 
         [ParentCombo(SAM_AoE_AdvancedMode)]
-        [ConflictingCombos(SAM_AoE_OkaCombo_TwoTarget)]
         [CustomComboInfo("Oka Combo", "Adds Oka combo to the rotation.", SAM.JobID)]
         SAM_AoE_Oka = 15104,
 
@@ -3369,7 +3367,6 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Shoha", "Adds Shoha when you have 3 meditation stacks.", SAM.JobID)]
         SAM_AoE_Shoha = 15111,
 
-        [ConflictingCombos(SAM_Kyuten_Shoha_Guren)]
         [ParentCombo(SAM_AoE_AdvancedMode)]
         [CustomComboInfo("Guren", "Adds Guren to the rotation.", SAM.JobID)]
         SAM_AoE_Guren = 15112,
@@ -3423,7 +3420,6 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Shinten to Shoha", "Replace Hissatsu: Shinten with Shoha when Meditation is full.", SAM.JobID)]
         SAM_Shinten_Shoha = 15205,
 
-        [ConflictingCombos(SAM_ST_CDs_Senei)]
         [ParentCombo(SAM_Shinten_Shoha)]
         [CustomComboInfo("Shinten to Senei", "Replace Hissatsu: Shinten with Senei when its cooldown is up.", SAM.JobID)]
         SAM_Shinten_Shoha_Senei = 15206,
@@ -3436,7 +3432,6 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Kyuten to Shoha", "Replace Hissatsu: Kyuten with Shoha when Meditation is full.", SAM.JobID)]
         SAM_Kyuten_Shoha = 15207,
 
-        [ConflictingCombos(SAM_AoE_Guren)]
         [ParentCombo(SAM_Kyuten_Shoha)]
         [CustomComboInfo("Kyuten to Guren", "Replace Hissatsu: Kyuten with Guren when its cooldown is up.", SAM.JobID)]
         SAM_Kyuten_Shoha_Guren = 15208,
@@ -3445,7 +3440,6 @@ namespace XIVSlothCombo.Combos
 
         #region Other
 
-        [ConflictingCombos(SAM_ST_Opener)]
         [ReplaceSkill(SAM.Gyoten)]
         [CustomComboInfo("Gyoten Feature", "Hissatsu: Gyoten becomes Yaten/Gyoten depending on the distance from your target.", SAM.JobID)]
         SAM_GyotenYaten = 15209,

--- a/XIVSlothCombo/Combos/JobHelpers/SAM.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/SAM.cs
@@ -1,6 +1,7 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using ECommons.DalamudServices;
 using FFXIVClientStructs.FFXIV.Client.Game;
+using System.Linq;
 using XIVSlothCombo.Combos.JobHelpers.Enums;
 using XIVSlothCombo.Combos.PvE;
 using XIVSlothCombo.CustomComboNS.Functions;
@@ -29,6 +30,40 @@ namespace XIVSlothCombo.Combos.JobHelpers
                 return true;
             return false;
         }
+
+        internal static bool UseTsubame => GetUseTsubame();
+
+        private static bool GetUseTsubame()
+        {
+            int MeikyoUsed = ActionWatching.CombatActions.Count(x => x == MeikyoShisui);
+
+            if (CustomComboFunctions.ActionReady(TsubameGaeshi))
+            {
+                //Tendo
+                if (CustomComboFunctions.HasEffect(Buffs.TendoKaeshiSetsugekkaReady))
+                    return true;
+
+                if (CustomComboFunctions.HasEffect(Buffs.TsubameReady))
+                {
+                    var meikyoModulo = MeikyoUsed % 15;
+                    //1 and 2 min
+                    if ((meikyoModulo is 0 or 1 or 2 or 3 or 4 or 9 or 10))
+                        return true;
+
+                    // 3 and 4 min
+                    if ((meikyoModulo is 5 or 6 or 11 or 12) &&
+                        CustomComboFunctions.GetBuffStacks(Buffs.MeikyoShisui) is 2)
+                        return true;
+
+                    // 5 and 6 min
+                    if ((meikyoModulo is 7 or 8 or 13 or 14) &&
+                        CustomComboFunctions.GetBuffStacks(Buffs.MeikyoShisui) is 1)
+                        return true;
+                }
+            }
+            return false;
+        }
+
     }
 
 

--- a/XIVSlothCombo/Combos/JobHelpers/SAM.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/SAM.cs
@@ -1,4 +1,6 @@
-﻿using ECommons.DalamudServices;
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using ECommons.DalamudServices;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using XIVSlothCombo.Combos.JobHelpers.Enums;
 using XIVSlothCombo.Combos.PvE;
 using XIVSlothCombo.CustomComboNS.Functions;
@@ -6,6 +8,30 @@ using XIVSlothCombo.Data;
 
 namespace XIVSlothCombo.Combos.JobHelpers
 {
+    internal class SAMHelper : SAM
+    {
+        internal static int SenCount => GetSenCount();
+        private static int GetSenCount()
+        {
+            var gauge = CustomComboFunctions.GetJobGauge<SAMGauge>();
+            var senCount = 0;
+            if (gauge.HasGetsu) senCount++;
+            if (gauge.HasSetsu) senCount++;
+            if (gauge.HasKa) senCount++;
+
+            return senCount;
+        }
+        internal static bool ComboStarted => GetComboStarted(); 
+        private unsafe static bool GetComboStarted()
+        {
+            var comboAction = ActionManager.Instance()->Combo.Action;
+            if (comboAction == CustomComboFunctions.OriginalHook(Hakaze) || comboAction == CustomComboFunctions.OriginalHook(Jinpu) || comboAction == CustomComboFunctions.OriginalHook(Shifu))
+                return true;
+            return false;
+        }
+    }
+
+
     internal class SAMOpenerLogic : SAM
     {
         private static bool HasCooldowns()

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -300,7 +300,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Iaijutsu Features
                         if (LevelChecked(Iaijutsu))
                         {
-                            if (UseTsubame())
+                            if (SAMHelper.UseTsubame)
                                 return OriginalHook(TsubameGaeshi);
 
                             if (!IsMoving &&
@@ -361,37 +361,6 @@ namespace XIVSlothCombo.Combos.PvE
                     return OriginalHook(Hakaze);
                 }
                 return actionID;
-            }
-
-            private static bool UseTsubame()
-            {
-                int MeikyoUsed = ActionWatching.CombatActions.Count(x => x == MeikyoShisui);
-
-                if (LevelChecked(TsubameGaeshi))
-                {
-                    //Tendo
-                    if (WasLastWeaponskill(TendoSetsugekka) && HasEffect(Buffs.TendoKaeshiSetsugekkaReady))
-                        return true;
-
-                    if (HasEffect(Buffs.TsubameReady))
-                    {
-                        //1 and 2 min
-                        if ((MeikyoUsed is 0 or 1 or 2 or 3 or 4 or 9 or 10) &&
-                            WasLastWeaponskill(MidareSetsugekka))
-                            return true;
-
-                        // 3 and 4 min
-                        if ((MeikyoUsed is 5 or 6 or 11 or 12) &&
-                            GetBuffStacks(Buffs.MeikyoShisui) is 2)
-                            return true;
-
-                        // 5 and 6 min
-                        if ((MeikyoUsed is 7 or 8 or 13 or 14) &&
-                            GetBuffStacks(Buffs.MeikyoShisui) is 1)
-                            return true;
-                    }
-                }
-                return false;
             }
         }
 
@@ -509,7 +478,7 @@ namespace XIVSlothCombo.Combos.PvE
                         // Iaijutsu Features
                         if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Iaijutsu) && LevelChecked(Iaijutsu))
                         {
-                            if (UseTsubame())
+                            if (SAMHelper.UseTsubame)
                                 return OriginalHook(TsubameGaeshi);
 
                             if ((!IsEnabled(CustomComboPreset.SAM_ST_CDs_Iaijutsu_Movement) ||
@@ -578,38 +547,6 @@ namespace XIVSlothCombo.Combos.PvE
                     return OriginalHook(Hakaze);
                 }
                 return actionID;
-            }
-
-            private static bool UseTsubame()
-            {
-                int MeikyoUsed = ActionWatching.CombatActions.Count(x => x == MeikyoShisui);
-
-                if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Iaijutsu) &&
-                    LevelChecked(TsubameGaeshi))
-                {
-                    //Tendo
-                    if (WasLastWeaponskill(TendoSetsugekka) && HasEffect(Buffs.TendoKaeshiSetsugekkaReady))
-                        return true;
-
-                    if (HasEffect(Buffs.TsubameReady))
-                    {
-                        //1 and 2 min
-                        if ((MeikyoUsed is 0 or 1 or 2 or 3 or 4 or 9 or 10) &&
-                            WasLastWeaponskill(MidareSetsugekka))
-                            return true;
-
-                        // 3 and 4 min
-                        if ((MeikyoUsed is 5 or 6 or 11 or 12) &&
-                            GetBuffStacks(Buffs.MeikyoShisui) is 2)
-                            return true;
-
-                        // 5 and 6 min
-                        if ((MeikyoUsed is 7 or 8 or 13 or 14) &&
-                            GetBuffStacks(Buffs.MeikyoShisui) is 1)
-                            return true;
-                    }
-                }
-                return false;
             }
         }
 

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -266,7 +266,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         //Senei Features
-                        if (gauge.Kenki >= 25 && ActionReady(Senei) && HasEffect(Buffs.MeikyoShisui) &&
+                        if (gauge.Kenki >= 25 && ActionReady(Senei) &&
                             HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
                             return Senei;
 
@@ -293,12 +293,8 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
                     {
                         //Ogi Namikiri Features
-                        if (!IsMoving &&
-                            LevelChecked(OgiNamikiri) &&
-                            (gauge.Kaeshi == Kaeshi.NAMIKIRI ||
-                            (HasEffect(Buffs.OgiNamikiriReady) && !HasEffect(Buffs.ZanshinReady) &&
-                            ((meikyostacks is 2 && WasLastWeaponskill(Higanbana)) ||
-                            GetBuffRemainingTime(Buffs.OgiNamikiriReady) <= 6))))
+                        if (ActionReady(OgiNamikiri) &&
+                            (gauge.Kaeshi == Kaeshi.NAMIKIRI || HasEffect(Buffs.OgiNamikiriReady)))
                             return OriginalHook(OgiNamikiri);
 
                         // Iaijutsu Features
@@ -470,7 +466,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                             //Senei Features
                             if (IsEnabled(CustomComboPreset.SAM_ST_CDs_Senei) &&
-                                gauge.Kenki >= 25 && ActionReady(Senei) && HasEffect(Buffs.MeikyoShisui) &&
+                                gauge.Kenki >= 25 && ActionReady(Senei) &&
                                 HasEffect(Buffs.Fugetsu) && HasEffect(Buffs.Fuka))
                                 return Senei;
 
@@ -506,11 +502,8 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.SAM_ST_CDs_OgiNamikiri) &&
                             (!IsEnabled(CustomComboPreset.SAM_ST_CDs_OgiNamikiri_Movement) ||
                             (IsEnabled(CustomComboPreset.SAM_ST_CDs_OgiNamikiri_Movement) && !IsMoving)) &&
-                            LevelChecked(OgiNamikiri) &&
-                            (gauge.Kaeshi == Kaeshi.NAMIKIRI ||
-                            (HasEffect(Buffs.OgiNamikiriReady) && !HasEffect(Buffs.ZanshinReady) &&
-                            ((meikyostacks is 2 && WasLastWeaponskill(Higanbana)) ||
-                            GetBuffRemainingTime(Buffs.OgiNamikiriReady) <= 6))))
+                            ActionReady(OgiNamikiri) &&
+                            (gauge.Kaeshi == Kaeshi.NAMIKIRI || HasEffect(Buffs.OgiNamikiriReady)))
                             return OriginalHook(OgiNamikiri);
 
                         // Iaijutsu Features

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -100,6 +100,8 @@ namespace XIVSlothCombo.Combos.PvE
                 SAM_Kasha_KenkiOvercapAmount = new(nameof(SAM_Kasha_KenkiOvercapAmount), 50),
                 SAM_Yukaze_KenkiOvercapAmount = new(nameof(SAM_Yukaze_KenkiOvercapAmount), 50),
                 SAM_Gekko_KenkiOvercapAmount = new(nameof(SAM_Gekko_KenkiOvercapAmount), 50),
+                SAM_Oka_KenkiOvercapAmount = new(nameof(SAM_Oka_KenkiOvercapAmount), 50),
+                SAM_Mangetsu_KenkiOvercapAmount = new(nameof(SAM_Mangetsu_KenkiOvercapAmount), 50),
                 SAM_ST_KenkiOvercapAmount = new(nameof(SAM_ST_KenkiOvercapAmount), 50),
                 SAM_AoE_KenkiOvercapAmount = new(nameof(SAM_AoE_KenkiOvercapAmount), 50),
                 SAM_VariantCure = new("SAM_VariantCure");
@@ -111,7 +113,9 @@ namespace XIVSlothCombo.Combos.PvE
             public static UserBool
                 SAM_Kasha_KenkiOvercap = new(nameof(SAM_Kasha_KenkiOvercap)),
                 SAM_Yukaze_KenkiOvercap = new(nameof(SAM_Yukaze_KenkiOvercap)),
-                SAM_Gekko_KenkiOvercap = new(nameof(SAM_Gekko_KenkiOvercap));
+                SAM_Gekko_KenkiOvercap = new(nameof(SAM_Gekko_KenkiOvercap)),
+                SAM_Oka_KenkiOvercap = new(nameof(SAM_Oka_KenkiOvercap)),
+                SAM_Mangetsu_KenkiOvercap = new(nameof(SAM_Mangetsu_KenkiOvercap));
         }
         internal class SAM_ST_YukikazeCombo : CustomCombo
         {
@@ -620,67 +624,43 @@ namespace XIVSlothCombo.Combos.PvE
 
                 if (actionID is Oka)
                 {
-                    if (IsNotEnabled(CustomComboPreset.SAM_AoE_OkaCombo_TwoTarget) &&
-                        gauge.Kenki >= Config.SAM_AoE_KenkiOvercapAmount && LevelChecked(Kyuten) && CanWeave(actionID))
+                    if (Config.SAM_Oka_KenkiOvercap && gauge.Kenki >= Config.SAM_Oka_KenkiOvercapAmount && LevelChecked(Kyuten) && CanWeave(actionID))
                         return Kyuten;
 
-                    if (IsNotEnabled(CustomComboPreset.SAM_AoE_OkaCombo_TwoTarget) &&
-                        HasEffect(Buffs.MeikyoShisui))
+                    if (HasEffect(Buffs.MeikyoShisui))
                         return Oka;
-
-                    //Two Target Rotation
-                    if (IsEnabled(CustomComboPreset.SAM_AoE_OkaCombo_TwoTarget))
-                    {
-                        if (CanWeave(actionID))
-                        {
-                            if (!HasEffect(Buffs.MeikyoShisui) && ActionReady(MeikyoShisui))
-                                return MeikyoShisui;
-
-                            if (ActionReady(Senei) && gauge.Kenki >= 25)
-                                return Senei;
-
-                            if (LevelChecked(Shinten) && gauge.Kenki >= 25)
-                                return Shinten;
-
-                            if (LevelChecked(Shoha) && gauge.MeditationStacks is 3)
-                                return Shoha;
-                        }
-
-                        if (HasEffect(Buffs.MeikyoShisui))
-                        {
-                            if (!gauge.Sen.HasFlag(Sen.SETSU) && Yukikaze.LevelChecked())
-                                return Yukikaze;
-
-                            if (!gauge.Sen.HasFlag(Sen.GETSU) && Gekko.LevelChecked())
-                                return Gekko;
-
-                            if (!gauge.Sen.HasFlag(Sen.KA) && Kasha.LevelChecked())
-                                return Kasha;
-                        }
-
-                        if (ActionReady(TsubameGaeshi) && gauge.Kaeshi is Kaeshi.SETSUGEKKA)
-                            return OriginalHook(TsubameGaeshi);
-
-                        if (LevelChecked(MidareSetsugekka) && OriginalHook(Iaijutsu) is MidareSetsugekka)
-                            return OriginalHook(Iaijutsu);
-
-                        if (comboTime > 1f)
-                        {
-                            if (lastComboMove is Hakaze && LevelChecked(Yukikaze))
-                                return Yukikaze;
-
-                            if (lastComboMove is Fuko or Fuga && !gauge.Sen.HasFlag(Sen.GETSU) && LevelChecked(Mangetsu))
-                                return Mangetsu;
-                        }
-
-                        if (!gauge.Sen.HasFlag(Sen.SETSU))
-                            return Hakaze;
-                    }
 
                     if (comboTime > 0 && LevelChecked(Oka))
                     {
-                        if (lastComboMove is Fuko || lastComboMove is Fuga)
+                        if (lastComboMove == OriginalHook(Fuko))
                             return Oka;
+                    }
+                    return OriginalHook(Fuko);
+                }
+                return actionID;
+            }
+        }
+
+        internal class SAM_AoE_MangetsuCombo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SAM_AoE_MangetsuCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                SAMGauge? gauge = GetJobGauge<SAMGauge>();
+
+                if (actionID is Mangetsu)
+                {
+                    if (Config.SAM_Mangetsu_KenkiOvercap && gauge.Kenki >= Config.SAM_Mangetsu_KenkiOvercapAmount && LevelChecked(Kyuten) && CanWeave(actionID))
+                        return Kyuten;
+
+                    if (HasEffect(Buffs.MeikyoShisui))
+                        return Mangetsu;
+
+                    if (comboTime > 0 && LevelChecked(Mangetsu))
+                    {
+                        if (lastComboMove == OriginalHook(Fuko))
+                            return Mangetsu;
                     }
                     return OriginalHook(Fuko);
                 }

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -97,13 +97,21 @@ namespace XIVSlothCombo.Combos.PvE
                 SAM_STBloodbathThreshold = new("SAM_STBloodbathThreshold", 40),
                 SAM_AoESecondWindThreshold = new("SAM_AoESecondWindThreshold", 25),
                 SAM_AoEBloodbathThreshold = new("SAM_AoEBloodbathThreshold", 40),
+                SAM_Kasha_KenkiOvercapAmount = new(nameof(SAM_Kasha_KenkiOvercapAmount), 50),
+                SAM_Yukaze_KenkiOvercapAmount = new(nameof(SAM_Yukaze_KenkiOvercapAmount), 50),
+                SAM_Gekko_KenkiOvercapAmount = new(nameof(SAM_Gekko_KenkiOvercapAmount), 50),
+                SAM_ST_KenkiOvercapAmount = new(nameof(SAM_ST_KenkiOvercapAmount), 50),
+                SAM_AoE_KenkiOvercapAmount = new(nameof(SAM_AoE_KenkiOvercapAmount), 50),
                 SAM_VariantCure = new("SAM_VariantCure");
 
             public static UserFloat
                 SAM_ST_Higanbana_Threshold = new("SAM_ST_Higanbana_Threshold", 1),
-                SAM_ST_KenkiOvercapAmount = new("SamKenkiOvercapAmount", 50),
-                SAM_AoE_KenkiOvercapAmount = new("SamAOEKenkiOvercapAmount", 50),
                  SAM_ST_ExecuteThreshold = new("SAM_ST_ExecuteThreshold", 1);
+
+            public static UserBool
+                SAM_Kasha_KenkiOvercap = new(nameof(SAM_Kasha_KenkiOvercap)),
+                SAM_Yukaze_KenkiOvercap = new(nameof(SAM_Yukaze_KenkiOvercap)),
+                SAM_Gekko_KenkiOvercap = new(nameof(SAM_Gekko_KenkiOvercap));
         }
         internal class SAM_ST_YukikazeCombo : CustomCombo
         {
@@ -112,25 +120,21 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
                 SAMGauge? gauge = GetJobGauge<SAMGauge>();
-                float SamKenkiOvercapAmount = Config.SAM_ST_KenkiOvercapAmount;
 
                 if (actionID is Yukikaze)
                 {
-                    if (CanWeave(actionID))
-                    {
-                        if (gauge.Kenki >= SamKenkiOvercapAmount && LevelChecked(Shinten))
-                            return Shinten;
-                    }
+                    if (Config.SAM_Yukaze_KenkiOvercap && CanWeave(actionID) && gauge.Kenki >= Config.SAM_Yukaze_KenkiOvercapAmount && LevelChecked(Shinten))
+                        return OriginalHook(Shinten);
 
                     if (HasEffect(Buffs.MeikyoShisui) && LevelChecked(Yukikaze))
-                        return Yukikaze;
+                        return OriginalHook(Yukikaze);
 
                     if (comboTime > 0)
                     {
-                        if (lastComboMove is Hakaze && LevelChecked(Yukikaze))
-                            return Yukikaze;
+                        if (lastComboMove == OriginalHook(Hakaze) && LevelChecked(Yukikaze))
+                            return OriginalHook(Yukikaze);
                     }
-                    return Hakaze;
+                    return OriginalHook(Hakaze);
                 }
                 return actionID;
             }
@@ -143,27 +147,54 @@ namespace XIVSlothCombo.Combos.PvE
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte levels)
             {
                 SAMGauge? gauge = GetJobGauge<SAMGauge>();
-                float SamKenkiOvercapAmount = Config.SAM_ST_KenkiOvercapAmount;
 
                 if (actionID is Kasha)
                 {
-                    if (CanWeave(actionID))
-                    {
-                        if (gauge.Kenki >= SamKenkiOvercapAmount && LevelChecked(Shinten))
-                            return Shinten;
-                    }
+                    if (Config.SAM_Kasha_KenkiOvercap && CanWeave(actionID) && gauge.Kenki >= Config.SAM_Kasha_KenkiOvercapAmount && LevelChecked(Shinten))
+                        return OriginalHook(Shinten);
+
                     if (HasEffect(Buffs.MeikyoShisui))
-                        return Kasha;
+                        return OriginalHook(Kasha);
 
                     if (comboTime > 0)
                     {
-                        if (lastComboMove is Hakaze && LevelChecked(Shifu))
-                            return Shifu;
+                        if (lastComboMove == OriginalHook(Hakaze) && LevelChecked(Shifu))
+                            return OriginalHook(Shifu);
 
                         if (lastComboMove is Shifu && LevelChecked(Kasha))
-                            return Kasha;
+                            return OriginalHook(Kasha);
                     }
-                    return Hakaze;
+                    return OriginalHook(Hakaze);
+                }
+                return actionID;
+            }
+        }
+
+        internal class SAM_ST_GeckoCombo : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SAM_ST_GekkoCombo;
+
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte levels)
+            {
+                SAMGauge? gauge = GetJobGauge<SAMGauge>();
+
+                if (actionID is Gekko)
+                {
+                    if (Config.SAM_Gekko_KenkiOvercap && CanWeave(actionID) && gauge.Kenki >= Config.SAM_Gekko_KenkiOvercapAmount && LevelChecked(Shinten))
+                        return OriginalHook(Shinten);
+
+                    if (HasEffect(Buffs.MeikyoShisui))
+                        return OriginalHook(Gekko);
+
+                    if (comboTime > 0)
+                    {
+                        if (lastComboMove == OriginalHook(Hakaze) && LevelChecked(Jinpu))
+                            return OriginalHook(Jinpu);
+
+                        if (lastComboMove is Jinpu && LevelChecked(Gekko))
+                            return OriginalHook(Gekko);
+                    }
+                    return OriginalHook(Hakaze);
                 }
                 return actionID;
             }
@@ -184,7 +215,7 @@ namespace XIVSlothCombo.Combos.PvE
                 bool trueNorthReady = TargetNeedsPositionals() && ActionReady(All.TrueNorth) && !HasEffect(All.Buffs.TrueNorth) && CanDelayedWeave(actionID);
                 float meikyostacks = GetBuffStacks(Buffs.MeikyoShisui);
 
-                if (actionID is Gekko)
+                if (actionID is Hakaze or Gyofu)
                 {
                     if (IsEnabled(CustomComboPreset.SAM_Variant_Cure) &&
                         IsEnabled(Variant.VariantCure) &&
@@ -371,12 +402,12 @@ namespace XIVSlothCombo.Combos.PvE
                 bool threeSeal = OriginalHook(Iaijutsu) is MidareSetsugekka or TendoSetsugekka;
                 float enemyHP = GetTargetHPPercent();
                 bool trueNorthReady = TargetNeedsPositionals() && ActionReady(All.TrueNorth) && !HasEffect(All.Buffs.TrueNorth) && CanDelayedWeave(actionID);
-                float kenkiOvercap = Config.SAM_ST_KenkiOvercapAmount;
+                int kenkiOvercap = Config.SAM_ST_KenkiOvercapAmount;
                 float shintenTreshhold = Config.SAM_ST_ExecuteThreshold;
                 float HiganbanaThreshold = Config.SAM_ST_Higanbana_Threshold;
                 float meikyostacks = GetBuffStacks(Buffs.MeikyoShisui);
 
-                if (actionID is Gekko)
+                if (actionID is Hakaze or Gyofu)
                 {
                     if (IsEnabled(CustomComboPreset.SAM_Variant_Cure) &&
                         IsEnabled(Variant.VariantCure) &&

--- a/XIVSlothCombo/Combos/PvE/SAM.cs
+++ b/XIVSlothCombo/Combos/PvE/SAM.cs
@@ -221,7 +221,7 @@ namespace XIVSlothCombo.Combos.PvE
                 float enemyHP = GetTargetHPPercent();
                 bool trueNorthReady = TargetNeedsPositionals() && ActionReady(All.TrueNorth) && !HasEffect(All.Buffs.TrueNorth) && CanDelayedWeave(actionID);
                 float meikyostacks = GetBuffStacks(Buffs.MeikyoShisui);
-
+                
                 if (actionID is Hakaze or Gyofu)
                 {
                     if (IsEnabled(CustomComboPreset.SAM_Variant_Cure) &&
@@ -247,7 +247,11 @@ namespace XIVSlothCombo.Combos.PvE
                     if (CanWeave(actionID))
                     {
                         //Meikyo Features
-                        if (ActionReady(MeikyoShisui) && WasLastWeaponskill(MidareSetsugekka))
+                        if (!HasEffect(Buffs.MeikyoShisui) &&
+                           ActionReady(MeikyoShisui) &&
+                           GetCooldownRemainingTime(MeikyoShisui) <= 10 &&
+                           SAMHelper.SenCount < 3 &&
+                           !SAMHelper.ComboStarted)
                             return MeikyoShisui;
 
                         //Ikishoten Features
@@ -304,8 +308,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(TsubameGaeshi);
 
                             if (!IsMoving &&
-                                ((oneSeal && GetDebuffRemainingTime(Debuffs.Higanbana) <= 10 && enemyHP > 1 && !LevelChecked(Traits.EnhancedMeikyoShishui2)) ||
-                                (oneSeal && enemyHP > 1 && LevelChecked(Traits.EnhancedMeikyoShishui2) && !HasEffect(Buffs.Tendo) && WasLastWeaponskill(Gekko)) ||
+                                ((oneSeal && GetDebuffRemainingTime(Debuffs.Higanbana) <= 10) ||
                                 (twoSeal && !LevelChecked(MidareSetsugekka)) ||
                                 (threeSeal && LevelChecked(MidareSetsugekka)) ||
                                 (threeSeal && LevelChecked(TendoSetsugekka) && !HasEffect(Buffs.TsubameReady))))
@@ -407,17 +410,12 @@ namespace XIVSlothCombo.Combos.PvE
                 bool oneSeal = OriginalHook(Iaijutsu) is Higanbana;
                 bool twoSeal = OriginalHook(Iaijutsu) is TenkaGoken or TendoGoken;
                 bool threeSeal = OriginalHook(Iaijutsu) is MidareSetsugekka or TendoSetsugekka;
-                int senCount = 0;
-                if (gauge.HasKa) senCount++;
-                if (gauge.HasGetsu) senCount++;
-                if (gauge.HasSetsu) senCount++;
                 float enemyHP = GetTargetHPPercent();
                 bool trueNorthReady = TargetNeedsPositionals() && ActionReady(All.TrueNorth) && !HasEffect(All.Buffs.TrueNorth) && CanDelayedWeave(actionID);
                 int kenkiOvercap = Config.SAM_ST_KenkiOvercapAmount;
                 float shintenTreshhold = Config.SAM_ST_ExecuteThreshold;
                 float HiganbanaThreshold = Config.SAM_ST_Higanbana_Threshold;
                 float meikyostacks = GetBuffStacks(Buffs.MeikyoShisui);
-                bool startedCombo = lastComboMove == OriginalHook(Hakaze) || lastComboMove == OriginalHook(Jinpu) || lastComboMove == OriginalHook(Shifu);
 
                 if (actionID is Hakaze or Gyofu)
                 {
@@ -455,8 +453,8 @@ namespace XIVSlothCombo.Combos.PvE
                                !HasEffect(Buffs.MeikyoShisui) &&
                                ActionReady(MeikyoShisui) &&
                                GetCooldownRemainingTime(MeikyoShisui) <= 10 &&
-                               senCount < 3 &&
-                               !startedCombo)
+                               SAMHelper.SenCount < 3 &&
+                               !SAMHelper.ComboStarted)
                                 return MeikyoShisui;
 
                             //Ikishoten Features

--- a/XIVSlothCombo/Core/IconReplacer.cs
+++ b/XIVSlothCombo/Core/IconReplacer.cs
@@ -69,7 +69,7 @@ namespace XIVSlothCombo.Core
                     return OriginalHook(actionID);
 
                 uint lastComboMove = ActionManager.Instance()->Combo.Action;
-                float comboTime = ActionManager.Instance()->Combo.Timer;
+                float comboTime = ActionManager.Instance()->Combo.Action != 0 ? ActionManager.Instance()->Combo.Timer : 0;
                 byte level = Svc.ClientState.LocalPlayer?.Level ?? 0;
 
                 foreach (CustomCombo? combo in customCombos)

--- a/XIVSlothCombo/Data/ActionWatching.cs
+++ b/XIVSlothCombo/Data/ActionWatching.cs
@@ -89,7 +89,7 @@ namespace XIVSlothCombo.Data
         {
             try
             {
-                if (CustomComboFunctions.GetMaxCharges(actionId) > 0)
+                if (actionType == 1 && CustomComboFunctions.GetMaxCharges(actionId) > 0)
                     ChargeTimestamps[actionId] = Environment.TickCount64;
 
                 CheckForChangedTarget(actionId, ref targetObjectId);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -2210,21 +2210,35 @@ namespace XIVSlothCombo.Window.Functions
             {
                 UserConfig.DrawAdditionalBoolChoice(SAM.Config.SAM_Kasha_KenkiOvercap, "Kenki Overcap Protection", "Spends Kenki when at the set value or above.");
                 if (SAM.Config.SAM_Kasha_KenkiOvercap)
-                    UserConfig.DrawSliderInt(50, 100, SAM.Config.SAM_Kasha_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
+                    UserConfig.DrawSliderInt(25, 100, SAM.Config.SAM_Kasha_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
             }
 
             if (preset == CustomComboPreset.SAM_ST_YukikazeCombo)
             {
                 UserConfig.DrawAdditionalBoolChoice(SAM.Config.SAM_Yukaze_KenkiOvercap, "Kenki Overcap Protection", "Spends Kenki when at the set value or above.");
                 if (SAM.Config.SAM_Yukaze_KenkiOvercap)
-                    UserConfig.DrawSliderInt(50, 100, SAM.Config.SAM_Yukaze_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
+                    UserConfig.DrawSliderInt(25, 100, SAM.Config.SAM_Yukaze_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
             }
 
             if (preset == CustomComboPreset.SAM_ST_GekkoCombo)
             {
                 UserConfig.DrawAdditionalBoolChoice(SAM.Config.SAM_Gekko_KenkiOvercap, "Kenki Overcap Protection", "Spends Kenki when at the set value or above.");
                 if (SAM.Config.SAM_Gekko_KenkiOvercap)
-                    UserConfig.DrawSliderInt(50, 100, SAM.Config.SAM_Gekko_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
+                    UserConfig.DrawSliderInt(25, 100, SAM.Config.SAM_Gekko_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
+            }
+
+            if (preset == CustomComboPreset.SAM_AoE_OkaCombo)
+            {
+                UserConfig.DrawAdditionalBoolChoice(SAM.Config.SAM_Oka_KenkiOvercap, "Kenki Overcap Protection", "Spends Kenki when at the set value or above.");
+                if (SAM.Config.SAM_Oka_KenkiOvercap)
+                    UserConfig.DrawSliderInt(25, 100, SAM.Config.SAM_Oka_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
+            }
+
+            if (preset == CustomComboPreset.SAM_AoE_MangetsuCombo)
+            {
+                UserConfig.DrawAdditionalBoolChoice(SAM.Config.SAM_Mangetsu_KenkiOvercap, "Kenki Overcap Protection", "Spends Kenki when at the set value or above.");
+                if (SAM.Config.SAM_Mangetsu_KenkiOvercap)
+                    UserConfig.DrawSliderInt(25, 100, SAM.Config.SAM_Mangetsu_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
             }
 
             #endregion

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -2206,6 +2206,27 @@ namespace XIVSlothCombo.Window.Functions
             if (preset == CustomComboPreset.SAMPvP_KashaFeatures_GapCloser && enabled)
                 UserConfig.DrawSliderInt(0, 100, SAMPvP.Config.SAMPvP_SotenHP, "Use Soten on enemies below selected HP.");
 
+            if (preset == CustomComboPreset.SAM_ST_KashaCombo)
+            {
+                UserConfig.DrawAdditionalBoolChoice(SAM.Config.SAM_Kasha_KenkiOvercap, "Kenki Overcap Protection", "Spends Kenki when at the set value or above.");
+                if (SAM.Config.SAM_Kasha_KenkiOvercap)
+                    UserConfig.DrawSliderInt(50, 100, SAM.Config.SAM_Kasha_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
+            }
+
+            if (preset == CustomComboPreset.SAM_ST_YukikazeCombo)
+            {
+                UserConfig.DrawAdditionalBoolChoice(SAM.Config.SAM_Yukaze_KenkiOvercap, "Kenki Overcap Protection", "Spends Kenki when at the set value or above.");
+                if (SAM.Config.SAM_Yukaze_KenkiOvercap)
+                    UserConfig.DrawSliderInt(50, 100, SAM.Config.SAM_Yukaze_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
+            }
+
+            if (preset == CustomComboPreset.SAM_ST_GekkoCombo)
+            {
+                UserConfig.DrawAdditionalBoolChoice(SAM.Config.SAM_Gekko_KenkiOvercap, "Kenki Overcap Protection", "Spends Kenki when at the set value or above.");
+                if (SAM.Config.SAM_Gekko_KenkiOvercap)
+                    UserConfig.DrawSliderInt(50, 100, SAM.Config.SAM_Gekko_KenkiOvercapAmount, "Kenki Amount", sliderIncrement: SliderIncrements.Fives);
+            }
+
             #endregion
             // ====================================================================================
             #region SCHOLAR


### PR DESCRIPTION
- [x] All 3 single target combo chains have their own features (was previously just Yukaze & Kasha, now includes Gekko).
- [x] Both AoE combo chains have their own features (was previously just Oka, now includes Mangetsu).
- [x] Kenki overcap options now separated per feature and is now optional for the standalone combo chains.
- [x] Move `Simple/Advanced Single Target` action being overriden from Gekko to Hakaze/Gyofu to remove the need for conflicting combo tag.
- [x] Removed conflicting combos throughout the job.
- [ ] Update names/descriptions to be more in line with established formatting.
- [ ] #1706.
- [X] Closes #1704 
- [X] Higabana now simplified to be applied more consistently for both `Simple & Advanced Single Target`.
- [X] Meikyo Shisui logic adjusted to not start mid-combo and used only before fully capping charges.
- [X] Senei & Ogi Namikiri will now fire off more consistently.