### PR TITLE
[NIN] True North Fix

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2321,9 +2321,9 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Suiton Uptime Option", "Adds Suiton as an uptime feature.", NIN.JobID)]
         NIN_ST_AdvancedMode_Suiton_Uptime = 10067,
 
-        [ParentCombo(NIN_ST_AdvancedMode_TrueNorth_ArmorCrush)]
-        [CustomComboInfo("Dynamic True North Option", "Adds True North before Armor Crush when you are not in the correct position for the enhanced potency bonus.", NIN.JobID)]
-        NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic = 10068,
+        //[ParentCombo(NIN_ST_AdvancedMode_TrueNorth_ArmorCrush)] Removed because true north is going to be dynamic inherently. Armor crush happens far more often now. Can just elimite all AC with TN.
+        //[CustomComboInfo("Dynamic True North Option", "Adds True North before Armor Crush when you are not in the correct position for the enhanced potency bonus.", NIN.JobID)]
+        //NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic = 10068,
 
         [Variant]
         [VariantParent(NIN_ST_SimpleMode, NIN_ST_AdvancedMode, NIN_AoE_SimpleMode, NIN_AoE_AdvancedMode)]

--- a/XIVSlothCombo/Combos/PvE/AST.cs
+++ b/XIVSlothCombo/Combos/PvE/AST.cs
@@ -207,7 +207,7 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     spellsSinceDraw = 1;
                 }
-                
+
                 bool AlternateMode = GetIntOptionAsBool(Config.AST_DPS_AltMode); //(0 or 1 radio values)
                 bool inOpener = IsEnabled(CustomComboPreset.AST_ST_DPS_Opener) && MaleficCount < 6;
 
@@ -215,11 +215,15 @@ namespace XIVSlothCombo.Combos.PvE
                 if (((!AlternateMode && MaleficList.Contains(actionID)) ||
                     (AlternateMode && CombustList.ContainsKey(actionID)) &&
                     !InCombat()))
-
+                {
                     if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
                         ActionReady(OriginalHook(AstralDraw)) && (Gauge.DrawnCards.All(x => x is CardType.NONE) || (DrawnCard == CardType.NONE && Config.AST_ST_DPS_OverwriteCards)))
                         return OriginalHook(AstralDraw);
 
+                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar) &&
+                        ActionReady(EarthlyStar))
+                        return EarthlyStar;
+                }
                 //In combat
                 if (((!AlternateMode && MaleficList.Contains(actionID)) ||
                      (AlternateMode && CombustList.ContainsKey(actionID))) &&
@@ -312,12 +316,11 @@ namespace XIVSlothCombo.Combos.PvE
 
 
                     //Play Card
-                    if (IsEnabled(CustomComboPreset.AST_DPS_AutoPlay) &&
-                        ActionReady(Play1) &&
-                        Gauge.DrawnCards[0] is not CardType.NONE &&
-                        CanSpellWeave(actionID) &&
-                        spellsSinceDraw >= Config.AST_ST_DPS_Play_SpeedSetting)
-                        return OriginalHook(Play1);
+                    if (IsEnabled(CustomComboPreset.AST_DPS_AutoPlay) && (ActionReady(Play1) &&
+                            Gauge.DrawnCards[0] is not CardType.NONE &&
+                            CanSpellWeave(actionID) &&
+                            spellsSinceDraw >= Config.AST_ST_DPS_Play_SpeedSetting))
+                            return OriginalHook(Play1);                                                           
 
                     //Card Draw
                     if (IsEnabled(CustomComboPreset.AST_DPS_AutoDraw) &&
@@ -335,11 +338,17 @@ namespace XIVSlothCombo.Combos.PvE
                         ActionWatching.NumberOfGcdsUsed >= 3)
                         return Divination;
 
+                    //Earthly Star
+                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar) &&
+                        ActionReady(EarthlyStar) &&
+                        CanSpellWeave(actionID))
+                        return EarthlyStar;
+
                     if (IsEnabled(CustomComboPreset.AST_DPS_Oracle) &&
                         HasEffect(Buffs.Divining) &&
                         CanSpellWeave(actionID))
                         return Oracle;
-
+                                        
                     //Minor Arcana / Lord of Crowns
                     if (ActionReady(OriginalHook(MinorArcana)) &&
                         IsEnabled(CustomComboPreset.AST_DPS_LazyLord) && Gauge.DrawnCrownCard is CardType.LORD &&
@@ -347,11 +356,25 @@ namespace XIVSlothCombo.Combos.PvE
                         CanDelayedWeave(actionID))
                         return OriginalHook(MinorArcana);
 
