### PR TITLE
[PCT] Lvl 100 Opener, Advanced ST, Advanced AoE 

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2366,6 +2366,10 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Balance Opener Option", $"Uses the Balance Opener depending on your current level. \n Supports lvl 70, 80, 90, 92, 100. \n - Requirements: \n - Starry Muse off cooldown \n - Pom. Weapon, Landscape Motif", PCT.JobID)]
         PCT_ST_Advanced_Openers = 20006,
 
+        [ParentCombo(PCT_ST_Advanced_Openers)]
+        [CustomComboInfo("Early Balance Opener Option", $"Uses Early Starry Muse Balance Opener depending on your current level.", PCT.JobID)]
+        PCT_ST_Advanced_Openers_EarlyOpener = 20034,
+
         [ParentCombo(PCT_ST_AdvancedMode)]
         [ReplaceSkill(PCT.FireInRed, PCT.AeroInGreen, PCT.WaterinBlue)]
         [CustomComboInfo("Prepull Motifs", "Adds missing Motifs to the combo while out of combat or while no target is present in combat.", PCT.JobID)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2363,7 +2363,7 @@ namespace XIVSlothCombo.Combos
         PCT_ST_AdvancedMode = 20005,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
-        [CustomComboInfo("Lvl 100 Opener Option", $"Uses the Balance Opener.", PCT.JobID)]
+        [CustomComboInfo("Balance Opener Option", $"Uses the Balance Opener depending on your current level. \n Supports lvl 70, 80, 90, 92, 100. \n - Requirements: \n - Starry Muse off cooldown \n - Pom. Weapon, Landscape Motif", PCT.JobID)]
         PCT_ST_Advanced_Openers = 20006,
 
         [ParentCombo(PCT_ST_AdvancedMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2332,29 +2332,263 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         #region PICTOMANCER
+
+        #region Single Target
         [ReplaceSkill(PCT.FireInRed)]
         [ConflictingCombos(CombinedAetherhues)]
-        [CustomComboInfo("Simple Mode - Single Target", $"Replaces Fire in Red with a one-button full single target rotation.\nThis is ideal for newcomers to the job.", PCT.JobID)]
+        [CustomComboInfo("Simple Mode - Single Target", "Consolidates the single target rotation into one button, ideal for newcomers.", PCT.JobID)]
         PCT_ST_SimpleMode = 20000,
 
         [ReplaceSkill(PCT.FireIIinRed)]
         [ConflictingCombos(CombinedAetherhues)]
-        [CustomComboInfo("Simple Mode - AoE", $"Replaces Fire II in Red with a one-button full single target rotation.\nThis is ideal for newcomers to the job.", PCT.JobID)]
+        [CustomComboInfo("Simple Mode - AoE", "Consolidates the AoE rotation into one button, ideal for newcomers.", PCT.JobID)]
         PCT_AoE_SimpleMode = 20001,
 
         [ReplaceSkill(PCT.FireInRed, PCT.FireIIinRed)]
         [ConflictingCombos(PCT_ST_SimpleMode, PCT_AoE_SimpleMode)]
-        [CustomComboInfo("Combined Aetherhues Feature", "Combines aetherhue actions onto one button for their respective target types.", PCT.JobID)]
+        [CustomComboInfo("Combined Aetherhues Feature", "Merges aetherhue actions for specific target types into a single button.", PCT.JobID)]
         CombinedAetherhues = 20002,
 
         [ReplaceSkill(PCT.CreatureMotif, PCT.WeaponMotif, PCT.LandscapeMotif)]
-        [CustomComboInfo("One Button Motifs", "Combine Motifs and Muses into one button.", PCT.JobID)]
+        [CustomComboInfo("One Button Motifs", "Merges Motifs and Muses into a single button.", PCT.JobID)]
         CombinedMotifs = 20003,
 
         [ReplaceSkill(PCT.HolyInWhite)]
-        [CustomComboInfo("One Button Paint", "Combines paint consuming actions into one button.", PCT.JobID)]
+        [CustomComboInfo("One Button Paint", "Consolidates paint-consuming actions into one button.", PCT.JobID)]
         CombinedPaint = 20004,
 
+        [ReplaceSkill(PCT.FireInRed)]
+        [ConflictingCombos(CombinedAetherhues, PCT_ST_SimpleMode)]
+        [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fire in Red with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", PCT.JobID)]
+        PCT_ST_AdvancedMode = 20005,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Lvl 100 Opener Option", $"Uses the Balance Opener.", PCT.JobID)]
+        PCT_ST_Advanced_Openers = 20006,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [ReplaceSkill(PCT.FireInRed, PCT.AeroInGreen, PCT.WaterinBlue)]
+        [CustomComboInfo("Prepull Motifs", "Adds missing Motifs to the combo while out of combat or while no target is present in combat.", PCT.JobID)]
+        PCT_ST_AdvancedMode_PrePullMotifs = 20007,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Starry Muse Burst Feature", $"Adds selected spells below to the burst phase.", PCT.JobID)]
+        PCT_ST_AdvancedMode_Burst_Phase = 20008,
+
+        [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the burst phase.", PCT.JobID)]
+        PCT_ST_AdvancedMode_Burst_CometInBlack = 20009,
+
+        [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Star Prism Option", $"Adds Star Prism to the burst phase.", PCT.JobID)]
+        PCT_ST_AdvancedMode_Burst_StarPrism = 20010,
+
+        [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Rainbow Drip Option", $"Adds Rainbow Drip to the burst phase.", PCT.JobID)]
+        PCT_ST_AdvancedMode_Burst_RainbowDrip = 20011,
+
+        [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp Combo to the burst phase.", PCT.JobID)]
+        PCT_ST_AdvancedMode_Burst_HammerCombo = 20012,
+
+        [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Blizzard in Cyan Option", $"Adds Blizzard in Cyan to the burst phase.", PCT.JobID)]
+        PCT_ST_AdvancedMode_Burst_BlizzardInCyan = 20013,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Motif Selection Feature", $"Add Selected Motifs to the combo.", PCT.JobID)]
+        PCT_ST_AdvancedMode_MotifFeature = 20014,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MotifFeature)]
+        [CustomComboInfo("Landscape Motif Option", $"Adds Landscape Motif.", PCT.JobID)]
+        PCT_ST_AdvancedMode_LandscapeMotif = 20015,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MotifFeature)]
+        [CustomComboInfo("Creature Motif Option", $"Adds Landscape Motif.", PCT.JobID)]
+        PCT_ST_AdvancedMode_CreatureMotif = 20016,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MotifFeature)]
+        [CustomComboInfo("Weapon Motif Option", $"Adds Weapon Motif.", PCT.JobID)]
+        PCT_ST_AdvancedMode_WeaponMotif = 20017,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Muse Selection Feature", $"Adds Selected Muses to the combo.", PCT.JobID)]
+        PCT_ST_AdvancedMode_MuseFeature = 20018,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MuseFeature)]
+        [CustomComboInfo("Scenic Muse Option", $"Adds Scenic Muse.", PCT.JobID)]
+        PCT_ST_AdvancedMode_ScenicMuse = 20019,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MuseFeature)]
+        [CustomComboInfo("Living Muse Option", $"Adds Living Muse.", PCT.JobID)]
+        PCT_ST_AdvancedMode_LivingMuse = 20020,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MuseFeature)]
+        [CustomComboInfo("Steel Muse Option", $"Adds Steel Muse.", PCT.JobID)]
+        PCT_ST_AdvancedMode_SteelMuse = 20021,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Mog/Madeen Feature", $"Adds Mog/Madeen to the combo.", PCT.JobID)]
+        PCT_ST_AdvancedMode_MogOfTheAges = 20022,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Subtractive Palette Feature", $"Adds Subtractive Palette to the combo.", PCT.JobID)]
+        PCT_ST_AdvancedMode_SubtractivePalette = 20023,
+
+        //Pooling option to be added - 20024
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the combo.", PCT.JobID)]
+        PCT_ST_AdvancedMode_CometinBlack = 20025,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp combo.", PCT.JobID)]
+        PCT_ST_AdvancedMode_HammerStampCombo = 20026,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Movement Features", $"Adds selected features to the combo while moving.", PCT.JobID)]
+        PCT_ST_AdvancedMode_MovementFeature = 20027,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
+        [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp Combo to the combo while moving.", PCT.JobID)]
+        PCT_ST_AdvancedMode_MovementOption_HammerStampCombo = 20028,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
+        [CustomComboInfo("Holy in White Option", $"Adds Holy in White to the combo while moving.", PCT.JobID)]
+        PCT_ST_AdvancedMode_MovementOption_HolyInWhite = 20029,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
+        [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the combo while moving.", PCT.JobID)]
+        PCT_ST_AdvancedMode_MovementOption_CometinBlack = 20030,
+
+        [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
+        [CustomComboInfo("Swiftcast Option ", $"Adds Swiftcast to the combo while moving.", PCT.JobID)]
+        PCT_ST_AdvancedMode_SwitfcastOption = 20031,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Blizzard in Cyan Option", $"Adds Blizzard in Cyan to the combo.", PCT.JobID)]
+        PCT_ST_AdvancedMode_BlizzardInCyan = 20032,
+
+        [ParentCombo(PCT_ST_AdvancedMode)]
+        [CustomComboInfo("Lucid Dreaming Option", $"Adds Lucid Dreaming to the combo.", PCT.JobID)]
+        PCT_ST_AdvancedMode_LucidDreaming = 20033,
+
+        // Last value for ST = 20033 
+        #endregion
+
+        [ReplaceSkill(PCT.FireIIinRed)]
+        [ConflictingCombos(CombinedAetherhues, PCT_AoE_SimpleMode)]
+        [CustomComboInfo("Advanced Mode - AoE", $"Replaces Fire II in Red with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", PCT.JobID)]
+        PCT_AoE_AdvancedMode = 20040,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [ReplaceSkill(PCT.FireIIinRed)]
+        [CustomComboInfo("Prepull Motifs", "Adds missing Motifs to the combo while out of combat or while no target is present in combat.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_PrePullMotifs = 20041,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Starry Muse Burst Feature", $"Adds selected spells below to the burst phase.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_Burst_Phase = 20042,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the burst phase.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_Burst_CometInBlack = 20043,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Star Prism Option", $"Adds Star Prism to the burst phase.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_Burst_StarPrism = 20044,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Rainbow Drip Option", $"Adds Rainbow Drip to the burst phase.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_Burst_RainbowDrip = 20045,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp Combo to the burst phase.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_Burst_HammerCombo = 20046,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
+        [CustomComboInfo("Blizzard in Cyan Option", $"Adds Blizzard in Cyan to the burst phase.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_Burst_BlizzardInCyan = 20047,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Motif Selection Feature", $"Add Selected Motifs to the combo.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_MotifFeature = 20048,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MotifFeature)]
+        [CustomComboInfo("Landscape Motif Option", $"Adds Landscape Motif.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_LandscapeMotif = 20049,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MotifFeature)]
+        [CustomComboInfo("Creature Motif Option", $"Adds Landscape Motif.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_CreatureMotif = 20050,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MotifFeature)]
+        [CustomComboInfo("Weapon Motif Option", $"Adds Weapon Motif.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_WeaponMotif = 20051,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Muse Selection Feature", $"Adds Selected Muses to the combo.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_MuseFeature = 20052,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MuseFeature)]
+        [CustomComboInfo("Scenic Muse Option", $"Adds Scenic Muse.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_ScenicMuse = 20053,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MuseFeature)]
+        [CustomComboInfo("Living Muse Option", $"Adds Living Muse.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_LivingMuse = 20054,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MuseFeature)]
+        [CustomComboInfo("Steel Muse Option", $"Adds Steel Muse.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_SteelMuse = 20055,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Mog/Madeen Feature", $"Adds Mog/Madeen to the combo.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_MogOfTheAges = 20056,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Subtractive Palette Feature", $"Adds Subtractive Palette to the combo.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_SubtractivePalette = 20057,
+
+        // Pooling Option to be added - 20058
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Comet in Black Feature", $"Adds Comet in Black to the combo.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_CometinBlack = 20059,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Hammer Stamp Combo Feature", $"Adds Hammer Stamp combo.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_HammerStampCombo = 20060,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Movement Features", $"Adds selected features to the combo while moving.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_MovementFeature = 20061,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MovementFeature)]
+        [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp Combo to the combo while moving.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo = 20062,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MovementFeature)]
+        [CustomComboInfo("Holy in White Option", $"Adds Holy in White to the combo while moving.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_MovementOption_HolyInWhite = 20063,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MovementFeature)]
+        [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the combo while moving.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_MovementOption_CometinBlack = 20064,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_MovementFeature)]
+        [CustomComboInfo("Swiftcast Option ", $"Adds Swiftcast to the combo while moving.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_SwitfcastOption = 20065,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Blizzard in Cyan Option", $"Adds Blizzard in Cyan to the combo.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_BlizzardInCyan = 20066,
+
+        [ParentCombo(PCT_AoE_AdvancedMode)]
+        [CustomComboInfo("Lucid Dreaming Option", $"Adds Lucid Dreaming to the combo.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_LucidDreaming = 20067,
+
+        // Last value for AoE = 20067
         #endregion
 
         #region PALADIN

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2333,7 +2333,6 @@ namespace XIVSlothCombo.Combos
 
         #region PICTOMANCER
 
-        #region Single Target
         [ReplaceSkill(PCT.FireInRed)]
         [ConflictingCombos(CombinedAetherhues)]
         [CustomComboInfo("Simple Mode - Single Target", "Consolidates the single target rotation into one button, ideal for newcomers.", PCT.JobID)]
@@ -2357,6 +2356,8 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("One Button Paint", "Consolidates paint-consuming actions into one button.", PCT.JobID)]
         CombinedPaint = 20004,
 
+        #region ST
+
         [ReplaceSkill(PCT.FireInRed)]
         [ConflictingCombos(CombinedAetherhues, PCT_ST_SimpleMode)]
         [CustomComboInfo("Advanced Mode - Single Target", $"Replaces Fire in Red with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", PCT.JobID)]
@@ -2368,200 +2369,204 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(PCT_ST_Advanced_Openers)]
         [CustomComboInfo("Early Balance Opener Option", $"Uses Early Starry Muse Balance Opener depending on your current level.", PCT.JobID)]
-        PCT_ST_Advanced_Openers_EarlyOpener = 20034,
+        PCT_ST_Advanced_Openers_EarlyOpener = 20007,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
-        [ReplaceSkill(PCT.FireInRed, PCT.AeroInGreen, PCT.WaterinBlue)]
-        [CustomComboInfo("Prepull Motifs", "Adds missing Motifs to the combo while out of combat or while no target is present in combat.", PCT.JobID)]
-        PCT_ST_AdvancedMode_PrePullMotifs = 20007,
+        [CustomComboInfo("Prepull Motifs Feature", "Adds missing Motifs to the combo while out of combat.", PCT.JobID)]
+        PCT_ST_AdvancedMode_PrePullMotifs = 20008,
+
+        [ParentCombo(PCT_ST_AdvancedMode_PrePullMotifs)]
+        [CustomComboInfo("Downtime Motifs Option", "Adds missing Motifs to the combo while no target is present in combat.", PCT.JobID)]
+        PCT_ST_AdvancedMode_NoTargetMotifs = 20009,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Starry Muse Burst Feature", $"Adds selected spells below to the burst phase.", PCT.JobID)]
-        PCT_ST_AdvancedMode_Burst_Phase = 20008,
+        PCT_ST_AdvancedMode_Burst_Phase = 20010,
 
         [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the burst phase.", PCT.JobID)]
-        PCT_ST_AdvancedMode_Burst_CometInBlack = 20009,
+        PCT_ST_AdvancedMode_Burst_CometInBlack = 20011,
 
         [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Star Prism Option", $"Adds Star Prism to the burst phase.", PCT.JobID)]
-        PCT_ST_AdvancedMode_Burst_StarPrism = 20010,
+        PCT_ST_AdvancedMode_Burst_StarPrism = 20012,
 
         [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Rainbow Drip Option", $"Adds Rainbow Drip to the burst phase.", PCT.JobID)]
-        PCT_ST_AdvancedMode_Burst_RainbowDrip = 20011,
+        PCT_ST_AdvancedMode_Burst_RainbowDrip = 20013,
 
         [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp Combo to the burst phase.", PCT.JobID)]
-        PCT_ST_AdvancedMode_Burst_HammerCombo = 20012,
+        PCT_ST_AdvancedMode_Burst_HammerCombo = 20014,
 
         [ParentCombo(PCT_ST_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Blizzard in Cyan Option", $"Adds Blizzard in Cyan to the burst phase.", PCT.JobID)]
-        PCT_ST_AdvancedMode_Burst_BlizzardInCyan = 20013,
+        PCT_ST_AdvancedMode_Burst_BlizzardInCyan = 20015,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Motif Selection Feature", $"Add Selected Motifs to the combo.", PCT.JobID)]
-        PCT_ST_AdvancedMode_MotifFeature = 20014,
+        PCT_ST_AdvancedMode_MotifFeature = 20016,
 
         [ParentCombo(PCT_ST_AdvancedMode_MotifFeature)]
         [CustomComboInfo("Landscape Motif Option", $"Adds Landscape Motif.", PCT.JobID)]
-        PCT_ST_AdvancedMode_LandscapeMotif = 20015,
+        PCT_ST_AdvancedMode_LandscapeMotif = 20017,
 
         [ParentCombo(PCT_ST_AdvancedMode_MotifFeature)]
         [CustomComboInfo("Creature Motif Option", $"Adds Landscape Motif.", PCT.JobID)]
-        PCT_ST_AdvancedMode_CreatureMotif = 20016,
+        PCT_ST_AdvancedMode_CreatureMotif = 20018,
 
         [ParentCombo(PCT_ST_AdvancedMode_MotifFeature)]
         [CustomComboInfo("Weapon Motif Option", $"Adds Weapon Motif.", PCT.JobID)]
-        PCT_ST_AdvancedMode_WeaponMotif = 20017,
+        PCT_ST_AdvancedMode_WeaponMotif = 20019,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Muse Selection Feature", $"Adds Selected Muses to the combo.", PCT.JobID)]
-        PCT_ST_AdvancedMode_MuseFeature = 20018,
+        PCT_ST_AdvancedMode_MuseFeature = 20020,
 
         [ParentCombo(PCT_ST_AdvancedMode_MuseFeature)]
         [CustomComboInfo("Scenic Muse Option", $"Adds Scenic Muse.", PCT.JobID)]
-        PCT_ST_AdvancedMode_ScenicMuse = 20019,
+        PCT_ST_AdvancedMode_ScenicMuse = 20021,
 
         [ParentCombo(PCT_ST_AdvancedMode_MuseFeature)]
         [CustomComboInfo("Living Muse Option", $"Adds Living Muse.", PCT.JobID)]
-        PCT_ST_AdvancedMode_LivingMuse = 20020,
+        PCT_ST_AdvancedMode_LivingMuse = 20022,
 
         [ParentCombo(PCT_ST_AdvancedMode_MuseFeature)]
         [CustomComboInfo("Steel Muse Option", $"Adds Steel Muse.", PCT.JobID)]
-        PCT_ST_AdvancedMode_SteelMuse = 20021,
+        PCT_ST_AdvancedMode_SteelMuse = 20023,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Mog/Madeen Feature", $"Adds Mog/Madeen to the combo.", PCT.JobID)]
-        PCT_ST_AdvancedMode_MogOfTheAges = 20022,
+        PCT_ST_AdvancedMode_MogOfTheAges = 20024,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Subtractive Palette Feature", $"Adds Subtractive Palette to the combo.", PCT.JobID)]
-        PCT_ST_AdvancedMode_SubtractivePalette = 20023,
-
-        //Pooling option to be added - 20024
+        PCT_ST_AdvancedMode_SubtractivePalette = 20025,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the combo.", PCT.JobID)]
-        PCT_ST_AdvancedMode_CometinBlack = 20025,
+        PCT_ST_AdvancedMode_CometinBlack = 20026,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp combo.", PCT.JobID)]
-        PCT_ST_AdvancedMode_HammerStampCombo = 20026,
+        PCT_ST_AdvancedMode_HammerStampCombo = 20027,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Movement Features", $"Adds selected features to the combo while moving.", PCT.JobID)]
-        PCT_ST_AdvancedMode_MovementFeature = 20027,
+        PCT_ST_AdvancedMode_MovementFeature = 20028,
 
         [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
         [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp Combo to the combo while moving.", PCT.JobID)]
-        PCT_ST_AdvancedMode_MovementOption_HammerStampCombo = 20028,
+        PCT_ST_AdvancedMode_MovementOption_HammerStampCombo = 20029,
 
         [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
         [CustomComboInfo("Holy in White Option", $"Adds Holy in White to the combo while moving.", PCT.JobID)]
-        PCT_ST_AdvancedMode_MovementOption_HolyInWhite = 20029,
+        PCT_ST_AdvancedMode_MovementOption_HolyInWhite = 20030,
 
         [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
         [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the combo while moving.", PCT.JobID)]
-        PCT_ST_AdvancedMode_MovementOption_CometinBlack = 20030,
+        PCT_ST_AdvancedMode_MovementOption_CometinBlack = 20031,
 
         [ParentCombo(PCT_ST_AdvancedMode_MovementFeature)]
         [CustomComboInfo("Swiftcast Option ", $"Adds Swiftcast to the combo while moving.", PCT.JobID)]
-        PCT_ST_AdvancedMode_SwitfcastOption = 20031,
+        PCT_ST_AdvancedMode_SwitfcastOption = 20032,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Blizzard in Cyan Option", $"Adds Blizzard in Cyan to the combo.", PCT.JobID)]
-        PCT_ST_AdvancedMode_BlizzardInCyan = 20032,
+        PCT_ST_AdvancedMode_BlizzardInCyan = 20033,
 
         [ParentCombo(PCT_ST_AdvancedMode)]
         [CustomComboInfo("Lucid Dreaming Option", $"Adds Lucid Dreaming to the combo.", PCT.JobID)]
-        PCT_ST_AdvancedMode_LucidDreaming = 20033,
+        PCT_ST_AdvancedMode_LucidDreaming = 20034,
 
-        // Last value for ST = 20033 
+        // Last value for ST = 20034 
         #endregion
+
+        #region AoE
 
         [ReplaceSkill(PCT.FireIIinRed)]
         [ConflictingCombos(CombinedAetherhues, PCT_AoE_SimpleMode)]
-        [CustomComboInfo("Advanced Mode - AoE", $"Replaces Fire II in Red with a one-button full single target rotation.\nThese features are ideal if you want to customize the rotation.", PCT.JobID)]
+        [CustomComboInfo("Advanced Mode - AoE", $"Replaces Fire II in Red with a one-button full AoE rotation.\nThese features are ideal if you want to customize the rotation.", PCT.JobID)]
         PCT_AoE_AdvancedMode = 20040,
 
         [ParentCombo(PCT_AoE_AdvancedMode)]
-        [ReplaceSkill(PCT.FireIIinRed)]
-        [CustomComboInfo("Prepull Motifs", "Adds missing Motifs to the combo while out of combat or while no target is present in combat.", PCT.JobID)]
+        [CustomComboInfo("Prepull Motifs Feature", "Adds missing Motifs to the combo while out of combat.", PCT.JobID)]
         PCT_AoE_AdvancedMode_PrePullMotifs = 20041,
+
+        [ParentCombo(PCT_AoE_AdvancedMode_PrePullMotifs)]
+        [CustomComboInfo("Downtime Motifs Option", "Adds missing Motifs to the combo while no target is present in combat.", PCT.JobID)]
+        PCT_AoE_AdvancedMode_NoTargetMotifs = 20042,
 
         [ParentCombo(PCT_AoE_AdvancedMode)]
         [CustomComboInfo("Starry Muse Burst Feature", $"Adds selected spells below to the burst phase.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_Burst_Phase = 20042,
+        PCT_AoE_AdvancedMode_Burst_Phase = 20043,
 
         [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the burst phase.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_Burst_CometInBlack = 20043,
+        PCT_AoE_AdvancedMode_Burst_CometInBlack = 20044,
 
         [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Star Prism Option", $"Adds Star Prism to the burst phase.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_Burst_StarPrism = 20044,
+        PCT_AoE_AdvancedMode_Burst_StarPrism = 20045,
 
         [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Rainbow Drip Option", $"Adds Rainbow Drip to the burst phase.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_Burst_RainbowDrip = 20045,
+        PCT_AoE_AdvancedMode_Burst_RainbowDrip = 20046,
 
         [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp Combo to the burst phase.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_Burst_HammerCombo = 20046,
+        PCT_AoE_AdvancedMode_Burst_HammerCombo = 20047,
 
         [ParentCombo(PCT_AoE_AdvancedMode_Burst_Phase)]
         [CustomComboInfo("Blizzard in Cyan Option", $"Adds Blizzard in Cyan to the burst phase.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_Burst_BlizzardInCyan = 20047,
+        PCT_AoE_AdvancedMode_Burst_BlizzardInCyan = 20048,
 
         [ParentCombo(PCT_AoE_AdvancedMode)]
         [CustomComboInfo("Motif Selection Feature", $"Add Selected Motifs to the combo.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_MotifFeature = 20048,
+        PCT_AoE_AdvancedMode_MotifFeature = 20049,
 
         [ParentCombo(PCT_AoE_AdvancedMode_MotifFeature)]
         [CustomComboInfo("Landscape Motif Option", $"Adds Landscape Motif.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_LandscapeMotif = 20049,
+        PCT_AoE_AdvancedMode_LandscapeMotif = 20050,
 
         [ParentCombo(PCT_AoE_AdvancedMode_MotifFeature)]
         [CustomComboInfo("Creature Motif Option", $"Adds Landscape Motif.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_CreatureMotif = 20050,
+        PCT_AoE_AdvancedMode_CreatureMotif = 20051,
 
         [ParentCombo(PCT_AoE_AdvancedMode_MotifFeature)]
         [CustomComboInfo("Weapon Motif Option", $"Adds Weapon Motif.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_WeaponMotif = 20051,
+        PCT_AoE_AdvancedMode_WeaponMotif = 20052,
 
         [ParentCombo(PCT_AoE_AdvancedMode)]
         [CustomComboInfo("Muse Selection Feature", $"Adds Selected Muses to the combo.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_MuseFeature = 20052,
+        PCT_AoE_AdvancedMode_MuseFeature = 20053,
 
         [ParentCombo(PCT_AoE_AdvancedMode_MuseFeature)]
         [CustomComboInfo("Scenic Muse Option", $"Adds Scenic Muse.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_ScenicMuse = 20053,
+        PCT_AoE_AdvancedMode_ScenicMuse = 20054,
 
         [ParentCombo(PCT_AoE_AdvancedMode_MuseFeature)]
         [CustomComboInfo("Living Muse Option", $"Adds Living Muse.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_LivingMuse = 20054,
+        PCT_AoE_AdvancedMode_LivingMuse = 20055,
 
         [ParentCombo(PCT_AoE_AdvancedMode_MuseFeature)]
         [CustomComboInfo("Steel Muse Option", $"Adds Steel Muse.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_SteelMuse = 20055,
+        PCT_AoE_AdvancedMode_SteelMuse = 20056,
 
         [ParentCombo(PCT_AoE_AdvancedMode)]
         [CustomComboInfo("Mog/Madeen Feature", $"Adds Mog/Madeen to the combo.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_MogOfTheAges = 20056,
+        PCT_AoE_AdvancedMode_MogOfTheAges = 20057,
 
         [ParentCombo(PCT_AoE_AdvancedMode)]
         [CustomComboInfo("Subtractive Palette Feature", $"Adds Subtractive Palette to the combo.", PCT.JobID)]
-        PCT_AoE_AdvancedMode_SubtractivePalette = 20057,
-
-        // Pooling Option to be added - 20058
+        PCT_AoE_AdvancedMode_SubtractivePalette = 20058,
 
         [ParentCombo(PCT_AoE_AdvancedMode)]
-        [CustomComboInfo("Comet in Black Feature", $"Adds Comet in Black to the combo.", PCT.JobID)]
+        [CustomComboInfo("Comet in Black Option", $"Adds Comet in Black to the combo.", PCT.JobID)]
         PCT_AoE_AdvancedMode_CometinBlack = 20059,
 
         [ParentCombo(PCT_AoE_AdvancedMode)]
-        [CustomComboInfo("Hammer Stamp Combo Feature", $"Adds Hammer Stamp combo.", PCT.JobID)]
+        [CustomComboInfo("Hammer Stamp Combo Option", $"Adds Hammer Stamp combo.", PCT.JobID)]
         PCT_AoE_AdvancedMode_HammerStampCombo = 20060,
 
         [ParentCombo(PCT_AoE_AdvancedMode)]
@@ -2593,6 +2598,8 @@ namespace XIVSlothCombo.Combos
         PCT_AoE_AdvancedMode_LucidDreaming = 20067,
 
         // Last value for AoE = 20067
+        #endregion
+
         #endregion
 
         #region PALADIN

--- a/XIVSlothCombo/Combos/JobHelpers/PCT.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/PCT.cs
@@ -1,0 +1,228 @@
+﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using ECommons.DalamudServices;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using XIVSlothCombo.Combos.JobHelpers.Enums;
+using XIVSlothCombo.Combos.PvE;
+using XIVSlothCombo.CustomComboNS.Functions;
+using XIVSlothCombo.Data;
+
+namespace XIVSlothCombo.Combos.JobHelpers
+{
+    internal class PCTOpenerLogic : PCT
+    {
+        private static bool HasCooldowns()
+        {
+            if (!CustomComboFunctions.ActionReady(StarryMuse))
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(LivingMuse) < 3)
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(SteelMuse) < 2)
+                return false;
+            return true;
+        }
+        private static bool HasMotifs()
+        {
+            var gauge = CustomComboFunctions.GetJobGauge<PCTGauge>();
+
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Pom))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            return true;
+        }
+
+        private static uint OpenerLevel => 100;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && HasMotifs() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns() && !HasMotifs())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull)
+            {
+                if (CustomComboFunctions.LocalPlayer.CastActionId == RainbowDrip && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = RainbowDrip;
+
+                if (CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                if(!HasMotifs())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+
+                if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = StrikingMuse;
+
+                if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = HolyInWhite;
+
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = PomMuse;
+
+                if (CustomComboFunctions.LocalPlayer.CastActionId == CustomComboFunctions.OriginalHook(CreatureMotif) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = CustomComboFunctions.OriginalHook(CreatureMotif);
+
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = StarryMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = SubtractivePalette;
+
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = BlizzardinCyan;
+
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = StoneinYellow;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = ThunderinMagenta;
+
+                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = CometinBlack;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = WingedMuse;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = MogoftheAges;
+
+                if (CustomComboFunctions.WasLastAction(StarPrism) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = StarPrism;
+
+                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == 15) OpenerStep++;
+                else if (OpenerStep == 15) actionID = HammerBrush;
+
+                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == 16) OpenerStep++;
+                else if (OpenerStep == 16) actionID = PolishingHammer;
+
+                if (CustomComboFunctions.WasLastAction(RainbowDrip) && OpenerStep == 17) OpenerStep++;
+                else if (OpenerStep == 17) actionID = RainbowDrip;
+
+                if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 18) OpenerStep++;
+                else if (OpenerStep == 18) actionID = HolyInWhite;
+
+                Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds > 4)
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    Svc.Log.Warning("Opener Failed due to timeout.");
+                    return false;
+                }
+
+                if (OpenerStep > 18) // Assuming 18 is the last step
+                {
+                    CurrentState = OpenerState.OpenerFinished;
+                    Svc.Log.Information("Opener completed successfully.");
+                    return false;
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+}
+

--- a/XIVSlothCombo/Combos/JobHelpers/PCT.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/PCT.cs
@@ -9,12 +9,16 @@ using XIVSlothCombo.Combos.JobHelpers.Enums;
 using XIVSlothCombo.Combos.PvE;
 using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Data;
+using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.JobHelpers
 {
+
     #region Lvl 100 Opener
     internal class PCTOpenerLogicLvl100 : PCT
     {
+
+
         private static bool HasCooldowns()
         {
             if (!CustomComboFunctions.ActionReady(StarryMuse))
@@ -36,6 +40,8 @@ namespace XIVSlothCombo.Combos.JobHelpers
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
                 return false;
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            if (CustomComboFunctions.HasEffect(Buffs.SubtractivePalette))
                 return false;
             return true;
         }
@@ -118,60 +124,95 @@ namespace XIVSlothCombo.Combos.JobHelpers
             if (!LevelChecked)
                 return false;
 
+            bool isEarlyOpenerEnabled = CustomComboFunctions.IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers_EarlyOpener);
+
             if (currentState == OpenerState.InOpener)
             {
-
                 if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
                 else if (OpenerStep == 1) actionID = StrikingMuse;
 
-                if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 2) OpenerStep++;
-                else if (OpenerStep == 2) actionID = HolyInWhite;
+                // If the early opener is not enabled, include HolyInWhite
+                if (!isEarlyOpenerEnabled)
+                {
+                    if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 2) OpenerStep++;
+                    else if (OpenerStep == 2) actionID = HolyInWhite;
+                }
 
-                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
-                else if (OpenerStep == 3) actionID = PomMuse;
+                // Adjust step numbers based on if HolyInWhite was skipped
+                int adjustedStep = isEarlyOpenerEnabled ? 2 : 3;
 
-                if (CustomComboFunctions.LocalPlayer.CastActionId == CustomComboFunctions.OriginalHook(CreatureMotif) && OpenerStep == 4) OpenerStep++;
-                else if (OpenerStep == 4) actionID = CustomComboFunctions.OriginalHook(CreatureMotif);
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = PomMuse;
 
-                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
-                else if (OpenerStep == 5) actionID = StarryMuse;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
-                else if (OpenerStep == 6) actionID = HammerStamp;
+                if (CustomComboFunctions.LocalPlayer.CastActionId == CustomComboFunctions.OriginalHook(CreatureMotif) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = CustomComboFunctions.OriginalHook(CreatureMotif);
 
-                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 7) OpenerStep++;
-                else if (OpenerStep == 7) actionID = SubtractivePalette;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 8) OpenerStep++;
-                else if (OpenerStep == 8) actionID = BlizzardinCyan;
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = StarryMuse;
 
-                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 9) OpenerStep++;
-                else if (OpenerStep == 9) actionID = StoneinYellow;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 10) OpenerStep++;
-                else if (OpenerStep == 10) actionID = ThunderinMagenta;
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerStamp;
 
-                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == 11) OpenerStep++;
-                else if (OpenerStep == 11) actionID = CometinBlack;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 12) OpenerStep++;
-                else if (OpenerStep == 12) actionID = WingedMuse;
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = SubtractivePalette;
 
-                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 13) OpenerStep++;
-                else if (OpenerStep == 13) actionID = MogoftheAges;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(StarPrism) && OpenerStep == 14) OpenerStep++;
-                else if (OpenerStep == 14) actionID = StarPrism;
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = BlizzardinCyan;
 
-                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == 15) OpenerStep++;
-                else if (OpenerStep == 15) actionID = HammerBrush;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == 16) OpenerStep++;
-                else if (OpenerStep == 16) actionID = PolishingHammer;
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = StoneinYellow;
 
-                if (CustomComboFunctions.WasLastAction(RainbowDrip) && OpenerStep == 17) OpenerStep++;
-                else if (OpenerStep == 17) actionID = RainbowDrip;
+                adjustedStep++;
 
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = ThunderinMagenta;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = CometinBlack;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = WingedMuse;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = MogoftheAges;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(StarPrism) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = StarPrism;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerBrush;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = PolishingHammer;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(RainbowDrip) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = RainbowDrip;
 
                 Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
 
@@ -182,7 +223,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     return false;
                 }
 
-                if (OpenerStep > 17) // Assuming 17 is the last step
+                if (OpenerStep > adjustedStep)
                 {
                     CurrentState = OpenerState.OpenerFinished;
                     Svc.Log.Information("Opener completed successfully.");
@@ -193,6 +234,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
             }
             return false;
         }
+
 
         private void ResetOpener()
         {
@@ -251,6 +293,8 @@ namespace XIVSlothCombo.Combos.JobHelpers
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
                 return false;
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            if (CustomComboFunctions.HasEffect(Buffs.SubtractivePalette))
                 return false;
             return true;
         }
@@ -335,56 +379,91 @@ namespace XIVSlothCombo.Combos.JobHelpers
 
             if (currentState == OpenerState.InOpener)
             {
+                bool isEarlyOpenerEnabled = CustomComboFunctions.IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers_EarlyOpener);
+
                 if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
                 else if (OpenerStep == 1) actionID = StrikingMuse;
 
-                if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 2) OpenerStep++;
-                else if (OpenerStep == 2) actionID = HolyInWhite;
+                if (!isEarlyOpenerEnabled)
+                {
+                    if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 2) OpenerStep++;
+                    else if (OpenerStep == 2) actionID = HolyInWhite;
+                }
 
-                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
-                else if (OpenerStep == 3) actionID = PomMuse;
+                int adjustedStep = isEarlyOpenerEnabled ? 2 : 3;
 
-                if (CustomComboFunctions.LocalPlayer.CastActionId == CustomComboFunctions.OriginalHook(CreatureMotif) && OpenerStep == 4) OpenerStep++;
-                else if (OpenerStep == 4) actionID = CustomComboFunctions.OriginalHook(CreatureMotif);
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = PomMuse;
 
-                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
-                else if (OpenerStep == 5) actionID = StarryMuse;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
-                else if (OpenerStep == 6) actionID = HammerStamp;
+                if (CustomComboFunctions.LocalPlayer.CastActionId == CustomComboFunctions.OriginalHook(CreatureMotif) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = CustomComboFunctions.OriginalHook(CreatureMotif);
 
-                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 7) OpenerStep++;
-                else if (OpenerStep == 7) actionID = SubtractivePalette;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 8) OpenerStep++;
-                else if (OpenerStep == 8) actionID = BlizzardinCyan;
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = StarryMuse;
 
-                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 9) OpenerStep++;
-                else if (OpenerStep == 9) actionID = StoneinYellow;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 10) OpenerStep++;
-                else if (OpenerStep == 10) actionID = ThunderinMagenta;
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerStamp;
 
-                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == 11) OpenerStep++;
-                else if (OpenerStep == 11) actionID = CometinBlack;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 12) OpenerStep++;
-                else if (OpenerStep == 12) actionID = WingedMuse;
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = SubtractivePalette;
 
-                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 13) OpenerStep++;
-                else if (OpenerStep == 13) actionID = MogoftheAges;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(FireInRed) && OpenerStep == 14) OpenerStep++;
-                else if (OpenerStep == 14) actionID = FireInRed;
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = BlizzardinCyan;
 
-                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == 15) OpenerStep++;
-                else if (OpenerStep == 15) actionID = HammerBrush;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == 16) OpenerStep++;
-                else if (OpenerStep == 16) actionID = PolishingHammer;
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = StoneinYellow;
 
-                if (CustomComboFunctions.WasLastAction(RainbowDrip) && OpenerStep == 17) OpenerStep++;
-                else if (OpenerStep == 17) actionID = RainbowDrip;
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = ThunderinMagenta;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = CometinBlack;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = WingedMuse;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = MogoftheAges;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(FireInRed) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = FireInRed;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerBrush;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = PolishingHammer;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(RainbowDrip) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = RainbowDrip;
 
                 Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
 
@@ -395,8 +474,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     return false;
                 }
 
-
-                if (OpenerStep > 17) // Assuming 15 is the last step
+                if (OpenerStep > adjustedStep)
                 {
                     CurrentState = OpenerState.OpenerFinished;
                     Svc.Log.Information("Opener completed successfully.");
@@ -407,6 +485,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
             }
             return false;
         }
+
 
         private void ResetOpener()
         {
@@ -465,6 +544,8 @@ namespace XIVSlothCombo.Combos.JobHelpers
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
                 return false;
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            if (CustomComboFunctions.HasEffect(Buffs.SubtractivePalette))
                 return false;
             return true;
         }
@@ -553,50 +634,104 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     return false;
                 }
 
+                bool isEarlyOpenerEnabled = CustomComboFunctions.IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers_EarlyOpener);
+
                 if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
                 else if (OpenerStep == 1) actionID = StrikingMuse;
 
-                if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
-                else if (OpenerStep == 2) actionID = AeroInGreen;
+                if (!isEarlyOpenerEnabled)
+                {
+                    if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
+                    else if (OpenerStep == 2) actionID = AeroInGreen;
+                }
 
-                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
-                else if (OpenerStep == 3) actionID = PomMuse;
+                int adjustedStep = isEarlyOpenerEnabled ? 2 : 3;
 
-                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
-                else if (OpenerStep == 4) actionID = WingMotif;
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = PomMuse;
 
-                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
-                else if (OpenerStep == 5) actionID = StarryMuse;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
-                else if (OpenerStep == 6) actionID = HammerStamp;
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = WingMotif;
 
-                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
-                else if (OpenerStep == 7) actionID = WingedMuse;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == 8) OpenerStep++;
-                else if (OpenerStep == 8) actionID = HammerBrush;
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = StarryMuse;
 
-                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
-                else if (OpenerStep == 9) actionID = MogoftheAges;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == 10) OpenerStep++;
-                else if (OpenerStep == 10) actionID = PolishingHammer;
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerStamp;
 
-                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
-                else if (OpenerStep == 11) actionID = SubtractivePalette;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 12) OpenerStep++;
-                else if (OpenerStep == 12) actionID = ThunderinMagenta;
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = WingedMuse;
 
-                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == 13) OpenerStep++;
-                else if (OpenerStep == 13) actionID = CometinBlack;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 14) OpenerStep++;
-                else if (OpenerStep == 14) actionID = BlizzardinCyan;
+                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerBrush;
 
-                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 15) CurrentState = OpenerState.OpenerFinished;
-                else if (OpenerStep == 15) actionID = StoneinYellow;
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = MogoftheAges;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = PolishingHammer;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = SubtractivePalette;
+
+                adjustedStep++;
+
+                if (!isEarlyOpenerEnabled)
+                {
+                    if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = ThunderinMagenta;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = CometinBlack;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = BlizzardinCyan;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == adjustedStep) CurrentState = OpenerState.OpenerFinished;
+                    else if (OpenerStep == adjustedStep) actionID = StoneinYellow;
+                }
+                else
+                {
+                    if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = StoneinYellow;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = ThunderinMagenta;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = CometinBlack;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == adjustedStep) CurrentState = OpenerState.OpenerFinished;
+                    else if (OpenerStep == adjustedStep) actionID = BlizzardinCyan;
+                }
 
                 Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
 
@@ -607,8 +742,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     return false;
                 }
 
-
-                if (OpenerStep > 15) // Assuming 15 is the last step
+                if (OpenerStep > adjustedStep)
                 {
                     CurrentState = OpenerState.OpenerFinished;
                     Svc.Log.Information("Opener completed successfully.");
@@ -619,6 +753,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
             }
             return false;
         }
+
 
         private void ResetOpener()
         {
@@ -677,6 +812,8 @@ namespace XIVSlothCombo.Combos.JobHelpers
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
                 return false;
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            if (CustomComboFunctions.HasEffect(Buffs.SubtractivePalette))
                 return false;
             return true;
         }
@@ -758,54 +895,119 @@ namespace XIVSlothCombo.Combos.JobHelpers
 
             if (currentState == OpenerState.InOpener && CustomComboFunctions.InCombat())
             {
-                if (!CustomComboFunctions.InCombat())
-                {
-                    CurrentState = OpenerState.FailedOpener;
-                    Svc.Log.Warning("Opener Failed due to not being in combat.");
-                    return false;
-                }
+                bool isEarlyOpenerEnabled = CustomComboFunctions.IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers_EarlyOpener);
 
                 if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
                 else if (OpenerStep == 1) actionID = StrikingMuse;
 
-                if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
-                else if (OpenerStep == 2) actionID = AeroInGreen;
+                if (!isEarlyOpenerEnabled)
+                {
+                    if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
+                    else if (OpenerStep == 2) actionID = AeroInGreen;
+                }
 
-                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
-                else if (OpenerStep == 3) actionID = PomMuse;
+                int adjustedStep = isEarlyOpenerEnabled ? 2 : 3;
 
-                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
-                else if (OpenerStep == 4) actionID = WingMotif;
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = PomMuse;
 
-                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
-                else if (OpenerStep == 5) actionID = StarryMuse;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
-                else if (OpenerStep == 6) actionID = HammerStamp;
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = WingMotif;
 
-                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
-                else if (OpenerStep == 7) actionID = WingedMuse;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 8) OpenerStep++;
-                else if (OpenerStep == 8) actionID = HammerStamp;
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = StarryMuse;
 
-                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
-                else if (OpenerStep == 9) actionID = MogoftheAges;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 10) OpenerStep++;
-                else if (OpenerStep == 10) actionID = HammerStamp;
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerStamp;
 
-                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
-                else if (OpenerStep == 11) actionID = SubtractivePalette;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 12) OpenerStep++;
-                else if (OpenerStep == 12) actionID = ThunderinMagenta;
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = WingedMuse;
 
-                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 13) OpenerStep++;
-                else if (OpenerStep == 13) actionID = BlizzardinCyan;
+                adjustedStep++;
+                if ((CustomComboFunctions.WasLastAction(HammerStamp) || CustomComboFunctions.WasLastAction(HammerBrush)) && OpenerStep == adjustedStep)
+                {
+                    OpenerStep++;
+                }
+                else if (OpenerStep == adjustedStep)
+                {
+                    if (HammerBrush.LevelChecked())
+                    {
+                        actionID = HammerBrush;
+                    }
+                    else
+                    {
+                        actionID = HammerStamp;
+                    }
+                }
 
-                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 14) CurrentState = OpenerState.OpenerFinished;
-                else if (OpenerStep == 14) actionID = StoneinYellow;
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = MogoftheAges;
+
+                adjustedStep++;
+                if ((CustomComboFunctions.WasLastAction(HammerStamp) || CustomComboFunctions.WasLastAction(PolishingHammer)) && OpenerStep == adjustedStep)
+                {
+                    OpenerStep++;
+                }
+                else if (OpenerStep == adjustedStep)
+                {
+                    if (PolishingHammer.LevelChecked())
+                    {
+                        actionID = PolishingHammer;
+                    }
+                    else
+                    {
+                        actionID = HammerStamp;
+                    }
+                }
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = SubtractivePalette;
+
+                adjustedStep++;
+
+                if (!isEarlyOpenerEnabled)
+                {
+                    if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = ThunderinMagenta;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = BlizzardinCyan;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == adjustedStep) CurrentState = OpenerState.OpenerFinished;
+                    else if (OpenerStep == adjustedStep) actionID = StoneinYellow;
+                }
+                else
+                {
+                    if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = StoneinYellow;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = ThunderinMagenta;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == adjustedStep) CurrentState = OpenerState.OpenerFinished;
+                    else if (OpenerStep == adjustedStep) actionID = BlizzardinCyan;
+                }
+
 
                 Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
 
@@ -816,7 +1018,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     return false;
                 }
 
-                if (OpenerStep > 14) // Assuming 15 is the last step
+                if (OpenerStep > (isEarlyOpenerEnabled ? 14 : 15))
                 {
                     CurrentState = OpenerState.OpenerFinished;
                     Svc.Log.Information("Opener completed successfully.");
@@ -827,6 +1029,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
             }
             return false;
         }
+
 
         private void ResetOpener()
         {
@@ -885,6 +1088,8 @@ namespace XIVSlothCombo.Combos.JobHelpers
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
                 return false;
             if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            if (CustomComboFunctions.HasEffect(Buffs.SubtractivePalette))
                 return false;
             return true;
         }
@@ -962,56 +1167,96 @@ namespace XIVSlothCombo.Combos.JobHelpers
             if (!LevelChecked)
                 return false;
 
-            if (currentState == OpenerState.InOpener && CustomComboFunctions.InCombat())
+            if (currentState == OpenerState.InOpener)
             {
-                if (!CustomComboFunctions.InCombat())
-                {
-                    CurrentState = OpenerState.FailedOpener;
-                    Svc.Log.Warning("Opener Failed due to not being in combat.");
-                    return false;
-                }
+                bool isEarlyOpenerEnabled = CustomComboFunctions.IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers_EarlyOpener);
 
                 if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
                 else if (OpenerStep == 1) actionID = StrikingMuse;
 
-                if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
-                else if (OpenerStep == 2) actionID = AeroInGreen;
+                if (!isEarlyOpenerEnabled)
+                {
+                    if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
+                    else if (OpenerStep == 2) actionID = AeroInGreen;
+                }
 
-                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
-                else if (OpenerStep == 3) actionID = PomMuse;
+                int adjustedStep = isEarlyOpenerEnabled ? 2 : 3;
 
-                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
-                else if (OpenerStep == 4) actionID = WingMotif;
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = PomMuse;
 
-                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
-                else if (OpenerStep == 5) actionID = StarryMuse;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
-                else if (OpenerStep == 6) actionID = HammerStamp;
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = WingMotif;
 
-                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
-                else if (OpenerStep == 7) actionID = WingedMuse;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 8) OpenerStep++;
-                else if (OpenerStep == 8) actionID = HammerStamp;
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = StarryMuse;
 
-                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
-                else if (OpenerStep == 9) actionID = MogoftheAges;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 10) OpenerStep++;
-                else if (OpenerStep == 10) actionID = HammerStamp;
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerStamp;
 
-                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
-                else if (OpenerStep == 11) actionID = SubtractivePalette;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 12) OpenerStep++;
-                else if (OpenerStep == 12) actionID = ThunderinMagenta;
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = WingedMuse;
 
-                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 13) OpenerStep++;
-                else if (OpenerStep == 13) actionID = BlizzardinCyan;
+                adjustedStep++;
 
-                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 14) CurrentState = OpenerState.OpenerFinished;
-                else if (OpenerStep == 14) actionID = StoneinYellow;
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerStamp;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = MogoftheAges;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = HammerStamp;
+
+                adjustedStep++;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == adjustedStep) OpenerStep++;
+                else if (OpenerStep == adjustedStep) actionID = SubtractivePalette;
+
+                adjustedStep++;
+
+                if (!isEarlyOpenerEnabled)
+                {
+                    if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = ThunderinMagenta;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = BlizzardinCyan;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == adjustedStep) CurrentState = OpenerState.OpenerFinished;
+                    else if (OpenerStep == adjustedStep) actionID = StoneinYellow;
+                }
+                else
+                {
+                    if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = StoneinYellow;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == adjustedStep) OpenerStep++;
+                    else if (OpenerStep == adjustedStep) actionID = ThunderinMagenta;
+
+                    adjustedStep++;
+
+                    if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == adjustedStep) CurrentState = OpenerState.OpenerFinished;
+                    else if (OpenerStep == adjustedStep) actionID = BlizzardinCyan;
+                }
 
                 Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
 
