### PR TITLE
[PvP] Rotations & Menu Descriptions overhaul

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4484,6 +4484,7 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         #region DRAGOON
+        [ReplaceSkill(DRGPvP.RaidenThrust)]
         [PvPCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Wheeling Thrust Combo into an all-in-one damage button.", DRG.JobID)]
         DRGPvP_Burst = 116000,
@@ -4579,21 +4580,57 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         #region MACHINIST
+        [ReplaceSkill(MCHPvP.BlastCharge)]
         [PvPCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Blast Charge into an all-in-one damage button.", MCHPvP.JobID)]
         MCHPvP_BurstMode = 118000,
 
         [PvPCustomCombo]
         [ParentCombo(MCHPvP_BurstMode)]
-        [CustomComboInfo("Alternate Drill Option", "Saves Drill for use after Wildfire.", MCHPvP.JobID)]
-        MCHPvP_BurstMode_AltDrill = 118001,
+        [CustomComboInfo("Wildfire Option", "Adds Wildfire into the rotation.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_Wildfire = 118001,
 
         [PvPCustomCombo]
         [ParentCombo(MCHPvP_BurstMode)]
-        [CustomComboInfo("Alternate Analysis Option", "Uses Analysis with Air Anchor instead of Chain Saw.", MCHPvP.JobID)]
-        MCHPvP_BurstMode_AltAnalysis = 118002,
+        [CustomComboInfo("Heat Blast Option", "Adds Heat Blast into the rotation when appropriate.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_HeatBlast = 118002,
 
-        // Last value = 118002
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Analysis Option", "Adds Analysis into the rotation when appropriate.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_Analysis = 118003,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Drill Option", "Adds Drill into the rotation when primed.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_Drill = 118004,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("BioBlaster Option", "Adds BioBlaster into the rotation when primed.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_BioBlaster = 118005,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Air Anchor Option", "Adds Heat Blast into the rotation when primed.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_AirAnchor = 118006,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode)]
+        [CustomComboInfo("Chain Saw Option", "Adds Heat Blast into the rotation when primed.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_ChainSaw = 118007,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode_Drill)]
+        [CustomComboInfo("Alternate Drill Option", "Saves Drill for use after Wildfire.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_AltDrill = 118008,
+
+        [PvPCustomCombo]
+        [ParentCombo(MCHPvP_BurstMode_AirAnchor)]
+        [CustomComboInfo("Alternate Analysis Option", "Uses Analysis with Air Anchor instead of Chain Saw.", MCHPvP.JobID)]
+        MCHPvP_BurstMode_AltAnalysis = 118009,
+
+        // Last value = 118009
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4485,7 +4485,7 @@ namespace XIVSlothCombo.Combos
 
         #region DRAGOON
         [PvPCustomCombo]
-        [CustomComboInfo("Advanced Mode", "Replaces Wheeling Thrust Combo with its optimal combo chain.", DRG.JobID)]
+        [CustomComboInfo("Burst Mode", "Turns Wheeling Thrust Combo into an all-in-one damage button.", DRG.JobID)]
         DRGPvP_Burst = 116000,
 
         [ParentCombo(DRGPvP_Burst)]
@@ -4828,7 +4828,7 @@ namespace XIVSlothCombo.Combos
 
         #region WARRIOR
         [PvPCustomCombo]
-        [CustomComboInfo("Advanced Mode", "Turns Heavy Swing Combo into its optimal combo chain.", WARPvP.JobID)]
+        [CustomComboInfo("Burst Mode", "Turns Heavy Swing Combo into its optimal combo chain.", WARPvP.JobID)]
         WARPvP_BurstMode = 128000,
 
         [PvPCustomCombo]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4828,25 +4828,48 @@ namespace XIVSlothCombo.Combos
 
         #region WARRIOR
         [PvPCustomCombo]
-        [CustomComboInfo("Burst Mode", "Turns Heavy Swing into an all-in-one damage button.", WARPvP.JobID)]
+        [CustomComboInfo("Advanced Mode", "Turns Heavy Swing Combo into its optimal combo chain.", WARPvP.JobID)]
         WARPvP_BurstMode = 128000,
 
         [PvPCustomCombo]
         [ParentCombo(WARPvP_BurstMode)]
-        [CustomComboInfo("Bloodwhetting Option", "Allows use of Bloodwhetting any time, not just between GCDs.", WARPvP.JobID)]
+        [CustomComboInfo("Bloodwhetting Option", "Adds Bloodwhetting to the rotation.", WARPvP.JobID)]
         WARPvP_BurstMode_Bloodwhetting = 128001,
 
         [PvPCustomCombo]
         [ParentCombo(WARPvP_BurstMode)]
-        [CustomComboInfo("Blota Option", "Adds Blota to Burst Mode when not in melee range.", WARPvP.JobID)]
-        WARPvP_BurstMode_Blota = 128003,
+        [CustomComboInfo("Onslaught Option", "Adds Onslaught to the rotation.", WARPvP.JobID)]
+        WARPvP_BurstMode_Onslaught = 128002,
 
         [PvPCustomCombo]
         [ParentCombo(WARPvP_BurstMode)]
-        [CustomComboInfo("Primal Rend Option", "Adds Primal Rend to Burst Mode.", WARPvP.JobID)]
-        WARPvP_BurstMode_PrimalRend = 128004,
+        [CustomComboInfo("Orogeny Option", "Adds Orogeny to the rotation when available.", WARPvP.JobID)]
+        WARPvP_BurstMode_Orogeny = 128003,
 
-        // Last value = 128002
+        [PvPCustomCombo]
+        [ConflictingCombos(WARPvP_BurstMode_Stunlock)]
+        [ParentCombo(WARPvP_BurstMode)]
+        [CustomComboInfo("Blota Option", "Adds Blota to the rotation.", WARPvP.JobID)]
+        WARPvP_BurstMode_Blota = 128004,
+
+        [PvPCustomCombo]
+        [ConflictingCombos(WARPvP_BurstMode_Blota, WARPvP_BurstMode_PrimalRend)]
+        [ParentCombo(WARPvP_BurstMode_PrimalRend)]
+        [CustomComboInfo("StunLock Option", "Adds Primal Rend & Blota to the rotation together to execute a 4s stun lock.", WARPvP.JobID)]
+        WARPvP_BurstMode_Stunlock = 128005,
+
+        [PvPCustomCombo]
+        [ConflictingCombos(WARPvP_BurstMode_Stunlock)]
+        [ParentCombo(WARPvP_BurstMode)]
+        [CustomComboInfo("Primal Rend Option", "Adds Primal Rend the rotation.", WARPvP.JobID)]
+        WARPvP_BurstMode_PrimalRend = 128006,
+
+        [PvPCustomCombo]
+        [ParentCombo(WARPvP_BurstMode)]
+        [CustomComboInfo("Chaotic Cyclone Option", "Adds Chaotic Cyclone the rotation when available.", WARPvP.JobID)]
+        WARPvP_BurstMode_ChaoticCyclone = 128007,
+
+        // Last value = 128007
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4485,38 +4485,50 @@ namespace XIVSlothCombo.Combos
 
         #region DRAGOON
         [PvPCustomCombo]
-        [CustomComboInfo("Burst Mode", "Using Elusive Jump turns Wheeling Thrust Combo into all-in-one burst damage button.", DRG.JobID)]
+        [CustomComboInfo("Advanced Mode", "Replaces Wheeling Thrust Combo with its optimal combo chain.", DRG.JobID)]
         DRGPvP_Burst = 116000,
 
         [ParentCombo(DRGPvP_Burst)]
-        [CustomComboInfo("Geirskogul Option", "Adds Geirskogul to Burst Mode.", DRG.JobID)]
-        DRGPvP_Geirskogul = 116001,
+        [CustomComboInfo("Elusive Jump Option", "Adds Elusive Jump to the rotation.\n WARNING: This does not take into account anything whatsoever besides the rotation.\n Will always use on CD no matter any situation regarding AoEs or outside interference. Use at your own risk.", DRG.JobID)]
+        DRGPvP_ElusiveJump = 116001,
+
+        [ParentCombo(DRGPvP_Burst)]
+        [CustomComboInfo("Geirskogul Option", "Adds Geirskogul to the rotation.", DRG.JobID)]
+        DRGPvP_Geirskogul = 116002,
 
         [ParentCombo(DRGPvP_Geirskogul)]
-        [CustomComboInfo("Nastrond Option", "Adds Nastrond to Burst Mode.", DRG.JobID)]
-        DRGPvP_Nastrond = 116002,
+        [CustomComboInfo("Nastrond Option", "Adds Nastrond to the rotation.", DRG.JobID)]
+        DRGPvP_Nastrond = 116003,
+
+        [ParentCombo(DRGPvP_Geirskogul)]
+        [CustomComboInfo("Optimal Nastrond Option", "Adds Nastrond to the rotation when the target has 50 percent or lower HP or when buff is about to expire, regardless of settings above.", DRG.JobID)]
+        DRGPvP_NastrondOpti = 116004,
 
         [ParentCombo(DRGPvP_Burst)]
-        [CustomComboInfo("Horrid Roar Option", "Adds Horrid Roar to Burst Mode.", DRG.JobID)]
-        DRGPvP_HorridRoar = 116003,
+        [CustomComboInfo("Horrid Roar Option", "Adds Horrid Roar to the rotation.", DRG.JobID)]
+        DRGPvP_HorridRoar = 116005,
 
         [ParentCombo(DRGPvP_Burst)]
-        [CustomComboInfo("Sustain Chaos Spring Option", "Adds Chaos Spring to Burst Mode when below the set HP percentage.", DRG.JobID)]
-        DRGPvP_ChaoticSpringSustain = 116004,
+        [CustomComboInfo("Chaotic Spring Option", "Adds Chaotic Spring to the rotation, essentially only for damage purposes.", DRG.JobID)]
+        DRGPvP_ChaoticSpring = 116006,
+
+        [ParentCombo(DRGPvP_ChaoticSpring)]
+        [CustomComboInfo("Chaotic Spring Self-Heal Option", "Adds Chaotic Spring to the rotation when below the set HP percentage, essentially only for healing purposes.", DRG.JobID)]
+        DRGPvP_ChaoticSpringSustain = 116007,
 
         [ParentCombo(DRGPvP_Burst)]
-        [CustomComboInfo("Wyrmwind Thrust Option", "Adds Wyrmwind Thrust to Burst Mode.", DRG.JobID)]
-        DRGPvP_WyrmwindThrust = 116006,
+        [CustomComboInfo("Wyrmwind Thrust Option", "Adds Wyrmwind Thrust to the rotation.", DRG.JobID)]
+        DRGPvP_WyrmwindThrust = 116008,
 
         [ParentCombo(DRGPvP_Burst)]
-        [CustomComboInfo("High Jump Weave Option", "Adds High Jump to Burst Mode.", DRG.JobID)]
-        DRGPvP_HighJump = 116007,
+        [CustomComboInfo("High Jump Option", "Adds High Jump to the rotation, optimally.", DRG.JobID)]
+        DRGPvP_HighJump = 116009,
 
         [ParentCombo(DRGPvP_Burst)]
         [CustomComboInfo("Elusive Jump Burst Protection Option", "Disables Elusive Jump if Burst is not ready.", DRG.JobID)]
-        DRGPvP_BurstProtection = 116008,
+        DRGPvP_BurstProtection = 116010,
 
-        // Last value = 116008
+        // Last value = 116010
 
         #endregion
 
@@ -4535,7 +4547,7 @@ namespace XIVSlothCombo.Combos
         GNBPvP_GnashingFang = 117002,
 
         [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Draw And Junction Option", "Adds Draw And Junction to Burst Mode.", GNB.JobID)]
+        [CustomComboInfo("Draw And Junction Option", "Adds Draw And Junction to the rotation.", GNB.JobID)]
         GNBPvP_DrawAndJunction = 117003,
 
         [ParentCombo(GNBPvP_Burst)]
@@ -4543,7 +4555,7 @@ namespace XIVSlothCombo.Combos
         GNBPvP_ST_GnashingFang = 117004,
 
         [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Continuation Option", "Adds Continuation to Burst Mode.", GNB.JobID)]
+        [CustomComboInfo("Continuation Option", "Adds Continuation to the rotation.", GNB.JobID)]
         GNBPvP_ST_Continuation = 117005,
 
         [ParentCombo(GNBPvP_Burst)]
@@ -4551,15 +4563,15 @@ namespace XIVSlothCombo.Combos
         GNBPvP_RoughDivide = 117006,
 
         [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Junction Cast DPS Option", "Adds Junction Cast (DPS) to Burst Mode.", GNB.JobID)]
+        [CustomComboInfo("Junction Cast DPS Option", "Adds Junction Cast (DPS) to the rotation.", GNB.JobID)]
         GNBPvP_JunctionDPS = 117007,
 
         [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Junction Cast Healer Option", "Adds Junction Cast (Healer) to Burst Mode.", GNB.JobID)]
+        [CustomComboInfo("Junction Cast Healer Option", "Adds Junction Cast (Healer) to the rotation.", GNB.JobID)]
         GNBPvP_JunctionHealer = 117008,
 
         [ParentCombo(GNBPvP_Burst)]
-        [CustomComboInfo("Junction Cast Tank Option", "Adds Junction Cast (Tank) to Burst Mode.", GNB.JobID)]
+        [CustomComboInfo("Junction Cast Tank Option", "Adds Junction Cast (Tank) to the rotation.", GNB.JobID)]
         GNBPvP_JunctionTank = 117009,
 
         // Last value = 117009

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -483,7 +483,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (LevelChecked(Bloodletter) && (empyrealCD > 1 || !LevelChecked(EmpyrealArrow)) && ((!openerFinished && IsOnCooldown(RagingStrikes)) || openerFinished))
                         {
-                            uint rainOfDeathCharges = GetRemainingCharges(RainOfDeath);
+                            uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
 
                             if (IsEnabled(CustomComboPreset.BRD_Simple_Pooling) && LevelChecked(WanderersMinuet))
                             {

--- a/XIVSlothCombo/Combos/PvP/DRGPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/DRGPVP.cs
@@ -51,32 +51,46 @@ namespace XIVSlothCombo.Combos.PvP
                 if (actionID is RaidenThrust or FangAndClaw or WheelingThrust)
                 {
                     bool enemyGuarded = TargetHasEffectAny(PvPCommon.Buffs.Guard);
+                    bool closeEnough = GetTargetDistance() <= 7;
+                    bool farEnough = GetTargetDistance() <= 13;
+                    float enemyHP = GetTargetHPPercent();
+                    float playerHP = PlayerHealthPercentageHp();
+                    float GCD = GetCooldown(WheelingThrust).CooldownTotal;
 
                     if (!enemyGuarded)
                     {
                         if (CanWeave(actionID))
                         {
-                            if (IsEnabled(CustomComboPreset.DRGPvP_HighJump) && IsOffCooldown(HighJump) && HasEffect(Buffs.LifeOfTheDragon))
+                            //ElusiveJump
+                            if (IsEnabled(CustomComboPreset.DRGPvP_ElusiveJump) && ActionReady(ElusiveJump) && GetCooldownRemainingTime(HighJump) < 1.5f) //use on CD to keep rotation going
+                                return ElusiveJump;
+
+                            //HighJump
+                            if (IsEnabled(CustomComboPreset.DRGPvP_HighJump) && ActionReady(HighJump) && (JustUsed(WyrmwindThrust) || enemyHP <= 10)) //use to re-engage after ElusiveJump > far WyrmwindThrust, best held for burst or to execute
                                 return HighJump;
 
-                            if (IsEnabled(CustomComboPreset.DRGPvP_Nastrond) && InMeleeRange())
+                            //Nastrond
+                            if (IsEnabled(CustomComboPreset.DRGPvP_Nastrond) && farEnough)
                             {
-                                if (HasEffect(Buffs.LifeOfTheDragon) && PlayerHealthPercentageHp() < GetOptionValue(Config.DRGPvP_LOTD_HPValue)
-                                 || HasEffect(Buffs.LifeOfTheDragon) && GetBuffRemainingTime(Buffs.LifeOfTheDragon) < GetOptionValue(Config.DRGPvP_LOTD_Duration))
+                                if (HasEffect(Buffs.LifeOfTheDragon) && 
+                                    ((IsEnabled(CustomComboPreset.DRGPvP_NastrondOpti) && (enemyHP <= 50 || GetBuffRemainingTime(Buffs.LifeOfTheDragon) <= GCD)) || //best used when TargetHP is lower than 50
+                                    (IsNotEnabled(CustomComboPreset.DRGPvP_NastrondOpti) && playerHP < GetOptionValue(Config.DRGPvP_LOTD_HPValue)) || //PlayerHP slider
+                                    (IsNotEnabled(CustomComboPreset.DRGPvP_NastrondOpti) && GetBuffRemainingTime(Buffs.LifeOfTheDragon) < GetOptionValue(Config.DRGPvP_LOTD_Duration)))) //Buff duration slider
                                     return Nastrond;
                             }
-                            if (IsEnabled(CustomComboPreset.DRGPvP_HorridRoar) && IsOffCooldown(HorridRoar) && InMeleeRange())
+                            if (IsEnabled(CustomComboPreset.DRGPvP_HorridRoar) && ActionReady(HorridRoar) && HasEffect(Buffs.LifeOfTheDragon) && closeEnough) //best used when under LOTD to prevent dying due to squishiness
                                 return HorridRoar;
                         }
-                        if (IsEnabled(CustomComboPreset.DRGPvP_ChaoticSpringSustain) && IsOffCooldown(ChaoticSpring) && PlayerHealthPercentageHp() < GetOptionValue(Config.DRGPvP_CS_HP_Threshold))
+                        if (IsEnabled(CustomComboPreset.DRGPvP_ChaoticSpring) && InMeleeRange() && ActionReady(ChaoticSpring))
                         {
-                            if (!HasEffect(Buffs.FirstmindsFocus) && !HasEffect(Buffs.LifeOfTheDragon) && IsOnCooldown(Geirskogul) && IsOnCooldown(ElusiveJump)
-                             || !HasEffect(Buffs.FirstmindsFocus) && HasEffect(Buffs.LifeOfTheDragon) && IsOnCooldown(Geirskogul) && IsOnCooldown(ElusiveJump) && WasLastWeaponskill(HeavensThrust))
+                            if ((!HasEffect(Buffs.FirstmindsFocus) && !HasEffect(Buffs.LifeOfTheDragon) && !ActionReady(Geirskogul) && !ActionReady(ElusiveJump)) //for damage
+                                || (IsEnabled(CustomComboPreset.DRGPvP_ChaoticSpringSustain) && playerHP < GetOptionValue(Config.DRGPvP_CS_HP_Threshold)) //PlayerHP slider
+                                || (!IsEnabled(CustomComboPreset.DRGPvP_ChaoticSpringSustain) && playerHP < 60)) //force heal self
                                 return ChaoticSpring;
                         }
-                        if (IsEnabled(CustomComboPreset.DRGPvP_Geirskogul) && IsOffCooldown(Geirskogul) && WasLastAbility(ElusiveJump) && HasEffect(Buffs.FirstmindsFocus))
+                        if (IsEnabled(CustomComboPreset.DRGPvP_Geirskogul) && ActionReady(Geirskogul) && farEnough)
                             return Geirskogul;
-                        if (IsEnabled(CustomComboPreset.DRGPvP_WyrmwindThrust) && HasEffect(Buffs.FirstmindsFocus) && GetTargetDistance() >= GetOptionValue(Config.DRGPvP_Distance_Threshold))
+                        if (IsEnabled(CustomComboPreset.DRGPvP_WyrmwindThrust) && JustUsed(ElusiveJump, 3f) && GetTargetDistance() >= GetOptionValue(Config.DRGPvP_Distance_Threshold))
                             return WyrmwindThrust;
                     }
                 }

--- a/XIVSlothCombo/Combos/PvP/MCHPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/MCHPVP.cs
@@ -49,42 +49,38 @@ namespace XIVSlothCombo.Combos.PvP
                     var canWeave = CanWeave(actionID);
                     var hasAnalysis = GetRemainingCharges(Analysis); //How many stacks of Analysis we have
                     var hasDrill = GetRemainingCharges(OriginalHook(Drill)); //How many charges
-                    var overheated = HasEffect(Buffs.Overheated);
+                    var hasHeat = HasEffect(Buffs.Overheated);
 
                     //Wildfire
-                    if (canWeave && overheated && ActionReady(Wildfire))
+                    if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_Wildfire) && 
+                        canWeave && hasHeat && ActionReady(Wildfire)) 
                         return OriginalHook(Wildfire);
 
-                    //Turret
-                    //TODO: I'm not sure the opti on this skill. So I'm just going to include it as an option.
-                    if (canWeave && ActionReady(BishopTurret))
-                        return OriginalHook(BishopTurret);
-
                     //HeatBlast
-                    if (overheated)
+                    if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_HeatBlast) && hasHeat)
                         return OriginalHook(HeatBlast);
 
                     //Analysis
-                    if ((HasEffect(Buffs.DrillPrimed) || //Drill
+                    if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_Analysis) && (HasEffect(Buffs.DrillPrimed) || //Drill
                         (HasEffect(Buffs.ChainSawPrimed) && !IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis)) || //Chainsaw
-                        (HasEffect(Buffs.AirAnchorPrimed) && IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis))) && //AirAnchor
-                        !HasEffect(Buffs.Analysis) && hasAnalysis > 0 && (!IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltDrill) //Optimal use
-                        || !ActionReady(Wildfire)) && !canWeave && !overheated && hasDrill > 0)
+                        (HasEffect(Buffs.AirAnchorPrimed) && IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis))) && //Alternate AirAnchor
+                        !HasEffect(Buffs.Analysis) && hasAnalysis > 0 && (!IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltDrill) //Althernate Drill
+                        || !ActionReady(Wildfire)) && !canWeave && !hasHeat && hasDrill > 0)
                         return OriginalHook(Analysis);
 
-                    //Analysis procs Primed skills
+                    //Primed skills
                     if (hasDrill > 0)
                     {
-                        if (HasEffect(Buffs.DrillPrimed))
+                        if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_Drill) && HasEffect(Buffs.DrillPrimed))
                             return OriginalHook(Drill);
 
-                        if (HasEffect(Buffs.BioblasterPrimed) && GetTargetDistance() <= 10)
+                        if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_BioBlaster) && HasEffect(Buffs.BioblasterPrimed) && GetTargetDistance() <= 10)
                             return OriginalHook(BioBlaster);
 
-                        if (HasEffect(Buffs.AirAnchorPrimed))
+                        if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AirAnchor) && HasEffect(Buffs.AirAnchorPrimed))
                             return OriginalHook(AirAnchor);
 
-                        if (HasEffect(Buffs.ChainSawPrimed))
+                        if (IsEnabled(CustomComboPreset.MCHPvP_BurstMode_ChainSaw) && HasEffect(Buffs.ChainSawPrimed))
                             return OriginalHook(ChainSaw);
                     }
                 }