-                    //Earthly Star
-                    if (IsEnabled(CustomComboPreset.AST_ST_DPS_EarthlyStar) &&
-                        ActionReady(EarthlyStar) &&
-                        CanSpellWeave(actionID))
-                        return EarthlyStar;
+                    if (IsEnabled(CustomComboPreset.AST_DPS_AutoPlay)) //Forbidden Knowledge
+                    {
+                        if ((Gauge.DrawnCards[1] == CardType.ARROW || Gauge.DrawnCards[1] == CardType.BOLE) &&
+                            ActionReady(Play2) && CanSpellWeave(actionID))
+                            return OriginalHook(Play2);
+
+                        if ((Gauge.DrawnCards[2] == CardType.SPIRE || Gauge.DrawnCards[2] == CardType.EWER) &&
+                            ActionReady(Play3) && CanSpellWeave(actionID))
+                            return OriginalHook(Play3);
+
+                        if (ActionReady(CelestialIntersection) &&
+                        CanSpellWeave(actionID) && !WasLastAbility(actionID))
+                            return CelestialIntersection;
+
+                        if (ActionReady(Exaltation) && CanSpellWeave(actionID))
+                            return Exaltation;
+                    }
+
+
 
                     if (HasBattleTarget())
                     {
@@ -429,12 +452,37 @@ namespace XIVSlothCombo.Combos.PvE
                         CanSpellWeave(actionID))
                         return All.LucidDreaming;
 
-                    //Play Card
-                    if (IsEnabled(CustomComboPreset.AST_AOE_AutoPlay) &&
-                        ActionReady(Play1) &&
-                        Gauge.DrawnCards[0] is not CardType.NONE &&
+                    //Earthly Star
+                    if (IsEnabled(CustomComboPreset.AST_AOE_DPS_EarthlyStar) &&
+                        ActionReady(EarthlyStar) &&
                         CanSpellWeave(actionID))
-                        return OriginalHook(Play1);
+                        return EarthlyStar;
+
+                    //Play Card
+                    if (IsEnabled(CustomComboPreset.AST_AOE_AutoPlay))
+                    {
+                        if (ActionReady(Play1) &&
+                            Gauge.DrawnCards[0] is not CardType.NONE &&
+                            CanSpellWeave(actionID))
+                            return OriginalHook(Play1);
+
+                        //Forbidden Knowledge
+
+                        if ((Gauge.DrawnCards[1] == CardType.ARROW || Gauge.DrawnCards[1] == CardType.BOLE) &&
+                            ActionReady(Play2) && CanSpellWeave(actionID))
+                            return OriginalHook(Play2);
+
+                        if ((Gauge.DrawnCards[2] == CardType.SPIRE || Gauge.DrawnCards[2] == CardType.EWER) &&
+                            ActionReady(Play3) && CanSpellWeave(actionID))
+                            return OriginalHook(Play3);
+
+                        if (ActionReady(CelestialIntersection) &&
+                        CanSpellWeave(actionID) && !WasLastAbility(actionID))
+                            return CelestialIntersection;
+
+                        if (ActionReady(Exaltation) && CanSpellWeave(actionID))
+                            return Exaltation;
+                    }
 
                     //Card Draw
                     if (IsEnabled(CustomComboPreset.AST_AOE_AutoDraw) &&
@@ -462,13 +510,7 @@ namespace XIVSlothCombo.Combos.PvE
                         IsEnabled(CustomComboPreset.AST_AOE_LazyLord) && Gauge.DrawnCrownCard is CardType.LORD &&
                         HasBattleTarget() &&
                         CanDelayedWeave(actionID))
-                        return OriginalHook(MinorArcana);
-
-                    //Earthly Star
-                    if (IsEnabled(CustomComboPreset.AST_AOE_DPS_EarthlyStar) &&
-                        ActionReady(EarthlyStar) &&
-                        CanSpellWeave(actionID))
-                        return EarthlyStar;
+                        return OriginalHook(MinorArcana);                    
 
                 }
                 return actionID;

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -385,6 +385,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (!NINHelper.MugDebuff && GetTargetHPPercent() > burnKazematoi)
                             {
+
                                 if (gauge.Kazematoi < 4)
                                 {
                                     if (trueNorthArmor)
@@ -415,7 +416,7 @@ namespace XIVSlothCombo.Combos.PvE
                                         return OriginalHook(All.TrueNorth);
                                     else
                                         return OriginalHook(AeolianEdge);
-                                }
+                                }                               
                             }
                         }                           
                         if (lastComboMove == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -127,6 +127,7 @@ namespace XIVSlothCombo.Combos.PvE
                 Advanced_Trick_Cooldown = "Advanced_Trick_Cooldown",
                 Advanced_DotonTimer = "Advanced_DotonTimer",
                 Advanced_DotonHP = "Advanced_DotonHP",
+                BurnKazematoi = "BurnKazematoi",
                 Advanced_TCJEnderAoE = "Advanced_TCJEnderAoe",
                 Advanced_ChargePool = "Advanced_ChargePool",
                 SecondWindThresholdST = "SecondWindThresholdST",
@@ -163,6 +164,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool suitonUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Suiton_Uptime);
                     int bhavaPool = GetOptionValue(Config.Ninki_BhavaPooling);
                     int bunshinPool = GetOptionValue(Config.Ninki_BunshinPoolingST);
