### PR TITLE
[PCT] Simple Modes, Motif % stop in advanced

### DIFF
--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -616,85 +616,174 @@ namespace XIVSlothCombo.Combos.PvE
                     var gauge = GetJobGauge<PCTGauge>();
                     bool canWeave = CanSpellWeave(ActionWatching.LastSpell);
 
-                    if (HasEffect(Buffs.Starstruck))
-                        return OriginalHook(StarPrism);
-
-                    if (HasEffect(Buffs.RainbowBright))
-                        return OriginalHook(RainbowDrip);
-
-                    if (IsMoving)
-                    {
-                        if (gauge.Paint > 0)
+                    // Prepull logic
+                   
+                    
+                        if (!InCombat() || InCombat() && CurrentTarget == null)
                         {
-                            if (HasEffect(Buffs.MonochromeTones))
-                                return OriginalHook(CometinBlack);
+                            if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                                return OriginalHook(CreatureMotif);
+                            if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                                return OriginalHook(WeaponMotif);
+                            if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && !HasEffect(Buffs.StarryMuse))
+                                return OriginalHook(LandscapeMotif);
+                        }
+                    
 
-                            return OriginalHook(HolyInWhite);
+                    // General Weaves
+                    if (InCombat() && canWeave)
+                    {
+                        // LivingMuse
+                                                
+                        if (LivingMuse.LevelChecked() &&
+                            gauge.CreatureMotifDrawn &&
+                            (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) ||
+                            GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse)))
+                        {
+                            if (HasCharges(OriginalHook(LivingMuse)))
+                            {
+                                if (!ScenicMuse.LevelChecked() ||
+                                    GetCooldown(ScenicMuse).CooldownRemaining > GetCooldownChargeRemainingTime(LivingMuse))
+                                {
+                                    return OriginalHook(LivingMuse);
+                                }
+                            }
+                        }
+                        
+                        // ScenicMuse
+                                                
+                        if (ScenicMuse.LevelChecked() &&
+                            gauge.LandscapeMotifDrawn &&
+                            gauge.WeaponMotifDrawn &&
+                            IsOffCooldown(ScenicMuse))
+                        {
+                            return OriginalHook(ScenicMuse);
+                        }
+                        
+                        // SteelMuse
+                                                
+                        if (SteelMuse.LevelChecked() &&
+                            !HasEffect(Buffs.HammerTime) &&
+                            gauge.WeaponMotifDrawn &&
+                            HasCharges(OriginalHook(SteelMuse)) &&
+                            (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining ||
+                                GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) ||
+                                !ScenicMuse.LevelChecked()))
+                        {
+                            return OriginalHook(SteelMuse);
+                        }
+                        
+                        // MogoftheAges
+                                                
+                        if (MogoftheAges.LevelChecked() &&
+                            (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) &&
+                            (IsOffCooldown(OriginalHook(MogoftheAges)) || !ScenicMuse.LevelChecked()))
+                        {
+                            return OriginalHook(MogoftheAges);
+                        }
+                        
+                        if (IsMoving &&
+                            IsOffCooldown(All.Swiftcast) &&
+                            All.Swiftcast.LevelChecked() &&
+                            !HasEffect(Buffs.HammerTime) &&
+                            gauge.Paint < 1 &&
+                            (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
+                        {
+                            return All.Swiftcast;
+                        }
+                        
+                        // Subtractive Palette
+                        if  (SubtractivePalette.LevelChecked() &&
+                            !HasEffect(Buffs.SubtractivePalette) &&
+                            !HasEffect(Buffs.MonochromeTones))
+                        {
+                            if (HasEffect(Buffs.SubtractiveSpectrum) || gauge.PalleteGauge >= 50)
+                                return SubtractivePalette;
                         }
                     }
 
-                    if (HasEffect(Buffs.StarryMuse))
+                    if (HasEffect(All.Buffs.Swiftcast))
                     {
-                        if (HasEffect(Buffs.SubtractiveSpectrum) && !HasEffect(Buffs.SubtractivePalette) && canWeave)
-                            return OriginalHook(SubtractivePalette);
-
-                        if (MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)))
-                            return OriginalHook(MogoftheAges);
-
-                        if (!HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && GetBuffRemainingTime(Buffs.StarryMuse) >= 15f)
-                            return OriginalHook(SteelMuse);
-
-                        if (gauge.CreatureMotifDrawn && HasCharges(OriginalHook(LivingMuse)) && canWeave)
-                            return OriginalHook(LivingMuse);
-
-                        if (HasEffect(Buffs.HammerTime))
-                            return OriginalHook(HammerStamp);
-
-                        if (HasEffect(Buffs.SubtractivePalette))
-                            return OriginalHook(BlizzardIIinCyan);
-
-                        return actionID;
+                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(CreatureMotif);
+                        if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(HammerMotif);
+                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                            return OriginalHook(LandscapeMotif);
                     }
 
