### PR TITLE
[SGE] Hold Phlegma stack option

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -110,7 +110,8 @@ namespace XIVSlothCombo.Combos.PvE
             #region DPS
             public static UserBool
                 SGE_ST_DPS_Adv = new("SGE_ST_DPS_Adv"),
-                SGE_ST_DPS_EDosis_Adv = new("SGE_ST_Dosis_EDosis_Adv");
+                SGE_ST_DPS_EDosis_Adv = new("SGE_ST_Dosis_EDosis_Adv"),
+                SGE_ST_DPS_Phlegma_Adv = new("SGE_ST_DPS_Phlegma_Adv");
             public static UserBoolArray
                 SGE_ST_DPS_Movement = new("SGE_ST_DPS_Movement");
             public static UserInt
@@ -122,7 +123,8 @@ namespace XIVSlothCombo.Combos.PvE
                 SGE_AoE_DPS_Rhizo = new("SGE_AoE_DPS_Rhizo"),
                 SGE_AoE_DPS_AddersgallProtect = new("SGE_AoE_DPS_AddersgallProtect", 3);
             public static UserFloat
-                SGE_ST_DPS_EDosisThreshold = new("SGE_ST_Dosis_EDosisThreshold", 3.0f);
+                SGE_ST_DPS_EDosisThreshold = new("SGE_ST_Dosis_EDosisThreshold", 3.0f),
+                SGE_ST_DPS_PhlegmaThreshold = new("SGE_ST_DPS_PhlegmaThreshold", 5.0f);
             #endregion
 
             #region Healing
@@ -416,7 +418,18 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Phlegma) && InCombat())
                         {
                             uint phlegma = OriginalHook(Phlegma);
-                            if (InActionRange(phlegma) && ActionReady(phlegma)) return phlegma;
+
+                            if (InActionRange(Phlegma) && ActionReady(Phlegma))
+                            {
+                                if (!Config.SGE_ST_DPS_Phlegma_Adv || GetRemainingCharges(Phlegma) == GetMaxCharges(Phlegma)) 
+                                    return phlegma;
+                                
+                                if (GetRemainingCharges(Phlegma) == 1 && 
+                                    GetCooldownChargeRemainingTime(Phlegma) <= Config.SGE_ST_DPS_PhlegmaThreshold)
+                                {
+                                    return phlegma;
+                                }
+                            }
                         }
 
                         // Psyche

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -2038,6 +2038,17 @@ namespace XIVSlothCombo.Window.Functions
                     ImGui.Unindent();
                 }
             }
+            
+            if (preset is CustomComboPreset.SGE_ST_DPS_Phlegma)
+            {
+                UserConfig.DrawAdditionalBoolChoice(SGE.Config.SGE_ST_DPS_Phlegma_Adv, "Hold Phlegma charges", "", isConditionalChoice: true);
+                if (SGE.Config.SGE_ST_DPS_Phlegma_Adv)
+                {
+                    ImGui.Indent();
+                    UserConfig.DrawRoundedSliderFloat(0, 40, SGE.Config.SGE_ST_DPS_PhlegmaThreshold, "Seconds of cooldown remaining before using Phlegma to avoid overcapping.", digits: 1);
+                    ImGui.Unindent();
+                }
+            }
 
             if (preset is CustomComboPreset.SGE_ST_DPS_Lucid)
                 UserConfig.DrawSliderInt(4000, 9500, SGE.Config.SGE_ST_DPS_Lucid, "MP Threshold", 150, SliderIncrements.Hundreds);


### PR DESCRIPTION
Option to hold Phlegma and not use it on cooldown - does not affect opener option and has overcapping protection.

![grafik](https://github.com/user-attachments/assets/a27bed42-dc4e-48fd-9155-40ccc51d0ba1)
