### PR TITLE
[GNB] fixes/adjustments

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1594,7 +1594,7 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Continuation Option", "Adds Continuation to Gnashing Fang when available.", GNB.JobID)]
         GNB_GF_Continuation = 7301,
 
-        [ConflictingCombos(GNB_ST_NoMercy)]
+        [ConflictingCombos(GNB_NM_Features)]
         [ParentCombo(GNB_GF_Features)]
         [CustomComboInfo("No Mercy Option", "Adds No Mercy to Gnashing Fang when available.", GNB.JobID)]
         GNB_GF_NoMercy = 7302,
@@ -1652,7 +1652,7 @@ namespace XIVSlothCombo.Combos
         #endregion
 
         #region No Mercy
-        [ConflictingCombos(GNB_ST_Simple, GNB_AoE_Simple, GNB_ST_NoMercy, GNB_AoE_NoMercy, GNB_GF_NoMercy)]
+        [ConflictingCombos(GNB_ST_Simple, GNB_AoE_Simple, GNB_GF_Features)]
         [ReplaceSkill(GNB.NoMercy)]
         [CustomComboInfo("No Mercy Features", "Collection of No Mercy related features.", GNB.JobID)]
         GNB_NM_Features = 7500,

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1484,59 +1484,61 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Advanced Mode - Single Target", "Replace Keen Edge with its combo chain.\nThis is the ideal selection for experienced users of the job.", GNB.JobID)]
         GNB_ST_Advanced = 7003,
 
-        #region Lightning Shot
-        [ParentCombo(GNB_ST_Advanced)]
-        [CustomComboInfo("Lightning Shot Uptime Option", "Adds Lightning Shot to the main combo when you are out of range.", GNB.JobID)]
-        GNB_ST_RangedUptime = 7004,
-        #endregion
-
-        #region Gnashing Fang
-        [ParentCombo(GNB_ST_Advanced)]
-        [CustomComboInfo("Continuation Option", "Adds Continuation & Hypervelocity into the rotation.\n'Gnashing Fang' option must be enabled or started manually.", GNB.JobID)]
-        GNB_ST_Continuation = 7005,
-
-        [ParentCombo(GNB_ST_Continuation)]
-        [CustomComboInfo("Gnashing Fang Option", "Adds Gnashing Fang combo into the rotation.", GNB.JobID)]
-        GNB_ST_GnashingStarter = 7006,
-        #endregion
-
         #region Cooldowns
         [ParentCombo(GNB_ST_Advanced)]
         [CustomComboInfo("Cooldowns Option", "Adds various cooldowns into the rotation.", GNB.JobID)]
-        GNB_ST_Advanced_CooldownsGroup = 7007,
+        GNB_ST_Advanced_CooldownsGroup = 7004,
 
         [ConflictingCombos(GNB_NM_Features)]
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
         [CustomComboInfo("No Mercy Option", "Adds No Mercy into the rotation when appropriate.", GNB.JobID)]