-                    if (gauge.PalleteGauge >= 50 && !HasEffect(Buffs.SubtractivePalette) && canWeave)
-                        return OriginalHook(SubtractivePalette);
-
-                    if (HasEffect(Buffs.HammerTime) && !canWeave)
-                        return OriginalHook(HammerStamp);
-
-                    if (InCombat())
+                    if (IsMoving && InCombat())
                     {
-                        if (gauge.LandscapeMotifDrawn && gauge.WeaponMotifDrawn && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(MogoftheAges) && IsOffCooldown(ScenicMuse) && canWeave)
-                            return OriginalHook(ScenicMuse);
+                        if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
+                            return OriginalHook(HammerStamp);
 
-                        if (MogoftheAges.LevelChecked() && (gauge.MooglePortraitReady || gauge.MadeenPortraitReady) && IsOffCooldown(OriginalHook(MogoftheAges)) && (GetCooldown(MogoftheAges).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || !ScenicMuse.LevelChecked()) && canWeave)
-                            return OriginalHook(MogoftheAges);
+                        if (CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
+                            return OriginalHook(CometinBlack);
 
-                        if (!HasEffect(Buffs.HammerTime) && gauge.WeaponMotifDrawn && HasCharges(OriginalHook(SteelMuse)) && (GetCooldown(SteelMuse).CooldownRemaining < GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(SteelMuse) == GetMaxCharges(SteelMuse) || !ScenicMuse.LevelChecked()) && canWeave)
-                            return OriginalHook(SteelMuse);
+                        if (HolyInWhite.LevelChecked() && gauge.Paint >= 1)
+                            return OriginalHook(HolyInWhite);
 
-                        if (gauge.CreatureMotifDrawn && (!(gauge.MooglePortraitReady || gauge.MadeenPortraitReady) || GetCooldown(LivingMuse).CooldownRemaining > GetCooldown(ScenicMuse).CooldownRemaining || GetRemainingCharges(LivingMuse) == GetMaxCharges(LivingMuse) || !ScenicMuse.LevelChecked()) && HasCharges(OriginalHook(LivingMuse)) && canWeave)
-                            return OriginalHook(LivingMuse);
+                    }
 
-                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= GetActionCastTime(OriginalHook(LandscapeMotif)))
+                    //Prepare for Burst
+                    if (GetCooldownRemainingTime(ScenicMuse) <= 20)
+                    {
+                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
                             return OriginalHook(LandscapeMotif);
 
-                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= GetActionCastTime(OriginalHook(CreatureMotif))))
+                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
                             return OriginalHook(CreatureMotif);
 
-                        if (WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= GetActionCastTime(OriginalHook(WeaponMotif))))
+                        if (WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
                             return OriginalHook(WeaponMotif);
                     }
 
-                    if (gauge.Paint > 0 && HasEffect(Buffs.MonochromeTones))
+                    // Burst 
+                    if (HasEffect(Buffs.StarryMuse))
+                    {
+                        // Check for CometInBlack
+                        if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0)
+                            return CometinBlack;
+
+                        // Check for HammerTime 
+                        if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.Starstruck))
+                            return OriginalHook(HammerStamp);
+
+                        // Check for Starstruck
+                        if (HasEffect(Buffs.Starstruck) || (HasEffect(Buffs.Starstruck) && GetBuffRemainingTime(Buffs.Starstruck) < 3))
+                                return StarPrism;
+                        
+                        // Check for RainbowBright
+                        if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
+                                return RainbowDrip;
+                    }
+
+                    if (HasEffect(Buffs.RainbowBright) && !HasEffect(Buffs.StarryMuse))
+                        return RainbowDrip;
+
+                    if (CometinBlack.LevelChecked() && HasEffect(Buffs.MonochromeTones) && gauge.Paint > 0 && GetCooldownRemainingTime(StarryMuse) > 60)
                         return OriginalHook(CometinBlack);
 
