### PR TITLE
[Tabs] Debug Window Update

### DIFF
--- a/XIVSlothCombo/CustomCombo/Functions/Status.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Status.cs
@@ -20,9 +20,16 @@ namespace XIVSlothCombo.CustomComboNS.Functions
             return eff?.StackCount ?? 0;
         }
 
-        public unsafe static float GetBuffRemainingTime(ushort effectId)
+        /// <summary> Gets the duration of a status effect on the player. By default, the effect must be owned by the player or unowned. </summary>
+        /// <param name="effectId"> Status effect ID. </param>
+        /// <param name="isPlayerOwned"> Whether the status effect must be owned by the player, or whether it can be owned by anyone. </param>
+        /// <returns> A value indicating if the effect exists. </returns>
+        public unsafe static float GetBuffRemainingTime(ushort effectId, bool isPlayerOwned = true)
         {
-            Status? eff = FindEffect(effectId);
+            Status? eff = (isPlayerOwned == true)
+                ? FindEffect(effectId)
+                : FindEffectAny(effectId);
+
             if (eff is null) return 0;
             if (eff.RemainingTime < 0) return (eff.RemainingTime * -1) + ActionManager.Instance()->AnimationLock;
             return eff.RemainingTime;
@@ -43,10 +50,16 @@ namespace XIVSlothCombo.CustomComboNS.Functions
         /// <returns> Status object or null. </returns>
         public static Status? FindTargetEffect(ushort effectID) => FindEffect(effectID, CurrentTarget, LocalPlayer?.GameObjectId);
 
-        /// <summary></summary>
-        public unsafe static float GetDebuffRemainingTime(ushort effectId)
+        /// <summary> Gets the duration of a status effect on the current target. By default, the effect must be owned by the player or unowned. </summary>
+        /// <param name="effectId"> Status effect ID. </param>
+        /// <param name="isPlayerOwned"> Whether the status effect must be owned by the player, or whether it can be owned by anyone. </param>
+        /// <returns> A value indicating if the effect exists. </returns>
+        public unsafe static float GetDebuffRemainingTime(ushort effectId, bool isPlayerOwned = true)
         {
-            Status? eff = FindTargetEffect(effectId);
+            Status? eff = (isPlayerOwned == true)
+                ? FindTargetEffect(effectId)
+                : FindTargetEffectAny(effectId);
+
             if (eff is null) return 0;
             if (eff.RemainingTime < 0) return (eff.RemainingTime * -1) + ActionManager.Instance()->AnimationLock;
             return eff.RemainingTime;

--- a/XIVSlothCombo/CustomCombo/Functions/Status.cs
+++ b/XIVSlothCombo/CustomCombo/Functions/Status.cs
@@ -22,8 +22,8 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 
         /// <summary> Gets the duration of a status effect on the player. By default, the effect must be owned by the player or unowned. </summary>
         /// <param name="effectId"> Status effect ID. </param>
-        /// <param name="isPlayerOwned"> Whether the status effect must be owned by the player, or whether it can be owned by anyone. </param>
-        /// <returns> A value indicating if the effect exists. </returns>
+        /// <param name="isPlayerOwned"> Whether the status effect must be owned by the player or can be owned by anyone. </param>
+        /// <returns> The duration of the status effect. </returns>
         public unsafe static float GetBuffRemainingTime(ushort effectId, bool isPlayerOwned = true)
         {
             Status? eff = (isPlayerOwned == true)
@@ -52,8 +52,8 @@ namespace XIVSlothCombo.CustomComboNS.Functions
 
         /// <summary> Gets the duration of a status effect on the current target. By default, the effect must be owned by the player or unowned. </summary>
         /// <param name="effectId"> Status effect ID. </param>
-        /// <param name="isPlayerOwned"> Whether the status effect must be owned by the player, or whether it can be owned by anyone. </param>
-        /// <returns> A value indicating if the effect exists. </returns>
+        /// <param name="isPlayerOwned"> Whether the status effect must be owned by the player or can be owned by anyone. </param>
+        /// <returns> The duration of the status effect. </returns>
         public unsafe static float GetDebuffRemainingTime(ushort effectId, bool isPlayerOwned = true)
         {
             Status? eff = (isPlayerOwned == true)

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -15,10 +15,8 @@ using Status = Dalamud.Game.ClientState.Statuses.Status;
 
 namespace XIVSlothCombo.Window.Tabs
 {
-
     internal class Debug : ConfigWindow
     {
-
         internal class DebugCombo : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; }
@@ -31,6 +29,7 @@ namespace XIVSlothCombo.Window.Tabs
         {
             IPlayerCharacter? LocalPlayer = Svc.ClientState.LocalPlayer;
             DebugCombo? comboClass = new();
+            uint[] statusBlacklist = { 360, 361, 362, 363, 364, 365, 366, 367, 368 }; // Prevents status duration from being displayed
 
             // Custom Styling
             static void CustomStyleText(string label, object? value)
@@ -50,7 +49,7 @@ namespace XIVSlothCombo.Window.Tabs
                 // Player Status Effects
                 if (ImGui.CollapsingHeader("Player Status Effects"))
                 {
-                    foreach (Status? status in Svc.ClientState.LocalPlayer.StatusList)
+                    foreach (Status? status in LocalPlayer.StatusList)
                     {
                         // Null Check (Source Name)
                         if (status.SourceObject is not null)
@@ -63,12 +62,29 @@ namespace XIVSlothCombo.Window.Tabs
                         if (!string.IsNullOrEmpty(ActionWatching.GetStatusName(status.StatusId)))
                         {
                             CustomStyleText(ActionWatching.GetStatusName(status.StatusId) + ":", status.StatusId);
-                            ImGui.SameLine(0, 4f);
-                            CustomStyleText("", $"({Math.Round(status.RemainingTime, 1)})");
+
                         }
                         else
                         {
-                            CustomStyleText("", $"{status.StatusId} ({Math.Round(status.RemainingTime, 1)})");
+                            CustomStyleText("", status.StatusId);
+                        }
+
+                        // Duration + Blacklist Check
+                        if (status.RemainingTime > 0 && !statusBlacklist.Contains(status.StatusId))
+                        {
+                            string formattedDuration;
+                            if (status.RemainingTime >= 60)
+                            {
+                                int minutes = (int)(status.RemainingTime / 60);
+                                formattedDuration = $"{minutes}m";
+                            }
+                            else
+                            {
+                                formattedDuration = $"{Math.Round(status.RemainingTime, 1)}s";
+                            }
+
+                            ImGui.SameLine(0, 4f);
+                            CustomStyleText("", $"({formattedDuration})");
                         }
                     }
                 }
@@ -76,7 +92,7 @@ namespace XIVSlothCombo.Window.Tabs
                 // Target Status Effects
                 if (ImGui.CollapsingHeader("Target Status Effects"))
                 {
-                    if (Svc.ClientState.LocalPlayer.TargetObject is IBattleChara chara)
+                    if (LocalPlayer.TargetObject is IBattleChara chara)
                     {
                         foreach (Status? status in chara.StatusList)
                         {
@@ -91,12 +107,29 @@ namespace XIVSlothCombo.Window.Tabs
                             if (!string.IsNullOrEmpty(ActionWatching.GetStatusName(status.StatusId)))
                             {
                                 CustomStyleText(ActionWatching.GetStatusName(status.StatusId) + ":", status.StatusId);
-                                ImGui.SameLine(0, 4f);
-                                CustomStyleText("", $"({Math.Round(status.RemainingTime, 1)})");
+
                             }
                             else
                             {
-                                CustomStyleText("", $"{status.StatusId} ({Math.Round(status.RemainingTime, 1)})");
+                                CustomStyleText("", status.StatusId);
+                            }
+
+                            // Duration + Blacklist Check
+                            if (status.RemainingTime > 0 && !statusBlacklist.Contains(status.StatusId))
+                            {
+                                string formattedDuration;
+                                if (status.RemainingTime >= 60)
+                                {
+                                    int minutes = (int)(status.RemainingTime / 60);
+                                    formattedDuration = $"{minutes}m";
+                                }
+                                else
+                                {
+                                    formattedDuration = $"{Math.Round(status.RemainingTime, 1)}s";
+                                }
+
+                                ImGui.SameLine(0, 4f);
+                                CustomStyleText("", $"({formattedDuration})");
                             }
                         }
 
@@ -108,25 +141,25 @@ namespace XIVSlothCombo.Window.Tabs
                 ImGui.Spacing();
                 ImGui.Text("Player Info");
                 ImGui.Separator();
-                CustomStyleText("Job:", $"{Svc.ClientState.LocalPlayer.ClassJob.GameData.NameEnglish} (ID: {Svc.ClientState.LocalPlayer.ClassJob.Id})");
+                CustomStyleText("Job:", $"{LocalPlayer.ClassJob.GameData.NameEnglish} (ID: {LocalPlayer.ClassJob.Id})");
                 CustomStyleText("Zone:", $"{Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.TerritoryType>()?.FirstOrDefault(x => x.RowId == Svc.ClientState.TerritoryType).PlaceName.Value.Name} (ID: {Svc.ClientState.TerritoryType})");
                 CustomStyleText("In PvP:", CustomComboFunctions.InPvP());
                 CustomStyleText("In Combat:", CustomComboFunctions.InCombat());
-                CustomStyleText("Hitbox Radius:", Svc.ClientState.LocalPlayer.HitboxRadius);
+                CustomStyleText("Hitbox Radius:", LocalPlayer.HitboxRadius);
                 ImGui.Spacing();
 
                 // Target Info
                 ImGui.Spacing();
                 ImGui.Text("Target Info");
                 ImGui.Separator();
-                CustomStyleText("ObjectId:", Svc.ClientState.LocalPlayer.TargetObject?.GameObjectId);
-                CustomStyleText("ObjectKind:", Svc.ClientState.LocalPlayer.TargetObject?.ObjectKind);
-                CustomStyleText("Is BattleChara:", Svc.ClientState.LocalPlayer.TargetObject is IBattleChara);
-                CustomStyleText("Is PlayerCharacter:", Svc.ClientState.LocalPlayer.TargetObject is IPlayerCharacter);
+                CustomStyleText("ObjectId:", LocalPlayer.TargetObject?.GameObjectId);
+                CustomStyleText("ObjectKind:", LocalPlayer.TargetObject?.ObjectKind);
+                CustomStyleText("Is BattleChara:", LocalPlayer.TargetObject is IBattleChara);
+                CustomStyleText("Is PlayerCharacter:", LocalPlayer.TargetObject is IPlayerCharacter);
                 CustomStyleText("Distance:", $"{Math.Round(CustomComboFunctions.GetTargetDistance(), 2)}y");
-                CustomStyleText("Hitbox Radius:", Svc.ClientState.LocalPlayer.TargetObject?.HitboxRadius);
+                CustomStyleText("Hitbox Radius:", LocalPlayer.TargetObject?.HitboxRadius);
                 CustomStyleText("In Melee Range:", CustomComboFunctions.InMeleeRange());
-                CustomStyleText("Relative Direction:", CustomComboFunctions.AngleToTarget() == 2 ? "Rear" : (CustomComboFunctions.AngleToTarget() == 1 || CustomComboFunctions.AngleToTarget() == 3) ? "Flank" : CustomComboFunctions.AngleToTarget() == 4 ? "Front" : "");
+                CustomStyleText("Relative Direction:", CustomComboFunctions.AngleToTarget() is 2 ? "Rear" : (CustomComboFunctions.AngleToTarget() is 1 or 3) ? "Flank" : CustomComboFunctions.AngleToTarget() is 4 ? "Front" : "");
                 CustomStyleText("Health:", $"{CustomComboFunctions.EnemyHealthCurrentHp().ToString("N0")} / {CustomComboFunctions.EnemyHealthMaxHp().ToString("N0")} ({Math.Round(CustomComboFunctions.GetTargetHPPercent(), 2)}%)");
                 ImGui.Spacing();
 
@@ -134,17 +167,17 @@ namespace XIVSlothCombo.Window.Tabs
                 ImGui.Spacing();
                 ImGui.Text("Action Info");
                 ImGui.Separator();
-                CustomStyleText("Last Action:", ActionWatching.LastAction == 0 ? string.Empty : $"{ActionWatching.GetActionName(ActionWatching.LastAction)} (ID: {ActionWatching.LastAction})");
+                CustomStyleText("Last Action:", ActionWatching.LastAction == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(ActionWatching.LastAction)) ? "Unknown" : ActionWatching.GetActionName(ActionWatching.LastAction))} (ID: {ActionWatching.LastAction})");
                 CustomStyleText("Last Action Cost:", CustomComboFunctions.GetResourceCost(ActionWatching.LastAction));
                 CustomStyleText("Last Action Type:", ActionWatching.GetAttackType(ActionWatching.LastAction));
                 CustomStyleText("Last Weaponskill:", ActionWatching.GetActionName(ActionWatching.LastWeaponskill));
                 CustomStyleText("Last Spell:", ActionWatching.GetActionName(ActionWatching.LastSpell));
                 CustomStyleText("Last Ability:", ActionWatching.GetActionName(ActionWatching.LastAbility));
-                CustomStyleText("Combo Timer:", Math.Round(CustomComboFunctions.ComboTimer, 1));
-                CustomStyleText("Combo Action:", CustomComboFunctions.ComboAction == 0 ? string.Empty : $"{ActionWatching.GetActionName(CustomComboFunctions.ComboAction)} (ID: {CustomComboFunctions.ComboAction})");
-                CustomStyleText("Cast Action:", Svc.ClientState.LocalPlayer.CastActionId == 0 ? string.Empty : $"{ActionWatching.GetActionName(Svc.ClientState.LocalPlayer.CastActionId)} (ID: {Svc.ClientState.LocalPlayer.CastActionId})");
-                CustomStyleText("Cast Time (Total):", Math.Round(Svc.ClientState.LocalPlayer.TotalCastTime, 2));
-                CustomStyleText("Cast Time (Current):", Math.Round(Svc.ClientState.LocalPlayer.CurrentCastTime, 2));
+                CustomStyleText("Combo Timer:", $"{Math.Round(CustomComboFunctions.ComboTimer, 1)}");
+                CustomStyleText("Combo Action:", CustomComboFunctions.ComboAction == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(CustomComboFunctions.ComboAction)) ? "Unknown" : ActionWatching.GetActionName(CustomComboFunctions.ComboAction))} (ID: {CustomComboFunctions.ComboAction})");
+                CustomStyleText("Cast Action:", LocalPlayer.CastActionId == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(LocalPlayer.CastActionId)) ? "Unknown" : ActionWatching.GetActionName(LocalPlayer.CastActionId))} (ID: {LocalPlayer.CastActionId})");
+                CustomStyleText("Cast Time (Total):", Math.Round(LocalPlayer.TotalCastTime, 2));
+                CustomStyleText("Cast Time (Current):", Math.Round(LocalPlayer.CurrentCastTime, 2));
                 ImGui.Spacing();
 
                 // Party Info

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -29,7 +29,7 @@ namespace XIVSlothCombo.Window.Tabs
         {
             IPlayerCharacter? LocalPlayer = Svc.ClientState.LocalPlayer;
             DebugCombo? comboClass = new();
-            uint[] statusBlacklist = { 360, 361, 362, 363, 364, 365, 366, 367, 368 }; // Prevents status duration from being displayed
+            uint[] statusBlacklist = { 360, 361, 362, 363, 364, 365, 366, 367, 368 }; // Prevents status durations from being displayed
 
             // Custom Styling
             static void CustomStyleText(string label, object? value)
@@ -173,7 +173,7 @@ namespace XIVSlothCombo.Window.Tabs
                 CustomStyleText("Last Weaponskill:", ActionWatching.GetActionName(ActionWatching.LastWeaponskill));
                 CustomStyleText("Last Spell:", ActionWatching.GetActionName(ActionWatching.LastSpell));
                 CustomStyleText("Last Ability:", ActionWatching.GetActionName(ActionWatching.LastAbility));
-                CustomStyleText("Combo Timer:", $"{Math.Round(CustomComboFunctions.ComboTimer, 1)}");
+                CustomStyleText("Combo Timer:", Math.Round(CustomComboFunctions.ComboTimer, 1));
                 CustomStyleText("Combo Action:", CustomComboFunctions.ComboAction == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(CustomComboFunctions.ComboAction)) ? "Unknown" : ActionWatching.GetActionName(CustomComboFunctions.ComboAction))} (ID: {CustomComboFunctions.ComboAction})");
                 CustomStyleText("Cast Action:", LocalPlayer.CastActionId == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(LocalPlayer.CastActionId)) ? "Unknown" : ActionWatching.GetActionName(LocalPlayer.CastActionId))} (ID: {LocalPlayer.CastActionId})");
                 CustomStyleText("Cast Time (Total):", Math.Round(LocalPlayer.TotalCastTime, 2));

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -158,7 +158,7 @@ namespace XIVSlothCombo.Window.Tabs
                 CustomStyleText("Distance:", $"{Math.Round(CustomComboFunctions.GetTargetDistance(), 2)}y");
                 CustomStyleText("Hitbox Radius:", LocalPlayer.TargetObject?.HitboxRadius);
                 CustomStyleText("In Melee Range:", CustomComboFunctions.InMeleeRange());
