### PR TITLE
[DRK] Fix Delirium Bloodspiller usage under 96

### DIFF
--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -59,8 +59,8 @@ namespace XIVSlothCombo.Combos.PvE
             public const ushort
                 // Main Buffs
                 BloodWeapon = 742,
-                OlderDelirium = 1972,
-                Delirium = 3836,
+                Delirium = 1972,
+                EnhancedDelirium = 3836,
 
                 // Periodic Buffs
                 Darkside = 741,
@@ -237,7 +237,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (LevelChecked(Delirium)
                     && LevelChecked(ScarletDelirium)
                     && IsEnabled(CustomComboPreset.DRK_ST_Delirium_Chain)
-                    && HasEffect(Buffs.Delirium)
+                    && HasEffect(Buffs.EnhancedDelirium)
                     && gauge.DarksideTimeRemaining > 0)
                     return OriginalHook(Bloodspiller);
 
@@ -246,9 +246,10 @@ namespace XIVSlothCombo.Combos.PvE
                     && IsEnabled(CustomComboPreset.DRK_ST_Bloodspiller))
                 {
                     //Bloodspiller under Delirium
-                    if (GetBuffStacks(Buffs.Delirium) > 0
-                        || (TraitLevelChecked(Traits.EnhancedDelirium)
-                            && GetBuffStacks(Buffs.OlderDelirium) > 0))
+                    var deliriumBuff = TraitLevelChecked(Traits.EnhancedDelirium)
+                        ? Buffs.Delirium
+                        : Buffs.EnhancedDelirium;
+                    if (GetBuffStacks(deliriumBuff) > 0)
                         return Bloodspiller;
 
                     //Blood management outside of Delirium
@@ -382,7 +383,7 @@ namespace XIVSlothCombo.Combos.PvE
                 if (LevelChecked(Delirium)
                     && LevelChecked(Impalement)
                     && IsEnabled(CustomComboPreset.DRK_AoE_Delirium_Chain)
-                    && HasEffect(Buffs.Delirium)
+                    && HasEffect(Buffs.EnhancedDelirium)
                     && gauge.DarksideTimeRemaining > 1)
                     return OriginalHook(Quietus);
 

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -247,8 +247,8 @@ namespace XIVSlothCombo.Combos.PvE
                 {
                     //Bloodspiller under Delirium
                     var deliriumBuff = TraitLevelChecked(Traits.EnhancedDelirium)
-                        ? Buffs.Delirium
-                        : Buffs.EnhancedDelirium;
+                        ? Buffs.EnhancedDelirium
+                        : Buffs.Delirium;
                     if (GetBuffStacks(deliriumBuff) > 0)
                         return Bloodspiller;
 

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -245,18 +245,16 @@ namespace XIVSlothCombo.Combos.PvE
                 if (LevelChecked(Delirium)
                     && IsEnabled(CustomComboPreset.DRK_ST_Bloodspiller))
                 {
-                    //Regular Bloodspiller
+                    //Bloodspiller under Delirium
                     if (GetBuffStacks(Buffs.Delirium) > 0
                         || (TraitLevelChecked(Traits.EnhancedDelirium)
                             && GetBuffStacks(Buffs.OlderDelirium) > 0))
                         return Bloodspiller;
 
-                    //Blood management before Delirium
+                    //Blood management outside of Delirium
                     if (IsEnabled(CustomComboPreset.DRK_ST_Delirium)
-                        && (
-                            (gauge.Blood >= 60 && GetCooldownRemainingTime(Delirium) is > 0 and < 3)
-                            || (gauge.Blood >= 50 && GetCooldownRemainingTime(Delirium) > 37)
-                            ))
+                        && ((gauge.Blood >= 60 && GetCooldownRemainingTime(Delirium) is > 0 and < 3) // Prep for Delirium
+                            || (gauge.Blood >= 50 && GetCooldownRemainingTime(Delirium) > 37))) // Regular Bloodspiller
                         return Bloodspiller;
                 }
 

--- a/XIVSlothCombo/Combos/PvE/DRK.cs
+++ b/XIVSlothCombo/Combos/PvE/DRK.cs
@@ -59,6 +59,7 @@ namespace XIVSlothCombo.Combos.PvE
             public const ushort
                 // Main Buffs
                 BloodWeapon = 742,
+                OlderDelirium = 1972,
                 Delirium = 3836,
 
                 // Periodic Buffs
@@ -70,10 +71,10 @@ namespace XIVSlothCombo.Combos.PvE
                 Scorn = 3837;
         }
 
-        public static class Debuffs
+        public static class Traits
         {
-            public const ushort
-                Placeholder = 1;
+            public const uint
+                EnhancedDelirium = 572;
         }
 
         public static class Config
@@ -245,7 +246,9 @@ namespace XIVSlothCombo.Combos.PvE
                     && IsEnabled(CustomComboPreset.DRK_ST_Bloodspiller))
                 {
                     //Regular Bloodspiller
-                    if (GetBuffStacks(Buffs.Delirium) > 0)
+                    if (GetBuffStacks(Buffs.Delirium) > 0
+                        || (TraitLevelChecked(Traits.EnhancedDelirium)
+                            && GetBuffStacks(Buffs.OlderDelirium) > 0))
                         return Bloodspiller;
 
                     //Blood management before Delirium


### PR DESCRIPTION
- [X] Add older Delirium buff ID, and check it when below the level of Enhanced Delirium when trying to use free Bloodspiller procs.

Closes #1764