@@ -1022,7 +1267,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     return false;
                 }
 
-                if (OpenerStep > 14) // Assuming 14 is the last step
+                if (OpenerStep > 14) // Assuming 15 is the last step
                 {
                     CurrentState = OpenerState.OpenerFinished;
                     Svc.Log.Information("Opener completed successfully.");
@@ -1033,6 +1278,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
             }
             return false;
         }
+
 
         private void ResetOpener()
         {

--- a/XIVSlothCombo/Combos/JobHelpers/PCT.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/PCT.cs
@@ -171,8 +171,6 @@ namespace XIVSlothCombo.Combos.JobHelpers
                 if (CustomComboFunctions.WasLastAction(RainbowDrip) && OpenerStep == 17) OpenerStep++;
                 else if (OpenerStep == 17) actionID = RainbowDrip;
 
-                if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 18) OpenerStep++;
-                else if (OpenerStep == 18) actionID = HolyInWhite;
 
                 Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
 
@@ -183,7 +181,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
                     return false;
                 }
 
-                if (OpenerStep > 18) // Assuming 18 is the last step
+                if (OpenerStep > 17) // Assuming 17 is the last step
                 {
                     CurrentState = OpenerState.OpenerFinished;
                     Svc.Log.Information("Opener completed successfully.");

--- a/XIVSlothCombo/Combos/JobHelpers/PCT.cs
+++ b/XIVSlothCombo/Combos/JobHelpers/PCT.cs
@@ -12,7 +12,8 @@ using XIVSlothCombo.Data;
 
 namespace XIVSlothCombo.Combos.JobHelpers
 {
-    internal class PCTOpenerLogic : PCT
+    #region Lvl 100 Opener
+    internal class PCTOpenerLogicLvl100 : PCT
     {
         private static bool HasCooldowns()
         {
@@ -103,7 +104,7 @@ namespace XIVSlothCombo.Combos.JobHelpers
                 if (CustomComboFunctions.InCombat())
                     CurrentState = OpenerState.FailedOpener;
 
-                if(!HasMotifs())
+                if (!HasMotifs())
                     CurrentState = OpenerState.FailedOpener;
 
                 return true;
@@ -222,5 +223,845 @@ namespace XIVSlothCombo.Combos.JobHelpers
             return false;
         }
     }
-}
+    #endregion
 
+    #region Lvl 92 Opener 
+    internal class PCTOpenerLogicLvl92 : PCT
+    {
+        private static bool HasCooldowns()
+        {
+            if (CustomComboFunctions.GetRemainingCharges(SteelMuse) < 2)
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(ScenicMuse))
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(LivingMuse) < 2)
+                return false;
+
+            return true;
+        }
+
+        private static bool HasMotifs()
+        {
+            var gauge = CustomComboFunctions.GetJobGauge<PCTGauge>();
+
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Pom))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            return true;
+        }
+
+        private static uint OpenerLevel => 92;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && HasMotifs() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns() && !HasMotifs())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.LocalPlayer.CastActionId == RainbowDrip && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = RainbowDrip;
+
+                if (CustomComboFunctions.InCombat())
+                    CurrentState = OpenerState.FailedOpener;
+
+                if (!HasMotifs())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = StrikingMuse;
+
+                if (CustomComboFunctions.WasLastAction(HolyInWhite) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = HolyInWhite;
+
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = PomMuse;
+
+                if (CustomComboFunctions.LocalPlayer.CastActionId == CustomComboFunctions.OriginalHook(CreatureMotif) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = CustomComboFunctions.OriginalHook(CreatureMotif);
+
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = StarryMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = SubtractivePalette;
+
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = BlizzardinCyan;
+
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = StoneinYellow;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = ThunderinMagenta;
+
+                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = CometinBlack;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = WingedMuse;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = MogoftheAges;
+
+                if (CustomComboFunctions.WasLastAction(FireInRed) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = FireInRed;
+
+                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == 15) OpenerStep++;
+                else if (OpenerStep == 15) actionID = HammerBrush;
+
+                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == 16) OpenerStep++;
+                else if (OpenerStep == 16) actionID = PolishingHammer;
+
+                if (CustomComboFunctions.WasLastAction(RainbowDrip) && OpenerStep == 17) OpenerStep++;
+                else if (OpenerStep == 17) actionID = RainbowDrip;
+
+                Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds > 3)
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    Svc.Log.Warning("Opener Failed due to timeout.");
+                    return false;
+                }
+
+
+                if (OpenerStep > 17) // Assuming 15 is the last step
+                {
+                    CurrentState = OpenerState.OpenerFinished;
+                    Svc.Log.Information("Opener completed successfully.");
+                    return false;
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+    #endregion
+
+    #region Lvl 90 Opener
+    internal class PCTOpenerLogicLvl90 : PCT
+    {
+        private static bool HasCooldowns()
+        {
+            if (CustomComboFunctions.GetRemainingCharges(SteelMuse) < 2)
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(ScenicMuse))
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(LivingMuse) < 2)
+                return false;
+
+            return true;
+        }
+
+        private static bool HasMotifs()
+        {
+            var gauge = CustomComboFunctions.GetJobGauge<PCTGauge>();
+
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Pom))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            return true;
+        }
+
+        private static uint OpenerLevel => 90;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && HasMotifs() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns() && !HasMotifs())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.WasLastAction(FireInRed) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = FireInRed;
+
+                if (!HasMotifs())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener)
+            {
+                if (!CustomComboFunctions.InCombat())
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    Svc.Log.Warning("Opener Failed due to not being in combat.");
+                    return false;
+                }
+
+                if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = StrikingMuse;
+
+                if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = AeroInGreen;
+
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = PomMuse;
+
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = WingMotif;
+
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = StarryMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = WingedMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerBrush) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = HammerBrush;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = MogoftheAges;
+
+                if (CustomComboFunctions.WasLastAction(PolishingHammer) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = PolishingHammer;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = SubtractivePalette;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = ThunderinMagenta;
+
+                if (CustomComboFunctions.WasLastAction(CometinBlack) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = CometinBlack;
+
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 14) OpenerStep++;
+                else if (OpenerStep == 14) actionID = BlizzardinCyan;
+
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 15) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 15) actionID = StoneinYellow;
+
+                Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds > 3)
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    Svc.Log.Warning("Opener Failed due to timeout.");
+                    return false;
+                }
+
+
+                if (OpenerStep > 15) // Assuming 15 is the last step
+                {
+                    CurrentState = OpenerState.OpenerFinished;
+                    Svc.Log.Information("Opener completed successfully.");
+                    return false;
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+    #endregion
+
+    #region Lvl 80 Opener
+    internal class PCTOpenerLogicLvl80 : PCT
+    {
+        private static bool HasCooldowns()
+        {
+            if (!CustomComboFunctions.ActionReady(SteelMuse))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(ScenicMuse))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(LivingMuse))
+                return false;
+
+            return true;
+        }
+
+        private static bool HasMotifs()
+        {
+            var gauge = CustomComboFunctions.GetJobGauge<PCTGauge>();
+
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Pom))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            return true;
+        }
+
+        private static uint OpenerLevel => 80;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+
+        private static bool CanOpener => HasCooldowns() && HasMotifs() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns() && !HasMotifs())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.WasLastAction(FireInRed) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = FireInRed;
+
+                if (!HasMotifs())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener && CustomComboFunctions.InCombat())
+            {
+                if (!CustomComboFunctions.InCombat())
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    Svc.Log.Warning("Opener Failed due to not being in combat.");
+                    return false;
+                }
+
+                if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = StrikingMuse;
+
+                if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = AeroInGreen;
+
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = PomMuse;
+
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = WingMotif;
+
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = StarryMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = WingedMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = MogoftheAges;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = SubtractivePalette;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = ThunderinMagenta;
+
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = BlizzardinCyan;
+
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 14) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 14) actionID = StoneinYellow;
+
+                Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds > 4)
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    Svc.Log.Warning("Opener Failed due to timeout.");
+                    return false;
+                }
+
+                if (OpenerStep > 14) // Assuming 15 is the last step
+                {
+                    CurrentState = OpenerState.OpenerFinished;
+                    Svc.Log.Information("Opener completed successfully.");
+                    return false;
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+    #endregion
+
+    #region Lvl 70 Opener
+    internal class PCTOpenerLogicLvl70 : PCT
+    {
+        private static bool HasCooldowns()
+        {
+            if (!CustomComboFunctions.ActionReady(SteelMuse))
+                return false;
+
+            if (!CustomComboFunctions.ActionReady(ScenicMuse))
+                return false;
+
+            if (CustomComboFunctions.GetRemainingCharges(LivingMuse) < 2)
+                return false;
+
+            return true;
+        }
+
+        private static bool HasMotifs()
+        {
+            var gauge = CustomComboFunctions.GetJobGauge<PCTGauge>();
+
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Pom))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Weapon))
+                return false;
+            if (!gauge.CanvasFlags.HasFlag(Dalamud.Game.ClientState.JobGauge.Enums.CanvasFlags.Landscape))
+                return false;
+            return true;
+        }
+
+        private static uint OpenerLevel => 70;
+
+        public uint PrePullStep = 0;
+
+        public uint OpenerStep = 0;
+        public static bool LevelChecked => CustomComboFunctions.LocalPlayer.Level >= OpenerLevel;
+        private static bool CanOpener => HasCooldowns() && HasMotifs() && LevelChecked;
+
+        private OpenerState currentState = OpenerState.PrePull;
+
+        public OpenerState CurrentState
+        {
+            get
+            {
+                return currentState;
+            }
+            set
+            {
+                if (value != currentState)
+                {
+                    if (value == OpenerState.PrePull)
+                    {
+                        Svc.Log.Debug($"Entered PrePull Opener");
+                    }
+                    if (value == OpenerState.InOpener) OpenerStep = 1;
+                    if (value == OpenerState.OpenerFinished || value == OpenerState.FailedOpener)
+                    {
+                        if (value == OpenerState.FailedOpener)
+                            Svc.Log.Information($"Opener Failed at step {OpenerStep}");
+
+                        ResetOpener();
+                    }
+                    if (value == OpenerState.OpenerFinished) Svc.Log.Information("Opener Finished");
+
+                    currentState = value;
+                }
+            }
+        }
+
+        private bool DoPrePullSteps(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CanOpener && PrePullStep == 0)
+            {
+                PrePullStep = 1;
+            }
+
+            if (!HasCooldowns() && !HasMotifs())
+            {
+                PrePullStep = 0;
+            }
+
+            if (CurrentState == OpenerState.PrePull && PrePullStep > 0)
+            {
+                if (CustomComboFunctions.WasLastAction(FireInRed) && PrePullStep == 1) CurrentState = OpenerState.InOpener;
+                else if (PrePullStep == 1) actionID = FireInRed;
+
+                if (!HasMotifs())
+                    CurrentState = OpenerState.FailedOpener;
+
+                return true;
+            }
+            PrePullStep = 0;
+            return false;
+        }
+
+        private bool DoOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (currentState == OpenerState.InOpener && CustomComboFunctions.InCombat())
+            {
+                if (!CustomComboFunctions.InCombat())
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    Svc.Log.Warning("Opener Failed due to not being in combat.");
+                    return false;
+                }
+
+                if (CustomComboFunctions.WasLastAction(StrikingMuse) && OpenerStep == 1) OpenerStep++;
+                else if (OpenerStep == 1) actionID = StrikingMuse;
+
+                if (CustomComboFunctions.WasLastAction(AeroInGreen) && OpenerStep == 2) OpenerStep++;
+                else if (OpenerStep == 2) actionID = AeroInGreen;
+
+                if (CustomComboFunctions.WasLastAction(PomMuse) && OpenerStep == 3) OpenerStep++;
+                else if (OpenerStep == 3) actionID = PomMuse;
+
+                if (CustomComboFunctions.WasLastAction(WingMotif) && OpenerStep == 4) OpenerStep++;
+                else if (OpenerStep == 4) actionID = WingMotif;
+
+                if (CustomComboFunctions.WasLastAction(StarryMuse) && OpenerStep == 5) OpenerStep++;
+                else if (OpenerStep == 5) actionID = StarryMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 6) OpenerStep++;
+                else if (OpenerStep == 6) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(WingedMuse) && OpenerStep == 7) OpenerStep++;
+                else if (OpenerStep == 7) actionID = WingedMuse;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 8) OpenerStep++;
+                else if (OpenerStep == 8) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(MogoftheAges) && OpenerStep == 9) OpenerStep++;
+                else if (OpenerStep == 9) actionID = MogoftheAges;
+
+                if (CustomComboFunctions.WasLastAction(HammerStamp) && OpenerStep == 10) OpenerStep++;
+                else if (OpenerStep == 10) actionID = HammerStamp;
+
+                if (CustomComboFunctions.WasLastAction(SubtractivePalette) && OpenerStep == 11) OpenerStep++;
+                else if (OpenerStep == 11) actionID = SubtractivePalette;
+
+                if (CustomComboFunctions.WasLastAction(ThunderinMagenta) && OpenerStep == 12) OpenerStep++;
+                else if (OpenerStep == 12) actionID = ThunderinMagenta;
+
+                if (CustomComboFunctions.WasLastAction(BlizzardinCyan) && OpenerStep == 13) OpenerStep++;
+                else if (OpenerStep == 13) actionID = BlizzardinCyan;
+
+                if (CustomComboFunctions.WasLastAction(StoneinYellow) && OpenerStep == 14) CurrentState = OpenerState.OpenerFinished;
+                else if (OpenerStep == 14) actionID = StoneinYellow;
+
+                Svc.Log.Debug($"TimeSinceLastAction: {ActionWatching.TimeSinceLastAction.TotalSeconds}, OpenerStep: {OpenerStep}");
+
+                if (ActionWatching.TimeSinceLastAction.TotalSeconds > 4)
+                {
+                    CurrentState = OpenerState.FailedOpener;
+                    Svc.Log.Warning("Opener Failed due to timeout.");
+                    return false;
+                }
+
+                if (OpenerStep > 14) // Assuming 14 is the last step
+                {
+                    CurrentState = OpenerState.OpenerFinished;
+                    Svc.Log.Information("Opener completed successfully.");
+                    return false;
+                }
+
+                return true;
+            }
+            return false;
+        }
+
+        private void ResetOpener()
+        {
+            PrePullStep = 0;
+            OpenerStep = 0;
+        }
+
+        public bool DoFullOpener(ref uint actionID)
+        {
+            if (!LevelChecked)
+                return false;
+
+            if (CurrentState == OpenerState.PrePull)
+                if (DoPrePullSteps(ref actionID))
+                    return true;
+
+            if (CurrentState == OpenerState.InOpener)
+            {
+                if (DoOpener(ref actionID))
+                    return true;
+            }
+
+            if (!CustomComboFunctions.InCombat())
+            {
+                ResetOpener();
+                CurrentState = OpenerState.PrePull;
+            }
+            return false;
+        }
+    }
+    #endregion
+}

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -1,6 +1,8 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
+using XIVSlothCombo.Combos.JobHelpers;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.CustomComboNS.Functions;
+using XIVSlothCombo.Data;
 using XIVSlothCombo.Extensions;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -11,15 +13,25 @@ namespace XIVSlothCombo.Combos.PvE
 
         public const uint
             BlizzardinCyan = 34653,
