### PR TITLE
[PCT] Move Swiftcast logic to IsMoving and add motif level checks

### DIFF
--- a/XIVSlothCombo/Combos/PvE/PCT.cs
+++ b/XIVSlothCombo/Combos/PvE/PCT.cs
@@ -303,20 +303,6 @@ namespace XIVSlothCombo.Combos.PvE
                             }
                         }
 
-                        // Swiftcast
-                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption))
-                        {
-                            if (IsMoving &&
-                                IsOffCooldown(All.Swiftcast) &&
-                                All.Swiftcast.LevelChecked() &&
-                                !HasEffect(Buffs.HammerTime) &&
-                                gauge.Paint < 1 &&
-                                (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
-                            {
-                                return All.Swiftcast;
-                            }
-                        }
-
                         // SubtractivePalette
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SubtractivePalette))
                         {
@@ -355,6 +341,12 @@ namespace XIVSlothCombo.Combos.PvE
 
                         if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
                             return OriginalHook(HolyInWhite);
+
+                        if (IsEnabled(CustomComboPreset.PCT_ST_AdvancedMode_SwitfcastOption) && ActionReady(All.Swiftcast) &&
+                            ((LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn) || 
+                             (LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn) || 
+                             (LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)))
+                            return All.Swiftcast;
                     }
 
                     //Prepare for Burst
@@ -633,20 +625,6 @@ namespace XIVSlothCombo.Combos.PvE
                         }
 
 
-                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption))
-                        {
-                            if (IsMoving &&
-                                IsOffCooldown(All.Swiftcast) &&
-                                All.Swiftcast.LevelChecked() &&
-                                !HasEffect(Buffs.HammerTime) &&
-                                gauge.Paint < 1 &&
-                                (!gauge.CreatureMotifDrawn || !gauge.WeaponMotifDrawn || !gauge.LandscapeMotifDrawn))
-                            {
-                                return All.Swiftcast;
-                            }
-                        }
-
-
                         // Subtractive Palette
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SubtractivePalette) &&
                             SubtractivePalette.LevelChecked() &&
@@ -680,6 +658,11 @@ namespace XIVSlothCombo.Combos.PvE
                         if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_MovementOption_HolyInWhite) && HolyInWhite.LevelChecked() && gauge.Paint >= 1)
                             return OriginalHook(HolyInWhite);
 
+                        if (IsEnabled(CustomComboPreset.PCT_AoE_AdvancedMode_SwitfcastOption) && ActionReady(All.Swiftcast) &&
+                            ((LevelChecked(CreatureMotif) && !gauge.CreatureMotifDrawn) ||
+                             (LevelChecked(WeaponMotif) && !gauge.WeaponMotifDrawn) ||
+                             (LevelChecked(LandscapeMotif) && !gauge.LandscapeMotifDrawn)))
+                            return All.Swiftcast;
                     }
 
                     //Prepare for Burst


### PR DESCRIPTION
Moves the Swiftcast logic to the `IsMoving` code block for Advanced ST and AoE and adds motif level checks to the logic, so it does not waste Swiftcast when synced below motif levels.
This also removes the weave check for Swiftcast, which I believe is fair as a movement option. If this is unacceptable, I can re-add it or make it an option.