-                    if (gauge.Paint > 0)
-                        return OriginalHook(HolyInWhite);
+                    if (HammerStamp.LevelChecked() && HasEffect(Buffs.HammerTime))
+                        return OriginalHook(HammerStamp);
 
-                    if (HasEffect(Buffs.SubtractivePalette))
+                    if (!HasEffect(Buffs.StarryMuse))
+                    {
+                        if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
+                                return OriginalHook(LandscapeMotif);
+                       
+                        if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
+                                return OriginalHook(CreatureMotif);
+                        
+                        if (WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
+                                return OriginalHook(WeaponMotif);
+                    }
+
+                    if (All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) && LocalPlayer.CurrentMp <= 6500)
+                        return All.LucidDreaming;
+
+                    if (BlizzardIIinCyan.LevelChecked() && HasEffect(Buffs.SubtractivePalette))
                         return OriginalHook(BlizzardIIinCyan);
-
                 }
                 return actionID;
             }

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -1,5 +1,6 @@
 ﻿using Dalamud.Game.ClientState.JobGauge.Types;
 using XIVSlothCombo.Combos.JobHelpers;
+using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
 using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Data;
@@ -75,7 +76,14 @@ namespace XIVSlothCombo.Combos.PvE
             public static UserInt
                 CombinedAetherhueChoices = new("CombinedAetherhueChoices"),
                 PCT_ST_AdvancedMode_LucidOption = new("PCT_ST_AdvancedMode_LucidOption", 6500),
+                PCT_ST_CreatureStop = new("PCT_ST_CreatureStop"),
+                PCT_AoE_CreatureStop = new("PCT_AoE_CreatureStop"),
+                PCT_ST_WeaponStop = new("PCT_ST_WeaponStop"),
+                PCT_AoE_WeaponStop = new("PCT_AoE_WeaponStop"),
+                PCT_ST_LandscapeStop = new("PCT_ST_LandscapeStop"),
+                PCT_AoE_LandscapeStop = new("PCT_AoE_LandscapeStop"),
                 PCT_AoE_AdvancedMode_LucidOption = new("PCT_AoE_AdvancedMode_LucidOption", 6500);
+                
 
             public static UserBool
                 CombinedMotifsMog = new("CombinedMotifsMog"),
@@ -345,6 +353,10 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     var gauge = GetJobGauge<PCTGauge>();
                     bool canWeave = CanSpellWeave(ActionWatching.LastSpell) || CanSpellWeave(actionID);
+                    int creatureStop = PluginConfiguration.GetCustomIntValue(Config.PCT_ST_CreatureStop);
+                    int landscapeStop = PluginConfiguration.GetCustomIntValue(Config.PCT_ST_LandscapeStop);
+                    int weaponStop = PluginConfiguration.GetCustomIntValue(Config.PCT_ST_WeaponStop);
+                    
 
                     // Prepull logic
                     if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_PrePullMotifs))
@@ -488,11 +500,11 @@ namespace XIVSlothCombo.Combos.PvE
                     // Swiftcast Motifs
                     if (HasEffect(All.Buffs.Swiftcast))
                     {
-                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > creatureStop)
                             return OriginalHook(CreatureMotif);
-                        if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
-                            return OriginalHook(HammerMotif);
-                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.WeaponMotifDrawn && WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > weaponStop)
+                            return OriginalHook(WeaponMotif);
+                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > landscapeStop)
                             return OriginalHook(LandscapeMotif);
 
                     }
@@ -513,13 +525,13 @@ namespace XIVSlothCombo.Combos.PvE
                     //Prepare for Burst
                     if (GetCooldownRemainingTime(ScenicMuse) <= 20)
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetTargetHPPercent() > landscapeStop)
                             return OriginalHook(LandscapeMotif);
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && GetTargetHPPercent() > creatureStop)
                             return OriginalHook(CreatureMotif);
 
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime) && GetTargetHPPercent() > weaponStop)
                             return OriginalHook(WeaponMotif);
                     }
 