+            StoneinYellow = 34654,
             BlizzardIIinCyan = 34659,
             ClawMotif = 34666,
             ClawedMuse = 34672,
             CometinBlack = 34663,
             CreatureMotif = 34689,
             FireInRed = 34650,
+            AeroInGreen = 34651,
+            WaterInBlue = 34652,
             FireIIinRed = 34656,
+            HammerMotif = 34668,
+            WingedMuse = 34671,
+            StrikingMuse = 34674,
+            StarryMuse = 34675,
             HammerStamp = 34678,
+            HammerBrush = 34679,
+            PolishingHammer = 34680,
             HolyInWhite = 34662,
+            StarrySkyMotif = 34669,
             LandscapeMotif = 34691,
             LivingMuse = 35347,
             MawMotif = 34667,
@@ -61,7 +73,9 @@ namespace XIVSlothCombo.Combos.PvE
         public static class Config
         {
             public static UserInt
-                CombinedAetherhueChoices = new("CombinedAetherhueChoices");
+                CombinedAetherhueChoices = new("CombinedAetherhueChoices"),
+                PCT_ST_AdvancedMode_LucidOption = new("PCT_ST_AdvancedMode_LucidOption", 6500),
+                PCT_AoE_AdvancedMode_LucidOption = new("PCT_AoE_AdvancedMode_LucidOption", 6500);
 
             public static UserBool
                 CombinedMotifsMog = new("CombinedMotifsMog"),
@@ -163,6 +177,172 @@ namespace XIVSlothCombo.Combos.PvE
             }
         }
 
