### PR TITLE
[AST] Aspected helios hot check fix

### DIFF
--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -514,8 +514,8 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     // Only check for our own HoTs
-                    var aspectedHeliosHoT = FindEffect(Buffs.AspectedBenefic, LocalPlayer, LocalPlayer?.GameObjectId);
-                    var heliosConjunctionHoT = FindEffect(Buffs.AspectedBenefic, LocalPlayer, LocalPlayer?.GameObjectId);
+                    var aspectedHeliosHoT = FindEffect(Buffs.AspectedHelios, LocalPlayer, LocalPlayer?.GameObjectId);
+                    var heliosConjunctionHoT = FindEffect(Buffs.HeliosConjunction, LocalPlayer, LocalPlayer?.GameObjectId);
 
                     if ((IsEnabled(CustomComboPreset.AST_AoE_SimpleHeals_Aspected) && NonaspectedMode) || // Helios mode: option must be on
                         !NonaspectedMode) // Aspected mode: option is not required
@@ -523,7 +523,6 @@ namespace XIVSlothCombo.Combos.PvE
                         if ((ActionReady(AspectedHelios)
                                  && aspectedHeliosHoT is null
                                  && heliosConjunctionHoT is null)
-                             || HasEffect(Buffs.Horoscope)
                              || (HasEffect(Buffs.NeutralSect) && !HasEffect(Buffs.NeutralSectShield)))
                             return OriginalHook(AspectedHelios);
                     }


### PR DESCRIPTION
Fixed the missed buff name and removed horoscope forcing aspected. any helios works for horoscope.

Closes discord report