-                CustomStyleText("Relative Direction:", CustomComboFunctions.AngleToTarget() is 2 ? "Rear" : (CustomComboFunctions.AngleToTarget() is 1 or 3) ? "Flank" : CustomComboFunctions.AngleToTarget() is 4 ? "Front" : "");
+                CustomStyleText("Relative Position:", CustomComboFunctions.AngleToTarget() is 2 ? "Rear" : (CustomComboFunctions.AngleToTarget() is 1 or 3) ? "Flank" : CustomComboFunctions.AngleToTarget() is 4 ? "Front" : "");
                 CustomStyleText("Health:", $"{CustomComboFunctions.EnemyHealthCurrentHp().ToString("N0")} / {CustomComboFunctions.EnemyHealthMaxHp().ToString("N0")} ({Math.Round(CustomComboFunctions.GetTargetHPPercent(), 2)}%)");
                 ImGui.Spacing();
 

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -140,7 +140,7 @@ namespace XIVSlothCombo.Window.Tabs
                 CustomStyleText("Last Weaponskill:", ActionWatching.GetActionName(ActionWatching.LastWeaponskill));
                 CustomStyleText("Last Spell:", ActionWatching.GetActionName(ActionWatching.LastSpell));
                 CustomStyleText("Last Ability:", ActionWatching.GetActionName(ActionWatching.LastAbility));