+                    int burnKazematoi = GetOptionValue(NIN.Config.BurnKazematoi);
                     int SecondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.SecondWindThresholdST);
                     int ShadeShiftThreshold = PluginConfiguration.GetCustomIntValue(Config.ShadeShiftThresholdST);
                     int BloodbathThreshold = PluginConfiguration.GetCustomIntValue(Config.BloodbathThresholdST);
@@ -381,7 +383,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (lastComboMove == GustSlash && ArmorCrush.LevelChecked())
                         {
-                            if (!NINHelper.MugDebuff)
+                            if (!NINHelper.MugDebuff && GetTargetHPPercent() > burnKazematoi)
                             {
                                 if (gauge.Kazematoi < 4)
                                 {
@@ -398,7 +400,7 @@ namespace XIVSlothCombo.Combos.PvE
                                         return OriginalHook(AeolianEdge);
                                 }
                             }
-                            if (NINHelper.MugDebuff)
+                            if (NINHelper.MugDebuff  || GetTargetHPPercent() <= burnKazematoi)
                             {
                                 if (gauge.Kazematoi == 0)
                                 {

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -169,6 +169,9 @@ namespace XIVSlothCombo.Combos.PvE
                     double playerHP = PlayerHealthPercentageHp();
                     bool phantomUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Phantom_Uptime);
                     var comboLength = GetCooldown(GustSlash).CooldownTotal * 3;
+                    bool trueNorthArmor = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && !OnTargetsFlank() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                    bool trueNorthEdge = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth_ArmorCrush) && !OnTargetsRear() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                        
 
                     if (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus) || (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat()))
                         mudraState.CurrentMudra = MudraCasting.MudraState.None;
@@ -376,26 +379,51 @@ namespace XIVSlothCombo.Combos.PvE
                         if (lastComboMove == SpinningEdge && GustSlash.LevelChecked())
                             return OriginalHook(GustSlash);
 
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() &&
-                            IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth_ArmorCrush) &&
-                            lastComboMove == GustSlash && GetRemainingCharges(All.TrueNorth) > 0 &&
-                            All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) &&
-                            canWeave)
-                            return OriginalHook(All.TrueNorth);
-
                         if (lastComboMove == GustSlash && ArmorCrush.LevelChecked())
                         {
-                            if ((!NINHelper.MugDebuff) || (NINHelper.MugDebuff &&  gauge.Kazematoi == 0))
+                            if (!NINHelper.MugDebuff)
                             {
                                 if (gauge.Kazematoi < 4)
-                                    return OriginalHook(ArmorCrush);
+                                {
+                                    if (trueNorthArmor)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(ArmorCrush);
+                                }
+                                else
+                                {
+                                    if (trueNorthEdge)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(AeolianEdge);
+                                }
                             }
+                            if (NINHelper.MugDebuff)
+                            {
+                                if (gauge.Kazematoi == 0)
+                                {
+                                    if (trueNorthArmor)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(ArmorCrush);
+                                }
+                                else
+                                {
+                                    if (trueNorthEdge)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(AeolianEdge);
+                                }
+                            }
+                        }                           
+                        if (lastComboMove == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())
+                        {
+                            if (trueNorthEdge)
+                                return OriginalHook(All.TrueNorth);
+                            else
+                                return OriginalHook(AeolianEdge);
                         }
-
-                        if (lastComboMove == GustSlash && AeolianEdge.LevelChecked() && (gauge.Kazematoi > 0 || !ArmorCrush.LevelChecked()))
-                            return OriginalHook(AeolianEdge);
                     }
-
                     return OriginalHook(SpinningEdge);
                 }
                 return actionID;
