### PR TITLE
[AST] Earthly Star Priority Shift

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -221,11 +221,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Earthly Star Option", "Adds Earthly Star." +
                                                 "\nTo be used in conjunction with Redirect/Reaction/etc", AST.JobID, 11)]
         AST_ST_DPS_EarthlyStar = 1051,
-
-        [ParentCombo(AST_ST_DPS)]
-        [CustomComboInfo("Earthly Star Prepull Option", "Adds Earthly Star Prepull." +
-                                               "\nIf using redirect stack, suggest target > melee > self", AST.JobID, 12)]
-        AST_ST_DPS_EarthlyStarPrepull = 1054,
+               
         #endregion
 
         #region AOE DPS

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -222,6 +222,10 @@ namespace XIVSlothCombo.Combos
                                                 "\nTo be used in conjunction with Redirect/Reaction/etc", AST.JobID, 11)]
         AST_ST_DPS_EarthlyStar = 1051,
 
+        [ParentCombo(AST_ST_DPS)]
+        [CustomComboInfo("Earthly Star Prepull Option", "Adds Earthly Star Prepull." +
+                                               "\nIf using redirect stack, suggest target > melee > self", AST.JobID, 12)]
+        AST_ST_DPS_EarthlyStarPrepull = 1054,
         #endregion
 
         #region AOE DPS
@@ -359,7 +363,7 @@ namespace XIVSlothCombo.Combos
         AST_Cards_QuickTargetCards_TargetExtra = 1031,
         #endregion
 
-        // Last value = 1053
+        // Last value = 1054
 
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -452,7 +452,7 @@ namespace XIVSlothCombo.Combos.PvE
                         ActionWatching.NumberOfGcdsUsed >= 3)
                         return Divination;
                     //Earthly Star
-                    if (IsEnabled(CustomComboPreset.AST_AOE_DPS_EarthlyStar) &&
+                    if (IsEnabled(CustomComboPreset.AST_AOE_DPS_EarthlyStar) && !IsMoving &&
                         ActionReady(EarthlyStar) &&
                         CanSpellWeave(actionID))
                         return EarthlyStar;

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -215,11 +215,15 @@ namespace XIVSlothCombo.Combos.PvE
                 if (((!AlternateMode && MaleficList.Contains(actionID)) ||
                     (AlternateMode && CombustList.ContainsKey(actionID)) &&
                     !InCombat()))
-
+                {
                     if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
                         ActionReady(OriginalHook(AstralDraw)) && (Gauge.DrawnCards.All(x => x is CardType.NONE) || (DrawnCard == CardType.NONE && Config.AST_ST_DPS_OverwriteCards)))
                         return OriginalHook(AstralDraw);
 
+                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar) &&
+                        ActionReady(EarthlyStar))
+                        return EarthlyStar;
+                }
                 //In combat
                 if (((!AlternateMode && MaleficList.Contains(actionID)) ||
                      (AlternateMode && CombustList.ContainsKey(actionID))) &&
@@ -335,6 +339,12 @@ namespace XIVSlothCombo.Combos.PvE
                         ActionWatching.NumberOfGcdsUsed >= 3)
                         return Divination;
 
+                    //Earthly Star
+                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar) &&
+                        ActionReady(EarthlyStar) &&
+                        CanSpellWeave(actionID))
+                        return EarthlyStar;
+
                     if (IsEnabled(CustomComboPreset.AST_DPS_Oracle) &&
                         HasEffect(Buffs.Divining) &&
                         CanSpellWeave(actionID))
@@ -345,13 +355,7 @@ namespace XIVSlothCombo.Combos.PvE
                         IsEnabled(CustomComboPreset.AST_DPS_LazyLord) && Gauge.DrawnCrownCard is CardType.LORD &&
                         HasBattleTarget() &&
                         CanDelayedWeave(actionID))
-                        return OriginalHook(MinorArcana);
-
-                    //Earthly Star
-                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar) &&
-                        ActionReady(EarthlyStar) &&
-                        CanSpellWeave(actionID))
-                        return EarthlyStar;
+                        return OriginalHook(MinorArcana);                                       
 
                     if (HasBattleTarget())
                     {
@@ -451,6 +455,11 @@ namespace XIVSlothCombo.Combos.PvE
                         CanDelayedWeave(actionID) &&
                         ActionWatching.NumberOfGcdsUsed >= 3)
                         return Divination;
+                    //Earthly Star
+                    if (IsEnabled(CustomComboPreset.AST_AOE_DPS_EarthlyStar) &&
+                        ActionReady(EarthlyStar) &&
+                        CanSpellWeave(actionID))
+                        return EarthlyStar;
 
                     if (IsEnabled(CustomComboPreset.AST_AOE_Oracle) &&
                         HasEffect(Buffs.Divining) &&
@@ -463,13 +472,6 @@ namespace XIVSlothCombo.Combos.PvE
                         HasBattleTarget() &&
                         CanDelayedWeave(actionID))
                         return OriginalHook(MinorArcana);
-
-                    //Earthly Star
-                    if (IsEnabled(CustomComboPreset.AST_AOE_DPS_EarthlyStar) &&
-                        ActionReady(EarthlyStar) &&
-                        CanSpellWeave(actionID))
-                        return EarthlyStar;
-
                 }
                 return actionID;
             }

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -219,10 +219,6 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
                         ActionReady(OriginalHook(AstralDraw)) && (Gauge.DrawnCards.All(x => x is CardType.NONE) || (DrawnCard == CardType.NONE && Config.AST_ST_DPS_OverwriteCards)))
                         return OriginalHook(AstralDraw);
-
-                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStarPrepull) &&
-                        ActionReady(EarthlyStar))
-                        return EarthlyStar;
                 }
                 //In combat
                 if (((!AlternateMode && MaleficList.Contains(actionID)) ||

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -220,7 +220,7 @@ namespace XIVSlothCombo.Combos.PvE
                         ActionReady(OriginalHook(AstralDraw)) && (Gauge.DrawnCards.All(x => x is CardType.NONE) || (DrawnCard == CardType.NONE && Config.AST_ST_DPS_OverwriteCards)))
                         return OriginalHook(AstralDraw);
 
-                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar) &&
+                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStarPrepull) &&
                         ActionReady(EarthlyStar))
                         return EarthlyStar;
                 }

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -248,7 +248,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (MaleficCount == 1 && CombustCount == 0)
                             return OriginalHook(Combust);
 
-                        if (MaleficCount == 1 && (CombustCount == 1) && ActionReady(Lightspeed) && CanDelayedWeave(actionID))
+                        if (MaleficCount == 1 && (CombustCount == 1) && ActionReady(Lightspeed) && CanDelayedWeave(actionID) && !HasEffect(Buffs.Lightspeed))
                             return OriginalHook(Lightspeed);
 
                         if (MaleficCount == 3 && CanWeave(actionID))


### PR DESCRIPTION
Reverted _Added earthly star to the prepull noncombat line with the card draw so you can plant your star before pull_ 

Shifted earthly star a bit higher above the ogcds that cant drift. oracle/arcana
Added tag to not be moving to lay earthly star in aoe to help prevent it wasting during aoe pulls
Added a buff check to the opener for lightspeed to fix rare double cast (discord rpt)