--- a/XIVSlothCombo/Combos/PvP/MCHPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/MCHPVP.cs
@@ -47,29 +47,38 @@ namespace XIVSlothCombo.Combos.PvP
                 if (actionID == BlastCharge)
                 {
                     var canWeave = CanWeave(actionID);
-                    var analysisStacks = GetRemainingCharges(Analysis);
-                    var bigDamageStacks = GetRemainingCharges(OriginalHook(Drill));
+                    var hasAnalysis = GetRemainingCharges(Analysis); //How many stacks of Analysis we have
+                    var hasDrill = GetRemainingCharges(OriginalHook(Drill)); //How many charges
                     var overheated = HasEffect(Buffs.Overheated);
 
-                    if (canWeave && HasEffect(Buffs.Overheated) && IsOffCooldown(Wildfire))
+                    //Wildfire
+                    if (canWeave && overheated && ActionReady(Wildfire))
                         return OriginalHook(Wildfire);
 
+                    //Turret
+                    //TODO: I'm not sure the opti on this skill. So I'm just going to include it as an option.
+                    if (canWeave && ActionReady(BishopTurret))
+                        return OriginalHook(BishopTurret);
+
+                    //HeatBlast
                     if (overheated)
                         return OriginalHook(HeatBlast);
 
-                    if ((HasEffect(Buffs.DrillPrimed) ||
-                        (HasEffect(Buffs.ChainSawPrimed) && !IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis)) ||
-                        (HasEffect(Buffs.AirAnchorPrimed) && IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis))) &&
-                        !HasEffect(Buffs.Analysis) && analysisStacks > 0 && (!IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltDrill)
-                        || IsOnCooldown(Wildfire)) && !canWeave && !overheated && bigDamageStacks > 0)
+                    //Analysis
+                    if ((HasEffect(Buffs.DrillPrimed) || //Drill
+                        (HasEffect(Buffs.ChainSawPrimed) && !IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis)) || //Chainsaw
+                        (HasEffect(Buffs.AirAnchorPrimed) && IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltAnalysis))) && //AirAnchor
+                        !HasEffect(Buffs.Analysis) && hasAnalysis > 0 && (!IsEnabled(CustomComboPreset.MCHPvP_BurstMode_AltDrill) //Optimal use
+                        || !ActionReady(Wildfire)) && !canWeave && !overheated && hasDrill > 0)
                         return OriginalHook(Analysis);
 
