### PR TITLE
[DRK] Burst Optimizations

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1177,7 +1177,7 @@ namespace XIVSlothCombo.Combos
         DRK_ST_ManaOvercap = 5011,
 
         [ParentCombo(DRK_ST_ManaOvercap)]
-        [CustomComboInfo("Edge of Shadow Burst Option", "Pools Edge of Shadow for even minute burst windows, and otherwise uses them until chosen MP limit is reached.", DRK.JobID)]
+        [CustomComboInfo("Edge of Shadow Burst Option", "Pools Edge of Shadow for even minute burst windows, and then uses them until chosen MP limit is reached.", DRK.JobID)]
         DRK_ST_ManaSpenderPooling = 5012,
 
         #endregion

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -119,7 +119,8 @@ namespace XIVSlothCombo.Combos.PvE
                     && LevelChecked(Disesteem)
                     && IsEnabled(CustomComboPreset.DRK_ST_CDs_Disesteem)
                     && HasEffect(Buffs.Scorn)
-                    && ((gauge.DarksideTimeRemaining > 0 && GetBuffRemainingTime(Buffs.Scorn) < 26) // Optimal usage
+                    && ((gauge.DarksideTimeRemaining > 0 // Optimal usage
+                         && GetBuffRemainingTime(Buffs.Scorn) < 24)
                         || GetBuffRemainingTime(Buffs.Scorn) < 14) // Emergency usage
                     )
                     return OriginalHook(Disesteem);

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -218,7 +218,8 @@ namespace XIVSlothCombo.Combos.PvE
                                     (IsEnabled(CustomComboPreset.DRK_ST_CDs_ShadowbringerBurst)
                                      && GetRemainingCharges(Shadowbringer) > 0
                                      && gauge.ShadowTimeRemaining > 1
-                                     && IsOnCooldown(Delirium))) // Burst
+                                     && IsOnCooldown(LivingShadow)
+                                     && !HasEffect(Buffs.Scorn))) // Burst
                                     return Shadowbringer;
                             }
 


### PR DESCRIPTION
- [X] Delay Disesteem in burst windows 1 more GCD, to try to ensure we catch all buffs.
- [X] Change Shadow Bringers logic to wait for Disesteem use, not Delirium use.