### PR TITLE
[DRG] Fix Wheeling Thrust & Fang and Claw

### DIFF
--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -232,7 +232,7 @@ internal class DRG
                         return OriginalHook(ChaosThrust);
                     }
 
-                    if (lastComboMove is ChaosThrust && LevelChecked(WheelingThrust))
+                    if (lastComboMove is ChaoticSpring && LevelChecked(WheelingThrust))
                     {
                         if (trueNorthReady && AnimationLock.CanDRGWeave(All.TrueNorth) &&
                             !OnTargetsRear())

--- a/XIVSlothCombo/Combos/PvE/DRG.cs
+++ b/XIVSlothCombo/Combos/PvE/DRG.cs
@@ -232,7 +232,7 @@ internal class DRG
                         return OriginalHook(ChaosThrust);
                     }
 
-                    if (lastComboMove == OriginalHook(ChaosThrust) && LevelChecked(WheelingThrust))
+                    if (lastComboMove is ChaosThrust && LevelChecked(WheelingThrust))
                     {
                         if (trueNorthReady && AnimationLock.CanDRGWeave(All.TrueNorth) &&
                             !OnTargetsRear())
@@ -244,7 +244,7 @@ internal class DRG
                     if (lastComboMove == OriginalHook(VorpalThrust) && LevelChecked(FullThrust))
                         return OriginalHook(FullThrust);
 
-                    if (lastComboMove == OriginalHook(FullThrust) && LevelChecked(FangAndClaw))
+                    if (lastComboMove is HeavensThrust && LevelChecked(FangAndClaw))
                     {
                         if (trueNorthReady && AnimationLock.CanDRGWeave(All.TrueNorth) &&
                             !OnTargetsFlank())
@@ -435,7 +435,7 @@ internal class DRG
                         return OriginalHook(ChaosThrust);
                     }
 
-                    if (lastComboMove == OriginalHook(ChaosThrust) && LevelChecked(WheelingThrust))
+                    if (lastComboMove is ChaoticSpring && LevelChecked(WheelingThrust))
                     {
                         if (IsEnabled(CustomComboPreset.DRG_TrueNorthDynamic) &&
                             trueNorthReady && AnimationLock.CanDRGWeave(All.TrueNorth) &&
@@ -448,7 +448,7 @@ internal class DRG
                     if (lastComboMove == OriginalHook(VorpalThrust) && LevelChecked(FullThrust))
                         return OriginalHook(FullThrust);
 
-                    if (lastComboMove == OriginalHook(FullThrust) && LevelChecked(FangAndClaw))
+                    if (lastComboMove is HeavensThrust && LevelChecked(FangAndClaw))
                     {
                         if (IsEnabled(CustomComboPreset.DRG_TrueNorthDynamic) &&
                             trueNorthReady && AnimationLock.CanDRGWeave(All.TrueNorth) &&


### PR DESCRIPTION
Fixed rotation logic to ensure both Wheeling Thrust & Fang and Claw fire if available. Looks like they were previously looking for the wrong preceding skill.