+        internal class PCT_ST_AdvancedMode : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_ST_AdvancedMode;
+            internal static PCTOpenerLogic PCTOpener = new();
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+            {
+                if (actionID is FireInRed)
+                {
+                    var gauge = GetJobGauge<PCTGauge>();
+                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardinCyan)) : CanSpellWeave(OriginalHook(FireInRed)) || CanSpellWeave(OriginalHook(HammerStamp)) || CanSpellWeave(CometinBlack) || CanSpellWeave(HolyInWhite);
+
+
+                    // Prepull logic
+                    if (!InCombat() || (InCombat() && CurrentTarget == null))
+                    {
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs))
+                        {
+                            if (LevelChecked(OriginalHook(CreatureMotif)) && !gauge.CreatureMotifDrawn)
+                                return OriginalHook(CreatureMotif);
+                            if (LevelChecked(OriginalHook(WeaponMotif)) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                                return OriginalHook(WeaponMotif);
+                            if (LevelChecked(OriginalHook(LandscapeMotif)) && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
+                                return OriginalHook(LandscapeMotif);
+                        }
+                    }
+
+                    // Lvl 100 Opener
+                    if (IsEnabled(CustomComboPreset.PCT_ST_Advanced_Openers) && LevelChecked(StarPrism))
+                    {
+                        if (PCTOpener.DoFullOpener(ref actionID))
+                            return actionID;
+                    }
+
+                    // General Weaves
+                    if (canWeave)
+                    {
+                        //Muses
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_ScenicMuse) && gauge.LandscapeMotifDrawn && gauge.WeaponMotifDrawn && IsOffCooldown(ScenicMuse))
+                            return OriginalHook(ScenicMuse);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LivingMuse) && gauge.CreatureMotifDrawn &&
+                            (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
+                            GetCooldown(LivingMuse).CooldownRemaining > GetCooldown(ScenicMuse).CooldownRemaining ||
+                            GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse) || !ScenicMuse.LevelChecked()) &&
+                            HasCharges(OriginalHook(LivingMuse)) && canWeave)
+                        {
+                            if (GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
+                                return OriginalHook(LivingMuse);
+                        }
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse) && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()))
+                            return OriginalHook(SteelMuse);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MogOfTheAges) && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldownRemainingTime(StarryMuse) >= 40 || !ScenicMuse.LevelChecked()))
+                            return OriginalHook(MogoftheAges);
+
+                        // Swiftcast motifs
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption) && IsMoving && IsOffCooldown(All.Swiftcast) && (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
+                            return All.Swiftcast;
+
+                        // Palette
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette) && LevelChecked(SubtractivePalette) && !HasEffect(Buffs.SubtractivePalette))
+                        {
+                            if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
+                                return SubtractivePalette;
+                        }
+                    }
+
+                    if (HasEffect(All.Buffs.Swiftcast))
+                    {
+                        if (!gauge.CreatureMotifDrawn && LevelChecked(CreatureMotif) && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(CreatureMotif);
+                        if (!gauge.WeaponMotifDrawn && LevelChecked(WeaponMotif) && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(HammerMotif);
+                        if (!gauge.LandscapeMotifDrawn && LevelChecked(LandscapeMotif) && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(LandscapeMotif);
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan) && HasEffect(Buffs.SubtractivePalette))
+                            return OriginalHook(BlizzardinCyan);
+                    }
+
+                    if (IsMoving && InCombat())
+                    {
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo) && HasEffect(Buffs.HammerTime))
+                            return OriginalHook(HammerStamp);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && gauge.Paint >= 1 && !HasEffect(Buffs.MonochromeTones))
+                            return OriginalHook(HolyInWhite);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
+                            return OriginalHook(CometinBlack);
+                    }
+
+                    //Prepare for Burst
+                    if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                    {
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)
+                            return OriginalHook(LandscapeMotif);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn)
+                            return OriginalHook(CreatureMotif);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                            return OriginalHook(WeaponMotif);
+                    }
+
+                    // Burst 
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
+                    {
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_CometInBlack) && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                            return CometinBlack;
+
+                        // Check for HammerTime 
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_HammerCombo) && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
+                            return OriginalHook(HammerStamp);
+
+                        // Check for Starstruck
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_StarPrism))
+                        {
+                            if (HasEffect(Buffs.Starstruck) || HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) <= 3f)
+                                return StarPrism;
+                        }
+
+                        // Check for RainbowBright
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_RainbowDrip))
+                        {
+                            if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
+                                return RainbowDrip;
+                        }
+
+                    }
+
+
+                    if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
+                        return RainbowDrip;
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack) && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(Buffs.StarryMuse) > 30f)
+                        return OriginalHook(CometinBlack);
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_HammerStampCombo) && HasEffect(Buffs.HammerTime))
+                        return OriginalHook(HammerStamp);
+
+
+                    if (!HasEffect(Buffs.StarryMuse))
+                    {
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
+                            return OriginalHook(LandscapeMotif);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                            return OriginalHook(CreatureMotif);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime) && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8 && !HasEffect(Buffs.HammerTime)))
+                            return OriginalHook(WeaponMotif);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming) && ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
+                        return All.LucidDreaming;
+
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan) && HasEffect(Buffs.SubtractivePalette))
+                        return OriginalHook(BlizzardinCyan);
+                }
+                return actionID;
+            }
+        }
+
         internal class PCT_AoE_SimpleMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_AoE_SimpleMode;
