### PR TITLE
[BRD] Bard fixes

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -677,8 +677,12 @@ namespace XIVSlothCombo.Combos
         //BardSimpleOpener = 3022,
 
         [ParentCombo(BRD_ST_AdvMode)]
-        [CustomComboInfo("Pooling Option", "Pools Bloodletter charges to allow for optimum burst phases, will also keep sidewinder in the buff window during wanderers.", BRD.JobID)]
+        [CustomComboInfo("Pooling Option", "84+ Pools Bloodletter charges to allow for optimum burst phases.", BRD.JobID)]
         BRD_Adv_Pooling = 3023,
+
+        [ParentCombo(BRD_AoE_AdvMode)]
+        [CustomComboInfo("Pooling Option", "84+ Pools Rain of death charges to allow for optimum burst phases.", BRD.JobID)]
+        BRD_AoE_Pooling = 3040,
 
         [ParentCombo(BRD_IronJaws)]
         [CustomComboInfo("Iron Jaws Apex Option", "Adds Apex and Blast Arrow to Iron Jaws when available.", BRD.JobID)]
@@ -717,7 +721,7 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(BRD_AoE_AdvMode)]
         [CustomComboInfo("AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
         BRD_AoE_Adv_NoWaste = 3033,
-        // Last value = 3038
+        // Last value = 3040
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -647,9 +647,17 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Buffs Option", "Adds buffs onto the Advanced Bard feature.", BRD.JobID)]
         BRD_Adv_Buffs = 3017,
 
-        [ParentCombo(BRD_Adv_Buffs)]
-        [CustomComboInfo("Buffs - Radiant Option", "Adds Radiant Finale to theBuffs feature.", BRD.JobID)]
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Resonant Option", "Adds Resonant Arrow to the Rotation after Barrage.", BRD.JobID)]
+        BRD_Adv_BuffsResonant = 3041,
+
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Buffs - Radiant Option", "Adds Radiant Finale to the Advanced Bard feature.", BRD.JobID)]
         BRD_Adv_BuffsRadiant = 3018,
+
+        [ParentCombo(BRD_ST_AdvMode)]
+        [CustomComboInfo("Encore Option", "Adds Radiant Encore to the Rotation after Finale.", BRD.JobID)]
+        BRD_Adv_BuffsEncore = 3042,
 
         [ParentCombo(BRD_ST_AdvMode)]
         [CustomComboInfo("No Waste Option", "Adds enemy health checking on mobs for buffs, DoTs and Songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
@@ -717,7 +725,7 @@ namespace XIVSlothCombo.Combos
         [ParentCombo(BRD_AoE_AdvMode)]
         [CustomComboInfo("AoE No Waste Option", "Adds enemy health checking on targetted mob for songs.\nThey will not be reapplied if less than specified.", BRD.JobID)]
         BRD_AoE_Adv_NoWaste = 3033,
-        // Last value = 3040
+        // Last value = 3042
 
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -621,11 +621,7 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(BRD_ST_AdvMode)]
         [CustomComboInfo("Bard Songs Option", "This option adds the Bard's Songs to the Advanced Bard Feature.", BRD.JobID)]
-        BRD_Adv_Song = 3011,
-
-        [ParentCombo(BRD_AoE_oGCD)]
-        [CustomComboInfo("Songs Option", "Adds Songs onto AoE oGCD Feature.", BRD.JobID)]
-        BRD_oGCDSongs = 3012,
+        BRD_Adv_Song = 3011,       
 
         [ReplaceSkill(BRD.Barrage)]
         [CustomComboInfo("Bard Buffs Feature", "Adds Raging Strikes and Battle Voice onto Barrage.", BRD.JobID)]

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -817,7 +817,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.BRD_Adv_DoT))
                         {
                             if (ActionReady(IronJaws) && IsEnabled(CustomComboPreset.BRD_Adv_RagingJaws) && HasEffect(Buffs.RagingStrikes) && 
-                            !WasLastAction(IronJaws) && ragingStrikesDuration < ragingJawsRenewTime && poisonRecast(40) && windRecast(40))                         
+                            !WasLastAction(IronJaws) && ragingStrikesDuration < ragingJawsRenewTime && poisonRecast(35) && windRecast(35))                         
                             { 
                                  openerFinished = true;
                                  return IronJaws;

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -791,7 +791,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
                     //Moved below weaves bc roobert says it is blocking his weaves from happening
-                    if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(BattleVoice) >= 4.2f && IsEnabled(CustomComboPreset.BRD_Adv_BuffsRadiant))
+                    if (HasEffect(Buffs.RadiantEncoreReady) && !JustUsed(RadiantFinale) && GetCooldownElapsed(RadiantFinale) >= 4.2f && IsEnabled(CustomComboPreset.BRD_Adv_BuffsEncore))
                         return OriginalHook(RadiantEncore);
 
                     if (isEnemyHealthHigh)
@@ -881,7 +881,7 @@ namespace XIVSlothCombo.Combos.PvE
                     if (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage))
                         return OriginalHook(StraightShot);
 
