### PR TITLE
[VPR] Add options to disable range checks in AoE combo

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4148,7 +4148,7 @@ namespace XIVSlothCombo.Combos
         VPR_AoE_Vicepit = 30105,
 
         [ParentCombo(VPR_AoE_Vicepit)]
-        [CustomComboInfo("Disable Range Check", "Disables the range check for Vicepit.", VPR.JobID)]
+        [CustomComboInfo("Disable Range Check", "Disables the range check for Vicepit, so it will be used even without a target selected.", VPR.JobID)]
         VPR_AoE_Vicepit_DisableRange = 30111,
 
         [ParentCombo(VPR_AoE_CDs)]
@@ -4156,7 +4156,7 @@ namespace XIVSlothCombo.Combos
         VPR_AoE_VicepitCombo = 30106,
 
         [ParentCombo(VPR_AoE_VicepitCombo)]
-        [CustomComboInfo("Disable Range Check", "Disables the range check for Swiftskin's Den and Hunter's Den.", VPR.JobID)]
+        [CustomComboInfo("Disable Range Check", "Disables the range check for Swiftskin's Den and Hunter's Den, so they will be used even without a target selected.", VPR.JobID)]
         VPR_AoE_VicepitCombo_DisableRange = 30113,
 
         #endregion
@@ -4179,7 +4179,7 @@ namespace XIVSlothCombo.Combos
         VPR_AoE_Reawaken = 30110,
 
         [ParentCombo(VPR_AoE_Reawaken)]