-                    if (bigDamageStacks > 0)
+                    //Analysis procs Primed skills
+                    if (hasDrill > 0)
                     {
                         if (HasEffect(Buffs.DrillPrimed))
                             return OriginalHook(Drill);
 
-                        if (HasEffect(Buffs.BioblasterPrimed) && GetTargetDistance() <= 12)
+                        if (HasEffect(Buffs.BioblasterPrimed) && GetTargetDistance() <= 10)
                             return OriginalHook(BioBlaster);
 
                         if (HasEffect(Buffs.AirAnchorPrimed))

--- a/XIVSlothCombo/Combos/PvP/WARPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/WARPVP.cs
@@ -1,3 +1,4 @@
+using FFXIVClientStructs.FFXIV.Client.Game;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.CustomComboNS.Functions;
 
@@ -15,6 +16,7 @@ namespace XIVSlothCombo.Combos.PvP
             Onslaught = 29079,
             Orogeny = 29080,
             Blota = 29081,
+            PrimalScream = 29083, //LB
             Bloodwhetting = 29082;
 
         internal class Buffs
@@ -24,46 +26,60 @@ namespace XIVSlothCombo.Combos.PvP
                 InnerRelease = 1303;
         }
 
-        public static class Config
+        internal class Debuffs
         {
-            public static UserInt
-                WARPVP_BlotaTiming = new("WARPVP_BlotaTiming");
-
+            internal const ushort
+                Onslaught = 3029;
         }