@@ -559,7 +571,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (!HasEffect(Buffs.StarryMuse))
                     {
                         // LandscapeMotif
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif) && GetTargetHPPercent() > landscapeStop)
                         {
                             if (LandscapeMotif.LevelChecked() &&
                                 !gauge.LandscapeMotifDrawn &&
@@ -570,7 +582,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // CreatureMotif
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif) && GetTargetHPPercent() > creatureStop)
                         {
                             if (CreatureMotif.LevelChecked() &&
                                 !gauge.CreatureMotifDrawn &&
@@ -581,7 +593,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         // WeaponMotif
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif))
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif) && GetTargetHPPercent() > weaponStop)
                         {
                             if (WeaponMotif.LevelChecked() &&
                                 !HasEffect(Buffs.HammerTime) &&
@@ -802,6 +814,9 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     var gauge = GetJobGauge<PCTGauge>();
                     bool canWeave = CanSpellWeave(ActionWatching.LastSpell);
+                    int creatureStop = PluginConfiguration.GetCustomIntValue(Config.PCT_AoE_CreatureStop);
+                    int landscapeStop = PluginConfiguration.GetCustomIntValue(Config.PCT_AoE_LandscapeStop);
+                    int weaponStop = PluginConfiguration.GetCustomIntValue(Config.PCT_AoE_WeaponStop);
 
                     // Prepull logic
                     if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_PrePullMotifs))
@@ -906,11 +921,11 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (HasEffect(All.Buffs.Swiftcast))
                     {
-                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.CreatureMotifDrawn && CreatureMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > creatureStop)
                             return OriginalHook(CreatureMotif);
-                        if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.WeaponMotifDrawn && HammerMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() >weaponStop)
                             return OriginalHook(HammerMotif);
-                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse))
+                        if (!gauge.LandscapeMotifDrawn && LandscapeMotif.LevelChecked() && !HasEffect(Buffs.StarryMuse) && GetTargetHPPercent() > landscapeStop)
                             return OriginalHook(LandscapeMotif);
                     }
 
@@ -930,13 +945,13 @@ namespace XIVSlothCombo.Combos.PvE
                     //Prepare for Burst
                     if (GetCooldownRemainingTime(ScenicMuse) <= 20)
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn)
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetTargetHPPercent() > landscapeStop)
                             return OriginalHook(LandscapeMotif);
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn)
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && GetTargetHPPercent() > creatureStop)
                             return OriginalHook(CreatureMotif);
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && WeaponMotif.LevelChecked() && !gauge.WeaponMotifDrawn && !HasEffect(Buffs.HammerTime) && GetTargetHPPercent() > weaponStop)
                             return OriginalHook(WeaponMotif);
                     }
 
@@ -979,19 +994,19 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (!HasEffect(Buffs.StarryMuse))
                     {
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif) && GetTargetHPPercent() > landscapeStop)
                         {
                             if (LandscapeMotif.LevelChecked() && !gauge.LandscapeMotifDrawn && GetCooldownRemainingTime(ScenicMuse) <= 20)
                                 return OriginalHook(LandscapeMotif);
                         }
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif) && GetTargetHPPercent() > creatureStop)
                         {
                             if (CreatureMotif.LevelChecked() && !gauge.CreatureMotifDrawn && (HasCharges(LivingMuse) || GetCooldownChargeRemainingTime(LivingMuse) <= 8))
                                 return OriginalHook(CreatureMotif);
                         }
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif))
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif) && GetTargetHPPercent() > weaponStop)
                         {
                             if (WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
                                 return OriginalHook(WeaponMotif);

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -778,6 +778,9 @@ namespace XIVSlothCombo.Combos.PvE
                         if (WeaponMotif.LevelChecked() && !HasEffect(Buffs.HammerTime) && !gauge.WeaponMotifDrawn && (HasCharges(SteelMuse) || GetCooldownChargeRemainingTime(SteelMuse) <= 8))
                                 return OriginalHook(WeaponMotif);
                     }
+                    //Saves one Charge of White paint for movement/Black paint.
+                    if (HolyInWhite.LevelChecked() && gauge.Paint >= 2)
+                        return OriginalHook(HolyInWhite);
 
                     if (All.LucidDreaming.LevelChecked() && ActionReady(All.LucidDreaming) && CanSpellWeave(actionID) && LocalPlayer.CurrentMp <= 6500)
                         return All.LucidDreaming;

--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -249,6 +249,9 @@ namespace XIVSlothCombo.Combos.PvE
                         if (CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
                             return OriginalHook(CometinBlack);
 
+                        if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
+                            return RainbowDrip;
+
                         if (HolyInWhite.LevelChecked() && gauge.Paint >= 1)
                             return OriginalHook(HolyInWhite);
                     }
@@ -518,6 +521,12 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
                             return OriginalHook(CometinBlack);
 
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_Burst_RainbowDrip))
+                        {
+                            if (HasEffect(Buffs.RainbowBright) || HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) <= 3f)
+                                return RainbowDrip;
+                        }
+
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
                             return OriginalHook(HolyInWhite);
                     }