-        GNB_ST_NoMercy = 7008,
-
-        [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Danger/Blasting Zone Option", "Adds Danger/Blasting Zone into the rotation when available.", GNB.JobID)]
-        GNB_ST_BlastingZone = 7009,
-
-        [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Bow Shock Option", "Adds Bow Shock into the rotation when appropriate.", GNB.JobID)]
-        GNB_ST_BowShock = 7010,
-
-        [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Bloodfest Option", "Adds Bloodfest into the rotation when appropriate.", GNB.JobID)]
-        GNB_ST_Bloodfest = 7011,
+        GNB_ST_NoMercy = 7005,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
         [CustomComboInfo("Sonic Break Option", "Adds Sonic Break into the rotation when appropriate.", GNB.JobID)]
-        GNB_ST_SonicBreak = 7012,
+        GNB_ST_SonicBreak = 7006,
+
+        [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
+        [CustomComboInfo("Danger/Blasting Zone Option", "Adds Danger/Blasting Zone into the rotation when available.", GNB.JobID)]
+        GNB_ST_BlastingZone = 7007,
+
+        [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
+        [CustomComboInfo("Bow Shock Option", "Adds Bow Shock into the rotation when appropriate.", GNB.JobID)]
+        GNB_ST_BowShock = 7008,
+
+        [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
+        [CustomComboInfo("Bloodfest Option", "Adds Bloodfest into the rotation when appropriate.", GNB.JobID)]
+        GNB_ST_Bloodfest = 7009,
+
+        [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
+        [CustomComboInfo("Gnashing Fang Option", "Adds Gnashing Fang combo into the rotation.", GNB.JobID)]
+        GNB_ST_Gnashing = 7010,
+
+        [ParentCombo(GNB_ST_Gnashing)]
+        [CustomComboInfo("Continuation Option", "Adds Continuation & Hypervelocity into the rotation.\n'Gnashing Fang' option must be enabled or started manually.", GNB.JobID)]
+        GNB_ST_Continuation = 7011,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
         [CustomComboInfo("Double Down Option", "Adds Double Down into the rotation when appropriate.", GNB.JobID)]
-        GNB_ST_DoubleDown = 7013,
+        GNB_ST_DoubleDown = 7012,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Reign combo Option", "Adds Reign/Noble/Lionheart into the rotation when appropriate.", GNB.JobID)]
-        GNB_ST_Reign = 7014,
+        [CustomComboInfo("Reign Combo Option", "Adds Reign/Noble/Lionheart into the rotation when appropriate.", GNB.JobID)]
+        GNB_ST_Reign = 7013,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
         [CustomComboInfo("Burst Strike Option", "Adds Burst Strike into the rotation when appropriate.", GNB.JobID)]
-        GNB_ST_BurstStrike = 7015,
+        GNB_ST_BurstStrike = 7014,
+
+        [ParentCombo(GNB_ST_Advanced)]
+        [CustomComboInfo("Ammo Overcap Option", "Adds Burst Strike into the AoE rotation if you have max cartridges & your last combo action was Brutal Shell.", GNB.JobID)]
+        GNB_ST_Overcap = 7015,
+        #endregion
+
+        #region Lightning Shot
+        [ParentCombo(GNB_ST_Advanced)]
+        [CustomComboInfo("Lightning Shot Uptime Option", "Adds Lightning Shot to the main combo when you are out of range.", GNB.JobID)]
+        GNB_ST_RangedUptime = 7016,
         #endregion
 
         #endregion 
@@ -1585,11 +1587,11 @@ namespace XIVSlothCombo.Combos
         GNB_AoE_noFatedCircle = 7209,
 
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("Ammo Overcap Option", "Adds Fated Circle into the AoE rotation if you have max cartridges & your last action was Demon Slice.", GNB.JobID)]
+        [CustomComboInfo("Ammo Overcap Option", "Adds Fated Circle into the AoE rotation if you have max cartridges & your last combo action was Demon Slice.", GNB.JobID)]
         GNB_AoE_Overcap = 7210,
 
         [ParentCombo(GNB_AoE_Overcap)]
-        [CustomComboInfo("Ammo Overcap Burst Strike Option", "Adds Burst Strike into the AoE rotation if you have max cartridges, your last action was Demon Slice, & you do not have Fated Circle unlocked yet.", GNB.JobID)]
+        [CustomComboInfo("Ammo Overcap Burst Strike Option", "Adds Burst Strike into the AoE rotation if you have max cartridges, your last combo action was Demon Slice, & you do not have Fated Circle unlocked yet.", GNB.JobID)]
         GNB_AoE_BSOvercap = 7211,
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1481,7 +1481,7 @@ namespace XIVSlothCombo.Combos
         #region Advanced ST
         [ConflictingCombos(GNB_ST_Simple)]
         [ReplaceSkill(GNB.KeenEdge)]
-        [CustomComboInfo("Advanced Mode - Single Target", "Replace Keen Edge with its combo chain.\n Uses Burst Strike when you have 3 cartridges & your last combo action was Brutal Shell.", GNB.JobID)]
+        [CustomComboInfo("Advanced Mode - Single Target", "Replace Keen Edge with its combo chain.\nThis is the ideal selection for experienced users of the job.", GNB.JobID)]
         GNB_ST_Advanced = 7003,
 
         #region Lightning Shot
@@ -1492,50 +1492,50 @@ namespace XIVSlothCombo.Combos
 
         #region Gnashing Fang
         [ParentCombo(GNB_ST_Advanced)]
-        [CustomComboInfo("Continuation Option", "Adds Continuation to the main combo.\n 'Gnashing Fang Starter' option must be enabled or started manually.", GNB.JobID)]
+        [CustomComboInfo("Continuation Option", "Adds Continuation & Hypervelocity into the rotation.\n'Gnashing Fang' option must be enabled or started manually.", GNB.JobID)]
         GNB_ST_Continuation = 7005,
 
         [ParentCombo(GNB_ST_Continuation)]
-        [CustomComboInfo("Gnashing Fang Starter Option", "Begins Gnashing Fang for you on the main combo.", GNB.JobID)]
+        [CustomComboInfo("Gnashing Fang Option", "Adds Gnashing Fang combo into the rotation.", GNB.JobID)]
         GNB_ST_GnashingStarter = 7006,
         #endregion
 
         #region Cooldowns
         [ParentCombo(GNB_ST_Advanced)]
-        [CustomComboInfo("Cooldowns Option", "Adds various cooldowns to the main combo.", GNB.JobID)]
+        [CustomComboInfo("Cooldowns Option", "Adds various cooldowns into the rotation.", GNB.JobID)]
         GNB_ST_Advanced_CooldownsGroup = 7007,
 
         [ConflictingCombos(GNB_NM_Features)]
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("No Mercy Option", "Adds No Mercy to the main combo when at full ammo.", GNB.JobID)]
+        [CustomComboInfo("No Mercy Option", "Adds No Mercy into the rotation when appropriate.", GNB.JobID)]
         GNB_ST_NoMercy = 7008,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Danger/Blasting Zone Option", "Adds Danger/Blasting Zone to the main combo.", GNB.JobID)]
+        [CustomComboInfo("Danger/Blasting Zone Option", "Adds Danger/Blasting Zone into the rotation when available.", GNB.JobID)]
         GNB_ST_BlastingZone = 7009,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Bow Shock Option", "Adds Bow Shock to the main combo.", GNB.JobID)]
+        [CustomComboInfo("Bow Shock Option", "Adds Bow Shock into the rotation when appropriate.", GNB.JobID)]
         GNB_ST_BowShock = 7010,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Bloodfest Option", "Adds Bloodfest to the main combo when ammo is 0.", GNB.JobID)]
+        [CustomComboInfo("Bloodfest Option", "Adds Bloodfest into the rotation when appropriate.", GNB.JobID)]
         GNB_ST_Bloodfest = 7011,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Sonic Break Option", "Adds Sonic Break to the main combo.", GNB.JobID)]
+        [CustomComboInfo("Sonic Break Option", "Adds Sonic Break into the rotation when appropriate.", GNB.JobID)]
         GNB_ST_SonicBreak = 7012,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Double Down Option", "Adds Double Down to the main combo when under No Mercy buff.", GNB.JobID)]
+        [CustomComboInfo("Double Down Option", "Adds Double Down into the rotation when appropriate.", GNB.JobID)]
         GNB_ST_DoubleDown = 7013,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Reign combo Option", "Adds Reign/Noble/Lionheart to the main combo.", GNB.JobID)]
+        [CustomComboInfo("Reign combo Option", "Adds Reign/Noble/Lionheart into the rotation when appropriate.", GNB.JobID)]
         GNB_ST_Reign = 7014,
 
         [ParentCombo(GNB_ST_Advanced_CooldownsGroup)]
-        [CustomComboInfo("Burst Strike Option", "Adds Burst Strike and Hypervelocity (when available) to the main combo when under No Mercy and Gnashing Fang is over.", GNB.JobID)]
+        [CustomComboInfo("Burst Strike Option", "Adds Burst Strike into the rotation when appropriate.", GNB.JobID)]
         GNB_ST_BurstStrike = 7015,
         #endregion
 
@@ -1544,44 +1544,44 @@ namespace XIVSlothCombo.Combos
         #region Advanced AoE
         [ConflictingCombos(GNB_AoE_Simple)]
         [ReplaceSkill(GNB.DemonSlice)]
-        [CustomComboInfo("Advanced Mode - AoE", "Replace Demon Slice with its combo chain.", GNB.JobID)]
+        [CustomComboInfo("Advanced Mode - AoE", "Replace Demon Slice with its combo chain.\nThis is the ideal selection for experienced users of the job.", GNB.JobID)]
         GNB_AoE_Advanced = 7200,
 
         [ConflictingCombos(GNB_NM_Features)]
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("No Mercy Option", "Adds No Mercy to the AoE combo when appropriate.", GNB.JobID)]
+        [CustomComboInfo("No Mercy Option", "Adds No Mercy into the AoE rotation when appropriate.", GNB.JobID)]
         GNB_AoE_NoMercy = 7201,
 
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("Danger/Blasting Zone Option", "Adds Danger/Blasting Zone to the AoE combo when appropriate.", GNB.JobID)]
+        [CustomComboInfo("Danger/Blasting Zone Option", "Adds Danger/Blasting Zone into the AoE rotation when appropriate.", GNB.JobID)]
         GNB_AoE_DangerZone = 7202,
 
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("Bow Shock Option", "Adds Bow Shock onto the AoE combo when appropriate.", GNB.JobID)]
+        [CustomComboInfo("Bow Shock Option", "Adds Bow Shock oninto the AoE rotation when appropriate.", GNB.JobID)]
         GNB_AoE_BowShock = 7203,
 
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("Bloodfest Option", "Adds Bloodfest to the AoE combo when appropriate.", GNB.JobID)]
+        [CustomComboInfo("Bloodfest Option", "Adds Bloodfest into the AoE rotation when appropriate.", GNB.JobID)]
         GNB_AoE_Bloodfest = 7204,
 
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("Sonic Break Option", "Adds Sonic Break to the AoE combo when appropriate.", GNB.JobID)]
+        [CustomComboInfo("Sonic Break Option", "Adds Sonic Break into the AoE rotation when appropriate.", GNB.JobID)]
         GNB_AoE_SonicBreak = 7205,
 
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("Double Down Option", "Adds Double Down to the AoE combo when appropriate.", GNB.JobID)]
+        [CustomComboInfo("Double Down Option", "Adds Double Down into the AoE rotation when appropriate.", GNB.JobID)]
         GNB_AoE_DoubleDown = 7206,
 
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("Reign Combo Option", "Adds Reign/Noble/LionHeart to the AoE combo when appropriate.", GNB.JobID)]
+        [CustomComboInfo("Reign Combo Option", "Adds Reign/Noble/LionHeart into the AoE rotation when appropriate.", GNB.JobID)]
         GNB_AoE_Reign = 7207,
 
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("Fated Circle Option", "Adds Fated Circle to the AoE combo when appropriate.", GNB.JobID)]
+        [CustomComboInfo("Fated Circle Option", "Adds Fated Circle into the AoE rotation when appropriate.", GNB.JobID)]
         GNB_AoE_FatedCircle = 7208,
 
         [ParentCombo(GNB_AoE_Advanced)]