+
         internal class WARPvP_BurstMode : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WARPvP_BurstMode;
 
             protected override uint Invoke(uint actionID, uint lastComboActionID, float comboTime, byte level)
             {
+                bool enemyStun = TargetHasEffectAny(PvPCommon.Debuffs.Stun);
+                bool enemyGuard = TargetHasEffectAny(PvPCommon.Buffs.Guard);
+                var canWeave = CanWeave(actionID);
+
                 if (actionID is HeavySwing or Maim or StormsPath)
                 {
-                    var canWeave = CanWeave(actionID);
-
-                    if (!GetCooldown(Bloodwhetting).IsCooldown && (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Bloodwhetting) || canWeave))
-                        return OriginalHook(Bloodwhetting);
-
-                    if (!InMeleeRange() && IsOffCooldown(Blota) && !TargetHasEffectAny(PvPCommon.Debuffs.Stun) && IsEnabled(CustomComboPreset.WARPvP_BurstMode_Blota) && Config.WARPVP_BlotaTiming == 0 && IsOffCooldown(PrimalRend))
-                        return OriginalHook(Blota);
-
-                    if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_PrimalRend) && IsOffCooldown(PrimalRend))
-                        return OriginalHook(PrimalRend);
-
-                    if (!InMeleeRange() && IsOffCooldown(Blota) && !TargetHasEffectAny(PvPCommon.Debuffs.Stun) && IsEnabled(CustomComboPreset.WARPvP_BurstMode_Blota) && Config.WARPVP_BlotaTiming == 1 && IsOnCooldown(PrimalRend))
-                        return OriginalHook(Blota);
-
-                    if (!GetCooldown(Onslaught).IsCooldown && canWeave)
-                        return OriginalHook(Onslaught);
-
-                    if (InMeleeRange())
+                    if (canWeave && !enemyGuard)
                     {
-                        if (HasEffect(Buffs.NascentChaos))
-                            return OriginalHook(Bloodwhetting);
-
-                        if (!GetCooldown(Orogeny).IsCooldown && canWeave)
+                        //Orogeny
+                        if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Orogeny) &&
+                            ActionReady(Orogeny) && InMeleeRange() && !enemyGuard) //use on CD
                             return OriginalHook(Orogeny);
                     }
