### PR TITLE
[SGE] Psyche Removal from movement, it's ogcd

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3256,7 +3256,7 @@ namespace XIVSlothCombo.Combos
         SGE_ST_DPS_Rhizo = 14007,
 
         [ParentCombo(SGE_ST_DPS)]
-        [CustomComboInfo("Psych Option", "Weaves Psych when available.", SGE.JobID, 112, "", "")]
+        [CustomComboInfo("Psyche Option", "Weaves Psyche when available.", SGE.JobID, 112, "", "")]
         SGE_ST_DPS_Psyche = 14008,
 
         [ParentCombo(SGE_ST_DPS)]

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -234,6 +234,16 @@ namespace XIVSlothCombo.Combos.PvE
                             CanSpellWeave(actionID))
                             return Variant.VariantSpiritDart;
 
+                        // Psyche
+                        if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Psyche))
+                        {
+                            if (ActionReady(Psyche) &&
+                                HasBattleTarget() &&
+                                InActionRange(Psyche) &&
+                                CanSpellWeave(actionID))
+                                return Psyche;
+                        }
+
                         // Lucid Dreaming
                         if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Lucid) &&
                             ActionReady(All.LucidDreaming) && CanSpellWeave(Dosis) &&
@@ -267,16 +277,7 @@ namespace XIVSlothCombo.Combos.PvE
                                     return Eukrasia;
                             }
                         }
-
-                        // Psyche
-                        if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Psyche))
-                        {
-                            if (ActionReady(Psyche) &&
-                                HasBattleTarget() &&
-                                InActionRange(Psyche) &&
-                                CanSpellWeave(actionID))
-                                return Psyche;
-                        }
+                                               
 
                         //Phlegma
                         if (IsEnabled(CustomComboPreset.SGE_AoE_DPS_Phlegma))
@@ -358,6 +359,13 @@ namespace XIVSlothCombo.Combos.PvE
                             return Dosis3;
                     }
 
+                    // Psyche
+                    if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Psyche) &&
+                        ActionReady(Psyche) &&
+                        InCombat() &&
+                        CanSpellWeave(actionID))
+                        return Psyche;
+
                     // Lucid Dreaming
                     if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Lucid) &&
                         All.CanUseLucid(actionID, Config.SGE_ST_DPS_Lucid))
@@ -418,14 +426,6 @@ namespace XIVSlothCombo.Combos.PvE
                             uint phlegma = OriginalHook(Phlegma);
                             if (InActionRange(phlegma) && ActionReady(phlegma)) return phlegma;
                         }
-
-                        // Psyche
-                        if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Psyche) &&
-                            ActionReady(Psyche) &&
-                            InCombat() &&
-                            CanSpellWeave(actionID))
-                            return Psyche;
-
 
                         // Movement Options
                         if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Movement) && InCombat() && IsMoving)

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -429,9 +429,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                         // Movement Options
                         if (IsEnabled(CustomComboPreset.SGE_ST_DPS_Movement) && InCombat() && IsMoving)
-                        {
-                            // Psyche
-                            if (Config.SGE_ST_DPS_Movement[3] && ActionReady(Psyche)) return Psyche;
+                        {                            
                             // Toxikon
                             if (Config.SGE_ST_DPS_Movement[0] && LevelChecked(Toxikon) && Gauge.HasAddersting()) return OriginalHook(Toxikon);
                             // Dyskrasia

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1972,10 +1972,9 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset is CustomComboPreset.SGE_ST_DPS_Movement)
             {
-                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, SGE.Toxikon.ActionName(), $"Use {SGE.Toxikon.ActionName()} when Addersting is available.", 4, 0);
-                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, SGE.Dyskrasia.ActionName(), $"Use {SGE.Dyskrasia.ActionName()} when in range of a selected enemy target.", 4, 1);
-                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, SGE.Eukrasia.ActionName(), $"Use {SGE.Eukrasia.ActionName()}.", 4, 2);
-                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, SGE.Psyche.ActionName(), $"Use {SGE.Psyche.ActionName()}.", 4, 3);
+                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, SGE.Toxikon.ActionName(), $"Use {SGE.Toxikon.ActionName()} when Addersting is available.", 3, 0);
+                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, SGE.Dyskrasia.ActionName(), $"Use {SGE.Dyskrasia.ActionName()} when in range of a selected enemy target.", 3, 1);
+                UserConfig.DrawHorizontalMultiChoice(SGE.Config.SGE_ST_DPS_Movement, SGE.Eukrasia.ActionName(), $"Use {SGE.Eukrasia.ActionName()}.", 3, 2);
             }
 
             if (preset is CustomComboPreset.SGE_AoE_DPS_Lucid)


### PR DESCRIPTION
- [x] Removed psyche from movement, it is an ogcd.
- [x] Fixed typo in custom-combo, irrelevant but may as well.
- [x] Moved psyche up in priority as i noticed a lucid dreaming caused it to drift. might help #1773 but we cant replicate
