### PR TITLE
[PCT PVP] Initial Release

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4643,7 +4643,7 @@ namespace XIVSlothCombo.Combos
         PCTPvP_BurstControl = 140001,
 
         [ParentCombo(PCTPvP_Burst)]
-        [CustomComboInfo("Tempera Coat Option", "Uses Tempera Coat when HP falls under the set threshold during combat.\n - Transforms Tempera Coat into Tempera Grassa before buff expires.", PCTPvP.JobID)]
+        [CustomComboInfo("Tempera Coat Option", "Uses Tempera Coat when HP falls under the set threshold during combat.\n- Transforms Tempera Coat into Tempera Grassa before buff expires.", PCTPvP.JobID)]
         PCTPvP_TemperaCoat = 140002,
 
         [ParentCombo(PCTPvP_Burst)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4639,15 +4639,15 @@ namespace XIVSlothCombo.Combos
         PCTPvP_Burst = 140000,
 
         [ParentCombo(PCTPvP_Burst)]
-        [CustomComboInfo("Burst Control Option", "Saves high-damaging actions until the target's HP falls below the set threshold.", PCTPvP.JobID)]
+        [CustomComboInfo("Burst Control Option", "Saves high-damaging actions until the target's HP falls below the threshold.", PCTPvP.JobID)]
         PCTPvP_BurstControl = 140001,
 
         [ParentCombo(PCTPvP_Burst)]
-        [CustomComboInfo("Tempera Coat Option", "Uses Tempera Coat when HP falls under the set threshold during combat.\n- Transforms Tempera Coat into Tempera Grassa before buff expires.", PCTPvP.JobID)]
+        [CustomComboInfo("Tempera Coat Option", "Uses Tempera Coat when HP falls below the threshold during combat.", PCTPvP.JobID)]
         PCTPvP_TemperaCoat = 140002,
 
         [ParentCombo(PCTPvP_Burst)]
-        [CustomComboInfo("Smart Subtractive Palette Option", "Uses Subtractive Palette when standing still and releases it when moving.", PCTPvP.JobID)]
+        [CustomComboInfo("Smart Palette Option", "Uses Subtractive Palette when standing still and releases it when moving.", PCTPvP.JobID)]
         PCTPvP_SubtractivePalette = 140003,
 
         // Last value = 140003

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4632,6 +4632,27 @@ namespace XIVSlothCombo.Combos
 
         #endregion
 
+        #region PICTOMANCER
+        [PvPCustomCombo]
+        [ReplaceSkill(PCTPvP.FireInRed)]
+        [CustomComboInfo("Burst Mode", "Turns Fire in Red into an all-in-one damage button.", PCTPvP.JobID)]
+        PCTPvP_Burst = 140000,
+
+        [ParentCombo(PCTPvP_Burst)]
+        [CustomComboInfo("Burst Control Option", "Saves high-damaging actions until the target's HP falls below the set threshold.", PCTPvP.JobID)]
+        PCTPvP_BurstControl = 140001,
+
+        [ParentCombo(PCTPvP_Burst)]
+        [CustomComboInfo("Tempera Coat Option", "Uses Tempera Coat when HP falls under the set threshold during combat.\n - Transforms Tempera Coat into Tempera Grassa before buff expires.", PCTPvP.JobID)]
+        PCTPvP_TemperaCoat = 140002,
+
+        [ParentCombo(PCTPvP_Burst)]
+        [CustomComboInfo("Smart Subtractive Palette Option", "Uses Subtractive Palette when standing still and releases it when moving.", PCTPvP.JobID)]
+        PCTPvP_SubtractivePalette = 140003,
+
+        // Last value = 140003
+        #endregion
+
         #region PALADIN
         [PvPCustomCombo]
         [CustomComboInfo("Burst Mode", "Turns Royal Authority Combo into an all-in-one damage button.", PLD.JobID)]

--- a/XIVSlothCombo/Combos/PvP/PCTPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/PCTPVP.cs
@@ -1,0 +1,105 @@
+﻿using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
+
+namespace XIVSlothCombo.Combos.PvP
+{
+    internal static class PCTPvP
+    {
+        public const byte JobID = 42;
+
+        internal const uint
+            FireInRed = 39191,
+            AeroInGreen = 39192,
+            WaterInBlue = 39193,
+            HolyInWhite = 39198,
+            CreatureMotif = 39204,
+            LivingMuse = 39209,
+            TemperaCoat = 39211,
+            TemperaGrassa = 39212,
+            SubtractivePalette = 39213,
+            StarPrism = 39216,
+            MogOfTheAges = 39782;
+
+        internal class Buffs
+        {
+            internal const ushort
+                PomMotif = 4105,
+                WingMotif = 4106,
+                ClawMotif = 4107,
+                MawMotif = 4108,
+                TemperaCoat = 4114,
+                PomMuse = 4109,
+                Starstruck = 4118,
+                MooglePortrait = 4103,
+                MadeenPortrait = 4104,
+                SubtractivePalette = 4102;
+        }
+
+        internal class Config
+        {
+            internal static UserInt
+                PCTPvP_BurstHP = new("PCTPvP_BurstHP", 100),
+                PCTPvP_TemperaHP = new("PCTPvP_TemperaHP", 50);
+        }
+
+        internal class PCTPvP_Burst : CustomCombo
+        {
+            protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.PCTPvP_Burst;
+            protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
+            {
+                #region Variables
+                bool isMoving = IsMoving;
+                bool hasStarPrism = HasEffect(Buffs.Starstruck);
+                bool targetHasGuard = TargetHasEffectAny(PvPCommon.Buffs.Guard);
+                bool hasSubtractivePalette = HasEffect(Buffs.SubtractivePalette);
+                bool hasPortrait = HasEffect(Buffs.MooglePortrait) || HasEffect(Buffs.MadeenPortrait);
+                bool isStarPrismExpiring = HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) <= 3;
+                bool isTemperaCoatExpiring = HasEffect(Buffs.TemperaCoat) && GetBuffRemainingTime(Buffs.TemperaCoat) <= 3;
+                bool hasMotifDrawn = HasEffect(Buffs.PomMotif) || HasEffect(Buffs.WingMotif) || HasEffect(Buffs.ClawMotif) || HasEffect(Buffs.MawMotif);
+                bool isBurstControlled = IsNotEnabled(CustomComboPreset.PCTPvP_BurstControl) || (IsEnabled(CustomComboPreset.PCTPvP_BurstControl) && GetTargetHPPercent() < Config.PCTPvP_BurstHP);
+                #endregion
+
+                if (actionID is FireInRed or AeroInGreen or WaterInBlue)
+                {
+                    // Tempera Coat / Tempera Grassa
+                    if (IsEnabled(CustomComboPreset.PCTPvP_TemperaCoat) && ((IsOffCooldown(TemperaCoat) &&
+                        InCombat() && PlayerHealthPercentageHp() < Config.PCTPvP_TemperaHP) || isTemperaCoatExpiring))
+                        return OriginalHook(TemperaCoat);
+
+                    if (HasTarget())
+                    {
+                        if (!targetHasGuard)
+                        {
+                            // Star Prism
+                            if (hasStarPrism && (isBurstControlled || isStarPrismExpiring))
+                                return StarPrism;
+
+                            // Moogle / Madeen Portrait
+                            if (hasPortrait && isBurstControlled)
+                                return OriginalHook(MogOfTheAges);
+
+                            // Living Muse
+                            if (hasMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && isBurstControlled)
+                                return OriginalHook(LivingMuse);
+
+                            // Holy in White / Comet in Black
+                            if (HasCharges(OriginalHook(HolyInWhite)) && isBurstControlled)
+                                return OriginalHook(HolyInWhite);
+                        }
+
+                        // Subtractive Palette
+                        if (IsEnabled(CustomComboPreset.PCTPvP_SubtractivePalette) && IsOffCooldown(OriginalHook(SubtractivePalette)) &&
+                            ((isMoving && hasSubtractivePalette) || (!isMoving && !hasSubtractivePalette)))
+                            return OriginalHook(SubtractivePalette);
+                    }
+
+                    // Creature Motif
+                    if (!hasMotifDrawn && !isMoving)
+                        return OriginalHook(CreatureMotif);
+                }
+
+                return actionID;
+            }
+        }
+    }
+}

