### PR TITLE
[NIN] Ninja True North Fixes, Kazematoi dump

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2321,9 +2321,9 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Suiton Uptime Option", "Adds Suiton as an uptime feature.", NIN.JobID)]
         NIN_ST_AdvancedMode_Suiton_Uptime = 10067,
 
-        [ParentCombo(NIN_ST_AdvancedMode_TrueNorth_ArmorCrush)]
-        [CustomComboInfo("Dynamic True North Option", "Adds True North before Armor Crush when you are not in the correct position for the enhanced potency bonus.", NIN.JobID)]
-        NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic = 10068,
+        //[ParentCombo(NIN_ST_AdvancedMode_TrueNorth_ArmorCrush)] Removed because true north is going to be dynamic inherently. Armor crush happens far more often now. Can just elimite all AC with TN.
+        //[CustomComboInfo("Dynamic True North Option", "Adds True North before Armor Crush when you are not in the correct position for the enhanced potency bonus.", NIN.JobID)]
+        //NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic = 10068,
 
         [Variant]
         [VariantParent(NIN_ST_SimpleMode, NIN_ST_AdvancedMode, NIN_AoE_SimpleMode, NIN_AoE_AdvancedMode)]

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -2188,6 +2188,7 @@ namespace XIVSlothCombo.Combos
         NIN_ST_AdvancedMode_TrueNorth = 10030,
 
         [ParentCombo(NIN_ST_AdvancedMode_TrueNorth)]
+        [ConflictingCombos(NIN_ST_AdvancedMode_Dynamic)]
         [CustomComboInfo("Use Before Armor Crush Only Option", "Only triggers the use of True North before Armor Crush.", NIN.JobID)]
         NIN_ST_AdvancedMode_TrueNorth_ArmorCrush = 10031,
 
@@ -2321,9 +2322,10 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Suiton Uptime Option", "Adds Suiton as an uptime feature.", NIN.JobID)]
         NIN_ST_AdvancedMode_Suiton_Uptime = 10067,
 
-        //[ParentCombo(NIN_ST_AdvancedMode_TrueNorth_ArmorCrush)] Removed because true north is going to be dynamic inherently. Armor crush happens far more often now. Can just elimite all AC with TN.
-        //[CustomComboInfo("Dynamic True North Option", "Adds True North before Armor Crush when you are not in the correct position for the enhanced potency bonus.", NIN.JobID)]
-        //NIN_ST_AdvancedMode_TrueNorth_ArmorCrush_Dynamic = 10068,
+        [ParentCombo(NIN_ST_AdvancedMode_TrueNorth)]
+        [ConflictingCombos(NIN_ST_AdvancedMode_TrueNorth_ArmorCrush)]
+        [CustomComboInfo("Dynamic Ninja Positional Option", "Dynamic choice of Armor crush/Aeolian Edge based on position and available charges.\nGo to Flank to build charges, Rear to spend them. \nPrevents overcap or waste and will use true north as needed." , NIN.JobID)]
+        NIN_ST_AdvancedMode_Dynamic = 10068,
 
         [Variant]
         [VariantParent(NIN_ST_SimpleMode, NIN_ST_AdvancedMode, NIN_AoE_SimpleMode, NIN_AoE_AdvancedMode)]

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -173,7 +173,8 @@ namespace XIVSlothCombo.Combos.PvE
                     var comboLength = GetCooldown(GustSlash).CooldownTotal * 3;
                     bool trueNorthArmor = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && !OnTargetsFlank() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
                     bool trueNorthEdge = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth_ArmorCrush) && !OnTargetsRear() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
-                        
+                    bool dynamic = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Dynamic);
+
 
                     if (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus) || (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat()))
                         mudraState.CurrentMudra = MudraCasting.MudraState.None;
@@ -380,28 +381,19 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (lastComboMove == SpinningEdge && GustSlash.LevelChecked())
                             return OriginalHook(GustSlash);