@@ -251,6 +431,162 @@ namespace XIVSlothCombo.Combos.PvE
                         return OriginalHook(HolyInWhite);
 
                     if (HasEffect(Buffs.SubtractivePalette))
+                        return OriginalHook(BlizzardIIinCyan);
+
+                }
+                return actionID;
+            }
+        }
+
+        internal class PCT_AoE_AdvancedMode : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCT_AoE_AdvancedMode;
+
+            protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
+            {
+                if (actionID is FireIIinRed)
+                {
+                    var gauge = GetJobGauge<PCTGauge>();
+                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardIIinCyan)) : CanSpellWeave(OriginalHook(FireIIinRed)) || CanSpellWeave(OriginalHook(HammerStamp)) || CanSpellWeave(CometinBlack) || CanSpellWeave(HolyInWhite);
+
+
+                    // Prepull logic
+                    if (!InCombat() || (InCombat() && CurrentTarget == null))
+                    {
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs))
+                        {
+                            if (LevelChecked(OriginalHook(CreatureMotif)) && !gauge.CreatureMotifDrawn)
+                                return OriginalHook(CreatureMotif);
+                            if (LevelChecked(OriginalHook(WeaponMotif)) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                                return OriginalHook(WeaponMotif);
+                            if (LevelChecked(OriginalHook(LandscapeMotif)) && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
+                                return OriginalHook(LandscapeMotif);
+                        }
+                    }
+
+                    // General Weaves
+                    if (canWeave)
+                    {
+                        //Muses
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_ScenicMuse) && gauge.LandscapeMotifDrawn && gauge.WeaponMotifDrawn && IsOffCooldown(ScenicMuse))
+                            return OriginalHook(ScenicMuse);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse) && gauge.CreatureMotifDrawn &&
+                            (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
+                            GetCooldown(LivingMuse).CooldownRemaining > GetCooldown(ScenicMuse).CooldownRemaining ||
+                            GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse) || !ScenicMuse.LevelChecked()) &&
+                            HasCharges(OriginalHook(LivingMuse)) && canWeave)
+                        {
+                            if (GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
+                                return OriginalHook(LivingMuse);
+                        }
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse) && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()))
+                            return OriginalHook(SteelMuse);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MogOfTheAges) && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldownRemainingTime(StarryMuse) >= 40 || !ScenicMuse.LevelChecked()))
+                            return OriginalHook(MogoftheAges);
+
+                        // Swiftcast motifs
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption) && IsMoving && IsOffCooldown(All.Swiftcast) && (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
+                            return All.Swiftcast;
+
+                        // Palette
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) && LevelChecked(SubtractivePalette) && !HasEffect(Buffs.SubtractivePalette))
+                        {
+                            if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
+                                return SubtractivePalette;
+                        }
+                    }
+
+                    if (HasEffect(All.Buffs.Swiftcast))
+                    {
+                        if (!gauge.CreatureMotifDrawn && LevelChecked(CreatureMotif) && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(CreatureMotif);
+                        if (!gauge.WeaponMotifDrawn && LevelChecked(WeaponMotif) && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(HammerMotif);
+                        if (!gauge.LandscapeMotifDrawn && LevelChecked(LandscapeMotif) && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(LandscapeMotif);
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan) && HasEffect(Buffs.SubtractivePalette))
+                            return OriginalHook(BlizzardIIinCyan);
+                    }
+
+                    if (IsMoving && InCombat())
+                    {
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo) && HasEffect(Buffs.HammerTime))
+                            return OriginalHook(HammerStamp);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && gauge.Paint >= 1 && !HasEffect(Buffs.MonochromeTones))
+                            return OriginalHook(HolyInWhite);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack) && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
+                            return OriginalHook(CometinBlack);
+                    }
+
+                    //Prepare for Burst
+                    if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                    {
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)
+                            return OriginalHook(LandscapeMotif);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn)
+                            return OriginalHook(CreatureMotif);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                            return OriginalHook(WeaponMotif);
+                    }
+
+                    // Burst 
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
+                    {
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                            return CometinBlack;
+
+                        // Check for HammerTime 
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_HammerCombo) && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
+                            return OriginalHook(HammerStamp);
+
+                        // Check for Starstruck
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_StarPrism) && HasEffect(Buffs.Starstruck) || HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) < 3)
+                            return StarPrism;
+
+                        // Check for RainbowBright
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_RainbowDrip))
+                        {
+                            if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3)
+                                return RainbowDrip;
+                        }
+
+                    }
+
+
+                    if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
+                        return RainbowDrip;
+
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack) && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30)
+                        return OriginalHook(CometinBlack);
+
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HammerStampCombo) && HasEffect(Buffs.HammerTime))
+                        return OriginalHook(HammerStamp);
+
+
+                    if (!HasEffect(Buffs.StarryMuse))
+                    {
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
+                            return OriginalHook(LandscapeMotif);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                            return OriginalHook(CreatureMotif);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime) && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8 && !HasEffect(Buffs.HammerTime)))
+                            return OriginalHook(WeaponMotif);
+                    }
+
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming) && ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
+                        return All.LucidDreaming;
+
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan) && HasEffect(Buffs.SubtractivePalette))
                         return OriginalHook(BlizzardIIinCyan);
 
                 }

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -236,14 +236,14 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption) &&
                             IsMoving &&
                             IsOffCooldown(All.Swiftcast) &&