-        [CustomComboInfo("Ammo Overcap Option", "Adds Fated Circle to the AoE combo when about to overcap.", GNB.JobID)]
+        [CustomComboInfo("Ammo Overcap Option", "Adds Fated Circle into the AoE rotation if you have max cartridges & your last action was Demon Slice.", GNB.JobID)]
         GNB_AoE_Overcap = 7209,
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1580,9 +1580,17 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Fated Circle Option", "Adds Fated Circle into the AoE rotation when appropriate.", GNB.JobID)]
         GNB_AoE_FatedCircle = 7208,
 
+        [ParentCombo(GNB_AoE_FatedCircle)]
+        [CustomComboInfo("Burst Strike Option", "Adds Burst Strike into the AoE rotation if you do not have Fated Circle unlocked yet.", GNB.JobID)]
+        GNB_AoE_noFatedCircle = 7209,
+
         [ParentCombo(GNB_AoE_Advanced)]
         [CustomComboInfo("Ammo Overcap Option", "Adds Fated Circle into the AoE rotation if you have max cartridges & your last action was Demon Slice.", GNB.JobID)]
-        GNB_AoE_Overcap = 7209,
+        GNB_AoE_Overcap = 7210,
+
+        [ParentCombo(GNB_AoE_Overcap)]
+        [CustomComboInfo("Ammo Overcap Burst Strike Option", "Adds Burst Strike into the AoE rotation if you have max cartridges, your last action was Demon Slice, & you do not have Fated Circle unlocked yet.", GNB.JobID)]
+        GNB_AoE_BSOvercap = 7211,
         #endregion
 
         #region Gnashing Fang

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -1531,7 +1531,7 @@ namespace XIVSlothCombo.Combos
         GNB_ST_BurstStrike = 7014,
 
         [ParentCombo(GNB_ST_Advanced)]