-
+                            
                         if (lastComboMove == GustSlash && ArmorCrush.LevelChecked())
                         {
-                            if (!NINHelper.MugDebuff && GetTargetHPPercent() > burnKazematoi)
-                            {
-                                if (gauge.Kazematoi < 4)
-                                {
-                                    if (trueNorthArmor)
-                                        return OriginalHook(All.TrueNorth);
-                                    else
-                                        return OriginalHook(ArmorCrush);
-                                }
-                                else
+                            if (dynamic)
+                            {                                
+                                if (gauge.Kazematoi > 3)
                                 {
                                     if (trueNorthEdge)
                                         return OriginalHook(All.TrueNorth);
                                     else
                                         return OriginalHook(AeolianEdge);
                                 }
-                            }
-                            if (NINHelper.MugDebuff  || GetTargetHPPercent() <= burnKazematoi)
-                            {
+                                
                                 if (gauge.Kazematoi == 0)
                                 {
                                     if (trueNorthArmor)
@@ -409,15 +401,54 @@ namespace XIVSlothCombo.Combos.PvE
                                     else
                                         return OriginalHook(ArmorCrush);
                                 }
-                                else
+                                if ((gauge.Kazematoi > 0) && (gauge.Kazematoi < 4))
                                 {
-                                    if (trueNorthEdge)
-                                        return OriginalHook(All.TrueNorth);
+                                    if (OnTargetsFlank())
+                                        return OriginalHook(ArmorCrush);
                                     else
                                         return OriginalHook(AeolianEdge);
                                 }
+
+
                             }
-                        }                           
+                            if (!dynamic)
+                            {
+                                if (!NINHelper.MugDebuff && GetTargetHPPercent() > burnKazematoi)
+                                {
+                                    if (gauge.Kazematoi < 4)
+                                    {
+                                        if (trueNorthArmor)
+                                            return OriginalHook(All.TrueNorth);
+                                        else
+                                            return OriginalHook(ArmorCrush);
+                                    }
+                                    else
+                                    {
+                                        if (trueNorthEdge)
+                                            return OriginalHook(All.TrueNorth);
+                                        else
+                                            return OriginalHook(AeolianEdge);
+                                    }
+                                }
+                                if (NINHelper.MugDebuff || GetTargetHPPercent() <= burnKazematoi)
+                                {
+                                    if (gauge.Kazematoi == 0)
+                                    {
+                                        if (trueNorthArmor)
+                                            return OriginalHook(All.TrueNorth);
+                                        else
+                                            return OriginalHook(ArmorCrush);
+                                    }
+                                    else
+                                    {
+                                        if (trueNorthEdge)
+                                            return OriginalHook(All.TrueNorth);
+                                        else
+                                            return OriginalHook(AeolianEdge);
+                                    }
+                                }
+                            }
+                        }
                         if (lastComboMove == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())
                         {
                             if (trueNorthEdge)

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -178,12 +178,23 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus) || (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat()))
                         mudraState.CurrentMudra = MudraCasting.MudraState.None;
-
+  
                     if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) && IsOnCooldown(TrickAttack) && mudraState.CurrentMudra == MudraCasting.MudraState.CastingSuiton && !setupSuitonWindow)
                         mudraState.CurrentMudra = MudraCasting.MudraState.None;
 
                     if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Suiton) && IsOnCooldown(TrickAttack) && mudraState.CurrentMudra != MudraCasting.MudraState.CastingSuiton && setupSuitonWindow)
                         mudraState.CurrentMudra = MudraCasting.MudraState.CastingSuiton;
+                   
+                    if (!Suiton.LevelChecked()) //For low level
+                    {
+                        if (Raiton.LevelChecked() && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_Raiton)) //under 45 will only use Raiton
+                        {
+                            if (mudraState.CastRaiton(ref actionID))
+                            return actionID;
+                        }
+                        else if (!Raiton.LevelChecked() && mudraState.CastFumaShuriken(ref actionID) && IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus_FumaShuriken)) // 30-35 will use only fuma
+                            return actionID;
+                    }
 
                     if (OriginalHook(Ninjutsu) is Rabbit)
                         return OriginalHook(Ninjutsu);

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -127,6 +127,7 @@ namespace XIVSlothCombo.Combos.PvE
                 Advanced_Trick_Cooldown = "Advanced_Trick_Cooldown",
                 Advanced_DotonTimer = "Advanced_DotonTimer",
                 Advanced_DotonHP = "Advanced_DotonHP",
+                BurnKazematoi = "BurnKazematoi",
                 Advanced_TCJEnderAoE = "Advanced_TCJEnderAoe",
                 Advanced_ChargePool = "Advanced_ChargePool",
                 SecondWindThresholdST = "SecondWindThresholdST",
@@ -163,6 +164,7 @@ namespace XIVSlothCombo.Combos.PvE
                     bool suitonUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Suiton_Uptime);
                     int bhavaPool = GetOptionValue(Config.Ninki_BhavaPooling);
                     int bunshinPool = GetOptionValue(Config.Ninki_BunshinPoolingST);