-                CustomStyleText("Combo Timer:", Math.Round(CustomComboFunctions.ComboTimer, 2));
+                CustomStyleText("Combo Timer:", Math.Round(CustomComboFunctions.ComboTimer, 1));
                 CustomStyleText("Combo Action:", CustomComboFunctions.ComboAction == 0 ? string.Empty : $"{ActionWatching.GetActionName(CustomComboFunctions.ComboAction)} (ID: {CustomComboFunctions.ComboAction})");
                 CustomStyleText("Cast Action:", Svc.ClientState.LocalPlayer.CastActionId == 0 ? string.Empty : $"{ActionWatching.GetActionName(Svc.ClientState.LocalPlayer.CastActionId)} (ID: {Svc.ClientState.LocalPlayer.CastActionId})");
                 CustomStyleText("Cast Time (Total):", Math.Round(Svc.ClientState.LocalPlayer.TotalCastTime, 2));

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -175,8 +175,7 @@ namespace XIVSlothCombo.Window.Tabs
                 CustomStyleText("Combo Timer:", Math.Round(CustomComboFunctions.ComboTimer, 1));
                 CustomStyleText("Combo Action:", CustomComboFunctions.ComboAction == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(CustomComboFunctions.ComboAction)) ? "Unknown" : ActionWatching.GetActionName(CustomComboFunctions.ComboAction))} (ID: {CustomComboFunctions.ComboAction})");
                 CustomStyleText("Cast Action:", LocalPlayer.CastActionId == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(LocalPlayer.CastActionId)) ? "Unknown" : ActionWatching.GetActionName(LocalPlayer.CastActionId))} (ID: {LocalPlayer.CastActionId})");