-        [CustomComboInfo("Disable Range Check", "Disables the range check for Reawaken.", VPR.JobID)]
+        [CustomComboInfo("Disable Range Check", "Disables the range check for Reawaken, so it will be used even without a target selected.", VPR.JobID)]
         VPR_AoE_Reawaken_DisableRange = 30114,
 
         [ParentCombo(VPR_AoE_AdvancedMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4147,9 +4147,17 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Vicepit", "Adds Vicepit to the rotation.", VPR.JobID)]
         VPR_AoE_Vicepit = 30105,
 
+        [ParentCombo(VPR_AoE_Vicepit)]
+        [CustomComboInfo("Disable Range Check", "Disables the range check for Vicepit.", VPR.JobID)]
+        VPR_AoE_Vicepit_DisableRange = 30111,
+
         [ParentCombo(VPR_AoE_CDs)]
         [CustomComboInfo("Vicepit Combo", "Adds Swiftskin's Den and Hunter's Den to the rotation.", VPR.JobID)]
         VPR_AoE_VicepitCombo = 30106,
+
+        [ParentCombo(VPR_AoE_VicepitCombo)]
+        [CustomComboInfo("Disable Range Check", "Disables the range check for Swiftskin's Den and Hunter's Den.", VPR.JobID)]
+        VPR_AoE_VicepitCombo_DisableRange = 30113,
 
         #endregion
 
@@ -4169,6 +4177,10 @@ namespace XIVSlothCombo.Combos
         [ConflictingCombos(VPR_ReawakenLegacy)]
         [CustomComboInfo("Reawaken", "Adds Reawaken to the rotation.", VPR.JobID)]
         VPR_AoE_Reawaken = 30110,
+
+        [ParentCombo(VPR_AoE_Reawaken)]
+        [CustomComboInfo("Disable Range Check", "Disables the range check for Reawaken.", VPR.JobID)]
+        VPR_AoE_Reawaken_DisableRange = 30114,
 
         [ParentCombo(VPR_AoE_AdvancedMode)]
         [ConflictingCombos(VPR_ReawakenLegacy)]

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -624,10 +624,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (!HasEffect(Buffs.Reawakened))
                         {
                             //Vicepit weaves
-                            if (HasEffect(Buffs.FellhuntersVenom))
+                            if (HasEffect(Buffs.FellhuntersVenom) && InMeleeRange())
                                 return OriginalHook(Twinfang);
 
-                            if (HasEffect(Buffs.FellskinsVenom))
+                            if (HasEffect(Buffs.FellskinsVenom) && InMeleeRange())
                                 return OriginalHook(Twinblood);
 
                             //Serpents Ire usage
@@ -637,7 +637,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     //Vicepit combo
-                    if (!HasEffect(Buffs.Reawakened))
+                    if (!HasEffect(Buffs.Reawakened) && InMeleeRange())
                     {
                         if (SwiftskinsDenReady)
                             return HuntersDen;
@@ -649,7 +649,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Reawakend Usage
                     if ((HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
                         HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                        !HasEffect(Buffs.Reawakened) &&
+                        !HasEffect(Buffs.Reawakened) && InActionRange(Reawaken) &&
                         !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
                         !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
                         return Reawaken;
@@ -661,7 +661,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     //Vicepit Usage
                     if (ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) &&
-                        ((ireCD >= GCD * 5) || !LevelChecked(SerpentsIre)))
+                        ((ireCD >= GCD * 5) || !LevelChecked(SerpentsIre)) && InMeleeRange())
                         return Vicepit;
 
                     // Uncoiled Fury usage
@@ -802,7 +802,8 @@ namespace XIVSlothCombo.Combos.PvE
                             !HasEffect(Buffs.Reawakened))
                         {
                             //Vicepit weaves
-                            if (IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo))
+                            if (IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo) &&
+                                InMeleeRange())
                             {
                                 if (HasEffect(Buffs.FellhuntersVenom))
                                     return OriginalHook(Twinfang);
@@ -821,7 +822,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Vicepit combo
                     if (IsEnabled(CustomComboPreset.VPR_AoE_CDs) &&
                         IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo) &&
-                        !HasEffect(Buffs.Reawakened))
+                        !HasEffect(Buffs.Reawakened) && InMeleeRange())
                     {
                         if (SwiftskinsDenReady)
                             return HuntersDen;
@@ -834,7 +835,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.VPR_AoE_Reawaken) &&
                         (HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
                         HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                        !HasEffect(Buffs.Reawakened) &&
+                        !HasEffect(Buffs.Reawakened) && InActionRange(Reawaken) &&
                         !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
                         !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
                         return Reawaken;
@@ -848,7 +849,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Vicepit Usage
                     if (IsEnabled(CustomComboPreset.VPR_AoE_CDs) &&
                         IsEnabled(CustomComboPreset.VPR_AoE_Vicepit) &&
-                        ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) &&
+                        ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) && InMeleeRange() &&
                         ((ireCD >= GCD * 5) || !LevelChecked(SerpentsIre)))
                         return Vicepit;
 

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -598,6 +598,7 @@ namespace XIVSlothCombo.Combos.PvE
                 bool VicepitReady = gauge.DreadCombo == DreadCombo.PitOfDread;
                 bool SwiftskinsDenReady = gauge.DreadCombo == DreadCombo.SwiftskinsDen;
                 bool HuntersDenReady = gauge.DreadCombo == DreadCombo.HuntersDen;
+                bool in5y = GetTargetDistance() <= 5;
                 bool CappedOnCoils = (TraitLevelChecked(Traits.EnhancedVipersRattle) && RattlingCoils > 2) || (!TraitLevelChecked(Traits.EnhancedVipersRattle) && RattlingCoils > 1);
                 float GCD = GetCooldown(OriginalHook(ReavingFangs)).CooldownTotal;
 