--- a/XIVSlothCombo/Combos/PvP/PCTPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/PCTPVP.cs
@@ -15,7 +15,6 @@ namespace XIVSlothCombo.Combos.PvP
             CreatureMotif = 39204,
             LivingMuse = 39209,
             TemperaCoat = 39211,
-            TemperaGrassa = 39212,
             SubtractivePalette = 39213,
             StarPrism = 39216,
             MogOfTheAges = 39782;
@@ -28,7 +27,6 @@ namespace XIVSlothCombo.Combos.PvP
                 ClawMotif = 4107,
                 MawMotif = 4108,
                 TemperaCoat = 4114,
-                PomMuse = 4109,
                 Starstruck = 4118,
                 MooglePortrait = 4103,
                 MadeenPortrait = 4104,
@@ -86,16 +84,16 @@ namespace XIVSlothCombo.Combos.PvP
                             if (HasCharges(OriginalHook(HolyInWhite)) && isBurstControlled)
                                 return OriginalHook(HolyInWhite);
                         }
-
-                        // Subtractive Palette
-                        if (IsEnabled(CustomComboPreset.PCTPvP_SubtractivePalette) && IsOffCooldown(OriginalHook(SubtractivePalette)) &&
-                            ((isMoving && hasSubtractivePalette) || (!isMoving && !hasSubtractivePalette)))
-                            return OriginalHook(SubtractivePalette);
                     }
 
                     // Creature Motif
                     if (!hasMotifDrawn && !isMoving)
                         return OriginalHook(CreatureMotif);