-                CustomStyleText("Cast Time (Total):", Math.Round(LocalPlayer.TotalCastTime, 2));
-                CustomStyleText("Cast Time (Current):", Math.Round(LocalPlayer.CurrentCastTime, 2));
+                CustomStyleText("Cast Time:", $"{LocalPlayer.CurrentCastTime:F2} / {LocalPlayer.TotalCastTime:F2}");
                 ImGui.Spacing();
 
                 // Party Info

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -162,8 +162,8 @@ namespace XIVSlothCombo.Window.Tabs
                 CustomStyleText("Last Ability:", ActionWatching.GetActionName(ActionWatching.LastAbility));
                 CustomStyleText("Combo Timer:", $"{CustomComboFunctions.ComboTimer:F1}");
                 CustomStyleText("Combo Action:", CustomComboFunctions.ComboAction == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(CustomComboFunctions.ComboAction)) ? "Unknown" : ActionWatching.GetActionName(CustomComboFunctions.ComboAction))} (ID: {CustomComboFunctions.ComboAction})");
-                CustomStyleText("Cast Action:", LocalPlayer.CastActionId == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(LocalPlayer.CastActionId)) ? "Unknown" : ActionWatching.GetActionName(LocalPlayer.CastActionId))} (ID: {LocalPlayer.CastActionId})");
                 CustomStyleText("Cast Time:", $"{LocalPlayer.CurrentCastTime:F2} / {LocalPlayer.TotalCastTime:F2}");
+                CustomStyleText("Cast Action:", LocalPlayer.CastActionId == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(LocalPlayer.CastActionId)) ? "Unknown" : ActionWatching.GetActionName(LocalPlayer.CastActionId))} (ID: {LocalPlayer.CastActionId})");
                 ImGui.Spacing();
 
                 // Party Info

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -1,10 +1,10 @@
 ﻿using Dalamud.Game.ClientState.Objects.SubKinds;
 using Dalamud.Game.ClientState.Objects.Types;
+using Dalamud.Interface.Colors;
 using ECommons.DalamudServices;
 using ImGuiNET;
 using System;
 using System.Linq;