-        [CustomComboInfo("Ammo Overcap Option", "Adds Burst Strike into the AoE rotation if you have max cartridges & your last combo action was Brutal Shell.", GNB.JobID)]
+        [CustomComboInfo("Ammo Overcap Option", "Adds Burst Strike into the rotation if you have max cartridges & your last combo action was Brutal Shell.", GNB.JobID)]
         GNB_ST_Overcap = 7015,
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -952,7 +952,7 @@ namespace XIVSlothCombo.Combos.PvE
                             ((IsEnabled(CustomComboPreset.GNB_AoE_FatedCircle) && HasEffect(Buffs.NoMercy) && !ActionReady(DoubleDown) && GunStep == 0) || //use when under NM after DD & ignores GF
                             (IsEnabled(CustomComboPreset.GNB_AoE_Bloodfest) && bfCD < 6))) // Bloodfest prep
                             return FatedCircle;
-                        if (Ammo > 0 && !LevelChecked(FatedCircle) && LevelChecked(BurstStrike) &&
+                        if (IsEnabled(CustomComboPreset.GNB_AoE_noFatedCircle) && Ammo > 0 && !LevelChecked(FatedCircle) && LevelChecked(BurstStrike) &&
                             (HasEffect(Buffs.NoMercy) && GunStep == 0)) // Bloodfest prep
                             return BurstStrike;
                     }
