### PR TITLE
[SGE] Sage Pneuma to zoe downleveled fix

### DIFF
--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3495,8 +3495,8 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Taurochole to Druochole Feature", "Turns Taurochole to Druochole when Taurochole is on cooldown.", SGE.JobID, 700, "", "")]
         SGE_TauroDruo = 14038,
 
-        [ReplaceSkill(SGE.Pneuma)]
-        [CustomComboInfo("Zoe Pneuma Feature", "Places Zoe on top of Pneuma when both actions are on cooldown.", SGE.JobID, 701, "", "")] //Temporary to keep the order
+        [ReplaceSkill(SGE.Zoe)]
+        [CustomComboInfo("Zoe to Pneuma Feature", "Replaces Zoe with Pnuema when zoe is on cd and Pnuema is available.", SGE.JobID, 701, "", "")] //Temporary to keep the order
         SGE_ZoePneuma = 14039,
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3496,7 +3496,7 @@ namespace XIVSlothCombo.Combos
         SGE_TauroDruo = 14038,
 
         [ReplaceSkill(SGE.Pneuma)]
-        [CustomComboInfo("Zoe Pnuema Feature", "Adds Zoe to Pnuema when Pnuema is on cd or below 90.", SGE.JobID, 701, "", "")]
+        [CustomComboInfo("Zoe Pnuema Feature", "Places Zoe on top of Pneuma when both actions are off cooldown.", SGE.JobID, 701, "", "")]
         SGE_ZoePneuma = 14039,
         #endregion
 

--- a/XIVSlothCombo/Combos/CustomComboPreset.cs
+++ b/XIVSlothCombo/Combos/CustomComboPreset.cs
@@ -3495,8 +3495,8 @@ namespace XIVSlothCombo.Combos
         [CustomComboInfo("Taurochole to Druochole Feature", "Turns Taurochole to Druochole when Taurochole is on cooldown.", SGE.JobID, 700, "", "")]
         SGE_TauroDruo = 14038,
 
-        [ReplaceSkill(SGE.Zoe)]
-        [CustomComboInfo("Zoe to Pneuma Feature", "Replaces Zoe with Pnuema when zoe is on cd and Pnuema is available.", SGE.JobID, 701, "", "")] //Temporary to keep the order
+        [ReplaceSkill(SGE.Pneuma)]
+        [CustomComboInfo("Zoe Pnuema Feature", "Adds Zoe to Pnuema when Pnuema is on cd or below 90.", SGE.JobID, 701, "", "")]
         SGE_ZoePneuma = 14039,
         #endregion
 

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -186,8 +186,7 @@ namespace XIVSlothCombo.Combos.PvE
 
         /*
          * Druo/Tauro
-         * Druochole Upgrade to Taurochole (like a trait upgrade)
-         * Replaces Druocole with Taurochole when Taurochole is available
+         * Replaces Taurochole with druochole when Taurochole is not available
          * (As of 6.0) Taurochole (single target massive insta heal w/ cooldown), Druochole (Single target insta heal)
          */
         internal class SGE_DruoTauro : CustomCombo
@@ -199,13 +198,13 @@ namespace XIVSlothCombo.Combos.PvE
 
         /*
          * SGE_ZoePneuma (Zoe to Pneuma Combo)
-         * Places Zoe on top of Pneuma when both are available.
+         * Places Zoe on top of Pneuma when both are available. When below 90, will only display Zoe for downscaling dungeons.
          */
         internal class SGE_ZoePneuma : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneuma;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-                => actionID is Pneuma && ActionReady(Pneuma) && IsOffCooldown(Zoe) ? Zoe : actionID;
+                => (actionID is Pneuma && ActionReady(Pneuma) && IsOffCooldown(Zoe)) || (actionID is Pneuma && !LevelChecked(Pneuma)) ? Zoe : actionID;
         }
 
         /*

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -198,13 +198,13 @@ namespace XIVSlothCombo.Combos.PvE
 
         /*
          * SGE_ZoePneuma (Zoe to Pneuma Combo)
-         * Places Zoe on top of Pneuma when both are available. When below 90, will only display Zoe for downscaling dungeons.
+         * rePlaces Zoe with Pneuma when zoe is on cd. When below 90, will only display Zoe for downscaling dungeons.
          */
         internal class SGE_ZoePneuma : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneuma;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-                => (actionID is Pneuma && ActionReady(Pneuma) && IsOffCooldown(Zoe)) || (actionID is Pneuma && !LevelChecked(Pneuma)) ? Zoe : actionID;
+                => actionID is Zoe && ActionReady(Pneuma) && IsOnCooldown(Zoe) ? Pneuma : actionID;
         }
 
         /*

--- a/XIVSlothCombo/Combos/PvE/SGE.cs
+++ b/XIVSlothCombo/Combos/PvE/SGE.cs
@@ -198,13 +198,13 @@ namespace XIVSlothCombo.Combos.PvE
 
         /*
          * SGE_ZoePneuma (Zoe to Pneuma Combo)
-         * rePlaces Zoe with Pneuma when zoe is on cd. When below 90, will only display Zoe for downscaling dungeons.
+         * Places Zoe on top of pnuema when zoe is off cd. When below 90, will only display Zoe for downscaling dungeons.
          */
         internal class SGE_ZoePneuma : CustomCombo
         {
             protected internal override CustomComboPreset Preset { get; } = CustomComboPreset.SGE_ZoePneuma;
             protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
-                => actionID is Zoe && ActionReady(Pneuma) && IsOnCooldown(Zoe) ? Pneuma : actionID;
+                => (actionID is Pneuma && ActionReady(Pneuma) && IsOffCooldown(Zoe)) || (actionID is Pneuma && !LevelChecked(Pneuma)) ? Zoe : actionID;
         }
 
         /*


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/f9e55fd3-6424-48d5-9c13-92778295f9f9)

- [x] Added or statement so below 90, Pnuema shows Zoe. No more need to put it somewhere else just for downleveled content. 