-using System.Numerics;
 using XIVSlothCombo.Combos;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.CustomComboNS.Functions;
@@ -32,43 +32,152 @@ namespace XIVSlothCombo.Window.Tabs
             IPlayerCharacter? LocalPlayer = Svc.ClientState.LocalPlayer;
             DebugCombo? comboClass = new();
 
+            // Custom Styling
+            static void CustomStyleText(string label, object? value)
+            {
+                if (!string.IsNullOrEmpty(label))
+                {
+                    ImGui.TextUnformatted(label);
+                    ImGui.SameLine(0, 4f);
+                }
+                ImGui.PushStyleColor(ImGuiCol.Text, ImGuiColors.DalamudGrey);
+                ImGui.TextUnformatted(value?.ToString() ?? "");
+                ImGui.PopStyleColor();
+            }
+
             if (LocalPlayer != null)
             {
-                if (Svc.ClientState.LocalPlayer.TargetObject is IBattleChara chara)
+                // Player Status Effects
+                if (ImGui.CollapsingHeader("Player Status Effects"))
                 {
-                    foreach (Status? status in chara.StatusList)
+                    foreach (Status? status in Svc.ClientState.LocalPlayer.StatusList)
                     {
-                        ImGui.TextUnformatted($"TARGET STATUS CHECK: {chara.Name} -> {ActionWatching.GetStatusName(status.StatusId)}: {status.StatusId} {Math.Round(status.RemainingTime, 1)}");
+                        // Null Check (Source Name)
+                        if (status.SourceObject is not null)
+                        {
+                            ImGui.TextUnformatted($"{status.SourceObject.Name} ->");
+                            ImGui.SameLine(0, 4f);
+                        }
+
+                        // Null Check (Status Name)
+                        if (!string.IsNullOrEmpty(ActionWatching.GetStatusName(status.StatusId)))
+                        {
+                            CustomStyleText(ActionWatching.GetStatusName(status.StatusId) + ":", status.StatusId);
+                            ImGui.SameLine(0, 4f);
+                            CustomStyleText("", $"({Math.Round(status.RemainingTime, 1)})");
+                        }
+                        else
+                        {
+                            CustomStyleText("", $"{status.StatusId} ({Math.Round(status.RemainingTime, 1)})");
+                        }
                     }
                 }
 
-                foreach (Status? status in (Svc.ClientState.LocalPlayer as IBattleChara).StatusList)
+                // Target Status Effects
+                if (ImGui.CollapsingHeader("Target Status Effects"))
                 {
-                    ImGui.TextUnformatted($"SELF STATUS CHECK: {Svc.ClientState.LocalPlayer.Name} -> {ActionWatching.GetStatusName(status.StatusId)}: {status.StatusId} {Math.Round(status.RemainingTime, 1)}");
-                }
+                    if (Svc.ClientState.LocalPlayer.TargetObject is IBattleChara chara)
+                    {
+                        foreach (Status? status in chara.StatusList)
+                        {
+                            // Null Check (Source Name)
+                            if (status.SourceObject is not null)
+                            {
+                                ImGui.TextUnformatted($"{status.SourceObject.Name} ->");
+                                ImGui.SameLine(0, 4f);
+                            }
 
-                ImGui.TextUnformatted($"TERRITORY: {Svc.ClientState.TerritoryType}");
-                ImGui.TextUnformatted($"TARGET OBJECT KIND: {Svc.ClientState.LocalPlayer.TargetObject?.ObjectKind}");
-                ImGui.TextUnformatted($"TARGET IS BATTLE CHARA: {Svc.ClientState.LocalPlayer.TargetObject is IBattleChara}");
-                ImGui.TextUnformatted($"IN COMBAT: {CustomComboFunctions.InCombat()}");
-                ImGui.TextUnformatted($"IN MELEE RANGE: {CustomComboFunctions.InMeleeRange()}");
-                ImGui.TextUnformatted($"DISTANCE FROM TARGET: {CustomComboFunctions.GetTargetDistance()}");
-                ImGui.TextUnformatted($"TARGET HP VALUE: {CustomComboFunctions.EnemyHealthCurrentHp()}");
-                ImGui.TextUnformatted($"LAST ACTION: {ActionWatching.GetActionName(ActionWatching.LastAction)} (ID:{ActionWatching.LastAction})");
-                ImGui.TextUnformatted($"LAST ACTION COST: {CustomComboFunctions.GetResourceCost(ActionWatching.LastAction)}");
-                ImGui.TextUnformatted($"LAST ACTION TYPE: {ActionWatching.GetAttackType(ActionWatching.LastAction)}");
-                ImGui.TextUnformatted($"LAST WEAPONSKILL: {ActionWatching.GetActionName(ActionWatching.LastWeaponskill)}");
-                ImGui.TextUnformatted($"LAST SPELL: {ActionWatching.GetActionName(ActionWatching.LastSpell)}");
-                ImGui.TextUnformatted($"LAST ABILITY: {ActionWatching.GetActionName(ActionWatching.LastAbility)}");
-                ImGui.TextUnformatted($"ZONE: {Svc.ClientState.TerritoryType}");
-                ImGui.BeginChild("BLUSPELLS", new Vector2(250, 100), false);
-                ImGui.TextUnformatted($"SELECTED BLU SPELLS:\n{string.Join("\n", Service.Configuration.ActiveBLUSpells.Select(x => ActionWatching.GetActionName(x)).OrderBy(x => x))}");
-                ImGui.EndChild();
+                            // Null Check (Status Name)
+                            if (!string.IsNullOrEmpty(ActionWatching.GetStatusName(status.StatusId)))
+                            {
+                                CustomStyleText(ActionWatching.GetStatusName(status.StatusId) + ":", status.StatusId);
+                                ImGui.SameLine(0, 4f);
+                                CustomStyleText("", $"({Math.Round(status.RemainingTime, 1)})");
+                            }
+                            else
+                            {
+                                CustomStyleText("", $"{status.StatusId} ({Math.Round(status.RemainingTime, 1)})");
+                            }
+                        }
+
+                    }
+                }
+                ImGui.Spacing();
+
+                // Player Info
+                ImGui.Spacing();
+                ImGui.Text("Player Info");
+                ImGui.Separator();
+                CustomStyleText("Job:", $"{Svc.ClientState.LocalPlayer.ClassJob.GameData.NameEnglish} (ID: {Svc.ClientState.LocalPlayer.ClassJob.Id})");
+                CustomStyleText("Zone:", $"{Svc.Data.GetExcelSheet<Lumina.Excel.GeneratedSheets.TerritoryType>()?.FirstOrDefault(x => x.RowId == Svc.ClientState.TerritoryType).PlaceName.Value.Name} (ID: {Svc.ClientState.TerritoryType})");
+                CustomStyleText("In PvP:", CustomComboFunctions.InPvP());
+                CustomStyleText("In Combat:", CustomComboFunctions.InCombat());
+                CustomStyleText("Hitbox Radius:", Svc.ClientState.LocalPlayer.HitboxRadius);
+                ImGui.Spacing();
+
+                // Target Info
+                ImGui.Spacing();
+                ImGui.Text("Target Info");
+                ImGui.Separator();
+                CustomStyleText("ObjectId:", Svc.ClientState.LocalPlayer.TargetObject?.GameObjectId);
+                CustomStyleText("ObjectKind:", Svc.ClientState.LocalPlayer.TargetObject?.ObjectKind);
+                CustomStyleText("Is BattleChara:", Svc.ClientState.LocalPlayer.TargetObject is IBattleChara);
+                CustomStyleText("Is PlayerCharacter:", Svc.ClientState.LocalPlayer.TargetObject is IPlayerCharacter);
+                CustomStyleText("Distance:", $"{Math.Round(CustomComboFunctions.GetTargetDistance(), 2)}y");
+                CustomStyleText("Hitbox Radius:", Svc.ClientState.LocalPlayer.TargetObject?.HitboxRadius);
+                CustomStyleText("In Melee Range:", CustomComboFunctions.InMeleeRange());
+                CustomStyleText("Relative Direction:", CustomComboFunctions.AngleToTarget() == 2 ? "Rear" : (CustomComboFunctions.AngleToTarget() == 1 || CustomComboFunctions.AngleToTarget() == 3) ? "Flank" : CustomComboFunctions.AngleToTarget() == 4 ? "Front" : "");
+                CustomStyleText("Health:", $"{CustomComboFunctions.EnemyHealthCurrentHp().ToString("N0")} / {CustomComboFunctions.EnemyHealthMaxHp().ToString("N0")} ({Math.Round(CustomComboFunctions.GetTargetHPPercent(), 2)}%)");
+                ImGui.Spacing();
+
+                // Action Info
+                ImGui.Spacing();
+                ImGui.Text("Action Info");
+                ImGui.Separator();
+                CustomStyleText("Last Action:", ActionWatching.LastAction == 0 ? string.Empty : $"{ActionWatching.GetActionName(ActionWatching.LastAction)} (ID: {ActionWatching.LastAction})");
+                CustomStyleText("Last Action Cost:", CustomComboFunctions.GetResourceCost(ActionWatching.LastAction));
+                CustomStyleText("Last Action Type:", ActionWatching.GetAttackType(ActionWatching.LastAction));
+                CustomStyleText("Last Weaponskill:", ActionWatching.GetActionName(ActionWatching.LastWeaponskill));
+                CustomStyleText("Last Spell:", ActionWatching.GetActionName(ActionWatching.LastSpell));
+                CustomStyleText("Last Ability:", ActionWatching.GetActionName(ActionWatching.LastAbility));
+                CustomStyleText("Combo Timer:", Math.Round(CustomComboFunctions.ComboTimer, 2));
+                CustomStyleText("Combo Action:", CustomComboFunctions.ComboAction == 0 ? string.Empty : $"{ActionWatching.GetActionName(CustomComboFunctions.ComboAction)} (ID: {CustomComboFunctions.ComboAction})");
+                CustomStyleText("Cast Action:", Svc.ClientState.LocalPlayer.CastActionId == 0 ? string.Empty : $"{ActionWatching.GetActionName(Svc.ClientState.LocalPlayer.CastActionId)} (ID: {Svc.ClientState.LocalPlayer.CastActionId})");
+                CustomStyleText("Cast Time (Total):", Math.Round(Svc.ClientState.LocalPlayer.TotalCastTime, 2));
+                CustomStyleText("Cast Time (Current):", Math.Round(Svc.ClientState.LocalPlayer.CurrentCastTime, 2));
+                ImGui.Spacing();
+
+                // Party Info
+                ImGui.Spacing();
+                ImGui.Text("Party Info");
+                ImGui.Separator();
+                CustomStyleText("Party ID:", Svc.Party.PartyId);
+                CustomStyleText("Party Size:", Svc.Party.Length);
+                if (ImGui.CollapsingHeader("Party Members"))
+                {
+                    for (int i = 1; i <= 8; i++)
+                    {
+                        if (CustomComboFunctions.GetPartySlot(i) is not IBattleChara member || member is null) continue;
+                        ImGui.TextUnformatted($"Slot {i} ->");
+                        ImGui.SameLine(0, 4f);
+                        CustomStyleText($"{CustomComboFunctions.GetPartySlot(i).Name}", $"({member.ClassJob.GameData.Abbreviation})");
+                    }
+                }
+                ImGui.Spacing();
+
+                // Misc. Info
+                ImGui.Spacing();
+                ImGui.Text("Miscellaneous Info");
+                ImGui.Separator();
+                if (ImGui.CollapsingHeader("Active Blue Mage Spells"))
+                {
+                    ImGui.TextUnformatted($"{string.Join("\n", Service.Configuration.ActiveBLUSpells.Select(x => ActionWatching.GetActionName(x)).OrderBy(x => x))}");
+                }
             }
 
             else
             {
-                ImGui.TextUnformatted("Please log in to use this tab.");
+                ImGui.TextUnformatted("Please log into the game to use this tab.");
             }
         }
     }

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -12,24 +12,23 @@ using XIVSlothCombo.Data;
 using XIVSlothCombo.Services;
 using Status = Dalamud.Game.ClientState.Statuses.Status;
 