@@ -964,9 +964,9 @@ namespace XIVSlothCombo.Combos.PvE
                         {
                             if (Ammo == MaxCartridges(level))
                             {
-                                if (LevelChecked(FatedCircle))
+                                if (IsEnabled(CustomComboPreset.GNB_AoE_Overcap) && LevelChecked(FatedCircle))
                                     return FatedCircle;
-                                if (!LevelChecked(FatedCircle))
+                                if (IsEnabled(CustomComboPreset.GNB_AoE_BSOvercap) && !LevelChecked(FatedCircle))
                                     return BurstStrike;
                             }
                             if (Ammo != MaxCartridges(level))

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -1,7 +1,9 @@
 using Dalamud.Game.ClientState.JobGauge.Types;
 using Dalamud.Game.ClientState.Statuses;
 using XIVSlothCombo.Combos.PvE.Content;
+using XIVSlothCombo.Core;
 using XIVSlothCombo.CustomComboNS;
+using XIVSlothCombo.CustomComboNS.Functions;
 using XIVSlothCombo.Data;
 
 namespace XIVSlothCombo.Combos.PvE
@@ -68,7 +70,11 @@ namespace XIVSlothCombo.Combos.PvE
         {
             public const string
                 GNB_VariantCure = "GNB_VariantCure";
+            public static UserInt
+                GNB_ST_NoMercyStop = new("GNB_ST_NoMercy"),
+                GNB_AoE_NoMercyStop = new ("GNB_AoE_NoMercy");
         }
+    
 
         internal class GNB_ST_SimpleMode : CustomCombo
         {
@@ -327,6 +333,7 @@ namespace XIVSlothCombo.Combos.PvE
                     var nmCD = GetCooldownRemainingTime(NoMercy); //NoMercy's cooldown; 60s total
                     var bfCD = GetCooldownRemainingTime(Bloodfest); // Bloodfest's cooldown; 120s total
                     float GCD = GetCooldown(KeenEdge).CooldownTotal; //2.5 is base SkS, but can work with 2.4x
+                    int nmStop = PluginConfiguration.GetCustomIntValue(Config.GNB_ST_NoMercyStop);
 
                     //Variant Cure
                     if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) && IsEnabled(Variant.VariantCure)
@@ -341,7 +348,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //NoMercy
                     if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_CooldownsGroup) && IsEnabled(CustomComboPreset.GNB_ST_NoMercy))
                     {
-                        if (ActionReady(NoMercy))
+                        if (ActionReady(NoMercy) && GetTargetHPPercent() >= nmStop)
                         {
                             if (CanWeave(actionID))
                             {
@@ -888,6 +895,7 @@ namespace XIVSlothCombo.Combos.PvE
                     var GunStep = GetJobGauge<GNBGauge>().AmmoComboStep; // For GnashingFang & (possibly) ReignCombo purposes
                     var bfCD = GetCooldownRemainingTime(Bloodfest); // Bloodfest's cooldown; 120s total
                     float GCD = GetCooldown(KeenEdge).CooldownTotal; //2.5 is base SkS, but can work with 2.4x
+                    int nmStop = PluginConfiguration.GetCustomIntValue(Config.GNB_AoE_NoMercyStop);
 
                     //Variant Cure
                     if (IsEnabled(CustomComboPreset.GNB_Variant_Cure) && IsEnabled(Variant.VariantCure) && PlayerHealthPercentageHp() <= GetOptionValue(Config.GNB_VariantCure))
@@ -909,7 +917,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return Variant.VariantUltimatum;
 
                             //NoMercy
-                            if (IsEnabled(CustomComboPreset.GNB_AoE_NoMercy) && ActionReady(NoMercy)) //use on CD
+                            if (IsEnabled(CustomComboPreset.GNB_AoE_NoMercy) && ActionReady(NoMercy) && GetTargetHPPercent() > nmStop) //use on CD
                                 return NoMercy;
                             //BowShock
                             if (IsEnabled(CustomComboPreset.GNB_AoE_BowShock) && ActionReady(BowShock) && LevelChecked(BowShock) && HasEffect(Buffs.NoMercy)) //use on CD under NM

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -70,9 +70,10 @@ namespace XIVSlothCombo.Combos.PvE
         {
             public const string
                 GNB_VariantCure = "GNB_VariantCure";
+
             public static UserInt
-                GNB_ST_NoMercyStop = new("GNB_ST_NoMercy"),
-                GNB_AoE_NoMercyStop = new ("GNB_AoE_NoMercy");
+                GNB_ST_NoMercyStop = new("GNB_ST_NoMercyStop"),
+                GNB_AoE_NoMercyStop = new ("GNB_AoE_NoMercyStop");
         }
     
 

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -102,7 +102,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return LightningShot;
 
                     //NoMercy
-                    if (ActionReady(NoMercy))
+                    if (ActionReady(NoMercy) && GetCooldownRemainingTime(DoubleDown) < GCD * 2 && GetCooldownRemainingTime(GnashingFang) < GCD * 3)
                     {
                         if (CanWeave(actionID))
                         {
@@ -119,6 +119,10 @@ namespace XIVSlothCombo.Combos.PvE
                         }
                     }
 
+                    //Bloodfest
+                    if (ActionReady(Bloodfest) && Ammo is 0 && (JustUsed(NoMercy, 20f)))
+                        return Bloodfest;
+
                     //oGCDs
                     if (CanWeave(actionID))
                     {
@@ -132,10 +136,6 @@ namespace XIVSlothCombo.Combos.PvE
                         //VariantUltimatum
                         if (IsEnabled(CustomComboPreset.GNB_Variant_Ultimatum) && IsEnabled(Variant.VariantUltimatum) && ActionReady(Variant.VariantUltimatum))
                             return Variant.VariantUltimatum;
-
-                        //Bloodfest
-                        if (ActionReady(Bloodfest) && Ammo is 0 && (JustUsed(NoMercy, 20f)))
-                            return Bloodfest;
 
                         //Zone
                         if (ActionReady(DangerZone) && !JustUsed(NoMercy))
@@ -225,7 +225,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         //Lv90-Lv99
-                        if (!LevelChecked(ReignOfBeasts) && LevelChecked(DoubleDown) && GetCooldownRemainingTime(DoubleDown) <= 0.6f)
+                        if (!LevelChecked(ReignOfBeasts) && LevelChecked(DoubleDown) && GetCooldownRemainingTime(DoubleDown) <= 0.3f)
                         {
                             if ((Ammo >= 2 && !HasEffect(Buffs.ReadyToBreak) && JustUsed(SonicBreak, 3f) && (bfCD < GCD * 6 || ActionReady(Bloodfest))) //2min NM 3 carts
                                 || (!HasEffect(Buffs.ReadyToBreak) && Ammo == 3 && JustUsed(SonicBreak, 3f) && bfCD is < 90 and > 15) //1min NM 3 carts
@@ -301,7 +301,7 @@ namespace XIVSlothCombo.Combos.PvE
                             return BrutalShell;
                         if (lastComboMove == BrutalShell && LevelChecked(SolidBarrel))
                         {
-                            if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast) && nmCD > 1) //Lv100 Hypervelocity fit into NM check
+                            if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast) && (nmCD is > 1 or <= 0.1f)) //Lv100 Hypervelocity fit into NM check
                                 return Hypervelocity;
                             if (LevelChecked(BurstStrike) && Ammo == MaxCartridges(level))
                                 return BurstStrike;
@@ -349,7 +349,7 @@ namespace XIVSlothCombo.Combos.PvE
                     //NoMercy
                     if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_CooldownsGroup) && IsEnabled(CustomComboPreset.GNB_ST_NoMercy))
                     {
-                        if (ActionReady(NoMercy) && GetTargetHPPercent() >= nmStop)
+                        if (ActionReady(NoMercy) && GetTargetHPPercent() >= nmStop && GetCooldownRemainingTime(DoubleDown) < GCD * 2 && GetCooldownRemainingTime(GnashingFang) < GCD * 3)
                         {
                             if (CanWeave(actionID))
                             {
@@ -366,6 +366,10 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
                     }
+
+                    //Bloodfest - Forced to prevent combo from spazzing out due to next action possibly requiring Ammo
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && ActionReady(Bloodfest) && Ammo is 0 && (JustUsed(NoMercy, 20f)))
+                        return Bloodfest;
 
                     //oGCDs
                     if (CanWeave(actionID))
@@ -384,10 +388,6 @@ namespace XIVSlothCombo.Combos.PvE
                         //CDs
                         if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_CooldownsGroup))
                         {
-                            //Bloodfest
-                            if (IsEnabled(CustomComboPreset.GNB_ST_Bloodfest) && ActionReady(Bloodfest) && Ammo is 0 && (JustUsed(NoMercy, 20f)))
-                                return Bloodfest;
-
                             //Zone
                             if (IsEnabled(CustomComboPreset.GNB_ST_BlastingZone) && ActionReady(DangerZone) && !JustUsed(NoMercy))
                             {
@@ -396,7 +396,7 @@ namespace XIVSlothCombo.Combos.PvE
                                     !LevelChecked(GnashingFang))) //<Lv60
                                     return OriginalHook(DangerZone);
                                 //Lv100 use