-                    if (HasEffect(Buffs.ResonantArrowReady) && IsEnabled(CustomComboPreset.BRD_Adv_Buffs))
+                    if (HasEffect(Buffs.ResonantArrowReady) && IsEnabled(CustomComboPreset.BRD_Adv_BuffsResonant))
                         return ResonantArrow;
 
                 }

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -1365,7 +1365,7 @@ namespace XIVSlothCombo.Combos.PvE
                         };
 
                         if (ActionReady(IronJaws) && HasEffect(Buffs.RagingStrikes) &&
-                        !WasLastAction(IronJaws) && ragingStrikesDuration < ragingJawsRenewTime && poisonRecast(40) && windRecast(40))
+                        !WasLastAction(IronJaws) && ragingStrikesDuration < ragingJawsRenewTime && poisonRecast(35) && windRecast(35))
                         {
                             openerFinished = true;
                             return IronJaws;

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -490,7 +490,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
-                    bool wideVolleyReady = LevelChecked(WideVolley) && HasEffect(Buffs.HawksEye);
+                    bool wideVolleyReady = LevelChecked(WideVolley) && (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage));
                     bool blastArrowReady = LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady);
                     bool resonantArrowReady = LevelChecked(ResonantArrow) && HasEffect(Buffs.ResonantArrowReady);
 
@@ -1114,7 +1114,7 @@ namespace XIVSlothCombo.Combos.PvE
                         
                     }
 
-                    bool wideVolleyReady = LevelChecked(WideVolley) && HasEffect(Buffs.HawksEye);
+                    bool wideVolleyReady = LevelChecked(WideVolley) && (HasEffect(Buffs.HawksEye) || HasEffect(Buffs.Barrage));
                     bool blastArrowReady = LevelChecked(BlastArrow) && HasEffect(Buffs.BlastArrowReady);
                     bool resonantArrowReady = LevelChecked(ResonantArrow) && HasEffect(Buffs.ResonantArrowReady);
 

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -429,7 +429,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return EmpyrealArrow;
 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)))
+                            (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
                             return OriginalHook(PitchPerfect);
 
                         if (ActionReady(Sidewinder))
@@ -730,7 +730,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return EmpyrealArrow;
 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)))
+                            (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
                             return OriginalHook(PitchPerfect);
 
                         if (ActionReady(Sidewinder))
@@ -1055,7 +1055,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return EmpyrealArrow;
 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)))
+                            (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
                             return OriginalHook(PitchPerfect);
 
                         if (ActionReady(Sidewinder))
@@ -1284,7 +1284,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return EmpyrealArrow;
 
                         if (LevelChecked(PitchPerfect) && songWanderer &&
-                            (gauge.Repertoire == 3 || (gauge.Repertoire == 2 && empyrealCD < 2)))
+                            (gauge.Repertoire == 3 || (LevelChecked(EmpyrealArrow) && gauge.Repertoire == 2 && empyrealCD < 2)))
                             return OriginalHook(PitchPerfect);
 
                         if (ActionReady(Sidewinder))