-
 namespace XIVSlothCombo.Window.Tabs
 {
     internal class Debug : ConfigWindow
     {
+        public static int debugNum = 0;
+
         internal class DebugCombo : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; }
-
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level) => actionID;
         }
 
-        public static int debugNum = 0;
         internal unsafe static new void Draw()
         {
-            IPlayerCharacter? LocalPlayer = Svc.ClientState.LocalPlayer;
             DebugCombo? comboClass = new();
-            uint[] statusBlacklist = { 360, 361, 362, 363, 364, 365, 366, 367, 368 }; // Prevents status durations from being displayed
+            IPlayerCharacter? LocalPlayer = Svc.ClientState.LocalPlayer;
+            uint[] statusBlacklist = { 360, 361, 362, 363, 364, 365, 366, 367, 368 }; // Duration will not be displayed for these status effects
 
             // Custom Styling
             static void CustomStyleText(string label, object? value)

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -2,7 +2,6 @@
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Interface.Colors;
 using ECommons.DalamudServices;
-using FFXIVClientStructs.FFXIV.Client.Game;
 using ImGuiNET;
 using System;
 using System.Linq;
@@ -62,18 +61,11 @@ namespace XIVSlothCombo.Window.Tabs
                         if (!string.IsNullOrEmpty(ActionWatching.GetStatusName(status.StatusId)))
                         {
                             CustomStyleText(ActionWatching.GetStatusName(status.StatusId) + ":", status.StatusId);
-
                         }
-                        else
-                        {
-                            CustomStyleText("", status.StatusId);
-                        }
-
-                        float buffDuration = (CustomComboFunctions.FindEffectAny((ushort)status.StatusId).RemainingTime < 0)
-                            ? (CustomComboFunctions.FindEffectAny((ushort)status.StatusId).RemainingTime * -1) + ActionManager.Instance()->AnimationLock
-                            : CustomComboFunctions.FindEffectAny((ushort)status.StatusId).RemainingTime;
+                        else CustomStyleText("", status.StatusId);
 
                         // Duration + Blacklist Check
+                        float buffDuration = CustomComboFunctions.GetBuffRemainingTime((ushort)status.StatusId, false);
                         if (buffDuration != 0 && !statusBlacklist.Contains(status.StatusId))
                         {
                             string formattedDuration;
@@ -82,10 +74,7 @@ namespace XIVSlothCombo.Window.Tabs
                                 int minutes = (int)(buffDuration / 60);
                                 formattedDuration = $"{minutes}m";
                             }
-                            else
-                            {
-                                formattedDuration = $"{Math.Round(buffDuration, 1)}s";
-                            }
+                            else formattedDuration = $"{buffDuration:F1}s";
 
                             ImGui.SameLine(0, 4f);
                             CustomStyleText("", $"({formattedDuration})");
@@ -111,18 +100,11 @@ namespace XIVSlothCombo.Window.Tabs
                             if (!string.IsNullOrEmpty(ActionWatching.GetStatusName(status.StatusId)))
                             {
                                 CustomStyleText(ActionWatching.GetStatusName(status.StatusId) + ":", status.StatusId);
-
                             }
-                            else
-                            {
-                                CustomStyleText("", status.StatusId);
-                            }
-
-                            float debuffDuration = (CustomComboFunctions.FindTargetEffectAny((ushort)status.StatusId).RemainingTime < 0)
-                                ? (CustomComboFunctions.FindTargetEffectAny((ushort)status.StatusId).RemainingTime * -1) + ActionManager.Instance()->AnimationLock
-                                : CustomComboFunctions.FindTargetEffectAny((ushort)status.StatusId).RemainingTime;
+                            else CustomStyleText("", status.StatusId);
 
                             // Duration + Blacklist Check
+                            float debuffDuration = CustomComboFunctions.GetDebuffRemainingTime((ushort)status.StatusId, false);
                             if (debuffDuration != 0 && !statusBlacklist.Contains(status.StatusId))
                             {
                                 string formattedDuration;
@@ -131,10 +113,7 @@ namespace XIVSlothCombo.Window.Tabs
                                     int minutes = (int)(debuffDuration / 60);
                                     formattedDuration = $"{minutes}m";
                                 }
-                                else
-                                {
-                                    formattedDuration = $"{Math.Round(debuffDuration, 1)}s";
-                                }
+                                else formattedDuration = $"{debuffDuration:F1}s";
 
                                 ImGui.SameLine(0, 4f);
                                 CustomStyleText("", $"({formattedDuration})");
@@ -181,7 +160,7 @@ namespace XIVSlothCombo.Window.Tabs
                 CustomStyleText("Last Weaponskill:", ActionWatching.GetActionName(ActionWatching.LastWeaponskill));
                 CustomStyleText("Last Spell:", ActionWatching.GetActionName(ActionWatching.LastSpell));
                 CustomStyleText("Last Ability:", ActionWatching.GetActionName(ActionWatching.LastAbility));
-                CustomStyleText("Combo Timer:", Math.Round(CustomComboFunctions.ComboTimer, 1));
+                CustomStyleText("Combo Timer:", $"{CustomComboFunctions.ComboTimer:F1}");
                 CustomStyleText("Combo Action:", CustomComboFunctions.ComboAction == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(CustomComboFunctions.ComboAction)) ? "Unknown" : ActionWatching.GetActionName(CustomComboFunctions.ComboAction))} (ID: {CustomComboFunctions.ComboAction})");
                 CustomStyleText("Cast Action:", LocalPlayer.CastActionId == 0 ? string.Empty : $"{(string.IsNullOrEmpty(ActionWatching.GetActionName(LocalPlayer.CastActionId)) ? "Unknown" : ActionWatching.GetActionName(LocalPlayer.CastActionId))} (ID: {LocalPlayer.CastActionId})");
                 CustomStyleText("Cast Time:", $"{LocalPlayer.CurrentCastTime:F2} / {LocalPlayer.TotalCastTime:F2}");

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -69,7 +69,7 @@ namespace XIVSlothCombo.Window.Tabs
                         }
 
                         // Duration + Blacklist Check