-                                if (LevelChecked(ReignOfBeasts) && (JustUsed(DoubleDown, 3f) || nmCD > 17))
+                                if (LevelChecked(ReignOfBeasts) && (JustUsed(DoubleDown, 5f) || nmCD > 17))
                                     return OriginalHook(DangerZone);
                             }
 
@@ -426,7 +426,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     //Hypervelocity
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) && JustUsed(BurstStrike) && LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast) && nmCD > 1)
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) && JustUsed(BurstStrike, 5f) && LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast) && nmCD > 1)
                         return Hypervelocity;
 
                     //GF combo
@@ -442,7 +442,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if ((Ammo == 2 && JustUsed(NoMercy, 3f) && !HasEffect(Buffs.ReadyToBlast) && (bfCD < GCD * 12 || ActionReady(Bloodfest))) //2min
                                 || (JustUsed(GnashingFang, 3f) && bfCD is < 90 and > 15 && !ActionReady(DoubleDown) && Ammo == 0 && !HasEffect(Buffs.ReadyToRip) && HasEffect(Buffs.ReadyToBreak)) //1min 2cart
                                 || (Ammo == 3 && (bfCD is < 90 and > 15 && JustUsed(NoMercy, 3f)) //1min 3cart
-                                || (JustUsed(Bloodfest, 2f) && JustUsed(BrutalShell)))) //opener
+                                || (JustUsed(Bloodfest, 3f) && JustUsed(BrutalShell, 3f)))) //opener
                                 return SonicBreak;
                         }
 
@@ -452,7 +452,7 @@ namespace XIVSlothCombo.Combos.PvE
                             if (JustUsed(NoMercy, 3f) &&
                                 ((!HasEffect(Buffs.ReadyToBlast) && Ammo == 3 && bfCD < GCD * 12 || ActionReady(Bloodfest)) //2min
                                 || (bfCD is < 90 and > 15 && Ammo == 3) //1min 3 carts
-                                || (JustUsed(Bloodfest, 2f) && JustUsed(BrutalShell)))) //opener
+                                || (JustUsed(Bloodfest, 3f) && JustUsed(BrutalShell)))) //opener
                                 return SonicBreak;
                         }
 
@@ -471,14 +471,14 @@ namespace XIVSlothCombo.Combos.PvE
                         //Lv100
                         if (LevelChecked(ReignOfBeasts) && GetCooldownRemainingTime(DoubleDown) < 0.7f)
                         {
-                            if ((JustUsed(SonicBreak, 3f) && !HasEffect(Buffs.ReadyToBreak) && bfCD < GCD * 6 || ActionReady(Bloodfest)) //2min
-                                || (JustUsed(SonicBreak, 3f) && Ammo == 3) //1min NM 3 carts
+                            if ((JustUsed(SonicBreak, 10f) && !HasEffect(Buffs.ReadyToBreak) && bfCD < GCD * 6 || ActionReady(Bloodfest)) //2min
+                                || (JustUsed(SonicBreak, 10f) && Ammo == 3) //1min NM 3 carts
                                 || (JustUsed(SolidBarrel, 3f) && Ammo == 3 && HasEffect(Buffs.ReadyToBreak) && HasEffect(Buffs.NoMercy))) //1min NM 2 carts
                                 return DoubleDown;
                         }
 
                         //Lv90-Lv99
-                        if (!LevelChecked(ReignOfBeasts) && LevelChecked(DoubleDown) && GetCooldownRemainingTime(DoubleDown) <= 0.6f)
+                        if (!LevelChecked(ReignOfBeasts) && LevelChecked(DoubleDown) && GetCooldownRemainingTime(DoubleDown) <= 0.3f)
                         {
                             if ((Ammo >= 2 && !HasEffect(Buffs.ReadyToBreak) && JustUsed(SonicBreak, 3f) && (bfCD < GCD * 6 || ActionReady(Bloodfest))) //2min NM 3 carts
                                 || (!HasEffect(Buffs.ReadyToBreak) && Ammo == 3 && JustUsed(SonicBreak, 3f) && bfCD is < 90 and > 15) //1min NM 3 carts
@@ -498,7 +498,7 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     //GnashingFang
-                    if (IsEnabled(CustomComboPreset.GNB_ST_GnashingStarter) && LevelChecked(GnashingFang) && GetCooldownRemainingTime(GnashingFang) < 0.7f && Ammo > 0)
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && LevelChecked(GnashingFang) && GetCooldownRemainingTime(GnashingFang) < 0.7f && Ammo > 0)
                     {
                         if (!HasEffect(Buffs.ReadyToBlast) && GunStep == 0 && ActionReady(GnashingFang)
                             && (LevelChecked(ReignOfBeasts) && HasEffect(Buffs.NoMercy) && JustUsed(DoubleDown, 3f)) //Lv100 odd/even minute use
@@ -540,12 +540,12 @@ namespace XIVSlothCombo.Combos.PvE
                     }
 
                     //Lv100 2cart 2min starter
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_CooldownsGroup) && IsEnabled(CustomComboPreset.GNB_ST_BurstStrike) &&
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Advanced_CooldownsGroup) && IsEnabled(CustomComboPreset.GNB_ST_BurstStrike) && GetTargetHPPercent() > nmStop &&
                         LevelChecked(ReignOfBeasts) && ((nmCD <= GCD || ActionReady(NoMercy)) && Ammo is 3 && (bfCD < GCD * 12 || ActionReady(Bloodfest))))
                         return BurstStrike;
 
                     //GnashingFang combo safety net
-                    if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) && GunStep is 1 or 2)
+                    if (IsEnabled(CustomComboPreset.GNB_ST_Gnashing) && GunStep is 1 or 2)
                         return OriginalHook(GnashingFang);
 
                     //123 (overcap included)