@@ -624,10 +625,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (!HasEffect(Buffs.Reawakened))
                         {
                             //Vicepit weaves
-                            if (HasEffect(Buffs.FellhuntersVenom) && InMeleeRange())
+                            if (HasEffect(Buffs.FellhuntersVenom) && in5y)
                                 return OriginalHook(Twinfang);
 
-                            if (HasEffect(Buffs.FellskinsVenom) && InMeleeRange())
+                            if (HasEffect(Buffs.FellskinsVenom) && in5y)
                                 return OriginalHook(Twinblood);
 
                             //Serpents Ire usage
@@ -637,7 +638,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     //Vicepit combo
-                    if (!HasEffect(Buffs.Reawakened) && InMeleeRange())
+                    if (!HasEffect(Buffs.Reawakened) && in5y)
                     {
                         if (SwiftskinsDenReady)
                             return HuntersDen;
@@ -649,7 +650,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Reawakend Usage
                     if ((HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
                         HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                        !HasEffect(Buffs.Reawakened) && InActionRange(Reawaken) &&
+                        !HasEffect(Buffs.Reawakened) && in5y &&
                         !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
                         !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
                         return Reawaken;
@@ -661,7 +662,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     //Vicepit Usage
                     if (ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) &&
-                        ((ireCD >= GCD * 5) || !LevelChecked(SerpentsIre)) && InMeleeRange())
+                        ((ireCD >= GCD * 5) || !LevelChecked(SerpentsIre)) && in5y)
                         return Vicepit;
 
                     // Uncoiled Fury usage
@@ -770,6 +771,7 @@ namespace XIVSlothCombo.Combos.PvE
                 bool VicepitReady = gauge.DreadCombo == DreadCombo.PitOfDread;
                 bool SwiftskinsDenReady = gauge.DreadCombo == DreadCombo.SwiftskinsDen;
                 bool HuntersDenReady = gauge.DreadCombo == DreadCombo.HuntersDen;
+                bool in5y = HasBattleTarget() && GetTargetDistance() <= 5;
                 bool CappedOnCoils = (TraitLevelChecked(Traits.EnhancedVipersRattle) && RattlingCoils > 2) || (!TraitLevelChecked(Traits.EnhancedVipersRattle) && RattlingCoils > 1);
                 float GCD = GetCooldown(OriginalHook(ReavingFangs)).CooldownTotal;
 
@@ -803,7 +805,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             //Vicepit weaves
                             if (IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo) &&
-                                InMeleeRange())
+                                (in5y || IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo_DisableRange)))
                             {
                                 if (HasEffect(Buffs.FellhuntersVenom))
                                     return OriginalHook(Twinfang);
@@ -822,7 +824,8 @@ namespace XIVSlothCombo.Combos.PvE
                     //Vicepit combo
                     if (IsEnabled(CustomComboPreset.VPR_AoE_CDs) &&
                         IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo) &&
-                        !HasEffect(Buffs.Reawakened) && InMeleeRange())
+                        !HasEffect(Buffs.Reawakened) && 
+                        (in5y || IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo_DisableRange)))
                     {
                         if (SwiftskinsDenReady)
                             return HuntersDen;
@@ -835,7 +838,8 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.VPR_AoE_Reawaken) &&
                         (HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
                         HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                        !HasEffect(Buffs.Reawakened) && InActionRange(Reawaken) &&
+                        !HasEffect(Buffs.Reawakened) && 
+                        (in5y || IsEnabled(CustomComboPreset.VPR_AoE_Reawaken_DisableRange)) &&
                         !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
                         !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
                         return Reawaken;
@@ -849,7 +853,8 @@ namespace XIVSlothCombo.Combos.PvE
                     //Vicepit Usage
                     if (IsEnabled(CustomComboPreset.VPR_AoE_CDs) &&
                         IsEnabled(CustomComboPreset.VPR_AoE_Vicepit) &&
-                        ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) && InMeleeRange() &&
+                        ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) && 
+                        (in5y || IsEnabled(CustomComboPreset.VPR_AoE_Vicepit_DisableRange)) &&
                         ((ireCD >= GCD * 5) || !LevelChecked(SerpentsIre)))
                         return Vicepit;
 

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -598,7 +598,7 @@ namespace XIVSlothCombo.Combos.PvE
                 bool VicepitReady = gauge.DreadCombo == DreadCombo.PitOfDread;
                 bool SwiftskinsDenReady = gauge.DreadCombo == DreadCombo.SwiftskinsDen;
                 bool HuntersDenReady = gauge.DreadCombo == DreadCombo.HuntersDen;
-                bool in5y = GetTargetDistance() <= 5;
+                bool in5y = HasBattleTarget() && GetTargetDistance() <= 5;
                 bool CappedOnCoils = (TraitLevelChecked(Traits.EnhancedVipersRattle) && RattlingCoils > 2) || (!TraitLevelChecked(Traits.EnhancedVipersRattle) && RattlingCoils > 1);
                 float GCD = GetCooldown(OriginalHook(ReavingFangs)).CooldownTotal;
 