+
+                    // Subtractive Palette
+                    if (IsEnabled(CustomComboPreset.PCTPvP_SubtractivePalette) && IsOffCooldown(OriginalHook(SubtractivePalette)) &&
+                        HasTarget() && ((isMoving && hasSubtractivePalette) || (!isMoving && !hasSubtractivePalette)))
+                        return OriginalHook(SubtractivePalette);
                 }
 
                 return actionID;

--- a/XIVSlothCombo/Combos/PvP/PCTPVP.cs
+++ b/XIVSlothCombo/Combos/PvP/PCTPVP.cs
@@ -47,6 +47,7 @@ namespace XIVSlothCombo.Combos.PvP
             {
                 #region Variables
                 bool isMoving = IsMoving;
+                bool hasTarget = HasTarget();
                 bool hasStarPrism = HasEffect(Buffs.Starstruck);
                 bool targetHasGuard = TargetHasEffectAny(PvPCommon.Buffs.Guard);
                 bool hasSubtractivePalette = HasEffect(Buffs.SubtractivePalette);
@@ -64,26 +65,23 @@ namespace XIVSlothCombo.Combos.PvP
                         InCombat() && PlayerHealthPercentageHp() < Config.PCTPvP_TemperaHP) || isTemperaCoatExpiring))
                         return OriginalHook(TemperaCoat);
 
-                    if (HasTarget())
+                    if (hasTarget && !targetHasGuard)
                     {
-                        if (!targetHasGuard)
-                        {
-                            // Star Prism
-                            if (hasStarPrism && (isBurstControlled || isStarPrismExpiring))
-                                return StarPrism;
+                        // Star Prism
+                        if (hasStarPrism && (isBurstControlled || isStarPrismExpiring))
+                            return StarPrism;
 
-                            // Moogle / Madeen Portrait
-                            if (hasPortrait && isBurstControlled)
-                                return OriginalHook(MogOfTheAges);
+                        // Moogle / Madeen Portrait
+                        if (hasPortrait && isBurstControlled)
+                            return OriginalHook(MogOfTheAges);
 
-                            // Living Muse
-                            if (hasMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && isBurstControlled)
-                                return OriginalHook(LivingMuse);
+                        // Living Muse
+                        if (hasMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && isBurstControlled)
+                            return OriginalHook(LivingMuse);
 
-                            // Holy in White / Comet in Black
-                            if (HasCharges(OriginalHook(HolyInWhite)) && isBurstControlled)
-                                return OriginalHook(HolyInWhite);
-                        }
+                        // Holy in White / Comet in Black
+                        if (HasCharges(OriginalHook(HolyInWhite)) && isBurstControlled)
+                            return OriginalHook(HolyInWhite);
                     }
 
                     // Creature Motif
@@ -92,7 +90,7 @@ namespace XIVSlothCombo.Combos.PvP
 
                     // Subtractive Palette
                     if (IsEnabled(CustomComboPreset.PCTPvP_SubtractivePalette) && IsOffCooldown(OriginalHook(SubtractivePalette)) &&
-                        HasTarget() && ((isMoving && hasSubtractivePalette) || (!isMoving && !hasSubtractivePalette)))
+                        hasTarget && ((isMoving && hasSubtractivePalette) || (!isMoving && !hasSubtractivePalette)))
                         return OriginalHook(SubtractivePalette);
                 }
 

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -2674,7 +2674,12 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawSliderInt(1, 100, NINPvP.Config.NINPvP_Meisui_AoE, description);
             }
 
+            // Pictomancer PvP
+            if (preset == CustomComboPreset.PCTPvP_BurstControl)
+                UserConfig.DrawSliderInt(1, 100, PCTPvP.Config.PCTPvP_BurstHP, "Target HP%", 200);
 
+            if (preset == CustomComboPreset.PCTPvP_TemperaCoat)
+                UserConfig.DrawSliderInt(1, 100, PCTPvP.Config.PCTPvP_TemperaHP, "Player HP%", 200);
             #endregion
         }
     }


### PR DESCRIPTION
### Basic Pictomancer PvP Logic
- Draws and uses motifs when appropriate.
- Includes a burst control option to hold abilities.
- Smart Subtractive Palette usage depending on movement.
- Uses Tempera Coat and converts it into Tempera Grassa before expiring.
- Happy PvP'ing!