### PR TITLE
[SCH] Aetherflow Fix

### DIFF
--- a/XIVSlothCombo/Combos/PvE/SCH.cs
+++ b/XIVSlothCombo/Combos/PvE/SCH.cs
@@ -365,7 +365,7 @@ namespace XIVSlothCombo.Combos.PvE
                         return Dissipation;
 
                     // Aetherflow
-                    if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) &&
+                    if (IsEnabled(CustomComboPreset.SCH_DPS_Aetherflow) && !WasLastAction(Dissipation) &&
                         ActionReady(Aetherflow) && !Gauge.HasAetherflow() &&
                         InCombat() && CanSpellWeave(actionID))
                         return Aetherflow;


### PR DESCRIPTION
- [x] Added line to aetherflow to not use if dissipation was just used. Bad server tick causing it not to register the aetherflow stack in time likely due to animation lock skipping. reported via combo issues. 