### PR TITLE
[WHM] Add AoE 'opener' option

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -4416,6 +4416,11 @@ namespace XIVSlothCombo.Combos
         WHM_AoE_DPS = 19190,
 
         [ParentCombo(WHM_AoE_DPS)]
+        [CustomComboInfo("Swift Holy Pull 'Opener' Option", "Adds a Swiftcast->Holy at the beginning of your AoE rotation." +
+                                                "\nRequires you to already be in combat, to have stopped moving, and to not have used Assize yet.", WHM.JobID, 20, "", "")]
+        WHM_AoE_DPS_SwiftHoly = 19197,
+
+        [ParentCombo(WHM_AoE_DPS)]
         [CustomComboInfo("Assize Option", "Adds Assize to the AoE combo.", WHM.JobID, 21, "", "")]
         WHM_AoE_DPS_Assize = 19192,
 

--- a/XIVSlothCombo/Combos/PvE/WHM.cs
+++ b/XIVSlothCombo/Combos/PvE/WHM.cs
@@ -429,6 +429,7 @@ namespace XIVSlothCombo.Combos.PvE
         internal class WHM_AoE_DPS : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.WHM_AoE_DPS;
+            internal static int AssizeCount => ActionWatching.CombatActions.Count(x => x == Assize);
 
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
             {
@@ -439,6 +440,14 @@ namespace XIVSlothCombo.Combos.PvE
                     bool liliesFullNoBlood = gauge.Lily == 3 && gauge.BloodLily < 3;
                     bool liliesNearlyFull = gauge.Lily == 2 && gauge.LilyTimer >= 17000;
                     bool PresenceOfMindReady = ActionReady(PresenceOfMind) && (!Config.WHM_AoEDPS_PresenceOfMindWeave);
+
+                    if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_SwiftHoly) &&
+                        ActionReady(All.Swiftcast) &&
+                        AssizeCount == 0 && !IsMoving && InCombat())
+                        return All.Swiftcast;
+                    if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_SwiftHoly) &&
+                        WasLastAction(All.Swiftcast))
+                        return actionID;
 
                     if (IsEnabled(CustomComboPreset.WHM_AoE_DPS_Assize) && ActionReady(Assize))
                         return Assize;


### PR DESCRIPTION
- [X] Add AoE 'opener' option
- [X] Implement AoE 'opener'

This adds an AoE 'opener', simply doing Swift->Holy, designed to work off of a dungeon pull where you were healing/DoTing during the pull and then come to a stop.
Also conveniently opens a weave window at the beginning of your AoE rotation, for Assize and Presence of Mind to fit into.

![image](https://github.com/user-attachments/assets/569a4c8f-0580-4485-99f9-a80d4c196c4d)