@@ -732,6 +741,9 @@ namespace XIVSlothCombo.Combos.PvE
                         if (CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
                             return OriginalHook(CometinBlack);
 
+                        if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
+                            return RainbowDrip;
+
                         if (HolyInWhite.LevelChecked() && gauge.Paint >= 1)
                             return OriginalHook(HolyInWhite);
 
@@ -936,6 +948,12 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_CometinBlack) && CometinBlack.LevelChecked() && gauge.Paint >= 1 && HasEffect(Buffs.MonochromeTones))
                             return OriginalHook(CometinBlack);
+
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_Burst_RainbowDrip))
+                        {
+                            if (HasEffect(Buffs.RainbowBright) || (HasEffect(Buffs.RainbowBright) && GetBuffRemainingTime(Buffs.StarryMuse) < 3))
+                                return RainbowDrip;
+                        }
 
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
                             return OriginalHook(HolyInWhite);

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1680,6 +1680,18 @@ namespace XIVSlothCombo.Window.Functions
             {
                 UserConfig.DrawSliderInt(0, 10000, PCT.Config.PCT_AoE_AdvancedMode_LucidOption, "Add Lucid Dreaming when below this MP", sliderIncrement: SliderIncrements.Hundreds);
             }
+            if (preset == CustomComboPreset.PCT_ST_AdvancedMode_LandscapeMotif)
+                UserConfig.DrawSliderInt(0, 10, PCT.Config.PCT_ST_LandscapeStop, "Health % to stop Drawing Motif");
+            if (preset == CustomComboPreset.PCT_ST_AdvancedMode_CreatureMotif)
+                UserConfig.DrawSliderInt(0, 10, PCT.Config.PCT_ST_CreatureStop, "Health % to stop Drawing Motif");
+            if (preset == CustomComboPreset.PCT_ST_AdvancedMode_WeaponMotif)
+                UserConfig.DrawSliderInt(0, 10, PCT.Config.PCT_ST_WeaponStop, "Health % to stop Drawing Motif");
+            if (preset == CustomComboPreset.PCT_AoE_AdvancedMode_LandscapeMotif)
+                UserConfig.DrawSliderInt(0, 10, PCT.Config.PCT_AoE_LandscapeStop, "Health % to stop Drawing Motif");
+            if (preset == CustomComboPreset.PCT_AoE_AdvancedMode_CreatureMotif)
+                UserConfig.DrawSliderInt(0, 10, PCT.Config.PCT_AoE_CreatureStop, "Health % to stop Drawing Motif");
+            if (preset == CustomComboPreset.PCT_AoE_AdvancedMode_WeaponMotif)
+                UserConfig.DrawSliderInt(0, 10, PCT.Config.PCT_AoE_WeaponStop, "Health % to stop Drawing Motif");
 
             // PvP
             if (preset == CustomComboPreset.PCTPvP_BurstControl)


### PR DESCRIPTION
Copied the ST advanced mode and removed configuration requirements for an optimized Simple mode
Fixes #1768

- [x] ST Simple mode Optimized based on advanced
- [x] Aoe Simple mode Optimized based on advanced
- [x] Holy in white added to simple aoe. Retains one charge for movement/comet
- [x] Added slider for each motif in advanced st and aoe to stop drawing. Done separately in case some are trying to save the 2min but not the hammer/moogle
- [x] Rainbow drip as moving option higher priority than Holy in white