-                            All.Swiftcast.LevelChecked() && 
+                            All.Swiftcast.LevelChecked() &&
                             (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
                         {
                             return All.Swiftcast;
                         }
 
                         // Palette
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette) && SubtractivePalette.LevelChecked() && !HasEffect(Buffs.SubtractivePalette))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette) && SubtractivePalette.LevelChecked() && !HasEffect(Buffs.SubtractivePalette) && !HasEffect(Buffs.MonochromeTones))
                         {
                             if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
                                 return SubtractivePalette;
@@ -317,7 +317,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
                         return RainbowDrip;
 
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(Buffs.StarryMuse) > 30f)
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30f)
                         return OriginalHook(CometinBlack);
 
                     if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
@@ -500,7 +500,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // Palette
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) && SubtractivePalette.LevelChecked() && !HasEffect(Buffs.SubtractivePalette))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) && SubtractivePalette.LevelChecked() && !HasEffect(Buffs.SubtractivePalette) && !HasEffect(Buffs.MonochromeTones))
                         {
                             if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
                                 return SubtractivePalette;

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -194,9 +194,9 @@ namespace XIVSlothCombo.Combos.PvE
                     bool canWeave = CanSpellWeave(ActionWatching.LastSpell) || CanSpellWeave(actionID);
 
                     // Prepull logic
-                    if (!InCombat() || (InCombat() && CurrentTarget == null))
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs))
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs))
+                        if (!InCombat() || (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_NoTargetMotifs) && InCombat() && CurrentTarget == null))
                         {
                             if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
                                 return OriginalHook(CreatureMotif);
@@ -245,7 +245,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // General Weaves
                     if (InCombat() && canWeave)
                     {
-                        // Scenic Muse
+                        // ScenicMuse
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_ScenicMuse))
                         {
                             if (ScenicMuse.LevelChecked() &&
@@ -257,7 +257,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Living Muse
+                        // LivingMuse
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LivingMuse))
                         {
                             if (LivingMuse.LevelChecked() &&
@@ -276,7 +276,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Steel Muse
+                        // SteelMuse
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse))
                         {
                             if (SteelMuse.LevelChecked() &&
@@ -317,7 +317,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Subtractive Palette
+                        // SubtractivePalette
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette))
                         {
                             if (SubtractivePalette.LevelChecked() &&
@@ -405,7 +405,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (!HasEffect(Buffs.StarryMuse))
                     {
-                        // Landscape Motif
+                        // LandscapeMotif
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif))
                         {
                             if (LandscapeMotif.LevelChecked() &&
@@ -416,7 +416,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Creature Motif
+                        // CreatureMotif
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif))
                         {
                             if (CreatureMotif.LevelChecked() &&
@@ -427,7 +427,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Weapon Motif
+                        // WeaponMotif
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif))
                         {
                             if (WeaponMotif.LevelChecked() &&
@@ -559,9 +559,9 @@ namespace XIVSlothCombo.Combos.PvE
                     bool canWeave = CanSpellWeave(ActionWatching.LastSpell);
 
                     // Prepull logic
-                    if (!InCombat() || (InCombat() && CurrentTarget == null))
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs))
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs))
+                        if (!InCombat() || (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_NoTargetMotifs) && InCombat() && CurrentTarget == null))
                         {
                             if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
                                 return OriginalHook(CreatureMotif);
@@ -575,7 +575,7 @@ namespace XIVSlothCombo.Combos.PvE
                     // General Weaves
                     if (InCombat() && canWeave)
                     {
-                        // Living Muse
+                        // LivingMuse
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse))
                         {
                             if (LivingMuse.LevelChecked() &&
@@ -594,7 +594,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Scenic Muse
+                        // ScenicMuse
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_ScenicMuse))
                         {
                             if (ScenicMuse.LevelChecked() &&
@@ -606,7 +606,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Steel Muse
+                        // SteelMuse
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse))
                         {
                             if (SteelMuse.LevelChecked() &&

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -254,8 +254,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(HammerMotif);
                         if (!gauge.LandscapeMotifDrawn && LevelChecked(LandscapeMotif) && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(LandscapeMotif);
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan) && HasEffect(Buffs.SubtractivePalette))
-                            return OriginalHook(BlizzardinCyan);
+
                     }
 
                     if (IsMoving && InCombat())