+                    int burnKazematoi = GetOptionValue(NIN.Config.BurnKazematoi);
                     int SecondWindThreshold = PluginConfiguration.GetCustomIntValue(Config.SecondWindThresholdST);
                     int ShadeShiftThreshold = PluginConfiguration.GetCustomIntValue(Config.ShadeShiftThresholdST);
                     int BloodbathThreshold = PluginConfiguration.GetCustomIntValue(Config.BloodbathThresholdST);
@@ -381,7 +383,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (lastComboMove == GustSlash && ArmorCrush.LevelChecked())
                         {
-                            if (!NINHelper.MugDebuff)
+                            if (!NINHelper.MugDebuff && GetTargetHPPercent() > burnKazematoi)
                             {
                                 if (gauge.Kazematoi < 4)
                                 {
@@ -398,7 +400,7 @@ namespace XIVSlothCombo.Combos.PvE
                                         return OriginalHook(AeolianEdge);
                                 }
                             }
-                            if (NINHelper.MugDebuff)
+                            if (NINHelper.MugDebuff  || GetTargetHPPercent() <= burnKazematoi)
                             {
                                 if (gauge.Kazematoi == 0)
                                 {

--- a/XIVSlothCombo/Combos/PvE/NIN.cs
+++ b/XIVSlothCombo/Combos/PvE/NIN.cs
@@ -169,6 +169,9 @@ namespace XIVSlothCombo.Combos.PvE
                     double playerHP = PlayerHealthPercentageHp();
                     bool phantomUptime = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Phantom_Uptime);
                     var comboLength = GetCooldown(GustSlash).CooldownTotal * 3;
+                    bool trueNorthArmor = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && !OnTargetsFlank() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                    bool trueNorthEdge = IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() && IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth_ArmorCrush) && !OnTargetsRear() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                        
 
                     if (IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_Ninjitsus) || (ActionWatching.TimeSinceLastAction.TotalSeconds >= 5 && !InCombat()))
                         mudraState.CurrentMudra = MudraCasting.MudraState.None;
@@ -376,26 +379,51 @@ namespace XIVSlothCombo.Combos.PvE
                         if (lastComboMove == SpinningEdge && GustSlash.LevelChecked())
                             return OriginalHook(GustSlash);
 
-                        if (IsEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth) && TargetNeedsPositionals() &&
-                            IsNotEnabled(CustomComboPreset.NIN_ST_AdvancedMode_TrueNorth_ArmorCrush) &&
-                            lastComboMove == GustSlash && GetRemainingCharges(All.TrueNorth) > 0 &&
-                            All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) &&
-                            canWeave)
-                            return OriginalHook(All.TrueNorth);
-
                         if (lastComboMove == GustSlash && ArmorCrush.LevelChecked())
                         {
-                            if ((!NINHelper.MugDebuff) || (NINHelper.MugDebuff &&  gauge.Kazematoi == 0))
+                            if (!NINHelper.MugDebuff)
                             {
                                 if (gauge.Kazematoi < 4)
-                                    return OriginalHook(ArmorCrush);
+                                {
+                                    if (trueNorthArmor)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(ArmorCrush);
+                                }
+                                else
+                                {
+                                    if (trueNorthEdge)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(AeolianEdge);
+                                }
                             }
+                            if (NINHelper.MugDebuff)
+                            {
+                                if (gauge.Kazematoi == 0)
+                                {
+                                    if (trueNorthArmor)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(ArmorCrush);
+                                }
+                                else
+                                {
+                                    if (trueNorthEdge)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(AeolianEdge);
+                                }
+                            }
+                        }                           
+                        if (lastComboMove == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())
+                        {
+                            if (trueNorthEdge)
+                                return OriginalHook(All.TrueNorth);
+                            else
+                                return OriginalHook(AeolianEdge);
                         }
-
-                        if (lastComboMove == GustSlash && AeolianEdge.LevelChecked() && (gauge.Kazematoi > 0 || !ArmorCrush.LevelChecked()))
-                            return OriginalHook(AeolianEdge);
                     }
-
                     return OriginalHook(SpinningEdge);
                 }
                 return actionID;
@@ -592,6 +620,10 @@ namespace XIVSlothCombo.Combos.PvE
                     bool canWeave = CanWeave(SpinningEdge);
                     bool inTrickBurstSaveWindow = GetCooldownRemainingTime(TrickAttack) <= 15 && Suiton.LevelChecked();
                     bool useBhakaBeforeTrickWindow = GetCooldownRemainingTime(TrickAttack) >= 3;
