### PR TITLE
[DNC] Increase the anti-drift for Technical Step

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -854,18 +854,19 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(DNC_ST_AdvancedMode)]
         [ConflictingCombos(DNC_ST_Adv_StandardFill)]
-        [CustomComboInfo("Standard Dance Option", "Includes Standard Step (and all steps) in the rotation.", DNC.JobID, 1)]
+        [CustomComboInfo("Standard Dance Option", "Includes Standard Step, all dance steps, and Finish in the rotation." +
+                                                  "\nIt is recommended to use one of the two Anti-Drift options along with this.", DNC.JobID, 1)]
         DNC_ST_Adv_SS = 4052,
 
         [ParentCombo(DNC_ST_Adv_SS)]
-        [ConflictingCombos(DNC_ST_Adv_StandardFill)]
         [CustomComboInfo("Standard Dance Opener Option", "Starts Standard Step (and steps) before combat.", DNC.JobID)]
         DNC_ST_Adv_SS_Prepull = 4090,
 
         [ParentCombo(DNC_ST_Adv_SS)]
         [ConflictingCombos(DNC_ST_Adv_Flourish_ForcedTripleWeave)]
-        [CustomComboInfo("Hold Standard Dance Option", "Will hold GCDs for Standard Step if it is going to come off cooldown before your next GCD. This WILL give you down-time." +
-                                                       "\nThis is recommended by The Balance if you have any extra skill speed, but this can also just be a good anti-drift option.", DNC.JobID)]
+        [CustomComboInfo("Hold for Standard Option (Anti-Drift)", "Will hold GCDs for Standard Step if it is going to come off cooldown before your next GCD." +
+                                                    "\nThis WILL give you down-time." +
+                                                    "\nONLY recommended if you have extra skill speed, but can be used as an anti-drift option.", DNC.JobID)]
         DNC_ST_Adv_SS_Hold = 4091,
 
         [ParentCombo(DNC_ST_AdvancedMode)]
@@ -881,7 +882,8 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(DNC_ST_AdvancedMode)]
         [ConflictingCombos(DNC_ST_Adv_TechFill)]
-        [CustomComboInfo("Technical Dance Option", "Includes Technical Step, all dance steps and Technical Finish in the rotation.", DNC.JobID, 4)]
+        [CustomComboInfo("Technical Dance Option", "Includes Technical Step, all dance steps, and Finish in the rotation." +
+                                                   "\nIt is recommended to use one of the two Anti-Drift options along with this.", DNC.JobID, 4)]
         DNC_ST_Adv_TS = 4053,
 
         [ParentCombo(DNC_ST_AdvancedMode)]
@@ -902,8 +904,9 @@ namespace XIVSlothCombo.Combos
 
         [ParentCombo(DNC_ST_Adv_Flourish)]
         [ConflictingCombos(DNC_ST_Adv_SS_Hold)]
-        [CustomComboInfo("Force Triple Weave for alignment", "Forces a triple weave of Flourish and Fan Dance 3 + 4 during non-opener burst windows." +
-                                                                    "\nFixes SS/FM drift where you use a gcd when SS/FM is on a 0.5sec CD.", DNC.JobID, 1)]
+        [CustomComboInfo("Force Triple Weave Option (Anti-Drift)", "Forces a triple weave of Flourish and Fan Dance 3 + 4 during non-opener burst windows." +
+                                                                    "\nFixes SS/FM drift where you use a gcd when SS/FM is on a 0.5sec CD." +
+                                                                    "\nRecommended to help prevent drift.", DNC.JobID, 1)]
         DNC_ST_Adv_Flourish_ForcedTripleWeave = 4088,
 
         [ParentCombo(DNC_ST_AdvancedMode)]

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -289,8 +289,6 @@ namespace XIVSlothCombo.Combos.PvE
                 var needToStandardOrFinish =
                     IsEnabled(CustomComboPreset.DNC_ST_Adv_SS) && // Enabled
                     GetTargetHPPercent() > targetHpThresholdStandard && // HP% check
-                    (IsOffCooldown(TechnicalStep) || // Checking burst is ready for standard
-                     GetCooldownRemainingTime(TechnicalStep) > 5) && // Don't mangle
                     LevelChecked(StandardStep);
 
                 // More Threshold, but only for SS

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -364,9 +364,6 @@ namespace XIVSlothCombo.Combos.PvE
                         : TechnicalFinish4;
                 #endregion
 