@@ -263,11 +262,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo) && HasEffect(Buffs.HammerTime))
                             return OriginalHook(HammerStamp);
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && gauge.Paint >= 1 && !HasEffect(Buffs.MonochromeTones))
-                            return OriginalHook(HolyInWhite);
-
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
                             return OriginalHook(CometinBlack);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && gauge.Paint >= 1)
+                            return OriginalHook(HolyInWhite);
                     }
 
                     //Prepare for Burst
@@ -507,8 +506,6 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(HammerMotif);
                         if (!gauge.LandscapeMotifDrawn && LevelChecked(LandscapeMotif) && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(LandscapeMotif);
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan) && HasEffect(Buffs.SubtractivePalette))
-                            return OriginalHook(BlizzardIIinCyan);
                     }
 
                     if (IsMoving && InCombat())
@@ -516,11 +513,12 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo) && HasEffect(Buffs.HammerTime))
                             return OriginalHook(HammerStamp);
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && gauge.Paint >= 1 && !HasEffect(Buffs.MonochromeTones))
-                            return OriginalHook(HolyInWhite);
-
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack) && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
                             return OriginalHook(CometinBlack);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && gauge.Paint >= 1)
+                            return OriginalHook(HolyInWhite);
+
                     }
 
                     //Prepare for Burst

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -230,7 +230,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse) && SteelMuse.LevelChecked() && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()))
                             return OriginalHook(SteelMuse);
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MogOfTheAges) && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldownRemainingTime(StarryMuse) >= 40 || !ScenicMuse.LevelChecked()))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MogOfTheAges) && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldownRemainingTime(StarryMuse) >= 60 || !ScenicMuse.LevelChecked()))
                             return OriginalHook(MogoftheAges);
 
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption) &&
@@ -488,7 +488,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse) && SteelMuse.LevelChecked() && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()))
                             return OriginalHook(SteelMuse);
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MogOfTheAges) && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldownRemainingTime(StarryMuse) >= 40 || !ScenicMuse.LevelChecked()))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MogOfTheAges) && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldownRemainingTime(StarryMuse) >= 60 || !ScenicMuse.LevelChecked()))
                             return OriginalHook(MogoftheAges);
 
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption) &&

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -187,19 +187,18 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is FireInRed)
                 {
                     var gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardinCyan)) : CanSpellWeave(OriginalHook(FireInRed)) || CanSpellWeave(OriginalHook(HammerStamp)) || CanSpellWeave(CometinBlack) || CanSpellWeave(HolyInWhite);
-
+                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardinCyan)) : CanSpellWeave(OriginalHook(FireInRed)) || CanSpellWeave(OriginalHook(HammerStamp)) || CanSpellWeave(CometinBlack) || CanSpellWeave(HolyInWhite) || CanSpellWeave(OriginalHook(CreatureMotif)) || CanSpellWeave(HammerMotif) || CanSpellWeave(LandscapeMotif);
 
                     // Prepull logic
                     if (!InCombat() || (InCombat() && CurrentTarget == null))
                     {
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs))
                         {
-                            if (LevelChecked(OriginalHook(CreatureMotif)) && !gauge.CreatureMotifDrawn)
+                            if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
                                 return OriginalHook(CreatureMotif);
-                            if (LevelChecked(OriginalHook(WeaponMotif)) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                            if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
                                 return OriginalHook(WeaponMotif);
-                            if (LevelChecked(OriginalHook(LandscapeMotif)) && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
+                            if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
                                 return OriginalHook(LandscapeMotif);
                         }
                     }
@@ -212,13 +211,13 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // General Weaves
-                    if (canWeave)
+                    if (InCombat() && canWeave)
                     {
                         //Muses
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_ScenicMuse) && gauge.LandscapeMotifDrawn && gauge.WeaponMotifDrawn && IsOffCooldown(ScenicMuse))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_ScenicMuse) && ScenicMuse.LevelChecked() && gauge.LandscapeMotifDrawn && gauge.WeaponMotifDrawn && IsOffCooldown(ScenicMuse))
                             return OriginalHook(ScenicMuse);
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LivingMuse) && gauge.CreatureMotifDrawn &&
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LivingMuse) && LivingMuse.LevelChecked() && gauge.CreatureMotifDrawn &&
                             (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
                             GetCooldown(LivingMuse).CooldownRemaining > GetCooldown(ScenicMuse).CooldownRemaining ||
                             GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse) || !ScenicMuse.LevelChecked()) &&
@@ -228,18 +227,23 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(LivingMuse);
                         }
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse) && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SteelMuse) && SteelMuse.LevelChecked() && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()))
                             return OriginalHook(SteelMuse);
 
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MogOfTheAges) && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldownRemainingTime(StarryMuse) >= 40 || !ScenicMuse.LevelChecked()))
                             return OriginalHook(MogoftheAges);
 
-                        // Swiftcast motifs
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption) && IsMoving && IsOffCooldown(All.Swiftcast) && (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption) &&
+                            IsMoving &&
+                            IsOffCooldown(All.Swiftcast) &&
+                            All.Swiftcast.LevelChecked() && 
+                            (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
+                        {
                             return All.Swiftcast;
+                        }
 
                         // Palette
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette) && LevelChecked(SubtractivePalette) && !HasEffect(Buffs.SubtractivePalette))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette) && SubtractivePalette.LevelChecked() && !HasEffect(Buffs.SubtractivePalette))
                         {
                             if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
                                 return SubtractivePalette;
@@ -248,37 +252,37 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (HasEffect(All.Buffs.Swiftcast))
                     {
-                        if (!gauge.CreatureMotifDrawn && LevelChecked(CreatureMotif) && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(CreatureMotif);
-                        if (!gauge.WeaponMotifDrawn && LevelChecked(WeaponMotif) && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(HammerMotif);
-                        if (!gauge.LandscapeMotifDrawn && LevelChecked(LandscapeMotif) && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(LandscapeMotif);
 
                     }
 
                     if (IsMoving && InCombat())
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo) && HasEffect(Buffs.HammerTime))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
                             return OriginalHook(HammerStamp);
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
                             return OriginalHook(CometinBlack);
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && gauge.Paint >= 1)
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
                             return OriginalHook(HolyInWhite);
                     }
 
                     //Prepare for Burst
                     if (GetCooldownRemainingTime(ScenicMuse) <= 20)
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
                             return OriginalHook(LandscapeMotif);
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn)
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
                             return OriginalHook(CreatureMotif);
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
                             return OriginalHook(WeaponMotif);
                     }
 
@@ -286,11 +290,11 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
                     {
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_CometInBlack) && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
                             return CometinBlack;
 
                         // Check for HammerTime 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_HammerCombo) && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_HammerCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
                             return OriginalHook(HammerStamp);
 
                         // Check for Starstruck
@@ -313,10 +317,10 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
                         return RainbowDrip;
 
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack) && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(Buffs.StarryMuse) > 30f)
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(Buffs.StarryMuse) > 30f)
                         return OriginalHook(CometinBlack);
 
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_HammerStampCombo) && HasEffect(Buffs.HammerTime))
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
                         return OriginalHook(HammerStamp);
 
 
@@ -332,10 +336,10 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(WeaponMotif);
                     }
 
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming) && ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming) && All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
                         return All.LucidDreaming;
 
-                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan) && HasEffect(Buffs.SubtractivePalette))
+                    if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan) && BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
                         return OriginalHook(BlizzardinCyan);
                 }
                 return actionID;
@@ -446,7 +450,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is FireIIinRed)
                 {
                     var gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardIIinCyan)) : CanSpellWeave(OriginalHook(FireIIinRed)) || CanSpellWeave(OriginalHook(HammerStamp)) || CanSpellWeave(CometinBlack) || CanSpellWeave(HolyInWhite);