-                        if (status.RemainingTime > 0 && !statusBlacklist.Contains(status.StatusId))
+                        if (status.RemainingTime != 0 && !statusBlacklist.Contains(status.StatusId))
                         {
                             string formattedDuration;
                             if (status.RemainingTime >= 60)
@@ -114,7 +114,7 @@ namespace XIVSlothCombo.Window.Tabs
                             }
 
                             // Duration + Blacklist Check
-                            if (status.RemainingTime > 0 && !statusBlacklist.Contains(status.StatusId))
+                            if (status.RemainingTime != 0 && !statusBlacklist.Contains(status.StatusId))
                             {
                                 string formattedDuration;
                                 if (status.RemainingTime >= 60)

--- a/XIVSlothCombo/Window/Tabs/Debug.cs
+++ b/XIVSlothCombo/Window/Tabs/Debug.cs
@@ -2,6 +2,7 @@
 using Dalamud.Game.ClientState.Objects.Types;
 using Dalamud.Interface.Colors;
 using ECommons.DalamudServices;
+using FFXIVClientStructs.FFXIV.Client.Game;
 using ImGuiNET;
 using System;
 using System.Linq;
@@ -68,18 +69,22 @@ namespace XIVSlothCombo.Window.Tabs
                             CustomStyleText("", status.StatusId);
                         }
 