-                // Bail if not in combat
-                if (!InCombat()) return Cascade;
-
                 #region Weaves
                 // ST Devilment
                 if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Devilment) &&
@@ -481,7 +478,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // ST Improvisation
                     if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Improvisation) &&
                         ActionReady(Improvisation) &&
-                        !HasEffect(Buffs.TechnicalFinish))
+                        !HasEffect(Buffs.TechnicalFinish) &&
+                        InCombat())
                         return Improvisation;
                 }
                 #endregion
@@ -691,9 +689,6 @@ namespace XIVSlothCombo.Combos.PvE
                         : TechnicalFinish4;
                 #endregion
 
-                // Bail if not in combat
-                if (!InCombat()) return Windmill;
-
                 #region Weaves
                 // AoE Devilment
                 if (IsEnabled(CustomComboPreset.DNC_AoE_Adv_Devilment) &&
@@ -794,7 +789,8 @@ namespace XIVSlothCombo.Combos.PvE
                     // AoE Improvisation
                     if (IsEnabled(CustomComboPreset.DNC_AoE_Adv_Improvisation) &&
                         ActionReady(Improvisation) &&
-                        !HasEffect(Buffs.TechnicalStep))
+                        !HasEffect(Buffs.TechnicalStep) &&
+                        InCombat())
                         return Improvisation;
                 }
                 #endregion

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -286,19 +286,19 @@ namespace XIVSlothCombo.Combos.PvE
                     GetTargetHPPercent() > targetHpThresholdTechnical &&// HP% check
                     LevelChecked(TechnicalStep);
 
-                // More Threshold, but only for SS
-                if (IsEnabled(CustomComboPreset.DNC_ST_Adv_SS_Hold))
-                {
-                    longAlignmentThreshold = gcd;
-                    shortAlignmentThreshold = gcd;
-                }
-
                 var needToStandardOrFinish =
                     IsEnabled(CustomComboPreset.DNC_ST_Adv_SS) && // Enabled
                     GetTargetHPPercent() > targetHpThresholdStandard && // HP% check
                     (IsOffCooldown(TechnicalStep) || // Checking burst is ready for standard
                      GetCooldownRemainingTime(TechnicalStep) > 5) && // Don't mangle
                     LevelChecked(StandardStep);
+
+                // More Threshold, but only for SS
+                if (IsEnabled(CustomComboPreset.DNC_ST_Adv_SS_Hold))
+                {
+                    longAlignmentThreshold = gcd;
+                    shortAlignmentThreshold = gcd;
+                }
 
                 var needToFinish =
                     HasEffect(Buffs.FinishingMoveReady) &&

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -271,7 +271,7 @@ namespace XIVSlothCombo.Combos.PvE
 
                 var needToTech =
                     IsEnabled(CustomComboPreset.DNC_ST_Adv_TS) && // Enabled
-                    GetCooldownRemainingTime(TechnicalStep) < 0.05f && // Up or about to be (some anti-drift)
+                    GetCooldownRemainingTime(TechnicalStep) < 0.3f && // Up or about to be (some anti-drift)
                     !HasEffect(Buffs.StandardStep) && // After Standard
                     IsOnCooldown(StandardStep) &&
                     GetTargetHPPercent() > targetHpThresholdTechnical &&// HP% check

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -364,6 +364,9 @@ namespace XIVSlothCombo.Combos.PvE
                         : TechnicalFinish4;
                 #endregion
 
+                // Bail if not in combat
+                if (!InCombat()) return Cascade;
+
                 #region Weaves
                 // ST Devilment
                 if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Devilment) &&
@@ -687,6 +690,9 @@ namespace XIVSlothCombo.Combos.PvE
                         ? gauge.NextStep
                         : TechnicalFinish4;
                 #endregion
+
+                // Bail if not in combat
+                if (!InCombat()) return Windmill;
 
                 #region Weaves
                 // AoE Devilment

--- a/XIVSlothCombo/Combos/PvE/DNC.cs
+++ b/XIVSlothCombo/Combos/PvE/DNC.cs
@@ -269,13 +269,29 @@ namespace XIVSlothCombo.Combos.PvE
                 var targetHpThresholdTechnical = Config.DNC_ST_Adv_TSBurstPercent;
                 var gcd = GetCooldown(Fountain).CooldownTotal;
 