@@ -592,6 +620,10 @@ namespace XIVSlothCombo.Combos.PvE
                     bool canWeave = CanWeave(SpinningEdge);
                     bool inTrickBurstSaveWindow = GetCooldownRemainingTime(TrickAttack) <= 15 && Suiton.LevelChecked();
                     bool useBhakaBeforeTrickWindow = GetCooldownRemainingTime(TrickAttack) >= 3;
+                    var canDelayedWeave = CanDelayedWeave(SpinningEdge);
+                    bool trueNorthArmor = TargetNeedsPositionals() && !OnTargetsFlank() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                    bool trueNorthEdge = TargetNeedsPositionals() && !OnTargetsRear() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+
 
                     if (OriginalHook(Ninjutsu) is Rabbit)
                         return OriginalHook(Ninjutsu);
@@ -685,18 +717,51 @@ namespace XIVSlothCombo.Combos.PvE
                         if (lastComboMove == SpinningEdge && GustSlash.LevelChecked())
                             return OriginalHook(GustSlash);
 
-                        if (lastComboMove == GustSlash && TargetNeedsPositionals() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canWeave)
-                            return OriginalHook(All.TrueNorth);
-
-                        if (lastComboMove == GustSlash && AeolianEdge.LevelChecked() && (gauge.Kazematoi > 0 || !ArmorCrush.LevelChecked()))
-                            return OriginalHook(AeolianEdge);
-
-                        if (lastComboMove == GustSlash && ArmorCrush.LevelChecked() && gauge.Kazematoi < 5)
-                            return OriginalHook(ArmorCrush);
-
-
+                        if (lastComboMove == GustSlash && ArmorCrush.LevelChecked())
+                        {
+                            if (!NINHelper.MugDebuff)
+                            {
+                                if (gauge.Kazematoi < 4)
+                                {
+                                    if (trueNorthArmor)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(ArmorCrush);
+                                }
+                                else
+                                {
+                                    if (trueNorthEdge)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(AeolianEdge);
+                                }
+                            }
+                            if (NINHelper.MugDebuff)
+                            {
+                                if (gauge.Kazematoi == 0)
+                                {
+                                    if (trueNorthArmor)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(ArmorCrush);
+                                }
+                                else
+                                {
+                                    if (trueNorthEdge)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(AeolianEdge);
+                                }
+                            }
+                        }
+                        if (lastComboMove == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())
+                        {
+                            if (trueNorthEdge)
+                                return OriginalHook(All.TrueNorth);
+                            else
+                                return OriginalHook(AeolianEdge);
+                        }
                     }
-
                     return OriginalHook(SpinningEdge);
                 }
                 return actionID;

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1598,6 +1598,8 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawRadioButton(NIN.Config.NIN_SimpleMudra_Choice, "Mudra Path Set 1", $"1. Ten Mudras -> Fuma Shuriken, Raiton/Hyosho Ranryu, Suiton (Doton under Kassatsu).\nChi Mudras -> Fuma Shuriken, Hyoton, Huton.\nJin Mudras -> Fuma Shuriken, Katon/Goka Mekkyaku, Doton", 1);
                 UserConfig.DrawRadioButton(NIN.Config.NIN_SimpleMudra_Choice, "Mudra Path Set 2", $"2. Ten Mudras -> Fuma Shuriken, Hyoton/Hyosho Ranryu, Doton.\nChi Mudras -> Fuma Shuriken, Katon, Suiton.\nJin Mudras -> Fuma Shuriken, Raiton/Goka Mekkyaku, Huton (Doton under Kassatsu).", 2);
             }
+            if (preset == CustomComboPreset.NIN_ST_AdvancedMode)
+                UserConfig.DrawSliderInt(0, 10, NIN.Config.BurnKazematoi, "Target HP% to dump all pooled Kazematoi below");
 
             if (preset == CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra)
                 UserConfig.DrawSliderInt(50, 100, NIN.Config.Ninki_BhavaPooling, "Set the minimal amount of Ninki required to have before spending on Bhavacakra.");


### PR DESCRIPTION
- [x] Fixed the True North support for Advanced mode. Updated to delayedweaves per discord discussion
- [x] Removed the option for Dynamic True north. With ninja changes and AC happening far more often, you cant just eliminate flank positionals with true north completely. All true north is dynamic.  YOU CAN STILL CHOOSE ARMOR CRUSH ONLY. 
- [x] Ported the Advanced TN changes and combo setup to Simple. This will also line positionals up with what avarice predicts as well as account for mug window if you happen to get a positional during it. 
- [x] Added a slider for target health % to burn pooled Kazematoi at the end of a fight. Every kaze at the end of a fight not used is 60 potency that could have been gained using edge instead of crush. 