+                        float buffDuration = (CustomComboFunctions.FindEffectAny((ushort)status.StatusId).RemainingTime < 0)
+                            ? (CustomComboFunctions.FindEffectAny((ushort)status.StatusId).RemainingTime * -1) + ActionManager.Instance()->AnimationLock
+                            : CustomComboFunctions.FindEffectAny((ushort)status.StatusId).RemainingTime;
+
                         // Duration + Blacklist Check
-                        if (status.RemainingTime != 0 && !statusBlacklist.Contains(status.StatusId))
+                        if (buffDuration != 0 && !statusBlacklist.Contains(status.StatusId))
                         {
                             string formattedDuration;
-                            if (status.RemainingTime >= 60)
+                            if (buffDuration >= 60)
                             {
-                                int minutes = (int)(status.RemainingTime / 60);
+                                int minutes = (int)(buffDuration / 60);
                                 formattedDuration = $"{minutes}m";
                             }
                             else
                             {
-                                formattedDuration = $"{Math.Round(status.RemainingTime, 1)}s";
+                                formattedDuration = $"{Math.Round(buffDuration, 1)}s";
                             }
 
                             ImGui.SameLine(0, 4f);
@@ -113,18 +118,22 @@ namespace XIVSlothCombo.Window.Tabs
                                 CustomStyleText("", status.StatusId);
                             }
 
+                            float debuffDuration = (CustomComboFunctions.FindTargetEffectAny((ushort)status.StatusId).RemainingTime < 0)
+                                ? (CustomComboFunctions.FindTargetEffectAny((ushort)status.StatusId).RemainingTime * -1) + ActionManager.Instance()->AnimationLock
+                                : CustomComboFunctions.FindTargetEffectAny((ushort)status.StatusId).RemainingTime;
+
                             // Duration + Blacklist Check
-                            if (status.RemainingTime != 0 && !statusBlacklist.Contains(status.StatusId))
+                            if (debuffDuration != 0 && !statusBlacklist.Contains(status.StatusId))
                             {
                                 string formattedDuration;
-                                if (status.RemainingTime >= 60)
+                                if (debuffDuration >= 60)
                                 {
-                                    int minutes = (int)(status.RemainingTime / 60);
+                                    int minutes = (int)(debuffDuration / 60);
                                     formattedDuration = $"{minutes}m";
                                 }
                                 else
                                 {
-                                    formattedDuration = $"{Math.Round(status.RemainingTime, 1)}s";
+                                    formattedDuration = $"{Math.Round(debuffDuration, 1)}s";
                                 }
 
                                 ImGui.SameLine(0, 4f);


### PR DESCRIPTION
- Gave the old debug window a haircut.
- Custom styling makes information more readable.
- Added several new entries of helpful debug information.
- Added several collapsing headers to help keep information organized.
- Status effects on player will now show their respective owners (if one exists).
- Status effects on the target will now show their respective owners (if one exists).
- Added several empty/null checks to handle IDs without a name or a SourceObject.
- Party members are now listed (if present).

![Debug](https://github.com/user-attachments/assets/f4c78580-0e32-40b3-a40a-ea279a68fe5f)