+                // Thresholds to wait for TS/SS to come off CD
+                var longAlignmentThreshold = 0.6f;
+                var shortAlignmentThreshold = 0.3f;
+                if (IsEnabled(CustomComboPreset.DNC_ST_Adv_Flourish_ForcedTripleWeave))
+                {
+                    longAlignmentThreshold = 0.3f;
+                    shortAlignmentThreshold = 0.1f;
+                }
+
                 var needToTech =
                     IsEnabled(CustomComboPreset.DNC_ST_Adv_TS) && // Enabled
-                    GetCooldownRemainingTime(TechnicalStep) < 0.3f && // Up or about to be (some anti-drift)
+                    GetCooldownRemainingTime(TechnicalStep) < longAlignmentThreshold && // Up or about to be (some anti-drift)
                     !HasEffect(Buffs.StandardStep) && // After Standard
                     IsOnCooldown(StandardStep) &&
                     GetTargetHPPercent() > targetHpThresholdTechnical &&// HP% check
                     LevelChecked(TechnicalStep);
+
+                // More Threshold, but only for SS
+                if (IsEnabled(CustomComboPreset.DNC_ST_Adv_SS_Hold))
+                {
+                    longAlignmentThreshold = gcd;
+                    shortAlignmentThreshold = gcd;
+                }
 
                 var needToStandardOrFinish =
                     IsEnabled(CustomComboPreset.DNC_ST_Adv_SS) && // Enabled
@@ -287,17 +303,13 @@ namespace XIVSlothCombo.Combos.PvE
                 var needToFinish =
                     HasEffect(Buffs.FinishingMoveReady) &&
                     !HasEffect(Buffs.LastDanceReady) &&
-                    ((GetCooldownRemainingTime(StandardStep) < 0.3f && // About to be up - some more aggressive anti-drift
+                    ((GetCooldownRemainingTime(StandardStep) < longAlignmentThreshold && // About to be up - some more aggressive anti-drift
                       HasEffect(Buffs.TechnicalFinish)) ||
                      (!HasEffect(Buffs.TechnicalFinish) && // Anti-Drift outside of Tech
-                      GetCooldownRemainingTime(StandardStep) < 0.05f));
+                      GetCooldownRemainingTime(StandardStep) < shortAlignmentThreshold));
 
                 var needToStandard =
-                    ((!IsEnabled(CustomComboPreset.DNC_ST_Adv_SS_Hold) &&
-                      GetCooldownRemainingTime(StandardStep) < 0.1f) || // Up or about to be (some anti-drift)
-                     IsEnabled(CustomComboPreset.DNC_ST_Adv_SS_Hold) &&
-                     GetCooldownRemainingTime(StandardStep) < gcd) // About to be up next GCD
-                    &&
+                    GetCooldownRemainingTime(StandardStep) < longAlignmentThreshold && // Up or about to be (some anti-drift)
                     !HasEffect(Buffs.FinishingMoveReady) &&
                     (IsOffCooldown(Flourish) ||
                      GetCooldownRemainingTime(Flourish) > 5) &&

--- a/XIVSlothCombo/Window/Functions/UserConfig.cs
+++ b/XIVSlothCombo/Window/Functions/UserConfig.cs
@@ -1391,14 +1391,18 @@ namespace XIVSlothCombo.Window.Functions
                 ImGui.Spacing();
             }
 
+            if (preset == CustomComboPreset.DNC_Variant_Cure)
+                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNCVariantCurePercent, "HP% to be at or under", 200);
+
+            #region Multi-Button Sliders
+
             if (preset == CustomComboPreset.DNC_ST_EspritOvercap)
                 UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_ST, "Esprit", 150, SliderIncrements.Fives);
 
             if (preset == CustomComboPreset.DNC_AoE_EspritOvercap)
                 UserConfig.DrawSliderInt(50, 100, DNC.Config.DNCEspritThreshold_AoE, "Esprit", 150, SliderIncrements.Fives);
 
-            if (preset == CustomComboPreset.DNC_Variant_Cure)
-                UserConfig.DrawSliderInt(1, 100, DNC.Config.DNCVariantCurePercent, "HP% to be at or under", 200);
+            #endregion
 
             #region Advanced ST Sliders
 


### PR DESCRIPTION
- [X] Increase the amount of down-time we're willing to take to try to make Technical/Standard Step align.
- [X] Clarify Anti-Drift Options, and that they should be used.
- [X] Stop oGCDs from flashing after prepull Standard.