+                    var canDelayedWeave = CanDelayedWeave(SpinningEdge);
+                    bool trueNorthArmor = TargetNeedsPositionals() && !OnTargetsFlank() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+                    bool trueNorthEdge = TargetNeedsPositionals() && !OnTargetsRear() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canDelayedWeave;
+
 
                     if (OriginalHook(Ninjutsu) is Rabbit)
                         return OriginalHook(Ninjutsu);
@@ -685,18 +717,51 @@ namespace XIVSlothCombo.Combos.PvE
                         if (lastComboMove == SpinningEdge && GustSlash.LevelChecked())
                             return OriginalHook(GustSlash);
 
-                        if (lastComboMove == GustSlash && TargetNeedsPositionals() && GetRemainingCharges(All.TrueNorth) > 0 && All.TrueNorth.LevelChecked() && !HasEffect(All.Buffs.TrueNorth) && canWeave)
-                            return OriginalHook(All.TrueNorth);
-
-                        if (lastComboMove == GustSlash && AeolianEdge.LevelChecked() && (gauge.Kazematoi > 0 || !ArmorCrush.LevelChecked()))
-                            return OriginalHook(AeolianEdge);
-
-                        if (lastComboMove == GustSlash && ArmorCrush.LevelChecked() && gauge.Kazematoi < 5)
-                            return OriginalHook(ArmorCrush);
-
-
+                        if (lastComboMove == GustSlash && ArmorCrush.LevelChecked())
+                        {
+                            if (!NINHelper.MugDebuff)
+                            {
+                                if (gauge.Kazematoi < 4)
+                                {
+                                    if (trueNorthArmor)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(ArmorCrush);
+                                }
+                                else
+                                {
+                                    if (trueNorthEdge)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(AeolianEdge);
+                                }
+                            }
+                            if (NINHelper.MugDebuff)
+                            {
+                                if (gauge.Kazematoi == 0)
+                                {
+                                    if (trueNorthArmor)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(ArmorCrush);
+                                }
+                                else
+                                {
+                                    if (trueNorthEdge)
+                                        return OriginalHook(All.TrueNorth);
+                                    else
+                                        return OriginalHook(AeolianEdge);
+                                }
+                            }
+                        }
+                        if (lastComboMove == GustSlash && !ArmorCrush.LevelChecked() && AeolianEdge.LevelChecked())
+                        {
+                            if (trueNorthEdge)
+                                return OriginalHook(All.TrueNorth);
+                            else
+                                return OriginalHook(AeolianEdge);
+                        }
                     }
-
                     return OriginalHook(SpinningEdge);
                 }
                 return actionID;

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1598,6 +1598,8 @@ namespace XIVSlothCombo.Window.Functions
                 UserConfig.DrawRadioButton(NIN.Config.NIN_SimpleMudra_Choice, "Mudra Path Set 1", $"1. Ten Mudras -> Fuma Shuriken, Raiton/Hyosho Ranryu, Suiton (Doton under Kassatsu).\nChi Mudras -> Fuma Shuriken, Hyoton, Huton.\nJin Mudras -> Fuma Shuriken, Katon/Goka Mekkyaku, Doton", 1);
                 UserConfig.DrawRadioButton(NIN.Config.NIN_SimpleMudra_Choice, "Mudra Path Set 2", $"2. Ten Mudras -> Fuma Shuriken, Hyoton/Hyosho Ranryu, Doton.\nChi Mudras -> Fuma Shuriken, Katon, Suiton.\nJin Mudras -> Fuma Shuriken, Raiton/Goka Mekkyaku, Huton (Doton under Kassatsu).", 2);
             }
+            if (preset == CustomComboPreset.NIN_ST_AdvancedMode)
+                UserConfig.DrawSliderInt(0, 10, NIN.Config.BurnKazematoi, "Target HP% to dump all pooled Kazematoi below");
 
             if (preset == CustomComboPreset.NIN_ST_AdvancedMode_Bhavacakra)
                 UserConfig.DrawSliderInt(50, 100, NIN.Config.Ninki_BhavaPooling, "Set the minimal amount of Ninki required to have before spending on Bhavacakra.");


### PR DESCRIPTION
- [x] Removed dynamic true north option that wasn't ever used
- [x] True north fixed for single target advanced, with option of only armor crush. Delayed weaved
- [x] True north fixed for single target simple. Delayed weaved
- [x] Kazematoi dump for under selected health % slider for single target advanced
- [x] Now that TN is fixed. Dynamic TN. To prevent wasting TN when you didn't really need it, chooses positional based on charges and position. Prevents overcap of charges or waste without charges. 
- [x] Added advanced section to fix low level <45 not using mudras. Will Raiton 35-44 and Fuma 30-34 as selected