### PR TITLE
[WHM] Fix checking for other WHM's Medicas

### DIFF
--- a/XIVSlothCombo/Combos/PvE/WHM.cs
+++ b/XIVSlothCombo/Combos/PvE/WHM.cs
@@ -320,8 +320,8 @@ namespace XIVSlothCombo.Combos.PvE
                     bool divineCaressReady = ActionReady(DivineCaress) && HasEffect(Buffs.DivineGrace);
                     bool assizeReady = ActionReady(Assize) && (!Config.WHM_AoEHeals_AssizeWeave || (Config.WHM_AoEHeals_AssizeWeave && canWeave));
                     var healTarget = GetHealTarget(Config.WHM_AoEHeals_MedicaMO);
-                    var hasMedica2 = FindEffectOnMember(Buffs.Medica2, healTarget);
-                    var hasMedica3 = FindEffectOnMember(Buffs.Medica3, healTarget);
+                    var hasMedica2 = FindEffect(Buffs.Medica2, healTarget, LocalPlayer?.GameObjectId);
+                    var hasMedica3 = FindEffect(Buffs.Medica3, healTarget, LocalPlayer?.GameObjectId);
 
                     if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Assize) && assizeReady)
                         return Assize;
@@ -345,9 +345,9 @@ namespace XIVSlothCombo.Combos.PvE
                         return ThinAir;
 
                     if (IsEnabled(CustomComboPreset.WHM_AoEHeals_Medica2)
-                        && ((FindEffectOnMember(Buffs.Medica2, healTarget) == null && FindEffectOnMember(Buffs.Medica3, healTarget) == null)
-                            || hasMedica2 != null && hasMedica2.RemainingTime <= Config.WHM_AoEHeals_MedicaTime
-                            || hasMedica3 != null && hasMedica3.RemainingTime <= Config.WHM_AoEHeals_MedicaTime)
+                        && ((hasMedica2 == null && hasMedica3 == null) // No Medica buffs
+                            || hasMedica2 != null && hasMedica2.RemainingTime <= Config.WHM_AoEHeals_MedicaTime // Medica buff, but falling off soon
+                            || hasMedica3 != null && hasMedica3.RemainingTime <= Config.WHM_AoEHeals_MedicaTime) // ^
                         && (ActionReady(Medica2) || ActionReady(Medica3)))
                     {
                         // Medica 3 upgrade


### PR DESCRIPTION
- [X] Fix Medica2/3 logic skipping Medica when other WHM's Medicas were found.
      Now only checks for Medica2/3 buffs owned by the player.