+
+                    //Bloodwhetting
+                    if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Bloodwhetting) &&
+                        ActionReady(Bloodwhetting) && (ActionReady(PrimalRend) || GetCooldownRemainingTime(PrimalRend) > 5) && GetCooldownRemainingTime(Onslaught) < 1) //use before Primal Rend burst
+                        return OriginalHook(Bloodwhetting);
+
+                    //Blota
+                    if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Blota) && !enemyStun && !enemyGuard &&
+                        (!InMeleeRange() && ActionReady(Blota) && !enemyStun && canWeave) || //use when out of range
+                        (!IsEnabled(CustomComboPreset.WARPvP_BurstMode_Blota) && IsEnabled(CustomComboPreset.WARPvP_BurstMode_Stunlock) && JustUsed(PrimalRend, 3f))) //stunlock
+                        return OriginalHook(Blota);
+
+                    //Onslaught
+                    if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_Onslaught) && 
+                        ActionReady(Onslaught) && (ActionReady(PrimalRend)) && !enemyGuard)
+                        return OriginalHook(Onslaught);
+
+                    //ChaoticCyclone
+                    if (IsEnabled(CustomComboPreset.WARPvP_BurstMode_ChaoticCyclone) && 
+                        HasEffect(Buffs.NascentChaos) && !ActionReady(PrimalRend) && InMeleeRange()) //use on CD
+                        return OriginalHook(Bloodwhetting);
+
+                    //PrimalRend
+                    if (!enemyGuard && JustUsed(Onslaught, 3f) && ActionReady(PrimalRend) &&
+                        (IsEnabled(CustomComboPreset.WARPvP_BurstMode_PrimalRend) || //use on CD
+                       (!IsEnabled(CustomComboPreset.WARPvP_BurstMode_PrimalRend) && IsEnabled(CustomComboPreset.WARPvP_BurstMode_Stunlock) && GetCooldownRemainingTime(Blota) < 0.6f))) //stunlock
+                        return OriginalHook(PrimalRend);
                 }