--- a/XIVSlothCombo/Combos/PvE/VPR.cs
+++ b/XIVSlothCombo/Combos/PvE/VPR.cs
@@ -624,10 +624,10 @@ namespace XIVSlothCombo.Combos.PvE
                         if (!HasEffect(Buffs.Reawakened))
                         {
                             //Vicepit weaves
-                            if (HasEffect(Buffs.FellhuntersVenom) && InMeleeRange())
+                            if (HasEffect(Buffs.FellhuntersVenom))
                                 return OriginalHook(Twinfang);
 
-                            if (HasEffect(Buffs.FellskinsVenom) && InMeleeRange())
+                            if (HasEffect(Buffs.FellskinsVenom))
                                 return OriginalHook(Twinblood);
 
                             //Serpents Ire usage
@@ -637,7 +637,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     //Vicepit combo
-                    if (!HasEffect(Buffs.Reawakened) && InMeleeRange())
+                    if (!HasEffect(Buffs.Reawakened))
                     {
                         if (SwiftskinsDenReady)
                             return HuntersDen;
@@ -649,7 +649,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Reawakend Usage
                     if ((HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
                         HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                        !HasEffect(Buffs.Reawakened) && InActionRange(Reawaken) &&
+                        !HasEffect(Buffs.Reawakened) &&
                         !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
                         !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
                         return Reawaken;
@@ -661,7 +661,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     //Vicepit Usage
                     if (ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) &&
-                        ((ireCD >= GCD * 5) || !LevelChecked(SerpentsIre)) && InMeleeRange())
+                        ((ireCD >= GCD * 5) || !LevelChecked(SerpentsIre)))
                         return Vicepit;
 
                     // Uncoiled Fury usage
@@ -802,8 +802,7 @@ namespace XIVSlothCombo.Combos.PvE
                             !HasEffect(Buffs.Reawakened))
                         {
                             //Vicepit weaves
-                            if (IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo) &&
-                                InMeleeRange())
+                            if (IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo))
                             {
                                 if (HasEffect(Buffs.FellhuntersVenom))
                                     return OriginalHook(Twinfang);
@@ -822,7 +821,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Vicepit combo
                     if (IsEnabled(CustomComboPreset.VPR_AoE_CDs) &&
                         IsEnabled(CustomComboPreset.VPR_AoE_VicepitCombo) &&
-                        !HasEffect(Buffs.Reawakened) && InMeleeRange())
+                        !HasEffect(Buffs.Reawakened))
                     {
                         if (SwiftskinsDenReady)
                             return HuntersDen;
@@ -835,7 +834,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.VPR_AoE_Reawaken) &&
                         (HasEffect(Buffs.ReadyToReawaken) || gauge.SerpentOffering >= 50) && LevelChecked(Reawaken) &&
                         HasEffect(Buffs.Swiftscaled) && HasEffect(Buffs.HuntersInstinct) &&
-                        !HasEffect(Buffs.Reawakened) && InActionRange(Reawaken) &&
+                        !HasEffect(Buffs.Reawakened) &&
                         !HasEffect(Buffs.FellhuntersVenom) && !HasEffect(Buffs.FellskinsVenom) &&
                         !HasEffect(Buffs.PoisedForTwinblood) && !HasEffect(Buffs.PoisedForTwinfang))
                         return Reawaken;
@@ -849,7 +848,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //Vicepit Usage
                     if (IsEnabled(CustomComboPreset.VPR_AoE_CDs) &&
                         IsEnabled(CustomComboPreset.VPR_AoE_Vicepit) &&
-                        ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) && InMeleeRange() &&
+                        ActionReady(Vicepit) && !HasEffect(Buffs.Reawakened) &&
                         ((ireCD >= GCD * 5) || !LevelChecked(SerpentsIre)))
                         return Vicepit;
 


### PR DESCRIPTION
Removes the action range checks from the Vicepit combo sequence and Reawaken in the AoE combo (simple and advanced), so they will still fire without a target selected.