### PR TITLE
[BRD] Heavy to straight shot barrage fix

### DIFF
--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -135,10 +135,8 @@ namespace XIVSlothCombo.Combos.PvE
                                 return BlastArrow;
                         }
 
-                    if (HasEffect(Buffs.HawksEye))
-                        return LevelChecked(RefulgentArrow)
-                            ? RefulgentArrow
-                            : StraightShot;
+                    if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
+                        return OriginalHook(StraightShot);
                 }
 
                 return actionID;


### PR DESCRIPTION
fixed barrage bug on heavy shot to straight shot. it wasnt accounting for barrage being its own new buff now
fixes #1741 