@@ -555,9 +555,9 @@ namespace XIVSlothCombo.Combos.PvE
                             return BrutalShell;
                         if (lastComboMove == BrutalShell && LevelChecked(SolidBarrel))
                         {
-                            if (LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast) && nmCD > 1) //Lv100 Hypervelocity fit into NM check
+                            if (IsEnabled(CustomComboPreset.GNB_ST_Continuation) && LevelChecked(Hypervelocity) && HasEffect(Buffs.ReadyToBlast) && (nmCD is > 1 or <= 0.1f || GetTargetHPPercent() < nmStop)) //Lv100 Hypervelocity fit into NM check
                                 return Hypervelocity;
-                            if (LevelChecked(BurstStrike) && Ammo == MaxCartridges(level))
+                            if (IsEnabled(CustomComboPreset.GNB_ST_Overcap) && LevelChecked(BurstStrike) && Ammo == MaxCartridges(level))
                                 return BurstStrike;
                             return SolidBarrel;
                         }
@@ -710,7 +710,7 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
                         //Lv90
-                        if (!LevelChecked(ReignOfBeasts) && LevelChecked(DoubleDown) && GetCooldownRemainingTime(DoubleDown) <= 0.6f)
+                        if (!LevelChecked(ReignOfBeasts) && LevelChecked(DoubleDown) && GetCooldownRemainingTime(DoubleDown) <= 0.3f)
                         {
                             if ((Ammo >= 2 && !HasEffect(Buffs.ReadyToBreak) && JustUsed(SonicBreak, 3f) && (bfCD < GCD * 6 || ActionReady(Bloodfest))) //2min NM 3 carts
                                 || (!HasEffect(Buffs.ReadyToBreak) && Ammo == 3 && JustUsed(SonicBreak, 3f) && bfCD is < 90 and > 15) //1min NM 3 carts
@@ -997,7 +997,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                     if (IsEnabled(CustomComboPreset.GNB_BS_Continuation) && HasEffect(Buffs.ReadyToBlast) && LevelChecked(Hypervelocity))
                         return Hypervelocity;
-                    if (IsEnabled(CustomComboPreset.GNB_BS_Bloodfest) && Ammo is 0 && LevelChecked(Bloodfest) && !HasEffect(Buffs.ReadyToBlast) && bfCD < 0.6f)
+                    if (IsEnabled(CustomComboPreset.GNB_BS_Bloodfest) && Ammo is 0 && LevelChecked(Bloodfest) && !HasEffect(Buffs.ReadyToBlast) && bfCD < 0.3f)
                         return Bloodfest;
                     if (IsEnabled(CustomComboPreset.GNB_BS_DoubleDown) && HasEffect(Buffs.NoMercy) && GetCooldownRemainingTime(DoubleDown) < 2 && Ammo >= 2 && LevelChecked(DoubleDown))
                         return DoubleDown;
@@ -1009,7 +1009,7 @@ namespace XIVSlothCombo.Combos.PvE
                                 return OriginalHook(ReignOfBeasts);
                         }
 
-                        if (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood))
+                        if (JustUsed(ReignOfBeasts, 10f) || JustUsed(NobleBlood, 10f))
                         {
                             return OriginalHook(ReignOfBeasts);
                         }

--- a/XIVSlothCombo/Combos/PvE/GNB.cs
+++ b/XIVSlothCombo/Combos/PvE/GNB.cs
@@ -264,14 +264,12 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(GnashingFang) && !ActionReady(DoubleDown) && GunStep == 0)
                         {
-                            if (JustUsed(WickedTalon) || (JustUsed(EyeGouge)))
+                            if (JustUsed(WickedTalon, 6f) || (JustUsed(EyeGouge, 5f)))
                                 return OriginalHook(ReignOfBeasts);
                         }
 
-                        if (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood))
-                        {
+                        if (GunStep is 3 or 4)
                             return OriginalHook(ReignOfBeasts);
-                        }
                     }
 
                     //BurstStrike
@@ -517,14 +515,12 @@ namespace XIVSlothCombo.Combos.PvE
                     {
                         if (GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(GnashingFang) && !ActionReady(DoubleDown) && GunStep == 0)
                         {
-                            if (JustUsed(WickedTalon) || (JustUsed(EyeGouge)))
+                            if (JustUsed(WickedTalon, 6f) || (JustUsed(EyeGouge, 5f)))
                                 return OriginalHook(ReignOfBeasts);
                         }
 
-                        if (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood))
-                        {
+                        if (GunStep is 3 or 4)
                             return OriginalHook(ReignOfBeasts);
-                        }
                     }
 
                     //BurstStrike
@@ -748,15 +744,10 @@ namespace XIVSlothCombo.Combos.PvE
                     if (IsEnabled(CustomComboPreset.GNB_GF_Features) && IsEnabled(CustomComboPreset.GNB_GF_Reign) && (LevelChecked(ReignOfBeasts)))
                     {
                         if (GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(GnashingFang) && !ActionReady(DoubleDown) && GunStep == 0)
-                        {
-                            if (JustUsed(WickedTalon) || (JustUsed(EyeGouge)))
-                                return OriginalHook(ReignOfBeasts);
-                        }
-
-                        if (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood))
-                        {
                             return OriginalHook(ReignOfBeasts);
-                        }
+
+                        if (GunStep is 3 or 4)
+                            return OriginalHook(ReignOfBeasts);
                     }
 
                     //Burst Strike