+
                 return actionID;
             }
         }

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -2476,12 +2476,6 @@ namespace XIVSlothCombo.Window.Functions
             if (preset == CustomComboPreset.WAR_AoE_Overpower_Infuriate)
                 UserConfig.DrawSliderInt(0, 50, WAR.Config.WAR_InfuriateAoEGauge, "Use when gauge is under or equal to");
 
-            if (preset == CustomComboPreset.WARPvP_BurstMode_Blota)
-            {
-                UserConfig.DrawHorizontalRadioButton(WARPvP.Config.WARPVP_BlotaTiming, "Before Primal Rend", "", 0);
-                UserConfig.DrawHorizontalRadioButton(WARPvP.Config.WARPVP_BlotaTiming, "After Primal Rend", "", 1);
-            }
-
             #endregion
             // ====================================================================================
             #region WHITE MAGE

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1583,10 +1583,10 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(2, 8, DRGPvP.Config.DRGPvP_LOTD_Duration, "Seconds remaining of Life of the Dragon buff before using Nastrond if you are still above the set HP percentage.", 150, SliderIncrements.Ones);
 
             if (preset is CustomComboPreset.DRGPvP_ChaoticSpringSustain)
-                UserConfig.DrawSliderInt(0, 101, DRGPvP.Config.DRGPvP_CS_HP_Threshold, "Chaos Spring HP percentage threshold", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 101, DRGPvP.Config.DRGPvP_CS_HP_Threshold, "Chaotic Spring HP percentage threshold", 150, SliderIncrements.Ones);
 
             if (preset is CustomComboPreset.DRGPvP_WyrmwindThrust)
-                UserConfig.DrawSliderInt(0, 20, DRGPvP.Config.DRGPvP_Distance_Threshold, "Distance Treshold for Wyrmwind Thrust", 150, SliderIncrements.Ones);
+                UserConfig.DrawSliderInt(0, 20, DRGPvP.Config.DRGPvP_Distance_Threshold, "Distance Threshold for Wyrmwind Thrust", 150, SliderIncrements.Ones);
             #endregion
 
             #endregion


### PR DESCRIPTION
I plan to do more later, but for now here's a few. 

- [x] GNB - some touchups to the rotation; clean up code & added options (completed in PR#1697)
- [x] DRG - reworked rotation; added options, big DPS 
- [x] WAR - small touchups to the rotation; added stunlock option
- [x] MCH - very small code & menu cleanup; added options for other skills