+                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardIIinCyan)) : CanSpellWeave(OriginalHook(FireInRed)) || CanSpellWeave(OriginalHook(HammerStamp)) || CanSpellWeave(CometinBlack) || CanSpellWeave(HolyInWhite) || CanSpellWeave(OriginalHook(CreatureMotif)) || CanSpellWeave(HammerMotif) || CanSpellWeave(LandscapeMotif);
 
 
                     // Prepull logic
@@ -454,23 +458,23 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs))
                         {
-                            if (LevelChecked(OriginalHook(CreatureMotif)) && !gauge.CreatureMotifDrawn)
+                            if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
                                 return OriginalHook(CreatureMotif);
-                            if (LevelChecked(OriginalHook(WeaponMotif)) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                            if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
                                 return OriginalHook(WeaponMotif);
-                            if (LevelChecked(OriginalHook(LandscapeMotif)) && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
+                            if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
                                 return OriginalHook(LandscapeMotif);
                         }
                     }
 
                     // General Weaves
-                    if (canWeave)
+                    if (InCombat() && canWeave)
                     {
                         //Muses
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_ScenicMuse) && gauge.LandscapeMotifDrawn && gauge.WeaponMotifDrawn && IsOffCooldown(ScenicMuse))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_ScenicMuse) && ScenicMuse.LevelChecked() && gauge.LandscapeMotifDrawn && gauge.WeaponMotifDrawn && IsOffCooldown(ScenicMuse))
                             return OriginalHook(ScenicMuse);
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse) && gauge.CreatureMotifDrawn &&
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LivingMuse) && LivingMuse.LevelChecked() && gauge.CreatureMotifDrawn &&
                             (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
                             GetCooldown(LivingMuse).CooldownRemaining > GetCooldown(ScenicMuse).CooldownRemaining ||
                             GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse) || !ScenicMuse.LevelChecked()) &&
@@ -480,18 +484,23 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(LivingMuse);
                         }
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse) && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SteelMuse) && SteelMuse.LevelChecked() && !HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()))
                             return OriginalHook(SteelMuse);
 
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MogOfTheAges) && MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldownRemainingTime(StarryMuse) >= 40 || !ScenicMuse.LevelChecked()))
                             return OriginalHook(MogoftheAges);
 
-                        // Swiftcast motifs
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption) && IsMoving && IsOffCooldown(All.Swiftcast) && (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption) &&
+                            IsMoving &&
+                            IsOffCooldown(All.Swiftcast) &&
+                            All.Swiftcast.LevelChecked() &&  // Added this condition
+                            (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
+                        {
                             return All.Swiftcast;
+                        }
 
                         // Palette
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) && LevelChecked(SubtractivePalette) && !HasEffect(Buffs.SubtractivePalette))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) && SubtractivePalette.LevelChecked() && !HasEffect(Buffs.SubtractivePalette))
                         {
                             if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
                                 return SubtractivePalette;
@@ -500,23 +509,23 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (HasEffect(All.Buffs.Swiftcast))
                     {
-                        if (!gauge.CreatureMotifDrawn && LevelChecked(CreatureMotif) && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(CreatureMotif);
-                        if (!gauge.WeaponMotifDrawn && LevelChecked(WeaponMotif) && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(HammerMotif);
-                        if (!gauge.LandscapeMotifDrawn && LevelChecked(LandscapeMotif) && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(LandscapeMotif);
                     }
 
                     if (IsMoving && InCombat())
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo) && HasEffect(Buffs.HammerTime))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
                             return OriginalHook(HammerStamp);
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack) && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
                             return OriginalHook(CometinBlack);
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && gauge.Paint >= 1)
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
                             return OriginalHook(HolyInWhite);
 
                     }
@@ -524,13 +533,13 @@ namespace XIVSlothCombo.Combos.PvE
                     //Prepare for Burst
                     if (GetCooldownRemainingTime(ScenicMuse) <= 20)
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
                             return OriginalHook(LandscapeMotif);
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn)
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
                             return OriginalHook(CreatureMotif);
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
                             return OriginalHook(WeaponMotif);
                     }
 
@@ -538,11 +547,11 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
                     {
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
                             return CometinBlack;
 
                         // Check for HammerTime 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_HammerCombo) && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_HammerCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
                             return OriginalHook(HammerStamp);
 
                         // Check for Starstruck
@@ -562,10 +571,10 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
                         return RainbowDrip;
 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack) && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30)
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CometinBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 30)
                         return OriginalHook(CometinBlack);
 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HammerStampCombo) && HasEffect(Buffs.HammerTime))
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_HammerStampCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
                         return OriginalHook(HammerStamp);
 
 
@@ -581,10 +590,10 @@ namespace XIVSlothCombo.Combos.PvE
                             return OriginalHook(WeaponMotif);
                     }
 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming) && ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming) && All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) && LocalPlayer.CurrentMp <= Config.PCT_ST_AdvancedMode_LucidOption)
                         return All.LucidDreaming;
 
-                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan) && HasEffect(Buffs.SubtractivePalette))
+                    if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_BlizzardInCyan) && BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
                         return OriginalHook(BlizzardIIinCyan);
 
                 }

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -93,7 +93,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is FireInRed)
                 {
                     var gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardinCyan)) : CanSpellWeave(OriginalHook(FireInRed));
+                    bool canWeave = CanSpellWeave(ActionWatching.LastSpell);
 
                     if (HasEffect(Buffs.Starstruck))
                         return OriginalHook(StarPrism);
@@ -187,7 +187,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is FireInRed)
                 {
                     var gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardinCyan)) : CanSpellWeave(OriginalHook(FireInRed)) || CanSpellWeave(OriginalHook(HammerStamp)) || CanSpellWeave(CometinBlack) || CanSpellWeave(HolyInWhite) || CanSpellWeave(OriginalHook(CreatureMotif)) || CanSpellWeave(HammerMotif) || CanSpellWeave(LandscapeMotif);
+                    bool canWeave = CanSpellWeave(ActionWatching.LastSpell);
 
                     // Prepull logic
                     if (!InCombat() || (InCombat() && CurrentTarget == null))
@@ -342,6 +342,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_BlizzardInCyan) && BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
                         return OriginalHook(BlizzardinCyan);
                 }
+
                 return actionID;
             }
         }
@@ -355,7 +356,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is FireIIinRed)
                 {
                     var gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardinCyan)) : CanSpellWeave(OriginalHook(FireInRed));
+                    bool canWeave = CanSpellWeave(ActionWatching.LastSpell);
 
                     if (HasEffect(Buffs.Starstruck))
                         return OriginalHook(StarPrism);
@@ -450,7 +451,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (actionID is FireIIinRed)
                 {
                     var gauge = GetJobGauge<PCTGauge>();
-                    bool canWeave = HasEffect(Buffs.SubtractivePalette) ? CanSpellWeave(OriginalHook(BlizzardIIinCyan)) : CanSpellWeave(OriginalHook(FireInRed)) || CanSpellWeave(OriginalHook(HammerStamp)) || CanSpellWeave(CometinBlack) || CanSpellWeave(HolyInWhite) || CanSpellWeave(OriginalHook(CreatureMotif)) || CanSpellWeave(HammerMotif) || CanSpellWeave(LandscapeMotif);
+                    bool canWeave = CanSpellWeave(ActionWatching.LastSpell);
 
 
                     // Prepull logic

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -425,7 +425,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Weapon Motif
+                        // WeaponMotif
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif))
                         {
                             if (WeaponMotif.LevelChecked() &&
@@ -651,10 +651,8 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(CreatureMotif);
-
                         if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(HammerMotif);
-
                         if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
                             return OriginalHook(LandscapeMotif);
                     }
@@ -688,7 +686,6 @@ namespace XIVSlothCombo.Combos.PvE
                     // Burst 
                     if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
                     {
-
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
                             return CometinBlack;
 

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -263,14 +263,15 @@ namespace XIVSlothCombo.Combos.PvE
                             if (LivingMuse.LevelChecked() &&
                                 gauge.CreatureMotifDrawn &&
                                 (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                                 GetCooldown(LivingMuse).CooldownRemaining > GetCooldown(ScenicMuse).CooldownRemaining ||
-                                 GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse) ||
-                                 !ScenicMuse.LevelChecked()) &&
-                                HasCharges(OriginalHook(LivingMuse)))
+                                GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
                             {
-                                if (GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
+                                if (HasCharges(OriginalHook(LivingMuse)))
                                 {
-                                    return OriginalHook(LivingMuse);
+                                    if (!ScenicMuse.LevelChecked() ||
+                                        GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
+                                    {
+                                        return OriginalHook(LivingMuse);
+                                    }
                                 }
                             }
                         }
@@ -308,6 +309,8 @@ namespace XIVSlothCombo.Combos.PvE
                             if (IsMoving &&
                                 IsOffCooldown(All.Swiftcast) &&
                                 All.Swiftcast.LevelChecked() &&
+                                !HasEffect(Buffs.HammerTime) &&
+                                gauge.Paint < 1 &&
                                 (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
                             {
                                 return All.Swiftcast;
@@ -391,7 +394,6 @@ namespace XIVSlothCombo.Combos.PvE
 
                     }
 
-
                     if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
                         return RainbowDrip;
 
@@ -425,7 +427,7 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // WeaponMotif
+                        // Weapon Motif
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif))
                         {
                             if (WeaponMotif.LevelChecked() &&
@@ -579,11 +581,16 @@ namespace XIVSlothCombo.Combos.PvE
                             if (LivingMuse.LevelChecked() &&
                                 gauge.CreatureMotifDrawn &&
                                 (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
-                                 GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse) ||
-                                 !ScenicMuse.LevelChecked()) &&
-                                HasCharges(OriginalHook(LivingMuse)))
+                                GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
                             {
-                                return OriginalHook(LivingMuse);
+                                if (HasCharges(OriginalHook(LivingMuse)))
+                                {
+                                    if (!ScenicMuse.LevelChecked() ||
+                                        GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
+                                    {
+                                        return OriginalHook(LivingMuse);
+                                    }
+                                }
                             }
                         }
 
@@ -625,15 +632,20 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Swiftcast Option
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption) &&
-                            IsMoving &&
-                            IsOffCooldown(All.Swiftcast) &&
-                            All.Swiftcast.LevelChecked() &&
-                            (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption))
                         {
-                            return All.Swiftcast;
+                            if (IsMoving &&
+                                IsOffCooldown(All.Swiftcast) &&
+                                All.Swiftcast.LevelChecked() &&
+                                !HasEffect(Buffs.HammerTime) &&
+                                gauge.Paint < 1 &&
+                                (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
+                            {
+                                return All.Swiftcast;
+                            }
                         }
+
 
                         // Subtractive Palette
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) &&
@@ -686,18 +698,22 @@ namespace XIVSlothCombo.Combos.PvE
                     // Burst 
                     if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_Phase) && HasEffect(Buffs.StarryMuse))
                     {
+                        // Check for CometInBlack
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_CometInBlack) && CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
                             return CometinBlack;
 
+                        // Check for HammerTime 
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_HammerCombo) && HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
                             return OriginalHook(HammerStamp);
 
+                        // Check for Starstruck
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_StarPrism))
                         {
                             if (HasEffect(Buffs.Starstruck) || (HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) < 3))
                                 return StarPrism;
                         }
 
+                        // Check for RainbowBright
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_RainbowDrip))
                         {
                             if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1766,6 +1766,15 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawAdditionalBoolChoice(PCT.Config.CombinedMotifsWeapon, $"{PCT.HammerStamp.ActionName()} Feature", $"Add {PCT.HammerStamp.ActionName()} when under the effect of {PCT.Buffs.HammerTime.StatusName()}.");
             }
 
+            if(preset == CustomComboPreset.PCT_ST_AdvancedMode_LucidDreaming )
+            {
+                UserConfig.DrawSliderInt(0, 10000, PCT.Config.PCT_ST_AdvancedMode_LucidOption, "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);
+            }
+            if(preset == CustomComboPreset.PCT_AoE_AdvancedMode_LucidDreaming)
+            {
+                UserConfig.DrawSliderInt(0, 10000, PCT.Config.PCT_AoE_AdvancedMode_LucidOption, "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);
+            }
+
             #endregion
             // ====================================================================================
             #region PALADIN


### PR DESCRIPTION
- [X] Added Lvl 100 PCT Balance opener
- [X] Added all in one lower Lvl openers 92, 90, 80, 70 
- [X] Added early Starry Muse choice to the openers
- [X] Added Advanced ST option with customization options
- [X] Added Advanced AoE option with customization options
- [X] Add levelchecks
- [X] Fixed mog/madeen not working on AoE - AoE just blasts now
- [X] Add additional options to expand customization + Few tiny fixes

Seems good to go! 
Few things i wanna update later on is re-working the opener code to be all in one piece and not segmented as it is now.
Plus other optimizations to come when i have time to do more testing.