@@ -845,7 +836,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (LevelChecked(ReignOfBeasts)) //because leaving this out anywhere is a waste
                         {
                             if ((GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(DoubleDown) && GunStep == 0) ||
-                                (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood)))
+                               (GunStep is 3 or 4))
                                 return OriginalHook(ReignOfBeasts);
                         }
                         //FatedCircle - if not unlocked, use BurstStrike
@@ -944,7 +935,7 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.GNB_AoE_Reign) && LevelChecked(ReignOfBeasts)) //because leaving this out anywhere is a waste
                         {
                             if ((GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(DoubleDown) && GunStep == 0) ||
-                                (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood)))
+                               (GunStep is 3 or 4))
                                 return OriginalHook(ReignOfBeasts);
                         }
                         //FatedCircle - if not unlocked, use BurstStrike
@@ -1003,16 +994,9 @@ namespace XIVSlothCombo.Combos.PvE
                         return DoubleDown;
                     if (IsEnabled(CustomComboPreset.GNB_BS_Reign) && (LevelChecked(ReignOfBeasts)))
                     {
-                        if (HasEffect(Buffs.ReadyToReign) && GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(DoubleDown) && GunStep == 0)
-                        {
-                            if (JustUsed(WickedTalon) || (JustUsed(EyeGouge)))
-                                return OriginalHook(ReignOfBeasts);
-                        }
-
-                        if (JustUsed(ReignOfBeasts, 10f) || JustUsed(NobleBlood, 10f))
-                        {
+                        if ((HasEffect(Buffs.ReadyToReign) && GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(DoubleDown) && GunStep == 0) ||
+                            (GunStep is 3 or 4))
                             return OriginalHook(ReignOfBeasts);
-                        }
                     }
                 }
 
@@ -1070,17 +1054,11 @@ namespace XIVSlothCombo.Combos.PvE
                             return SonicBreak;
                         if (IsEnabled(CustomComboPreset.GNB_NM_DD) && LevelChecked(DoubleDown) && ActionReady(DoubleDown) && Ammo >= 2 && LevelChecked(DoubleDown))
                             return DoubleDown;
-                        if (IsEnabled(CustomComboPreset.GNB_NM_Reign) && LevelChecked(ReignOfBeasts))
+                        if (IsEnabled(CustomComboPreset.GNB_NM_Reign) && (LevelChecked(ReignOfBeasts)))
                         {
-                            if (GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(GnashingFang) && !ActionReady(DoubleDown) && GunStep == 0)
-                            {
-                                    return OriginalHook(ReignOfBeasts);
-                            }
-
-                            if (JustUsed(ReignOfBeasts) || JustUsed(NobleBlood))
-                            {
+                            if ((HasEffect(Buffs.ReadyToReign) && GetBuffRemainingTime(Buffs.ReadyToReign) > 0 && !ActionReady(DoubleDown) && GunStep == 0) ||
+                                (GunStep is 3 or 4))
                                 return OriginalHook(ReignOfBeasts);
-                            }
                         }
                     }
                 }

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1518,6 +1518,10 @@ namespace XIVSlothCombo.Window.Functions
 
             if (preset == CustomComboPreset.GNB_Variant_Cure)
                 UserConfig.DrawSliderInt(1, 100, GNB.Config.GNB_VariantCure, "HP% to be at or under", 200);
+            if (preset == CustomComboPreset.GNB_ST_NoMercy)
+                UserConfig.DrawSliderInt(0, 10, GNB.Config.GNB_ST_NoMercyStop, "Disable Usage if Target HP% is below set value.\nTo Disable this, set to 0.");
+            if (preset == CustomComboPreset.GNB_AoE_NoMercy)
+                UserConfig.DrawSliderInt(0, 10, GNB.Config.GNB_AoE_NoMercyStop, "Disable Usage if Target HP% is below set value.\nTo Disable this, set to 0.");
 
             #endregion
             // ====================================================================================

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1519,9 +1519,9 @@ namespace XIVSlothCombo.Window.Functions
             if (preset == CustomComboPreset.GNB_Variant_Cure)
                 UserConfig.DrawSliderInt(1, 100, GNB.Config.GNB_VariantCure, "HP% to be at or under", 200);
             if (preset == CustomComboPreset.GNB_ST_NoMercy)
-                UserConfig.DrawSliderInt(0, 10, GNB.Config.GNB_ST_NoMercyStop, "Disable Usage if Target HP% is below set value.\nTo Disable this, set to 0.");
+                UserConfig.DrawSliderInt(0, 25, GNB.Config.GNB_ST_NoMercyStop, "Stop Usage if Target HP% is below set value.\nTo Disable this option, set to 0.");
             if (preset == CustomComboPreset.GNB_AoE_NoMercy)
-                UserConfig.DrawSliderInt(0, 10, GNB.Config.GNB_AoE_NoMercyStop, "Disable Usage if Target HP% is below set value.\nTo Disable this, set to 0.");
+                UserConfig.DrawSliderInt(0, 25, GNB.Config.GNB_AoE_NoMercyStop, "Stop Usage if Target HP% is below set value.\nTo Disable this option, set to 0.");
 
             #endregion
             // ====================================================================================


### PR DESCRIPTION
closes #1783 
- [x] Add **HP%** slider option to _NoMercy_
- [x] Add _BurstStrike_ option for _AoE_
- [x] Add _BurstStrike Overcap_ option for _AoE_
- [x] Add _Ammo Overcap_ option for _ST_
- [x] Fix issue with burst windows spazzing if _GnashingFang_ was delayed
- [x] Fix issue with burst windows spazzing if _DoubleDown_ was delayed
- [x] Fix issue with _ReignCombo_ not being called if force-disengaged during burst
- [x] Menu cleanup