--- a/XIVSlothCombo/Combos/PvE/BRD.cs
+++ b/XIVSlothCombo/Combos/PvE/BRD.cs
@@ -84,7 +84,11 @@ namespace XIVSlothCombo.Combos.PvE
                 BRD_AoESecondWindThreshold = "BRD_AoESecondWindThreshold",
                 BRD_VariantCure = "BRD_VariantCure";
         }
-
+        internal static class Traits
+        {
+            internal const ushort
+                EnhancedBloodletter = 445;
+        }
         #region Song status
         internal static bool SongIsNotNone(Song value) => value != Song.NONE;
         internal static bool SongIsNone(Song value) => value == Song.NONE;
@@ -451,7 +455,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
 
-                            if (LevelChecked(WanderersMinuet))
+                            if (IsEnabled(CustomComboPreset.BRD_AoE_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                             {
                                 if (songWanderer)
                                 {
@@ -755,7 +759,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             uint bloodletterCharges = GetRemainingCharges(Bloodletter);
 
-                            if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && LevelChecked(WanderersMinuet))
+                            if (IsEnabled(CustomComboPreset.BRD_Adv_Pooling) && LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                             {
                                 if (songWanderer)
                                 {
@@ -1076,7 +1080,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             uint rainOfDeathCharges = LevelChecked(RainOfDeath) ? GetRemainingCharges(RainOfDeath) : 0;
 
-                            if (LevelChecked(WanderersMinuet))
+                            if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                             {
                                 if (songWanderer)
                                 {
@@ -1305,7 +1309,7 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             uint bloodletterCharges = GetRemainingCharges(Bloodletter);
 
-                            if (LevelChecked(WanderersMinuet))
+                            if (LevelChecked(WanderersMinuet) && TraitLevelChecked(Traits.EnhancedBloodletter))
                             {
                                 if (songWanderer)
                                 {

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1347,7 +1347,7 @@ namespace XIVSlothCombo.Window.Functions
             #region BARD
 
             if (preset == CustomComboPreset.BRD_Adv_RagingJaws)
-                UserConfig.DrawSliderInt(3, 5, BRD.Config.BRD_RagingJawsRenewTime, "Remaining time (In seconds)");
+                UserConfig.DrawSliderInt(3, 10, BRD.Config.BRD_RagingJawsRenewTime, "Remaining time (In seconds). Recommended 5, increase little by little if refresh is outside of radiant window");
 
             if (preset == CustomComboPreset.BRD_Adv_NoWaste)
                 UserConfig.DrawSliderInt(1, 10, BRD.Config.BRD_NoWasteHPPercentage, "Remaining target HP percentage");


### PR DESCRIPTION
- [x] Added lvl check to empycd check in Pitch perfect line to prevent it from popping at 2 in dusk vigil. See discord combo issues 
- [x] Increased slider on raging jaws from 3-5 to 3-10. Was reported via dm
- [x] added option choice for pooling aoe rain of death. it was always pooling now its a choice just like st. See discord combo issues 
- [x] added trait check for enhanced bloodletter into the pooling to fix issue from 54-84 where it was trying to pool to 3 and couldn't. See discord combo issues 
- [x] Removed the option for songs on ogcd. There was no actual code in brd.cs to support it. it was just an checkbox to nowhere. See discord combo issues 
- [x] Split resonant and encore into their own options separate from the buffs option in st-adv for the manual buffers. #1785 
- [x] fix wide volley aoe to account for barrage buff. See discord not combo issues bc why would we post it there

Raging jaws was not catching the radiant buff for some people. 5 seconds was a tight window. Loosened it significantly so they can even make sure jaws catches other classes buffs that are far less prone to drift. 